### PR TITLE
harden(context): pal + quorum review follow-ups for v0.16.0

### DIFF
--- a/src/context/bootstrap.rs
+++ b/src/context/bootstrap.rs
@@ -78,14 +78,54 @@ pub fn build_production_injector(
         return None;
     }
 
-    let (src_name, db_path) = cfg.sources.iter().find_map(|s| {
+    // Walk registered sources and pick the first one whose `index.db` is
+    // actually openable and queryable. Existence alone isn't enough — a
+    // stale tempfile or truncated db would hand a dead connection to the
+    // retriever and fail on the first real review. Skip those and fall
+    // through so the caller degrades to pre-context behavior.
+    let picked = cfg.sources.iter().find_map(|s| {
         let layout = SourceLayout::for_source(home, &s.name);
-        if layout.db.exists() {
-            Some((s.name.clone(), layout.db))
-        } else {
-            None
+        if !layout.db.exists() {
+            return None;
         }
-    })?;
+        ensure_vec_loaded();
+        match Connection::open_with_flags(&layout.db, rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY) {
+            Ok(conn) => match conn.query_row::<u32, _, _>(
+                "SELECT COUNT(*) FROM chunks",
+                [],
+                |r| r.get(0),
+            ) {
+                Ok(_) => Some((s.name.clone(), layout.db)),
+                Err(e) => {
+                    tracing::warn!(
+                        source = %s.name,
+                        path = %layout.db.display(),
+                        error = %e,
+                        "context bootstrap: index.db present but unusable; skipping"
+                    );
+                    None
+                }
+            },
+            Err(e) => {
+                tracing::warn!(
+                    source = %s.name,
+                    path = %layout.db.display(),
+                    error = %e,
+                    "context bootstrap: index.db present but cannot be opened; skipping"
+                );
+                None
+            }
+        }
+    });
+    let (src_name, db_path) = match picked {
+        Some(v) => v,
+        None => {
+            tracing::info!(
+                "context bootstrap: no registered source has a usable index; run `quorum context index` to enable auto-injection"
+            );
+            return None;
+        }
+    };
 
     // Own the db path directly so non-UTF-8 bytes (rare on macOS/Linux but
     // legal on ext4/APFS) survive the hand-off into the `'static` closure
@@ -109,8 +149,7 @@ pub fn build_production_injector(
             ensure_vec_loaded();
             let conn = Connection::open_with_flags(
                 &db_path_owned,
-                rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY
-                    | rusqlite::OpenFlags::SQLITE_OPEN_URI,
+                rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY,
             )?;
             let clock = SystemClock;
             let retriever = Retriever::new(&conn, embedder.as_ref(), &clock);
@@ -247,5 +286,36 @@ weight = 10
         let out = injector.inject(&req);
         assert!(out.telemetry.auto_inject_enabled);
         assert!(out.telemetry.injector_available);
+    }
+
+    #[test]
+    fn returns_none_when_only_index_is_corrupt() {
+        // A file named `index.db` that isn't a valid SQLite database should
+        // not be picked as a usable source. Before the validation was added
+        // bootstrap would hand a dead connection to the retriever and each
+        // query inside a real review would fail, instead of degrading to the
+        // pre-context behavior as the contract states.
+        let dir = tempdir().unwrap();
+        let home = dir.path();
+        std::fs::create_dir_all(home.join("sources/broken")).unwrap();
+        std::fs::write(
+            home.join("sources/broken/index.db"),
+            b"this is not a sqlite database",
+        )
+        .unwrap();
+        std::fs::write(
+            home.join("sources.toml"),
+            r#"
+[context]
+auto_inject = true
+
+[[source]]
+name = "broken"
+kind = "rust"
+path = "/tmp/broken"
+"#,
+        )
+        .unwrap();
+        assert!(build_production_injector(home, &[]).is_none());
     }
 }

--- a/src/context/bootstrap.rs
+++ b/src/context/bootstrap.rs
@@ -90,22 +90,32 @@ pub fn build_production_injector(
         }
         ensure_vec_loaded();
         match Connection::open_with_flags(&layout.db, rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY) {
-            Ok(conn) => match conn.query_row::<u32, _, _>(
-                "SELECT COUNT(*) FROM chunks",
-                [],
-                |r| r.get(0),
-            ) {
-                Ok(_) => Some((s.name.clone(), layout.db)),
-                Err(e) => {
-                    tracing::warn!(
-                        source = %s.name,
-                        path = %layout.db.display(),
-                        error = %e,
-                        "context bootstrap: index.db present but unusable; skipping"
-                    );
-                    None
+            Ok(conn) => {
+                // Probe all three tables the retriever actually uses. A db
+                // with only `chunks` would pass a naive check but fail the
+                // BM25 leg of the first query; likewise a missing
+                // `chunks_vec` would fail the vector leg. Using one
+                // compound query keeps the cost minimal.
+                let probe = conn.query_row::<u32, _, _>(
+                    "SELECT (SELECT COUNT(*) FROM chunks) \
+                          + (SELECT COUNT(*) FROM chunks_fts) \
+                          + (SELECT COUNT(*) FROM chunks_vec)",
+                    [],
+                    |r| r.get(0),
+                );
+                match probe {
+                    Ok(_) => Some((s.name.clone(), layout.db)),
+                    Err(e) => {
+                        tracing::warn!(
+                            source = %s.name,
+                            path = %layout.db.display(),
+                            error = %e,
+                            "context bootstrap: index.db present but unusable (missing table?); skipping"
+                        );
+                        None
+                    }
                 }
-            },
+            }
             Err(e) => {
                 tracing::warn!(
                     source = %s.name,
@@ -286,6 +296,37 @@ weight = 10
         let out = injector.inject(&req);
         assert!(out.telemetry.auto_inject_enabled);
         assert!(out.telemetry.injector_available);
+    }
+
+    #[test]
+    fn returns_none_when_index_is_missing_fts_table() {
+        // A db that only has `chunks` but no `chunks_fts` would pass the
+        // old single-table probe but fail the BM25 leg of every real
+        // retrieval. Force the smoke test to cover all three tables so
+        // partially-built indexes also fall through to None.
+        let dir = tempdir().unwrap();
+        let home = dir.path();
+        std::fs::create_dir_all(home.join("sources/partial")).unwrap();
+        let db_path = home.join("sources/partial/index.db");
+        let conn = rusqlite::Connection::open(&db_path).unwrap();
+        conn.execute_batch("CREATE TABLE chunks (id TEXT PRIMARY KEY);")
+            .unwrap();
+        // Intentionally omit chunks_fts and chunks_vec.
+        drop(conn);
+        std::fs::write(
+            home.join("sources.toml"),
+            r#"
+[context]
+auto_inject = true
+
+[[source]]
+name = "partial"
+kind = "rust"
+path = "/tmp/partial"
+"#,
+        )
+        .unwrap();
+        assert!(build_production_injector(home, &[]).is_none());
     }
 
     #[test]

--- a/src/context/cli.rs
+++ b/src/context/cli.rs
@@ -161,6 +161,16 @@ impl ProdDeps {
 
     fn resolve_quorum_root() -> Result<PathBuf> {
         let from = |k: &str| std::env::var_os(k).filter(|v| !v.is_empty());
+        // On Windows, `USERPROFILE` is the canonical user dir. `HOME` is
+        // often set by MSYS/Cygwin/Git Bash to an MSYS-mangled path that
+        // doesn't match the profile CreateFile + Explorer see. Prefer
+        // USERPROFILE there and fall back to HOME for non-standard envs.
+        // Elsewhere (macOS/Linux), HOME is canonical.
+        #[cfg(windows)]
+        let home = from("USERPROFILE")
+            .or_else(|| from("HOME"))
+            .ok_or_else(|| anyhow!("neither USERPROFILE nor HOME is set"))?;
+        #[cfg(not(windows))]
         let home = from("HOME")
             .or_else(|| from("USERPROFILE"))
             .ok_or_else(|| anyhow!("neither HOME nor USERPROFILE is set"))?;

--- a/src/context/cli.rs
+++ b/src/context/cli.rs
@@ -483,47 +483,63 @@ pub fn run_context_cmd<D: ContextDeps>(cmd: &ContextCmd, deps: &D) -> Result<Cmd
 // --- Init handler -----------------------------------------------------------
 
 fn run_init<D: ContextDeps>(deps: &D) -> Result<CmdOutput> {
+    use std::io::Write;
+
     // `home_dir()` already points at the quorum state root (e.g. `~/.quorum`
     // in production, a tempdir in tests) — don't append `.quorum` again here.
     let sources_path = deps.home_dir().join("sources.toml");
 
-    // Distinguish "already a regular file" (idempotent success) from "the
-    // path exists but is a directory / symlink / device" (hard error). The
-    // bare `.exists()` check can't tell them apart; without this, a stray
-    // `mkdir sources.toml` under `~/.quorum` makes every future `init` and
-    // `add` silently no-op instead of complaining.
-    if sources_path.exists() {
-        let meta = std::fs::symlink_metadata(&sources_path).map_err(|e| {
-            anyhow!(
-                "cannot stat {}: {e}",
-                sources_path.display()
-            )
-        })?;
-        if !meta.file_type().is_file() {
-            return Err(anyhow!(
-                "{} exists but is not a regular file; refusing to initialize over it",
-                sources_path.display()
-            ));
-        }
-        return Ok(CmdOutput {
-            stdout: format!("context already initialized at {}", sources_path.display()),
-            created_paths: Vec::new(),
-            removed_paths: Vec::new(),
-            warnings: vec![format!(
-                "{} already exists; leaving it untouched",
-                sources_path.display()
-            )],
-        });
+    if let Some(parent) = sources_path.parent() {
+        std::fs::create_dir_all(parent)
+            .map_err(|e| anyhow!("cannot create {}: {e}", parent.display()))?;
     }
 
-    SourcesConfig::write_default(&sources_path)?;
-
-    Ok(CmdOutput {
-        stdout: format!("initialized context at {}", sources_path.display()),
-        created_paths: vec![sources_path],
-        removed_paths: Vec::new(),
-        warnings: Vec::new(),
-    })
+    // Atomic create-or-fail: previously we did `exists()` + `write()`, which
+    // left a TOCTOU window where a concurrent process could slip in and get
+    // its config clobbered. `create_new(true)` hands that race to the OS.
+    match std::fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(&sources_path)
+    {
+        Ok(mut f) => {
+            f.write_all(crate::context::config::default_sources_toml().as_bytes())
+                .map_err(|e| anyhow!("write {}: {e}", sources_path.display()))?;
+            Ok(CmdOutput {
+                stdout: format!("initialized context at {}", sources_path.display()),
+                created_paths: vec![sources_path],
+                removed_paths: Vec::new(),
+                warnings: Vec::new(),
+            })
+        }
+        Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {
+            // Distinguish "already a regular file" (idempotent success) from
+            // "exists but is a directory / symlink / device" (hard error).
+            // Without this, a stray `mkdir sources.toml` under `~/.quorum`
+            // would make every future `init`/`add` silently no-op.
+            let meta = std::fs::symlink_metadata(&sources_path)
+                .map_err(|e| anyhow!("cannot stat {}: {e}", sources_path.display()))?;
+            if !meta.file_type().is_file() {
+                return Err(anyhow!(
+                    "{} exists but is not a regular file; refusing to initialize over it",
+                    sources_path.display()
+                ));
+            }
+            Ok(CmdOutput {
+                stdout: format!(
+                    "context already initialized at {}",
+                    sources_path.display()
+                ),
+                created_paths: Vec::new(),
+                removed_paths: Vec::new(),
+                warnings: vec![format!(
+                    "{} already exists; leaving it untouched",
+                    sources_path.display()
+                )],
+            })
+        }
+        Err(e) => Err(anyhow!("create {}: {e}", sources_path.display())),
+    }
 }
 
 // --- Add handler ------------------------------------------------------------

--- a/src/context/cli.rs
+++ b/src/context/cli.rs
@@ -1072,7 +1072,7 @@ fn run_query<D: ContextDeps>(args: &QueryArgs, deps: &D) -> Result<CmdOutput> {
 
     let conn = Connection::open_with_flags(
         &db_path,
-        rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY | rusqlite::OpenFlags::SQLITE_OPEN_URI,
+        rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY,
     )
     .map_err(|e| anyhow!("open {}: {e}", db_path.display()))?;
 
@@ -1510,7 +1510,7 @@ fn db_chunk_count(db: &Path) -> Result<i64> {
     ensure_vec_loaded();
     let conn = Connection::open_with_flags(
         db,
-        rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY | rusqlite::OpenFlags::SQLITE_OPEN_URI,
+        rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY,
     )?;
     let n: i64 = conn.query_row("SELECT count(*) FROM chunks", [], |r| r.get(0))?;
     Ok(n)

--- a/src/context/cli.rs
+++ b/src/context/cli.rs
@@ -130,16 +130,24 @@ impl ProdDeps {
     }
 
     /// Resolve `~/.quorum` from `$HOME` (Unix) or `%USERPROFILE%` (Windows).
-    /// Returns an error if neither is set or if either is empty (an empty
-    /// value would yield a relative `.quorum` path that resolves against
-    /// the current working directory, which is never the user's intent).
+    /// Returns an error if neither is set, if either is empty, or if the
+    /// value is not an absolute path. An empty or relative value would
+    /// yield a `.quorum` path that resolves against the current working
+    /// directory, which is never the user's intent and would silently
+    /// scatter state across wherever the binary happened to launch.
     pub fn from_env() -> Result<Self> {
         let from = |k: &str| std::env::var_os(k).filter(|v| !v.is_empty());
         let home = from("HOME")
             .or_else(|| from("USERPROFILE"))
             .ok_or_else(|| anyhow!("neither HOME nor USERPROFILE is set"))?;
-        let root = PathBuf::from(home).join(".quorum");
-        Ok(Self::new(root))
+        let home_path = PathBuf::from(&home);
+        if !home_path.is_absolute() {
+            anyhow::bail!(
+                "HOME/USERPROFILE must be an absolute path, got {:?}",
+                home_path
+            );
+        }
+        Ok(Self::new(home_path.join(".quorum")))
     }
 }
 

--- a/src/context/cli.rs
+++ b/src/context/cli.rs
@@ -129,6 +129,19 @@ impl ProdDeps {
         }
     }
 
+    /// Construct a `ProdDeps` whose embedder is the **strict** production
+    /// embedder: fastembed init failures surface as errors instead of
+    /// falling back to HashEmbedder. Use this for paths that would
+    /// otherwise silently corrupt the on-disk index (`index`, `refresh`).
+    pub fn new_strict(home_dir: PathBuf) -> Result<Self> {
+        Ok(Self {
+            git: SystemGit,
+            clock: SystemClock,
+            embedder: new_prod_embedder_strict()?,
+            home_dir,
+        })
+    }
+
     /// Resolve `~/.quorum` from `$HOME` (Unix) or `%USERPROFILE%` (Windows).
     /// Returns an error if neither is set, if either is empty, or if the
     /// value is not an absolute path. An empty or relative value would
@@ -136,6 +149,17 @@ impl ProdDeps {
     /// directory, which is never the user's intent and would silently
     /// scatter state across wherever the binary happened to launch.
     pub fn from_env() -> Result<Self> {
+        Ok(Self::new(Self::resolve_quorum_root()?))
+    }
+
+    /// Like `from_env` but uses the strict embedder factory. Use for paths
+    /// that write to the on-disk index (`index`, `refresh`) so a silent
+    /// fastembed fallback can't corrupt `chunks_vec`.
+    pub fn from_env_strict() -> Result<Self> {
+        Self::new_strict(Self::resolve_quorum_root()?)
+    }
+
+    fn resolve_quorum_root() -> Result<PathBuf> {
         let from = |k: &str| std::env::var_os(k).filter(|v| !v.is_empty());
         let home = from("HOME")
             .or_else(|| from("USERPROFILE"))
@@ -147,14 +171,14 @@ impl ProdDeps {
                 home_path
             );
         }
-        Ok(Self::new(home_path.join(".quorum")))
+        Ok(home_path.join(".quorum"))
     }
 }
 
-/// Construct the production embedder. Fastembed can fail on first run
-/// (model download needs network) — we log a warning and fall back to
-/// HashEmbedder so reviews still execute. BM25 retrieval still works
-/// in the fallback; only the vector-similarity leg is degraded.
+/// Construct the production embedder for **review/query** paths. Fastembed
+/// can fail on first run (model download needs network) — we log a warning
+/// and fall back to HashEmbedder so reviews still execute. BM25 retrieval
+/// still works in the fallback; only the vector-similarity leg is degraded.
 pub(crate) fn new_prod_embedder() -> ProdEmbedder {
     #[cfg(feature = "embeddings")]
     {
@@ -175,6 +199,33 @@ pub(crate) fn new_prod_embedder() -> ProdEmbedder {
     #[cfg(not(feature = "embeddings"))]
     {
         ProdEmbedder::Hash(HashEmbedder::new(384))
+    }
+}
+
+/// Construct the production embedder for **index/refresh** paths. Unlike
+/// [`new_prod_embedder`], a fastembed init failure here returns `Err`
+/// instead of falling back. Silently rebuilding the `chunks_vec` table
+/// with HashEmbedder noise vectors would corrupt semantic retrieval
+/// until the user discovers the drift and reruns with the model present,
+/// so we refuse to alter the index without the production embedder.
+///
+/// When built without the `embeddings` feature HashEmbedder *is* the
+/// intended production embedder, so this returns `Ok` just like the
+/// lenient factory.
+pub(crate) fn new_prod_embedder_strict() -> anyhow::Result<ProdEmbedder> {
+    #[cfg(feature = "embeddings")]
+    {
+        let e = FastEmbedEmbedder::new().map_err(|e| {
+            anyhow!(
+                "fastembed init failed ({e}); refusing to rebuild the index with \
+                 HashEmbedder fallback — retry once the model is available"
+            )
+        })?;
+        Ok(ProdEmbedder::Fast(e))
+    }
+    #[cfg(not(feature = "embeddings"))]
+    {
+        Ok(ProdEmbedder::Hash(HashEmbedder::new(384)))
     }
 }
 

--- a/src/context/cli_tests.rs
+++ b/src/context/cli_tests.rs
@@ -115,6 +115,36 @@ fn prod_deps_from_env_rejects_empty_home() {
 }
 
 #[test]
+fn prod_deps_from_env_rejects_relative_home() {
+    // A non-empty but *relative* HOME (e.g. accidentally set to "foo" by a
+    // test harness or container init) would also yield a relative
+    // `.quorum` path. The doc comment on from_env promises an anchored
+    // state dir; reject relative values so the promise holds.
+    use super::cli::ProdDeps;
+    let prev_home = std::env::var_os("HOME");
+    let prev_up = std::env::var_os("USERPROFILE");
+    unsafe {
+        std::env::set_var("HOME", "relative/path");
+        std::env::remove_var("USERPROFILE");
+    }
+    let r = ProdDeps::from_env();
+    unsafe {
+        match prev_home {
+            Some(v) => std::env::set_var("HOME", v),
+            None => std::env::remove_var("HOME"),
+        }
+        match prev_up {
+            Some(v) => std::env::set_var("USERPROFILE", v),
+            None => std::env::remove_var("USERPROFILE"),
+        }
+    }
+    assert!(
+        r.is_err(),
+        "relative HOME must error rather than silently anchor state to cwd"
+    );
+}
+
+#[test]
 fn run_context_cmd_init_errors_when_sources_path_is_a_directory() {
     // If something created a *directory* at <home>/sources.toml, treating it
     // as an already-initialized regular file would silently disable future

--- a/src/context/index/traits.rs
+++ b/src/context/index/traits.rs
@@ -66,9 +66,21 @@ pub struct HashEmbedder {
 }
 
 impl HashEmbedder {
+    /// Construct a `HashEmbedder` with a positive dimension.
+    ///
+    /// Returns `Err` when `dim == 0`. Prefer this in any path that derives
+    /// `dim` from configuration or user input; callers with a compile-time
+    /// constant can use [`HashEmbedder::new`], which forwards to this and
+    /// panics on failure.
+    pub fn try_new(dim: usize) -> anyhow::Result<Self> {
+        if dim == 0 {
+            anyhow::bail!("HashEmbedder dim must be positive");
+        }
+        Ok(Self { dim })
+    }
+
     pub fn new(dim: usize) -> Self {
-        assert!(dim > 0, "HashEmbedder dim must be positive");
-        Self { dim }
+        Self::try_new(dim).expect("HashEmbedder dim must be positive")
     }
 }
 

--- a/src/context/index/traits_tests.rs
+++ b/src/context/index/traits_tests.rs
@@ -81,3 +81,14 @@ fn dispatch_reexports_still_work() {
     use crate::context::extract::dispatch::FixedClock as DispatchFixedClock;
     let _ = DispatchFixedClock::epoch();
 }
+
+#[test]
+fn try_new_returns_err_on_zero_dim() {
+    assert!(HashEmbedder::try_new(0).is_err());
+}
+
+#[test]
+fn try_new_succeeds_for_positive_dim() {
+    let e = HashEmbedder::try_new(384).expect("positive dim must succeed");
+    assert_eq!(e.dim(), 384);
+}

--- a/src/context/inject/injector.rs
+++ b/src/context/inject/injector.rs
@@ -182,21 +182,32 @@ impl ContextInjectionSource for ContextInjector {
             };
         }
 
-        // Calibrator gate (Task 8.4): drop chunks whose score falls below
-        // their per-chunk injection threshold. `f32::INFINITY` from the
-        // calibrator (N+ ContextMisleading confirmations) is a hard seal.
+        // Post-retrieve gate, two stages:
         //
-        // This is a post-retrieve concern — the raw retriever contract is
-        // unchanged — and runs before precedence/plan so neither sees
-        // chunks the operator has already flagged as misleading.
+        // 1. Global floor (`inject_min_score`) — applied unconditionally, even
+        //    when no calibrator is wired. A prior version only applied the
+        //    floor via `max(floor, threshold)` inside the calibrator branch,
+        //    so reviewers without a calibrator silently skipped it.
+        // 2. Per-chunk calibrator threshold — runs on the survivors of stage 1
+        //    so `suppressed_by_calibrator` strictly counts feedback-driven
+        //    drops (including `f32::INFINITY` seals from N+ `ContextMisleading`
+        //    confirmations). Splitting the counters lets dashboards tell
+        //    "config rejected it" apart from "feedback poisoned this chunk".
+        //
+        // Both stages run before precedence/plan so neither sees chunks the
+        // operator has already flagged as misleading.
+        let floor = self.context.inject_min_score;
+        let before_floor = hits.len();
+        let hits: Vec<ScoredChunk> = hits.into_iter().filter(|h| h.score >= floor).collect();
+        tele.suppressed_by_floor = (before_floor - hits.len()) as u32;
+
         let hits = if let Some(cal) = self.calibrator.as_ref() {
-            let before = hits.len();
-            let floor = self.context.inject_min_score;
+            let before_cal = hits.len();
             let kept: Vec<ScoredChunk> = hits
                 .into_iter()
-                .filter(|h| h.score >= cal.injection_threshold_for(&h.chunk.id).max(floor))
+                .filter(|h| h.score >= cal.injection_threshold_for(&h.chunk.id))
                 .collect();
-            tele.suppressed_by_calibrator = (before - kept.len()) as u32;
+            tele.suppressed_by_calibrator = (before_cal - kept.len()) as u32;
             kept
         } else {
             hits
@@ -356,16 +367,21 @@ mod tests {
     }
 
     #[test]
-    fn gate_applies_config_min_score_when_calibrator_floor_is_lower() {
+    fn gate_applies_config_min_score_before_calibrator() {
         // Calibrator floor = 0.0 (no confirmations -> threshold 0.0), but the
         // configured inject_min_score is 0.5. A chunk scoring 0.3 must be
-        // suppressed by the gate (not just later by plan filtering) so the
-        // telemetry correctly attributes the drop to the calibrator tier.
+        // suppressed by the gate. After the floor/calibrator split the drop
+        // is attributed to the floor tier so dashboards can distinguish
+        // "config rejected it" from "feedback poisoned this chunk".
         let (injector, req) = injector_with(0.5, Calibrator::new(0.0), 0.3);
         let out = injector.inject(&req);
         assert_eq!(
-            out.telemetry.suppressed_by_calibrator, 1,
-            "config min_score must be enforced at the calibrator gate"
+            out.telemetry.suppressed_by_floor, 1,
+            "config min_score must drop the chunk at the floor stage"
+        );
+        assert_eq!(
+            out.telemetry.suppressed_by_calibrator, 0,
+            "calibrator never sees chunks already dropped by the floor"
         );
         assert!(out.rendered.is_none());
     }
@@ -378,5 +394,33 @@ mod tests {
         let (injector, req) = injector_with(0.5, Calibrator::new(0.0), 0.7);
         let out = injector.inject(&req);
         assert_eq!(out.telemetry.suppressed_by_calibrator, 0);
+        assert_eq!(out.telemetry.suppressed_by_floor, 0);
+    }
+
+    #[test]
+    fn gate_applies_floor_when_no_calibrator_is_wired() {
+        // Regression: the previous gate did `if let Some(cal) = self.calibrator
+        // { filter by max(floor, threshold) } else { hits }`, so a reviewer
+        // running without any calibrator wired had `inject_min_score`
+        // silently bypassed and low-score chunks leaked through to plan.
+        let sources = SourcesConfig {
+            sources: vec![],
+            context: ctx_with_min_score(0.5),
+        };
+        let retriever: Arc<RetrieverFn> = Arc::new(|_q| Ok(vec![scored("chunk-a", 0.3)]));
+        let injector = ContextInjector::new(&sources, retriever); // no calibrator
+        let req = InjectionRequest {
+            file_path: "x.rs".into(),
+            language: Some("rust".into()),
+            identifiers: vec!["foo".into()],
+            text: "foo bar".into(),
+        };
+        let out = injector.inject(&req);
+        assert_eq!(
+            out.telemetry.suppressed_by_floor, 1,
+            "inject_min_score must be enforced even without a calibrator"
+        );
+        assert_eq!(out.telemetry.suppressed_by_calibrator, 0);
+        assert!(out.rendered.is_none());
     }
 }

--- a/src/dimensions.rs
+++ b/src/dimensions.rs
@@ -615,6 +615,7 @@ mod tests {
             render_duration_ms: 0,
             rendered_prompt_hash: rendered_hash.map(String::from),
             suppressed_by_calibrator: 0,
+            suppressed_by_floor: 0,
         };
         r
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -290,7 +290,18 @@ fn run_context(opts: cli::ContextOpts) -> i32 {
         }
     };
 
-    let deps = match ProdDeps::from_env() {
+    // `index` and `refresh` write to `chunks_vec`; if fastembed fell back to
+    // HashEmbedder we'd rebuild the vector table with hashing-noise vectors
+    // and silently degrade every subsequent retrieval. Use the strict
+    // factory so a fastembed init failure surfaces as a clear error the
+    // user can retry, rather than a corrupted index they have to discover.
+    let needs_strict_embedder = matches!(cmd, ContextCmd::Index(_) | ContextCmd::Refresh(_));
+    let deps_result = if needs_strict_embedder {
+        ProdDeps::from_env_strict()
+    } else {
+        ProdDeps::from_env()
+    };
+    let deps = match deps_result {
         Ok(d) => d,
         Err(e) => {
             eprintln!("error: {}", e);

--- a/src/review_log.rs
+++ b/src/review_log.rs
@@ -122,6 +122,11 @@ pub struct ContextTelemetry {
     /// wired into the injector.
     #[serde(default)]
     pub suppressed_by_calibrator: u32,
+    /// Chunks dropped post-retrieve by the global `inject_min_score` floor.
+    /// Split out from `suppressed_by_calibrator` so dashboards can tell
+    /// "config rejected it" apart from "feedback poisoned this chunk".
+    #[serde(default)]
+    pub suppressed_by_floor: u32,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -545,6 +550,7 @@ mod tests {
             render_duration_ms: 42,
             rendered_prompt_hash: Some("deadbeef".into()),
             suppressed_by_calibrator: 0,
+            suppressed_by_floor: 0,
         }
     }
 


### PR DESCRIPTION
Addresses the findings from the pal (gemini-3-pro-preview) codereview and the quorum self-review of PR #28 (v0.16.0 context injection). All commits follow RED-GREEN TDD where a behavioral assertion was meaningful; refactor-only commits lean on existing tests as regression guards.

## Summary of changes

| Commit | Concern | Source |
|---|---|---|
| `aaa1405` | `HashEmbedder::new` panicked on dim=0 — add `try_new` returning `Result` | quorum self-review [HIGH] |
| `8d79ac8` | Bootstrap accepted any existing `index.db` without probing; silent `None` when no source indexed; unnecessary `SQLITE_OPEN_URI` | quorum [HIGH] + pal [LOW x2] |
| `e9a870a` | Injector gate bypassed `inject_min_score` when no calibrator wired; telemetry conflated floor/calibrator drops | pal [MEDIUM] |
| `9869d51` | `ProdDeps::from_env` accepted relative `HOME`/`USERPROFILE`, violating the anchored-state promise | quorum [HIGH] |
| `53dea1c` | `run_init` did check-then-act on `sources.toml`, racy under concurrent init | quorum [HIGH] |
| `c98291b` | `new_prod_embedder` silently fell back to HashEmbedder during `context index`/`refresh`, corrupting `chunks_vec` with hashing-noise vectors | pal [HIGH] |

## Tests

- 1232 unit tests (+4 new) — `cargo test --bin quorum -- --test-threads=1`
- New: `try_new_returns_err_on_zero_dim`, `try_new_succeeds_for_positive_dim`, `returns_none_when_only_index_is_corrupt`, `gate_applies_floor_when_no_calibrator_is_wired`, `prod_deps_from_env_rejects_relative_home`
- Updated: `gate_applies_config_min_score_before_calibrator` now asserts `suppressed_by_floor == 1` instead of `suppressed_by_calibrator == 1` (semantic now splits floor-drops from calibrator-drops)
- Struct-literal additions of `suppressed_by_floor: 0` in `review_log.rs` and `dimensions.rs` test helpers; `#[serde(default)]` keeps legacy `reviews.jsonl` deserialising

## Not addressed here

- `ContextInjector::inject()` cyclomatic complexity 11 (quorum flagged) — deferred; the function is cohesive and refactoring it mid-hardening would dilute the reviewable diff.
- Issue #29 (generalise Context7 for Rust + framework-agnostic)
- Issue #30 (`--skip-context7` doesn't actually skip)
- Issue #31 (ast-grep head-only extraction)
- Issue #32 (external-agent feedback ingestion — filed pre-merge)

## Test plan

- [x] `cargo test --bin quorum -- --test-threads=1` passes (1232/1232)
- [x] `cargo build --release` succeeds
- [x] `quorum context init` still idempotent against existing regular files
- [x] `quorum context query` still works against a prior index

🤖 Generated with [Claude Code](https://claude.com/claude-code)