### PR TITLE
chore: release v0.16.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2694,7 +2694,7 @@ checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quorum"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quorum"
-version = "0.15.0"
+version = "0.16.0"
 edition = "2024"
 description = "Multi-source code review: LLM ensemble + local AST analysis + linter orchestration"
 license = "MIT"


### PR DESCRIPTION
## Summary

Version bump to 0.16.0 covering everything since v0.15.0.

### Features
- Hybrid context retrieval (local + structural qname legs) with self-file filter and XML framing (#43, #45)
- Per-leg retrieval telemetry + rendered-prompt sha256 (#46)
- Cache-friendly prompt restructure with `cached_tokens` telemetry + `QUORUM_BYPASS_PROXY_CACHE` escape hatch (#49)

### Calibration / quality
- Severity rubric tightened — high reserved for confirmed bugs with default-path triggers (#50)
- Cyclomatic complexity findings capped at Medium severity
- Six-bug correctness sweep on dimensions + calibrator (#51)

### Fixes
- NaN-safety on gate filters + aggregator gaps (#48)

## Test plan
- [x] `cargo test --bin quorum` — 1272 pass
- [x] `cargo build` — clean
- [ ] Tag `v0.16.0` after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)