### PR TITLE
fix: trust boundaries round 2 (#71, #68, #69)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -69,7 +69,16 @@ async fn main() -> anyhow::Result<()> {
 
             if want_context_dim {
                 let log = review_log::ReviewLog::new(home_path.join(".quorum/reviews.jsonl"));
-                let all_records = log.load_all().unwrap_or_default();
+                let all_records = match log.load_all() {
+                    Ok(r) => r,
+                    Err(e) => {
+                        eprintln!(
+                            "error: cannot read reviews log at {}: {e}",
+                            log.path().display()
+                        );
+                        std::process::exit(3);
+                    }
+                };
                 let records: Vec<_> = match opts.rolling {
                     Some(n) if n < all_records.len() => {
                         all_records[all_records.len() - n..].to_vec()
@@ -114,7 +123,16 @@ async fn main() -> anyhow::Result<()> {
 
             if want_classic_dim {
                 let log = review_log::ReviewLog::new(home_path.join(".quorum/reviews.jsonl"));
-                let records = log.load_all().unwrap_or_default();
+                let records = match log.load_all() {
+                    Ok(r) => r,
+                    Err(e) => {
+                        eprintln!(
+                            "error: cannot read reviews log at {}: {e}",
+                            log.path().display()
+                        );
+                        std::process::exit(3);
+                    }
+                };
                 let (mode, slices) = if opts.by_repo {
                     ("by-repo", dimensions::group_by_repo(&records))
                 } else if opts.by_caller {

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -74,22 +74,57 @@ fn write_calibrator_traces(
     }
 }
 
-/// Acquire a semaphore permit if configured. Uses Handle::block_on (not block_in_place)
-/// because this may be called from spawn_blocking threads.
-/// Returns an owned permit that is released on drop (RAII).
+/// Acquire a semaphore permit if configured. Returns an owned permit
+/// that is released on drop (RAII).
 ///
-/// Degrades gracefully (returns `None`) in three failure modes that
-/// shouldn't crash the caller — same observable behavior as the
-/// no-semaphore path:
-/// - No semaphore configured (the common case)
-/// - Semaphore closed (shutdown in flight)
-/// - No Tokio runtime in the current thread (issue #58 — happens when a
-///   pipeline is wired lazily from a sync caller; throttling can't work
-///   without a runtime, so degrade rather than panic)
+/// This is a *synchronous* function that may be called from any of:
+/// `spawn_blocking` threads, plain sync callers with no runtime, or
+/// from inside an async context (via deeply-nested sync wrappers).
+/// To handle all three without panicking we mirror the runtime-flavor
+/// pattern from `llm_client::block_on_async` (issue #71):
+///
+/// - `MultiThread` runtime: use `block_in_place` + `Handle::block_on`
+///   so the worker can pick up other tasks while we wait.
+/// - `CurrentThread` (or any future flavor where `block_in_place` is
+///   disallowed): drive the future on a dedicated OS thread with its
+///   own current-thread runtime. We can't reuse the calling runtime
+///   (`block_on` panics inside an async context) and `block_in_place`
+///   is not allowed there either, so we hand the work off to a fresh
+///   executor. Throttling still works because the new runtime awaits
+///   the same `Arc<Semaphore>`.
+/// - No runtime at all (issue #58): degrade to `None`. Throttling
+///   can't work without a runtime, but the caller (lazy sync wiring,
+///   embedders, tests) shouldn't crash — same observable behavior as
+///   the no-semaphore path.
+///
+/// Degrades to `None` (rather than panicking) on: no semaphore
+/// configured, semaphore closed, no runtime, or a transient failure
+/// to build the fallback runtime.
 fn acquire_llm_permit(sem: &Option<std::sync::Arc<tokio::sync::Semaphore>>) -> Option<tokio::sync::OwnedSemaphorePermit> {
+    use tokio::runtime::{Handle, RuntimeFlavor};
     let sem = sem.as_ref()?.clone();
-    let handle = tokio::runtime::Handle::try_current().ok()?;
-    handle.block_on(sem.acquire_owned()).ok()
+    let handle = Handle::try_current().ok()?;
+    match handle.runtime_flavor() {
+        RuntimeFlavor::MultiThread => {
+            tokio::task::block_in_place(|| handle.block_on(sem.acquire_owned()).ok())
+        }
+        // CurrentThread or any future flavor where block_in_place is
+        // disallowed: drive on a separate thread with its own runtime.
+        // Throttling still works (the new runtime awaits the same
+        // semaphore arc) and we don't re-enter the calling runtime.
+        _ => std::thread::scope(|s| {
+            s.spawn(|| {
+                let rt = tokio::runtime::Builder::new_current_thread()
+                    .enable_all()
+                    .build()
+                    .ok()?;
+                rt.block_on(sem.acquire_owned()).ok()
+            })
+            .join()
+            .ok()
+            .flatten()
+        }),
+    }
 }
 
 /// Trait for LLM review — allows testing with fake implementations.
@@ -857,6 +892,36 @@ mod tests {
     fn acquire_llm_permit_returns_none_when_no_semaphore() {
         let result = acquire_llm_permit(&None);
         assert!(result.is_none());
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn acquire_llm_permit_does_not_panic_inside_current_thread_runtime() {
+        // Issue #71: handle.block_on(...) panics inside an async
+        // execution context ("Cannot start a runtime from within a
+        // runtime"). Mirror block_on_async's RuntimeFlavor pattern.
+        let sem = Some(std::sync::Arc::new(tokio::sync::Semaphore::new(1)));
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            acquire_llm_permit(&sem)
+        }));
+        assert!(
+            result.is_ok(),
+            "acquire_llm_permit panicked inside current_thread runtime: {:?}",
+            result.err()
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn acquire_llm_permit_does_not_panic_inside_multi_thread_runtime() {
+        // Multi-thread coverage so the fix isn't current_thread-specific.
+        let sem = Some(std::sync::Arc::new(tokio::sync::Semaphore::new(1)));
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            acquire_llm_permit(&sem)
+        }));
+        assert!(
+            result.is_ok(),
+            "acquire_llm_permit panicked inside multi_thread runtime: {:?}",
+            result.err()
+        );
     }
 
     // -- Complexity threshold default --

--- a/src/redact.rs
+++ b/src/redact.rs
@@ -35,9 +35,15 @@ static PATTERNS: LazyLock<Vec<(Regex, &'static str)>> = LazyLock::new(|| {
         //
         // Captured boundary char ($1) is preserved in the replacement so we
         // don't accidentally rewrite surrounding source.
-        (Regex::new(r#"(?i)(^|[^A-Za-z0-9])((?:api[_-]?key|password|secret|token|passwd|auth)(?:[_-][A-Za-z0-9]+)*\s*[=:]\s*)"([^\n"]{6,})""#).unwrap(),
+        // Issue #68: value class is escape-aware: `\\.` matches any
+        // backslash-escape sequence (`\"`, `\\`, etc.); `[^\n"]` matches
+        // any other non-quote/non-newline char. Greedy `+` still stops at
+        // the first UNESCAPED closing quote, so we don't over-match across
+        // adjacent quoted values on the same line. The `{6,}` floor is
+        // dropped — the secret-keyword anchor is sufficient (cf. #61).
+        (Regex::new(r#"(?i)(^|[^A-Za-z0-9])((?:api[_-]?key|password|secret|token|passwd|auth)(?:[_-][A-Za-z0-9]+)*\s*[=:]\s*)"((?:\\.|[^\n"])+)""#).unwrap(),
          "$1$2\"[REDACTED]\""),
-        (Regex::new(r#"(?i)(^|[^A-Za-z0-9])((?:api[_-]?key|password|secret|token|passwd|auth)(?:[_-][A-Za-z0-9]+)*\s*[=:]\s*)'([^\n']{6,})'"#).unwrap(),
+        (Regex::new(r#"(?i)(^|[^A-Za-z0-9])((?:api[_-]?key|password|secret|token|passwd|auth)(?:[_-][A-Za-z0-9]+)*\s*[=:]\s*)'((?:\\.|[^\n'])+)'"#).unwrap(),
          "$1$2'[REDACTED]'"),
         // OpenAI-style keys
         (Regex::new(r"sk-[a-zA-Z0-9\-]{6,}").unwrap(), "[REDACTED]"),
@@ -216,5 +222,65 @@ mod tests {
         let input = "STRIPE_KEY=sk_live_abc123def456ghi789jkl012";
         let output = redact_secrets(input);
         assert!(!output.contains("sk_live_"));
+    }
+
+    #[test]
+    fn redact_quoted_secret_with_escaped_quote_in_value() {
+        // Issue #68: PASSWORD="pa\"ssword" — the value class [^\n"]{6,}
+        // stops at the first " and the {6,} floor fails on the 3-char
+        // prefix `pa\`, so the secret leaks through.
+        let cases = [
+            r#"PASSWORD = "pa\"ssword""#,
+            r#"API_KEY = "abc\"def""#,
+        ];
+        for input in cases {
+            let output = redact_secrets(input);
+            assert!(
+                output.contains("[REDACTED]"),
+                "expected redaction for {input:?}; got: {output}"
+            );
+            // Tighten: assert inner secret bytes are gone.
+            assert!(
+                !output.contains("ssword") && !output.contains("def"),
+                "secret bytes leaked through; got: {output}"
+            );
+        }
+    }
+
+    #[test]
+    fn redact_quoted_secret_with_escaped_single_quote_in_value() {
+        let input = r#"TOKEN = 'it\'s-secret'"#;
+        let output = redact_secrets(input);
+        assert!(output.contains("[REDACTED]"));
+        assert!(!output.contains("s-secret"));
+    }
+
+    #[test]
+    fn redact_does_not_consume_trailing_quote_after_escaped_quoted_value() {
+        // Greedy escape-aware class must still stop at the FIRST unescaped
+        // closing quote — not consume everything between first and last "
+        // on the line.
+        let input = r#"PASSWORD = "pa\"ssword" PUBLIC = "visible""#;
+        let output = redact_secrets(input);
+        assert!(output.contains("[REDACTED]"), "expected redaction; got: {output}");
+        // The non-secret keyword `PUBLIC` is not in the secret-keyword
+        // anchor list, so its value should remain literally visible.
+        assert!(
+            output.contains("visible"),
+            "regex over-matched and ate trailing keyword's value; got: {output}"
+        );
+    }
+
+    #[test]
+    fn redact_does_not_match_empty_quoted_value() {
+        // Without the {6,} floor, the value class (?:\\.|[^\n"])+ requires
+        // at least one char — empty quoted value should not redact.
+        // (`+` is one-or-more; this pins that we didn't accidentally use `*`.)
+        let input = r#"PASSWORD = """#;
+        let output = redact_secrets(input);
+        assert!(
+            !output.contains("[REDACTED]"),
+            "empty quoted value should not match; got: {output}"
+        );
     }
 }

--- a/tests/stats_hard_fail.rs
+++ b/tests/stats_hard_fail.rs
@@ -75,6 +75,25 @@ fn stats_by_rolling_fails_loudly_on_unreadable_log() {
 }
 
 #[test]
+fn stats_by_source_fails_loudly_on_unreadable_log() {
+    // Context-dim branch (main.rs:72) shares the same load_all + exit 3
+    // pattern as the classic-dim branch (main.rs:126). Both code paths
+    // were fixed in #69; this test pins the context-dim path so a
+    // future refactor can't regress only one of them.
+    let tmp = unreadable_log_dir();
+    let output = Command::cargo_bin("quorum")
+        .unwrap()
+        .arg("stats")
+        .arg("--by-source")
+        .env("HOME", tmp.path())
+        .output()
+        .unwrap();
+    assert_eq!(output.status.code(), Some(3));
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains(".quorum/reviews.jsonl"));
+}
+
+#[test]
 fn stats_succeeds_when_log_missing() {
     // Guard against an over-fix that promotes "missing file" to error.
     // load_all on a non-existent file currently returns Ok(empty vec) via

--- a/tests/stats_hard_fail.rs
+++ b/tests/stats_hard_fail.rs
@@ -1,0 +1,98 @@
+//! Issue #69: `quorum stats` dimensional commands previously swallowed
+//! `ReviewLog::load_all` errors via `unwrap_or_default()`, silently producing
+//! empty stats when the reviews log was unreadable. These tests pin the
+//! contract that file-level read failures hard-fail with exit code 3 and a
+//! diagnostic naming the failing path, while preserving the existing
+//! "missing file -> Ok(empty)" semantic at the line-parse layer.
+
+use assert_cmd::Command;
+
+/// Build a HOME directory whose `.quorum/reviews.jsonl` is a *directory*,
+/// causing `File::open` to fail with "Is a directory" on Unix. Portable
+/// across macOS/Linux without relying on chmod or root-only tricks.
+fn unreadable_log_dir() -> tempfile::TempDir {
+    let tmp = tempfile::tempdir().unwrap();
+    let quorum_dir = tmp.path().join(".quorum");
+    std::fs::create_dir_all(&quorum_dir).unwrap();
+    std::fs::create_dir(quorum_dir.join("reviews.jsonl")).unwrap();
+    tmp
+}
+
+#[test]
+fn stats_by_repo_fails_loudly_on_unreadable_log() {
+    let tmp = unreadable_log_dir();
+    let output = Command::cargo_bin("quorum")
+        .unwrap()
+        .arg("stats")
+        .arg("--by-repo")
+        .env("HOME", tmp.path())
+        .output()
+        .unwrap();
+    assert_eq!(
+        output.status.code(),
+        Some(3),
+        "expected exit code 3 (tool error per CLAUDE.md); got: {:?}, stderr: {}",
+        output.status.code(),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let expected_path = tmp.path().join(".quorum/reviews.jsonl");
+    assert!(
+        stderr.contains(expected_path.to_string_lossy().as_ref()),
+        "stderr should name the failing path; got: {stderr}"
+    );
+}
+
+#[test]
+fn stats_by_caller_fails_loudly_on_unreadable_log() {
+    let tmp = unreadable_log_dir();
+    let output = Command::cargo_bin("quorum")
+        .unwrap()
+        .arg("stats")
+        .arg("--by-caller")
+        .env("HOME", tmp.path())
+        .output()
+        .unwrap();
+    assert_eq!(output.status.code(), Some(3));
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains(".quorum/reviews.jsonl"));
+}
+
+#[test]
+fn stats_by_rolling_fails_loudly_on_unreadable_log() {
+    let tmp = unreadable_log_dir();
+    let output = Command::cargo_bin("quorum")
+        .unwrap()
+        .arg("stats")
+        .arg("--rolling")
+        .arg("5")
+        .env("HOME", tmp.path())
+        .output()
+        .unwrap();
+    assert_eq!(output.status.code(), Some(3));
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains(".quorum/reviews.jsonl"));
+}
+
+#[test]
+fn stats_succeeds_when_log_missing() {
+    // Guard against an over-fix that promotes "missing file" to error.
+    // load_all on a non-existent file currently returns Ok(empty vec) via
+    // iter() — the fix MUST NOT change that semantic.
+    let tmp = tempfile::tempdir().unwrap();
+    // Note: NO ~/.quorum/reviews.jsonl created.
+    let output = Command::cargo_bin("quorum")
+        .unwrap()
+        .arg("stats")
+        .arg("--by-repo")
+        .env("HOME", tmp.path())
+        .output()
+        .unwrap();
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "missing log should still exit 0 (empty stats); got: {:?}, stderr: {}",
+        output.status.code(),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}

--- a/tests/stats_hard_fail.rs
+++ b/tests/stats_hard_fail.rs
@@ -43,35 +43,31 @@ fn stats_by_repo_fails_loudly_on_unreadable_log() {
     );
 }
 
-#[test]
-fn stats_by_caller_fails_loudly_on_unreadable_log() {
+/// Helper for the three near-identical `stats <flag>` hard-fail tests.
+/// `stats_by_repo_fails_loudly_on_unreadable_log` is intentionally NOT
+/// collapsed into this — it carries the verbose assertion messages that
+/// surface useful context the first time the contract regresses.
+fn assert_stats_flag_fails_loudly(flag_args: &[&str]) {
     let tmp = unreadable_log_dir();
-    let output = Command::cargo_bin("quorum")
-        .unwrap()
-        .arg("stats")
-        .arg("--by-caller")
-        .env("HOME", tmp.path())
-        .output()
-        .unwrap();
+    let mut cmd = Command::cargo_bin("quorum").unwrap();
+    cmd.arg("stats");
+    for arg in flag_args {
+        cmd.arg(arg);
+    }
+    let output = cmd.env("HOME", tmp.path()).output().unwrap();
     assert_eq!(output.status.code(), Some(3));
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(stderr.contains(".quorum/reviews.jsonl"));
 }
 
 #[test]
+fn stats_by_caller_fails_loudly_on_unreadable_log() {
+    assert_stats_flag_fails_loudly(&["--by-caller"]);
+}
+
+#[test]
 fn stats_by_rolling_fails_loudly_on_unreadable_log() {
-    let tmp = unreadable_log_dir();
-    let output = Command::cargo_bin("quorum")
-        .unwrap()
-        .arg("stats")
-        .arg("--rolling")
-        .arg("5")
-        .env("HOME", tmp.path())
-        .output()
-        .unwrap();
-    assert_eq!(output.status.code(), Some(3));
-    let stderr = String::from_utf8_lossy(&output.stderr);
-    assert!(stderr.contains(".quorum/reviews.jsonl"));
+    assert_stats_flag_fails_loudly(&["--rolling", "5"]);
 }
 
 #[test]
@@ -80,17 +76,7 @@ fn stats_by_source_fails_loudly_on_unreadable_log() {
     // pattern as the classic-dim branch (main.rs:126). Both code paths
     // were fixed in #69; this test pins the context-dim path so a
     // future refactor can't regress only one of them.
-    let tmp = unreadable_log_dir();
-    let output = Command::cargo_bin("quorum")
-        .unwrap()
-        .arg("stats")
-        .arg("--by-source")
-        .env("HOME", tmp.path())
-        .output()
-        .unwrap();
-    assert_eq!(output.status.code(), Some(3));
-    let stderr = String::from_utf8_lossy(&output.stderr);
-    assert!(stderr.contains(".quorum/reviews.jsonl"));
+    assert_stats_flag_fails_loudly(&["--by-source"]);
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Three small pre-existing trust/failure-mode bugs under the same defense-in-depth theme as PRs #67/#70. Each fix is local, follows established patterns, and is covered by RED→GREEN TDD.

- **#71** — `acquire_llm_permit` panicked when called from inside an async context. Now mirrors `block_on_async`'s RuntimeFlavor pattern: `block_in_place` on MultiThread, dedicated thread + fresh current-thread runtime otherwise. Discovery during RED: multi_thread also panicked, validating the full mirror.
- **#68** — redact regex didn't handle escaped quotes inside quoted secret values. Value class is now escape-aware (`(?:\\.|[^\n"])+`), `{6,}` floor dropped (consistent with #61).
- **#69** — `stats` commands swallowed `ReviewLog::load_all` errors via `unwrap_or_default()`. Both the classic-dim (`--by-repo`/`--by-caller`/`--rolling`) and context-dim (`--by-source`/`--by-reviewed-repo`/`--misleading`) branches now exit 3 with a stderr error naming the failing path. Missing-file semantic preserved (still exits 0).

## Plan

`docs/plans/2026-04-22-pr-c-trust-boundaries-round-2.md` — locked design choices from brainstorm, three TDD tasks, drafted test code per task. Augmented with test-planning + testing-antipatterns review before RED phase.

## Test plan

- [x] `cargo test --bin quorum` — 1327 passed, 1 ignored, 0 failed (was 1321 on main → +6 unit tests)
- [x] `cargo test` — 1356 passed, 1 ignored, 0 failed (+ 4 CLI integration tests in new `tests/stats_hard_fail.rs`)
- [x] `cargo build --release` — clean
- [x] `cargo clippy --bin quorum --tests` — only pre-existing warnings; none in modified surfaces (pipeline `acquire_llm_permit`, redact regex, main `Stats` branches)
- [x] `ast-grep scan` rules `builder-unwrap-or-default.yml` and `handle-block-on-no-flavor-check.yml` — zero new offenders
- [x] Quorum self-review (Phase 6): triaged 18 findings; only HIGH on touched surface is the documented `acquire_llm_permit` graceful-degradation trade-off (locked design from #58, marked wontfix)

## Pre-existing bugs surfaced & filed

Phase 6 quorum self-review surfaced two HIGH findings unrelated to this branch's changes — filed as separate issues per scope discipline:

- **#72** — `redact: 'auth' keyword over-redacts benign content` (keyword list, not the value class touched in #68)
- **#73** — `main: doctor exit status inferred by brittle stdout substring matching` (in `run_context`, not the `Stats` branch touched in #69)

## Calibrator feedback recorded

3 entries (1 wontfix, 2 tp pre-existing) — corpus 1900 → 1902.

## Commits

- 7c5a0b0 fix(pipeline): acquire_llm_permit handles async-context too (#71)
- ed0a51a fix(redact): escape-aware value class for quoted-secret regex (#68)
- 1881b00 fix(main): stats commands fail loudly on unreadable reviews log (#69)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Stats commands now print a clear error (including the log path) and exit with code 3 on unreadable review logs instead of continuing silently.
  * Permit acquisition improved to avoid hangs across different runtime configurations.
  * Secret redaction correctly handles escaped characters inside quoted values.

* **Tests**
  * Added integration and regression tests for unreadable-log failures, permit acquisition behavior, and escaped-secret redaction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->