### PR TITLE
fix(calibration): correctness sweep on dimensions + calibrator

### DIFF
--- a/src/calibrator.rs
+++ b/src/calibrator.rs
@@ -281,10 +281,13 @@ pub fn precedent_metric_compatible(finding_title: &str, precedent_title: &str) -
     let f = extract_complexity_metric(finding_title);
     let p = extract_complexity_metric(precedent_title);
     match (f, p) {
-        (Some(fn_), Some(pn)) => {
-            fn_.abs_diff(pn) <= 2
-        }
-        _ => true,
+        (Some(fn_), Some(pn)) => fn_.abs_diff(pn) <= 2,
+        (None, None) => true,
+        // One-sided metric mismatch: a complexity-specific finding must not
+        // match a non-metric precedent (or vice versa). Without this guard a
+        // CC=11 finding could be suppressed/boosted by a precedent like
+        // "Function `foo` is unused", which has nothing to do with complexity.
+        (Some(_), None) | (None, Some(_)) => false,
     }
 }
 
@@ -1496,6 +1499,22 @@ mod tests {
         assert!(precedent_metric_compatible(
             "SQL injection in query builder",
             "SQL injection risk"
+        ));
+    }
+
+    #[test]
+    fn precedent_metric_compatible_rejects_one_sided_metric_mismatch() {
+        // Regression: previously the `_ => true` arm allowed a metric finding
+        // to match a non-metric precedent (and vice versa). A CC=11 complexity
+        // finding must not be calibrated by an unrelated "function is unused"
+        // precedent that happens to share the same function name.
+        assert!(!precedent_metric_compatible(
+            "Function `foo` has cyclomatic complexity 11",
+            "Function `foo` is unused"
+        ));
+        assert!(!precedent_metric_compatible(
+            "Function `foo` is unused",
+            "Function `foo` has cyclomatic complexity 11"
         ));
     }
 

--- a/src/calibrator.rs
+++ b/src/calibrator.rs
@@ -50,7 +50,11 @@ fn verdict_weight(entry: &FeedbackEntry) -> f64 {
         crate::feedback::Provenance::Unknown => 0.3,
     };
 
-    let age_days = (chrono::Utc::now() - entry.timestamp).num_days().max(0) as f64;
+    // Future-dated entries (clock skew, mis-set system clocks, manual edits)
+    // would otherwise clamp to age=0 and receive maximum recency weight.
+    // Use absolute age so a future-dated entry decays the same as one written
+    // the same delta in the past, instead of being the most-trusted precedent.
+    let age_days = (chrono::Utc::now() - entry.timestamp).num_days().unsigned_abs() as f64;
     let recency_weight = (-age_days / 120.0).exp(); // half-life ~83 days
 
     provenance_weight * recency_weight
@@ -306,11 +310,16 @@ pub fn calibrate_with_index(
         let first_evidence = finding.evidence.first().map(String::as_str).unwrap_or("");
         let excerpt = finding.based_on_excerpt.as_deref().unwrap_or("");
         let discriminators: [&str; 3] = [&finding.description, first_evidence, excerpt];
+        // Pull a deeper candidate pool than we ultimately consume so the
+        // downstream provenance and metric-compatibility filters don't starve
+        // calibration when the top-k is dominated by auto-calibrate or
+        // off-metric precedents. The post-filter is used only for weight
+        // accumulation; there is no per-finding cap that requires <=10.
         let similar_entries = index.find_similar_enriched(
             &finding.title,
             &finding.category,
             &discriminators,
-            10,
+            50,
         );
 
         // Filter by similarity threshold, provenance, and metric compatibility.
@@ -618,6 +627,26 @@ mod tests {
             timestamp: Utc::now(),
             provenance: crate::feedback::Provenance::Human,
         }
+    }
+
+    #[test]
+    fn verdict_weight_future_dated_entry_is_not_max_weight() {
+        // Regression: `(now - timestamp).num_days().max(0)` clamped negative
+        // ages to 0 for future-dated entries (clock skew, manual JSONL edits),
+        // giving them maximum recency weight. Use absolute age so a year-future
+        // entry decays the same as a year-old one.
+        let mut future = fb("anything", "x", Verdict::Tp);
+        future.timestamp = Utc::now() + chrono::Duration::days(365);
+        let w_future = verdict_weight(&future);
+
+        let mut now = fb("anything", "x", Verdict::Tp);
+        now.timestamp = Utc::now();
+        let w_now = verdict_weight(&now);
+
+        assert!(
+            w_future < w_now * 0.1,
+            "future-dated entry weight {w_future} should decay below 10% of fresh weight {w_now}"
+        );
     }
 
     // -- No feedback: passthrough --

--- a/src/dimensions.rs
+++ b/src/dimensions.rs
@@ -56,7 +56,7 @@ fn aggregate(key: String, records: &[&ReviewRecord]) -> DimensionSlice {
         tokens_out += r.tokens_out;
         tokens_cache_read += r.tokens_cache_read;
         match (r.lines_added, r.lines_removed) {
-            (Some(a), Some(d)) => { lines_touched += (a + d) as u64; has_any_lines = true; }
+            (Some(a), Some(d)) => { lines_touched += a as u64 + d as u64; has_any_lines = true; }
             (Some(a), None) => { lines_touched += a as u64; has_any_lines = true; }
             (None, Some(d)) => { lines_touched += d as u64; has_any_lines = true; }
             (None, None) => {}
@@ -146,20 +146,19 @@ fn sparkline_buckets(records: &[&ReviewRecord], n_buckets: usize) -> Vec<f64> {
     out
 }
 
-/// Display key for records whose `repo` field is `None`. Parentheses are
-/// disallowed in git repo names on any reasonable system, so this cannot
-/// collide with a real repo basename.
+/// Display key for records whose `repo` field is `None`. Bucketing groups
+/// `None` separately from any real repo name (`Option<String>` keys), so a
+/// repo literally named `(no repo)` never collides with the no-repo bucket.
 pub const NO_REPO_KEY: &str = "(no repo)";
 
 pub fn group_by_repo(records: &[ReviewRecord]) -> Vec<DimensionSlice> {
-    let mut buckets: HashMap<String, Vec<&ReviewRecord>> = HashMap::new();
+    let mut buckets: HashMap<Option<String>, Vec<&ReviewRecord>> = HashMap::new();
     for r in records {
-        let key = r.repo.clone().unwrap_or_else(|| NO_REPO_KEY.to_string());
-        buckets.entry(key).or_default().push(r);
+        buckets.entry(r.repo.clone()).or_default().push(r);
     }
     let mut slices: Vec<_> = buckets
         .into_iter()
-        .map(|(k, v)| aggregate(k, &v))
+        .map(|(k, v)| aggregate(k.unwrap_or_else(|| NO_REPO_KEY.to_string()), &v))
         .collect();
     slices.sort_by(|a, b| b.n_reviews.cmp(&a.n_reviews).then_with(|| a.key.cmp(&b.key)));
     slices
@@ -298,15 +297,14 @@ pub fn aggregate_by_source(records: &[ReviewRecord]) -> Vec<ContextDimensionSlic
 /// context injection behaving per repo?". Sorting matches
 /// `group_by_repo` (most reviews first, then alphabetic tiebreak).
 pub fn aggregate_by_reviewed_repo(records: &[ReviewRecord]) -> Vec<ContextDimensionSlice> {
-    let mut buckets: HashMap<String, Vec<&ReviewRecord>> = HashMap::new();
+    let mut buckets: HashMap<Option<String>, Vec<&ReviewRecord>> = HashMap::new();
     for r in records {
         if !r.context.injector_available { continue; }
-        let key = r.repo.clone().unwrap_or_else(|| NO_REPO_KEY.to_string());
-        buckets.entry(key).or_default().push(r);
+        buckets.entry(r.repo.clone()).or_default().push(r);
     }
     let mut out: Vec<_> = buckets
         .into_iter()
-        .map(|(k, v)| aggregate_context_slice(k, &v))
+        .map(|(k, v)| aggregate_context_slice(k.unwrap_or_else(|| NO_REPO_KEY.to_string()), &v))
         .collect();
     out.sort_by(|a, b| b.n_reviews.cmp(&a.n_reviews).then_with(|| a.key.cmp(&b.key)));
     out
@@ -366,14 +364,15 @@ pub fn rolling_window(records: &[ReviewRecord], n: usize, max_windows: usize) ->
     let mut out = Vec::new();
     let total = records.len();
     for w in 0..max_windows {
-        let end = total.saturating_sub(w * n);
+        let offset = w.saturating_mul(n);
+        let end = total.saturating_sub(offset);
         if end == 0 { break; }
         let start = end.saturating_sub(n);
         let slice: Vec<&ReviewRecord> = records[start..end].iter().collect();
         let label = match w {
             0 => format!("last {}", n),
             1 => format!("prev {}", n),
-            k => format!("prev {}", k * n),
+            _ => format!("prev {}", offset),
         };
         out.push(aggregate(label, &slice));
     }
@@ -446,6 +445,44 @@ mod tests {
             .expect("real 'unknown' repo must remain addressable by its name");
         assert_eq!(none_slice.n_findings, 5);
         assert_eq!(real_slice.n_findings, 3);
+    }
+
+    #[test]
+    fn group_by_repo_none_does_not_collide_with_repo_literally_named_no_repo() {
+        // Regression: bucketing on the stringified sentinel `(no repo)` would
+        // silently merge a real repo coincidentally named the same string with
+        // None-repo records. Bucket on Option<String> instead.
+        let r_real = rec("(no repo)", "tty", 1, 3);
+        let mut r_none = rec("ignored", "tty", 1, 5);
+        r_none.repo = None;
+        let slices = group_by_repo(&[r_real, r_none]);
+        assert_eq!(slices.len(), 2, "None and real '(no repo)' must bucket separately");
+        let none_total: u32 = slices.iter().map(|s| s.n_findings).sum();
+        assert_eq!(none_total, 8);
+    }
+
+    #[test]
+    fn aggregate_lines_touched_does_not_overflow_on_large_diffs() {
+        // Regression: previously `(a + d) as u64` overflowed u32 before widening,
+        // panicking in debug builds and wrapping in release.
+        let mut a = rec("r", "tty", 1, 1);
+        a.lines_added = Some(u32::MAX);
+        a.lines_removed = Some(u32::MAX);
+        // The fix uses `a as u64 + d as u64`; this call must not panic.
+        let slices = group_by_repo(&[a]);
+        // findings_per_kloc = 1 * 1000 / (2 * u32::MAX) -- tiny but well-defined.
+        let fpk = slices[0].findings_per_kloc.expect("kloc set when lines>0");
+        let expected = 1000.0 / (2.0 * u32::MAX as f64);
+        assert!((fpk - expected).abs() < 1e-12, "got {fpk}, expected {expected}");
+    }
+
+    #[test]
+    fn rolling_window_does_not_panic_on_extreme_window_count() {
+        // Regression: `w * n` could overflow usize for adversarial max_windows.
+        let records: Vec<_> = (0..3).map(|_| rec("r", "tty", 1, 0)).collect();
+        let out = rolling_window(&records, usize::MAX / 2, usize::MAX / 2);
+        // Either returns the single first window or breaks early; must not panic.
+        assert!(out.len() <= 1);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Six defensive fixes surfaced during the 3-way review comparison + self-review (PR #50 follow-up). Each fix is paired with a regression test where the behavioral change is observable.

### dimensions.rs
- **aggregate(): u32 → u64 widening** — `(a + d) as u64` overflowed u32 *before* widening for adversarial diffs (panics in debug, wraps in release). Now widens first, then adds.
- **`(no repo)` sentinel collision** — `group_by_repo` / `aggregate_by_reviewed_repo` bucketed on the stringified sentinel, so a real repo literally named `(no repo)` would silently merge into the no-repo bucket. Bucket on `Option<String>` and stringify only at display time.
- **`rolling_window` usize overflow** — `w * n` could overflow usize for adversarial `max_windows`. Use `saturating_mul` and reuse the offset for the label.

### calibrator.rs
- **Future-dated entries got max recency weight** — `(now - timestamp).num_days().max(0)` clamped negative ages (clock skew, mis-set system clocks, manual JSONL edits) to 0, giving them maximum weight. Use `unsigned_abs` so a year-future entry decays the same as a year-old one.
- **Top-10 truncation before provenance/metric filter** — the post-retrieval filter (similarity threshold + auto-calibrate provenance + metric compatibility) can drop most candidates. Pulling only top-10 from the index could starve calibration when leaders were all auto-cal or off-metric. Widened to top-50.
- **One-sided metric compatibility** — `precedent_metric_compatible` returned true for `(Some, None)` / `(None, Some)` via a catch-all arm, letting complexity findings be calibrated by unrelated non-metric precedents. Tightened to require either both-Some-within-gap or both-None. Self-review catch (cross-corroborated by gemini-3.1-pro in prior comparison).

## Test plan
- [x] `cargo test --bin quorum` — 1272 pass (5 new regression tests)
- [x] `cargo build` — clean
- [x] Self-reviewed via `quorum review --diff-file` — surfaced the 6th bug above
- [ ] Pre-existing CLI integration failures (`review_complex_file_exits_nonzero`, etc.) are unrelated — they fall out of PR #50's complexity severity cap. Not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)