### PR TITLE
fix(inject): NaN-safety on gate filters + telemetry aggregator gaps

### DIFF
--- a/src/context/inject/injector.rs
+++ b/src/context/inject/injector.rs
@@ -193,6 +193,28 @@ impl ContextInjectionSource for ContextInjector {
             };
         }
 
+        // Strip NaN scores up front. The gate filters below use `>=`,
+        // which already drops NaNs (NaN is unordered), but the drop is
+        // silent — a retriever that suddenly emits NaN would look like
+        // "everything scored below threshold" on dashboards. Counting
+        // NaN drops separately makes the upstream bug visible.
+        let before_nan = hits.len();
+        let hits: Vec<ScoredChunk> = hits.into_iter().filter(|h| !h.score.is_nan()).collect();
+        tele.nan_scores_dropped = (before_nan - hits.len()) as u32;
+        if tele.nan_scores_dropped > 0 {
+            tracing::warn!(
+                dropped = tele.nan_scores_dropped,
+                "retriever emitted NaN scores; dropped before gating"
+            );
+        }
+        if hits.is_empty() {
+            tele.render_duration_ms = started.elapsed().as_millis() as u64;
+            return InjectionOutcome {
+                rendered: None,
+                telemetry: tele,
+            };
+        }
+
         // Capture the rerank score distribution before any gating so
         // dashboards can see whether `inject_min_score` is binding.
         // Returns None only if every score was NaN — an upstream bug.
@@ -226,7 +248,16 @@ impl ContextInjectionSource for ContextInjector {
             let before_cal = hits.len();
             let kept: Vec<ScoredChunk> = hits
                 .into_iter()
-                .filter(|h| h.score >= cal.injection_threshold_for(&h.chunk.id))
+                .filter(|h| {
+                    let thr = cal.injection_threshold_for(&h.chunk.id);
+                    // Calibrator invariant: thresholds are either finite
+                    // or f32::INFINITY (sealed). A NaN would silently
+                    // nuke every remaining chunk via a `>=` that can
+                    // never be true — fail loud in debug builds and
+                    // drop defensively in release.
+                    debug_assert!(!thr.is_nan(), "calibrator returned NaN threshold for {}", h.chunk.id);
+                    !thr.is_nan() && h.score >= thr
+                })
                 .collect();
             tele.suppressed_by_calibrator = (before_cal - kept.len()) as u32;
             kept
@@ -549,5 +580,57 @@ mod tests {
     fn score_distribution_all_nan_returns_none() {
         let hits = vec![scored("x", f32::NAN), scored("y", f32::NAN)];
         assert!(super::score_distribution(&hits).is_none());
+    }
+
+    #[test]
+    fn nan_score_is_counted_and_dropped_before_gating() {
+        // A single chunk with NaN score is dropped up front. Before the
+        // explicit filter, the floor gate's `>=` would drop it silently
+        // and attribute the drop to `suppressed_by_floor`, masking an
+        // upstream retriever bug.
+        let sources = SourcesConfig {
+            sources: vec![],
+            context: ctx_with_min_score(0.5),
+        };
+        let retriever: Arc<RetrieverFn> = Arc::new(|_q| {
+            Ok(vec![scored("ok", 0.9), scored("bad", f32::NAN)])
+        });
+        let injector = ContextInjector::new(&sources, retriever);
+        let req = InjectionRequest {
+            file_path: "x.rs".into(),
+            language: Some("rust".into()),
+            identifiers: vec!["foo".into()],
+            structural_names: vec![],
+            text: "foo".into(),
+        };
+        let out = injector.inject(&req);
+        assert_eq!(out.telemetry.nan_scores_dropped, 1);
+        assert_eq!(out.telemetry.retrieved_chunk_count, 2);
+        assert_eq!(out.telemetry.suppressed_by_floor, 0,
+            "NaN was counted as a NaN drop, not as a floor drop");
+    }
+
+    #[test]
+    fn all_nan_scores_short_circuit_to_no_render() {
+        let sources = SourcesConfig {
+            sources: vec![],
+            context: ctx_with_min_score(0.5),
+        };
+        let retriever: Arc<RetrieverFn> = Arc::new(|_q| {
+            Ok(vec![scored("a", f32::NAN), scored("b", f32::NAN)])
+        });
+        let injector = ContextInjector::new(&sources, retriever);
+        let req = InjectionRequest {
+            file_path: "x.rs".into(),
+            language: Some("rust".into()),
+            identifiers: vec![],
+            structural_names: vec![],
+            text: "x".into(),
+        };
+        let out = injector.inject(&req);
+        assert_eq!(out.telemetry.nan_scores_dropped, 2);
+        assert!(out.rendered.is_none());
+        assert!(out.telemetry.rerank_score_median.is_none(),
+            "score distribution must not be populated when every score was NaN");
     }
 }

--- a/src/dimensions.rs
+++ b/src/dimensions.rs
@@ -620,6 +620,7 @@ mod tests {
             rerank_score_p90: None,
             suppressed_by_calibrator: 0,
             suppressed_by_floor: 0,
+            nan_scores_dropped: 0,
             retrieved_by_leg: crate::review_log::LegCounts::default(),
             injected_by_leg: crate::review_log::LegCounts::default(),
         };

--- a/src/main.rs
+++ b/src/main.rs
@@ -997,6 +997,15 @@ fn run_review(opts: cli::ReviewOpts) -> i32 {
                     context_telem.render_duration_ms.saturating_add(t.render_duration_ms);
                 context_telem.retrieved_by_leg.saturating_add(&t.retrieved_by_leg);
                 context_telem.injected_by_leg.saturating_add(&t.injected_by_leg);
+                context_telem.nan_scores_dropped = context_telem
+                    .nan_scores_dropped
+                    .saturating_add(t.nan_scores_dropped);
+                context_telem.suppressed_by_floor = context_telem
+                    .suppressed_by_floor
+                    .saturating_add(t.suppressed_by_floor);
+                context_telem.suppressed_by_calibrator = context_telem
+                    .suppressed_by_calibrator
+                    .saturating_add(t.suppressed_by_calibrator);
                 if context_telem.rerank_score_min.is_none() {
                     context_telem.rerank_score_min = t.rerank_score_min;
                 }

--- a/src/review_log.rs
+++ b/src/review_log.rs
@@ -127,6 +127,12 @@ pub struct ContextTelemetry {
     /// "config rejected it" apart from "feedback poisoned this chunk".
     #[serde(default)]
     pub suppressed_by_floor: u32,
+    /// Chunks dropped before any gating because their rerank score was
+    /// NaN. A nonzero value means the retriever or rerank produced
+    /// invalid floats — an upstream bug — and we stripped them so the
+    /// downstream comparisons wouldn't silently misbehave.
+    #[serde(default)]
+    pub nan_scores_dropped: u32,
     /// Per-leg breakdown of the candidate pool BEFORE top-K truncation.
     /// Answers: "how often does each leg surface hits at all?"
     #[serde(default)]
@@ -645,6 +651,7 @@ mod tests {
             rendered_prompt_hash: Some("deadbeef".into()),
             suppressed_by_calibrator: 0,
             suppressed_by_floor: 0,
+            nan_scores_dropped: 2,
             retrieved_by_leg: super::LegCounts::default(),
             injected_by_leg: super::LegCounts::default(),
             rerank_score_min: Some(0.41),


### PR DESCRIPTION
## Summary

Post-merge three-way review (quorum + third-opinion + PAL) of the leg-telemetry PR flagged two real issues that made it through the earlier ensemble review.

### 1. NaN scores in the floor gate

\`hits.into_iter().filter(|h| h.score >= floor)\` drops NaN safely (NaN >= anything is false), but silently — a retriever bug that emitted NaN would show up as \`suppressed_by_floor == len\`, masking the root cause.

Fix: filter NaN scores up front with their own counter (\`ContextTelemetry.nan_scores_dropped\`) and log a warning when non-zero. Score distribution and downstream gating run on the clean set.

### 2. NaN calibrator threshold

\`h.score >= cal.injection_threshold_for(&h.chunk.id)\` trusted the threshold unconditionally. A NaN threshold (invariant violation) would silently drop every remaining chunk.

Fix: \`debug_assert!(!thr.is_nan(), ...)\` fires loud in dev builds; defensive \`!thr.is_nan()\` guard prevents silent all-drops in release.

### 3. Closes #47 — telemetry aggregator gaps

While editing the per-file aggregator in \`main.rs\`, wired the fields that were silently dropped across multi-file reviews:
- \`nan_scores_dropped\` (new)
- \`suppressed_by_floor\` (issue #47)
- \`suppressed_by_calibrator\` (issue #47)

All three now saturating-add across files like the other count fields.

## Test plan

- [x] \`cargo test --bin quorum\` — 1264 passing (+2 new NaN tests)
- [x] \`nan_score_is_counted_and_dropped_before_gating\` — NaN in mixed input bumps nan_scores_dropped, not suppressed_by_floor
- [x] \`all_nan_scores_short_circuit_to_no_render\` — all-NaN returns no render, distribution stays None

Closes #47

🤖 Generated with [Claude Code](https://claude.com/claude-code)