### PR TITLE
fix(calibrator): cap External contribution (#97) + feedback parent dir (#100)

### DIFF
--- a/docs/plans/test-plan-calibrator-cap.md
+++ b/docs/plans/test-plan-calibrator-cap.md
@@ -16,13 +16,15 @@
 
 | # | Name | Setup | Assertion | Rationale |
 |---|------|-------|-----------|-----------|
-| 1 | `external_flood_does_not_overwhelm_human_fp` | 1 finding "SQL injection". Feedback: 100 External TP + 1 Human FP, all matching title/cat. | `result.findings.len() == 0` AND `result.suppressed == 1`. | Behavioral outcome — does not couple to the constant. Survives any cap value `<= human_fp_weight ≈ 1.0`. This is the headline regression. |
-| 2 | `external_tp_bucket_capped_at_constant` | 1 finding. Feedback: 10 External TP entries (timestamps = `Utc::now()`, so recency≈1.0). No other entries. Build via path that produces a single `CalibratorTraceEntry`. | `trace.tp_weight` is approximately `EXTERNAL_WEIGHT_CAP` (within `1e-6`), NOT `10 * 0.7 = 7.0`. | Direct verification the cap is applied. References the constant so cap-value changes propagate. |
-| 3 | `external_fp_bucket_capped_at_constant` | Mirror of #2 but verdict=Fp. | `trace.fp_weight ≈ EXTERNAL_WEIGHT_CAP`. | Symmetry — both TP and FP buckets must cap. |
-| 4 | `external_below_cap_passes_through_unchanged` | 1 External TP fresh. | `assert!((trace.tp_weight - 0.7).abs() < 1e-3)` (not `EXTERNAL_WEIGHT_CAP`). | `.min()` must not floor — single entries stay at their natural weight. Kills a `.min` → `.max` mutant (would force weight up to 1.4). |
-| 5 | `human_and_postfix_remain_uncapped` | 5 Human TP + 5 PostFix TP, fresh. | `trace.tp_weight > EXTERNAL_WEIGHT_CAP + 1.0` (i.e. ≈ 5\*1.0 + 5\*1.5 = 12.5). | Cap must NOT leak into the humanish bucket. |
-| 6 | `external_global_across_agents` | 50 External TP from agent="pal" + 50 External TP from agent="third-opinion". | `trace.tp_weight ≈ EXTERNAL_WEIGHT_CAP`. | Per #97 spec: cap is global across agents, not per-agent. |
-| 7 | `external_cap_applies_in_similarity_scaled_block` | Same as #2 but invoked via the embedding-similar code path (L360+). | Same assertion as #2. | Both code blocks must be patched — easy to fix one and forget the other. |
+| 1 | `external_tp_bucket_capped_at_constant` | 1 finding. Feedback: 10 External TP entries (timestamps = `Utc::now()`, so recency≈1.0). No other entries. Build via path that produces a single `CalibratorTraceEntry`. | `trace.tp_weight` is approximately `EXTERNAL_WEIGHT_CAP` (within `1e-3`), NOT `10 * 0.7 = 7.0`. | Direct verification the cap is applied. References the constant so cap-value changes propagate. |
+| 2 | `external_fp_bucket_capped_at_constant` | Mirror of #1 but verdict=Fp. | `trace.fp_weight ≈ EXTERNAL_WEIGHT_CAP`. | Symmetry — both TP and FP buckets must cap. |
+| 3 | `external_below_cap_passes_through_unchanged` | 1 External TP fresh. | `assert!((trace.tp_weight - 0.7).abs() < 1e-3)` (not `EXTERNAL_WEIGHT_CAP`). | `.min()` must not floor — single entries stay at their natural weight. Kills a `.min` → `.max` mutant (would force weight up to 1.4). |
+| 4 | `humanish_bucket_remains_uncapped` | 5 Human TP + 5 PostFix TP, fresh. | `trace.tp_weight > EXTERNAL_WEIGHT_CAP + 5.0`. | Cap must NOT leak into the humanish bucket. |
+| 5 | `external_cap_is_global_across_agents` | 50 External TP from agent="pal" + 50 External TP from agent="third-opinion". | `trace.tp_weight ≈ EXTERNAL_WEIGHT_CAP`. | Per #97 spec: cap is global across agents, not per-agent. |
+| 6 | `humanish_empty_external_bucket_is_no_regression` | 3 Human FP, 0 External. | `trace.fp_weight` in `[2.95, 3.05]`. | Zero-External case: cap logic must be a pure no-op. |
+| 7 | `external_cap_applies_in_calibrate_with_index_path` | Build `FeedbackIndex` via `build_jaccard_only` (avoids embedding-model flake), seed with 10 External TP, call `calibrate_with_index` with `embedding_similarity_threshold=0.0`. | `trace.tp_weight ≈ EXTERNAL_WEIGHT_CAP`. | Both code paths (Jaccard & embedding) must apply the cap — easy to fix one and forget the other. |
+
+Note: an earlier draft also proposed a behavioral flood test (`external_flood_does_not_overwhelm_human_fp`) expecting `result.suppressed == 1` with 100 External TPs + 1 Human FP. Dropped before implementation — the suppression path requires `fp_weight >= 1.5`, so 1 Human FP (weight 1.0) cannot trigger it regardless of the cap. The behavioral intent is covered by tests #1-7 (bucket-level assertions) and by the updated `external_fp_accumulation_thresholds` table adding an n=100 row that locks in "flood cannot reach Full".
 
 ### #100 — feedback record parent dir
 
@@ -54,6 +56,7 @@
 ## 4. Fixture strategy
 
 **External FeedbackEntry builder** (add to calibrator `tests` module):
+
 ```rust
 fn fb_external(title: &str, cat: &str, verdict: Verdict, age_days: i64) -> FeedbackEntry {
     FeedbackEntry {
@@ -76,7 +79,7 @@ fn fb_external(title: &str, cat: &str, verdict: Verdict, age_days: i64) -> Feedb
 **Determinism without stubbing `Utc::now`:** `verdict_weight` reads `Utc::now()` directly. Rather than introduce a clock trait (out of scope), use **age-based assertions with tolerances**:
 - For "fresh" entries, set `timestamp = Utc::now()` and assert weights within `±1e-3` (floor of single-call drift).
 - For decayed-entry tests, assert ratios/orderings (e.g. `w_stale < w_fresh * 0.5`), not absolute values.
-- For the headline flood test (#1), behavioral assertion (`suppressed == 1`) is clock-independent.
+- Behavioral-level assertions in `external_fp_accumulation_thresholds` (outcome-based: Soft/Full classification) are clock-independent.
 
 **Tempdir for #100:** use existing `tempfile::TempDir` pattern from `feedback.rs::tests::test_store()`. New helper `test_store_with_missing_parent()` returns `(FeedbackStore, TempDir)` where the store path is `tempdir.path().join("a/b/c/feedback.jsonl")`.
 

--- a/docs/plans/test-plan-calibrator-cap.md
+++ b/docs/plans/test-plan-calibrator-cap.md
@@ -7,7 +7,7 @@
 ## Design pre-conditions for testability
 
 - Promote the cap to a module constant: `pub(crate) const EXTERNAL_WEIGHT_CAP: f64 = 1.4;` and reference it in tests rather than hardcoding `1.4`. Cap value can then change without test churn.
-- Apply the cap in **both** weight-computation blocks (similar~v1 around L88-151 and similarity-scaled~v2 around L365-389). Each must add `external_*_weight` parallel to `auto_*_weight` and combine: `tp_weight = auto.min(1.0) + external.min(EXTERNAL_WEIGHT_CAP) + humanish` (Human + PostFix + Unknown go in `humanish`, uncapped).
+- Centralize the bucketing + cap math in a shared helper (`accumulate_capped`) so the Jaccard path (`calibrate`) and the embedding path (`calibrate_with_index`) both call into it. Tests then need to verify the cap once per *path*, not once per *bucket per path*. Final formula: `tp_weight = auto.min(1.0) + external.min(EXTERNAL_WEIGHT_CAP) + humanish` (Human + PostFix + Unknown go in `humanish`, uncapped).
 - Tests live next to existing `mod tests` blocks; reuse `fb()` helper and add `fb_external(title, cat, verdict, age_days)` builder.
 
 ## 1. Test cases
@@ -49,7 +49,7 @@ Note: an earlier draft also proposed a behavioral flood test (`external_flood_do
 - Do NOT re-test `verdict_weight` provenance multipliers (already covered).
 - Do NOT test recency half-life math — covered by `verdict_weight_future_dated_entry_is_not_max_weight`.
 - Do NOT test inbox-drain, agent-name normalization, or confidence clamping — owned by `record_external` tests.
-- Do NOT test `OpenOptions` flag semantics for `record` — stdlib contract.
+- Do NOT test `OpenOptions` flag mechanics in isolation (e.g. asserting `create=true`, `append=true` are wired). The append-without-truncation guard in test #10 above is the *contract* assertion — that adding `create_dir_all` doesn't silently flip the open mode — not a re-test of the underlying stdlib flags.
 - Do NOT test full `calibrate` suppression thresholds for non-External cases — existing tests cover.
 - Do NOT add CLI/MCP integration tests; these are pure unit fixes.
 

--- a/docs/plans/test-plan-calibrator-cap.md
+++ b/docs/plans/test-plan-calibrator-cap.md
@@ -1,0 +1,83 @@
+# Test Plan — #97 External cap + #100 feedback parent dir
+
+**Scope:** Two unrelated bugfixes shipped together.
+- `src/calibrator.rs::calibrate` — cap External-provenance contribution to weight buckets.
+- `src/feedback.rs::FeedbackStore::record` — auto-create parent dir before opening file.
+
+## Design pre-conditions for testability
+
+- Promote the cap to a module constant: `pub(crate) const EXTERNAL_WEIGHT_CAP: f64 = 1.4;` and reference it in tests rather than hardcoding `1.4`. Cap value can then change without test churn.
+- Apply the cap in **both** weight-computation blocks (similar~v1 around L88-151 and similarity-scaled~v2 around L365-389). Each must add `external_*_weight` parallel to `auto_*_weight` and combine: `tp_weight = auto.min(1.0) + external.min(EXTERNAL_WEIGHT_CAP) + humanish` (Human + PostFix + Unknown go in `humanish`, uncapped).
+- Tests live next to existing `mod tests` blocks; reuse `fb()` helper and add `fb_external(title, cat, verdict, age_days)` builder.
+
+## 1. Test cases
+
+### #97 — calibrator External cap
+
+| # | Name | Setup | Assertion | Rationale |
+|---|------|-------|-----------|-----------|
+| 1 | `external_flood_does_not_overwhelm_human_fp` | 1 finding "SQL injection". Feedback: 100 External TP + 1 Human FP, all matching title/cat. | `result.findings.len() == 0` AND `result.suppressed == 1`. | Behavioral outcome — does not couple to the constant. Survives any cap value `<= human_fp_weight ≈ 1.0`. This is the headline regression. |
+| 2 | `external_tp_bucket_capped_at_constant` | 1 finding. Feedback: 10 External TP entries (timestamps = `Utc::now()`, so recency≈1.0). No other entries. Build via path that produces a single `CalibratorTraceEntry`. | `trace.tp_weight` is approximately `EXTERNAL_WEIGHT_CAP` (within `1e-6`), NOT `10 * 0.7 = 7.0`. | Direct verification the cap is applied. References the constant so cap-value changes propagate. |
+| 3 | `external_fp_bucket_capped_at_constant` | Mirror of #2 but verdict=Fp. | `trace.fp_weight ≈ EXTERNAL_WEIGHT_CAP`. | Symmetry — both TP and FP buckets must cap. |
+| 4 | `external_below_cap_passes_through_unchanged` | 1 External TP fresh. | `assert!((trace.tp_weight - 0.7).abs() < 1e-3)` (not `EXTERNAL_WEIGHT_CAP`). | `.min()` must not floor — single entries stay at their natural weight. Kills a `.min` → `.max` mutant (would force weight up to 1.4). |
+| 5 | `human_and_postfix_remain_uncapped` | 5 Human TP + 5 PostFix TP, fresh. | `trace.tp_weight > EXTERNAL_WEIGHT_CAP + 1.0` (i.e. ≈ 5\*1.0 + 5\*1.5 = 12.5). | Cap must NOT leak into the humanish bucket. |
+| 6 | `external_global_across_agents` | 50 External TP from agent="pal" + 50 External TP from agent="third-opinion". | `trace.tp_weight ≈ EXTERNAL_WEIGHT_CAP`. | Per #97 spec: cap is global across agents, not per-agent. |
+| 7 | `external_cap_applies_in_similarity_scaled_block` | Same as #2 but invoked via the embedding-similar code path (L360+). | Same assertion as #2. | Both code blocks must be patched — easy to fix one and forget the other. |
+
+### #100 — feedback record parent dir
+
+| # | Name | Setup | Assertion | Rationale |
+|---|------|-------|-----------|-----------|
+| 8 | `record_creates_missing_parent_directory` | `tempdir / "missing/nested/feedback.jsonl"` (parent does not exist). | `record(&entry).is_ok()`; file exists; `load_all().len() == 1`. | Headline regression. |
+| 9 | `record_works_when_parent_exists` | `tempdir / "feedback.jsonl"` (parent = tempdir, exists). | `record(&entry).is_ok()`; round-trip via `load_all`. | No regression in happy path. |
+| 10 | `record_appends_without_truncating` | Pre-create file with 1 entry, parent exists. Call `record` again. | `load_all().len() == 2`. | Guards the `OpenOptions::append(true)` contract — `create_dir_all` must not switch mode to truncate/create-new. |
+| 11 | `record_returns_err_on_unwritable_parent` | Set parent to a path that cannot be created (e.g. existing **file** where parent dir should go). | `record(&entry).is_err()`. Walk error chain via `err.chain()` and assert at least one link is an `io::Error`. Do NOT match on error message strings. | Confirms error path propagates; decoupled from message wording. |
+
+## 2. Edge cases
+
+- **Recency decay on cap (age>0):** External entry with `timestamp = now - 365 days` should produce `verdict_weight ≈ 0.7 * exp(-365/120) ≈ 0.033`. 100 such entries → `~3.3` raw → capped to `EXTERNAL_WEIGHT_CAP`. Already covered behaviorally by #1 with age=0; add one test where 2 stale Externals (raw sum ≈ `0.07`) should pass through uncapped (verifies cap is `min`, not `clamp`).
+- **Mixed provenance:** 1 PostFix TP (1.5) + 1 Human TP (1.0) + 50 External TP. Expect `tp_weight ≈ 1.5 + 1.0 + EXTERNAL_WEIGHT_CAP = 3.9`. Asserts each bucket sums correctly without cross-contamination.
+- **Empty External (no regression):** 3 Human FP, 0 External. Assert `trace.fp_weight` within `[2.95, 3.05]` (3 × Human × recency ≈ 1.0) — numeric range, no snapshots, no clock coupling.
+- **Pre-existing parent dir for #100:** covered by test #9 above (explicit no-regression).
+- **Path with no parent component**: dropped — `std::fs::create_dir_all("")` behavior is stdlib-owned and `Path::parent()` returns `None` for `"feedback.jsonl"` (guard already `if let Some(parent)`). Not a real failure mode for our code.
+
+## 3. What NOT to test
+
+- Do NOT assert the literal value `1.4` — reference `EXTERNAL_WEIGHT_CAP`.
+- Do NOT re-test `verdict_weight` provenance multipliers (already covered).
+- Do NOT test recency half-life math — covered by `verdict_weight_future_dated_entry_is_not_max_weight`.
+- Do NOT test inbox-drain, agent-name normalization, or confidence clamping — owned by `record_external` tests.
+- Do NOT test `OpenOptions` flag semantics for `record` — stdlib contract.
+- Do NOT test full `calibrate` suppression thresholds for non-External cases — existing tests cover.
+- Do NOT add CLI/MCP integration tests; these are pure unit fixes.
+
+## 4. Fixture strategy
+
+**External FeedbackEntry builder** (add to calibrator `tests` module):
+```rust
+fn fb_external(title: &str, cat: &str, verdict: Verdict, age_days: i64) -> FeedbackEntry {
+    FeedbackEntry {
+        file_path: "test.rs".into(),
+        finding_title: title.into(),
+        finding_category: cat.into(),
+        verdict,
+        reason: "ext".into(),
+        model: None,
+        timestamp: Utc::now() - chrono::Duration::days(age_days),
+        provenance: crate::feedback::Provenance::External {
+            agent: "pal".into(),
+            model: None,
+            confidence: None,
+        },
+    }
+}
+```
+
+**Determinism without stubbing `Utc::now`:** `verdict_weight` reads `Utc::now()` directly. Rather than introduce a clock trait (out of scope), use **age-based assertions with tolerances**:
+- For "fresh" entries, set `timestamp = Utc::now()` and assert weights within `±1e-3` (floor of single-call drift).
+- For decayed-entry tests, assert ratios/orderings (e.g. `w_stale < w_fresh * 0.5`), not absolute values.
+- For the headline flood test (#1), behavioral assertion (`suppressed == 1`) is clock-independent.
+
+**Tempdir for #100:** use existing `tempfile::TempDir` pattern from `feedback.rs::tests::test_store()`. New helper `test_store_with_missing_parent()` returns `(FeedbackStore, TempDir)` where the store path is `tempdir.path().join("a/b/c/feedback.jsonl")`.
+
+**Trace inspection:** tests #2-7 need `CalibratorTraceEntry`. Build a single finding, single similar-precedent set, then read `result.traces[0].tp_weight` / `fp_weight`. Existing tests already do this pattern — just extend.

--- a/src/calibrator.rs
+++ b/src/calibrator.rs
@@ -41,6 +41,16 @@ impl Default for CalibratorConfig {
     }
 }
 
+// Issue #97: cap on the global External-provenance contribution to any single
+// finding's TP or FP weight accumulator. Prevents a misbehaving or compromised
+// agent from flooding verdicts and dominating calibration.
+//
+// 1.4 ≈ 2 fresh External TPs (each at 0.7 before recency decay). This ties
+// max External influence to roughly 1 Human TP (1.0) or 1 PostFix (1.5) —
+// External is advisory precedent, not authoritative. Cap applies GLOBALLY
+// across agents (one pool summing pal + third-opinion + ...), not per-agent.
+pub(crate) const EXTERNAL_WEIGHT_CAP: f64 = 1.4;
+
 /// Compute the weight of a single feedback entry based on provenance and recency.
 fn verdict_weight(entry: &FeedbackEntry) -> f64 {
     let provenance_weight = match &entry.provenance {
@@ -126,29 +136,34 @@ pub fn calibrate(
             continue;
         }
 
-        // Compute weighted verdict scores with auto-calibrate cap
+        // Compute weighted verdict scores with provenance-specific caps:
+        //   auto_*  capped at 1.0   (AutoCalibrate is now disabled by default)
+        //   external_* capped at EXTERNAL_WEIGHT_CAP (issue #97 — bound flood)
+        //   humanish (Human + PostFix + Unknown) uncapped
         let mut auto_tp_weight: f64 = 0.0;
-        let mut other_tp_weight: f64 = 0.0;
+        let mut external_tp_weight: f64 = 0.0;
+        let mut humanish_tp_weight: f64 = 0.0;
         for e in similar.iter().filter(|e| e.verdict == Verdict::Tp || e.verdict == Verdict::Partial) {
-            if matches!(e.provenance, crate::feedback::Provenance::AutoCalibrate(_)) {
-                auto_tp_weight += verdict_weight(e);
-            } else {
-                other_tp_weight += verdict_weight(e);
+            match &e.provenance {
+                crate::feedback::Provenance::AutoCalibrate(_) => auto_tp_weight += verdict_weight(e),
+                crate::feedback::Provenance::External { .. } => external_tp_weight += verdict_weight(e),
+                _ => humanish_tp_weight += verdict_weight(e),
             }
         }
-        let tp_weight = auto_tp_weight.min(1.0) + other_tp_weight;
+        let tp_weight = auto_tp_weight.min(1.0) + external_tp_weight.min(EXTERNAL_WEIGHT_CAP) + humanish_tp_weight;
 
         // Strict FP weight (drives full suppression)
         let mut auto_fp_weight: f64 = 0.0;
-        let mut other_fp_weight: f64 = 0.0;
+        let mut external_fp_weight: f64 = 0.0;
+        let mut humanish_fp_weight: f64 = 0.0;
         for e in similar.iter().filter(|e| e.verdict == Verdict::Fp) {
-            if matches!(e.provenance, crate::feedback::Provenance::AutoCalibrate(_)) {
-                auto_fp_weight += verdict_weight(e);
-            } else {
-                other_fp_weight += verdict_weight(e);
+            match &e.provenance {
+                crate::feedback::Provenance::AutoCalibrate(_) => auto_fp_weight += verdict_weight(e),
+                crate::feedback::Provenance::External { .. } => external_fp_weight += verdict_weight(e),
+                _ => humanish_fp_weight += verdict_weight(e),
             }
         }
-        let fp_weight = auto_fp_weight.min(1.0) + other_fp_weight;
+        let fp_weight = auto_fp_weight.min(1.0) + external_fp_weight.min(EXTERNAL_WEIGHT_CAP) + humanish_fp_weight;
 
         // Wontfix weight — retained only for trace diagnostics. Wontfix no longer
         // contributes to soft or full suppression (see inertness rationale below).
@@ -363,30 +378,34 @@ pub fn calibrate_with_index(
             continue;
         }
 
+        // Same cap scheme as the Jaccard path (see above) — External weights
+        // (scaled by similarity here) are capped at EXTERNAL_WEIGHT_CAP.
         let mut auto_tp_weight: f64 = 0.0;
-        let mut other_tp_weight: f64 = 0.0;
+        let mut external_tp_weight: f64 = 0.0;
+        let mut humanish_tp_weight: f64 = 0.0;
         for s in similar.iter().filter(|s| s.entry.verdict == Verdict::Tp || s.entry.verdict == Verdict::Partial) {
             let w = verdict_weight(&s.entry) * s.similarity as f64;
-            if matches!(s.entry.provenance, crate::feedback::Provenance::AutoCalibrate(_)) {
-                auto_tp_weight += w;
-            } else {
-                other_tp_weight += w;
+            match &s.entry.provenance {
+                crate::feedback::Provenance::AutoCalibrate(_) => auto_tp_weight += w,
+                crate::feedback::Provenance::External { .. } => external_tp_weight += w,
+                _ => humanish_tp_weight += w,
             }
         }
-        let tp_weight = auto_tp_weight.min(1.0) + other_tp_weight;
+        let tp_weight = auto_tp_weight.min(1.0) + external_tp_weight.min(EXTERNAL_WEIGHT_CAP) + humanish_tp_weight;
 
         // Strict FP weight (drives full suppression)
         let mut auto_fp_weight: f64 = 0.0;
-        let mut other_fp_weight: f64 = 0.0;
+        let mut external_fp_weight: f64 = 0.0;
+        let mut humanish_fp_weight: f64 = 0.0;
         for s in similar.iter().filter(|s| s.entry.verdict == Verdict::Fp) {
             let w = verdict_weight(&s.entry) * s.similarity as f64;
-            if matches!(s.entry.provenance, crate::feedback::Provenance::AutoCalibrate(_)) {
-                auto_fp_weight += w;
-            } else {
-                other_fp_weight += w;
+            match &s.entry.provenance {
+                crate::feedback::Provenance::AutoCalibrate(_) => auto_fp_weight += w,
+                crate::feedback::Provenance::External { .. } => external_fp_weight += w,
+                _ => humanish_fp_weight += w,
             }
         }
-        let fp_weight = auto_fp_weight.min(1.0) + other_fp_weight;
+        let fp_weight = auto_fp_weight.min(1.0) + external_fp_weight.min(EXTERNAL_WEIGHT_CAP) + humanish_fp_weight;
 
         // Wontfix weight — retained only for trace diagnostics. Wontfix no longer
         // contributes to soft or full suppression (see inertness rationale below).
@@ -1973,10 +1992,15 @@ mod tests {
         // (lightweight FP with no TP → already concerning). So 1 external FP
         // at 0.7 weight already trips the low soft trigger. Full-suppression
         // requires full_suppress_weight >= 1.5.
+        //
+        // Issue #97: External weights are now capped at EXTERNAL_WEIGHT_CAP
+        // (1.4). Full suppression (>=1.5) is UNREACHABLE via External alone —
+        // it requires humanish FP corroboration. The n=100 row locks this in.
         let cases: &[(usize, Outcome)] = &[
-            (1, Outcome::Soft), // 1 × 0.7 = 0.7: tp=0 → trips low soft (>=0.5)
-            (2, Outcome::Soft), // 2 × 0.7 = 1.4: also soft (>=1.0), not full (<1.5)
-            (3, Outcome::Full), // 3 × 0.7 = 2.1: full-suppress (>=1.5)
+            (1, Outcome::Soft),   // 1 × 0.7 = 0.7: tp=0 → trips low soft (>=0.5)
+            (2, Outcome::Soft),   // 2 × 0.7 = 1.4: soft (>=1.0), below cap
+            (3, Outcome::Soft),   // 2.1 raw → capped at 1.4 → stays Soft (was Full pre-#97)
+            (100, Outcome::Soft), // flood: cap holds; External alone can never trigger Full
         ];
 
         for (n, expected) in cases {
@@ -2005,28 +2029,172 @@ mod tests {
         }
     }
 
+    // -- Issue #97: External accumulator cap --
+    //
+    // External-provenance entries (from other review agents) share the
+    // `other_*_weight` bucket with Human and PostFix. Without a cap, a single
+    // misbehaving or compromised agent can flood TP/FP verdicts and dominate
+    // calibration. Per issue #97, we cap the global External sum at
+    // `EXTERNAL_WEIGHT_CAP` (≈ 2 fresh External entries = 1 Human entry's
+    // worth). Cap is global across agents, not per-agent.
+
+    fn external_tp(age_days: i64) -> FeedbackEntry {
+        FeedbackEntry {
+            file_path: "test.rs".into(),
+            finding_title: "SQL injection".into(),
+            finding_category: "security".into(),
+            verdict: Verdict::Tp,
+            reason: "ext".into(),
+            model: None,
+            timestamp: Utc::now() - chrono::Duration::days(age_days),
+            provenance: crate::feedback::Provenance::External {
+                agent: "pal".into(),
+                model: None,
+                confidence: None,
+            },
+        }
+    }
+
+    fn external_tp_from(agent_name: &str, age_days: i64) -> FeedbackEntry {
+        let mut e = external_tp(age_days);
+        if let crate::feedback::Provenance::External { ref mut agent, .. } = e.provenance {
+            *agent = agent_name.into();
+        }
+        e
+    }
+
     #[test]
-    fn external_accumulator_uncapped_verified_via_trace() {
-        // Stronger pin than outcome-based tests: inspect the calibrator trace
-        // to confirm the actual fp_weight exceeds 1.0 (the AutoCalibrate cap).
-        // If a future edit accidentally routes External into auto_fp_weight.min(1.0),
-        // this test fails even if the outcome happens to still be full-suppress.
+    fn external_tp_bucket_capped_at_constant() {
         let findings = vec![
             FindingBuilder::new()
                 .title("SQL injection")
                 .category("security")
-                .severity(Severity::High)
                 .build(),
         ];
-        let feedback: Vec<_> = (0..3).map(external_fp).collect();
+        let feedback: Vec<_> = (0..10).map(|_| external_tp(0)).collect();
         let result = calibrate(findings, &feedback, &CalibratorConfig::default());
-        let trace = result.traces.last().expect("expected a trace");
-        // 3 fresh External FPs → fp_weight ≈ 3 × 0.7 = 2.1 (modulo tiny recency
-        // decay at age=0,1,2 days). If External were capped at 1.0, fp_weight
-        // would be ≤ 1.0.
+        let trace = result.traces.last().expect("expected trace");
         assert!(
-            trace.fp_weight > 1.0,
-            "expected uncapped fp_weight > 1.0 (got {}) — External must not be capped like AutoCalibrate",
+            (trace.tp_weight - EXTERNAL_WEIGHT_CAP).abs() < 1e-3,
+            "expected tp_weight ≈ {} (got {}) — External bucket must be capped",
+            EXTERNAL_WEIGHT_CAP,
+            trace.tp_weight
+        );
+    }
+
+    #[test]
+    fn external_fp_bucket_capped_at_constant() {
+        let findings = vec![
+            FindingBuilder::new()
+                .title("SQL injection")
+                .category("security")
+                .build(),
+        ];
+        let feedback: Vec<_> = (0..10)
+            .map(|_| {
+                let mut e = external_tp(0);
+                e.verdict = Verdict::Fp;
+                e
+            })
+            .collect();
+        let result = calibrate(findings, &feedback, &CalibratorConfig::default());
+        let trace = result.traces.last().expect("expected trace");
+        assert!(
+            (trace.fp_weight - EXTERNAL_WEIGHT_CAP).abs() < 1e-3,
+            "expected fp_weight ≈ {} (got {})",
+            EXTERNAL_WEIGHT_CAP,
+            trace.fp_weight
+        );
+    }
+
+    #[test]
+    fn external_below_cap_passes_through_unchanged() {
+        // .min() must not floor: a single External at 0.7 stays at 0.7. Kills
+        // a .min → .max mutant that would force every External up to the cap.
+        let findings = vec![
+            FindingBuilder::new()
+                .title("SQL injection")
+                .category("security")
+                .build(),
+        ];
+        let feedback = vec![external_tp(0)];
+        let result = calibrate(findings, &feedback, &CalibratorConfig::default());
+        let trace = result.traces.last().expect("expected trace");
+        assert!(
+            (trace.tp_weight - 0.7).abs() < 1e-3,
+            "expected tp_weight ≈ 0.7 (got {}) — below-cap values must pass through",
+            trace.tp_weight
+        );
+    }
+
+    #[test]
+    fn humanish_bucket_remains_uncapped() {
+        let findings = vec![
+            FindingBuilder::new()
+                .title("SQL injection")
+                .category("security")
+                .build(),
+        ];
+        let mut feedback = Vec::new();
+        for _ in 0..5 {
+            feedback.push(fb("SQL injection", "security", Verdict::Tp));
+        }
+        for _ in 0..5 {
+            let mut e = fb("SQL injection", "security", Verdict::Tp);
+            e.provenance = crate::feedback::Provenance::PostFix;
+            feedback.push(e);
+        }
+        let result = calibrate(findings, &feedback, &CalibratorConfig::default());
+        let trace = result.traces.last().expect("expected trace");
+        assert!(
+            trace.tp_weight > EXTERNAL_WEIGHT_CAP + 5.0,
+            "humanish bucket must NOT be capped; got tp_weight={} cap={}",
+            trace.tp_weight,
+            EXTERNAL_WEIGHT_CAP
+        );
+    }
+
+    #[test]
+    fn external_cap_is_global_across_agents() {
+        // Per issue #97 spec: cap applies to the sum across all External
+        // agents, not per-agent.
+        let findings = vec![
+            FindingBuilder::new()
+                .title("SQL injection")
+                .category("security")
+                .build(),
+        ];
+        let mut feedback: Vec<_> = (0..50).map(|_| external_tp_from("pal", 0)).collect();
+        feedback.extend((0..50).map(|_| external_tp_from("third-opinion", 0)));
+        let result = calibrate(findings, &feedback, &CalibratorConfig::default());
+        let trace = result.traces.last().expect("expected trace");
+        assert!(
+            (trace.tp_weight - EXTERNAL_WEIGHT_CAP).abs() < 1e-3,
+            "cap must be global across agents; got tp_weight={} (cap={})",
+            trace.tp_weight,
+            EXTERNAL_WEIGHT_CAP
+        );
+    }
+
+    #[test]
+    fn humanish_empty_external_bucket_is_no_regression() {
+        // Zero External entries: cap logic is a pure no-op.
+        let findings = vec![
+            FindingBuilder::new()
+                .title("SQL injection")
+                .category("security")
+                .build(),
+        ];
+        let feedback = vec![
+            fb("SQL injection", "security", Verdict::Fp),
+            fb("SQL injection", "security", Verdict::Fp),
+            fb("SQL injection", "security", Verdict::Fp),
+        ];
+        let result = calibrate(findings, &feedback, &CalibratorConfig::default());
+        let trace = result.traces.last().expect("expected trace");
+        assert!(
+            (2.95..=3.05).contains(&trace.fp_weight),
+            "3 fresh Human FPs should give fp_weight ≈ 3.0 (got {})",
             trace.fp_weight
         );
     }

--- a/src/calibrator.rs
+++ b/src/calibrator.rs
@@ -51,6 +51,28 @@ impl Default for CalibratorConfig {
 // across agents (one pool summing pal + third-opinion + ...), not per-agent.
 pub(crate) const EXTERNAL_WEIGHT_CAP: f64 = 1.4;
 
+/// Bucket an iterator of `(provenance, weight)` pairs into three accumulators
+/// (auto / external / humanish), apply per-bucket caps, and return the final
+/// capped sum. Used by both `calibrate` (Jaccard path) and
+/// `calibrate_with_index` (embedding path) so that the cap scheme stays in
+/// exactly one place — a future cap-value or bucket-membership change can't
+/// accidentally diverge between the two paths.
+fn accumulate_capped<'a>(
+    weighted: impl IntoIterator<Item = (&'a crate::feedback::Provenance, f64)>,
+) -> f64 {
+    let mut auto = 0.0_f64;
+    let mut external = 0.0_f64;
+    let mut humanish = 0.0_f64;
+    for (prov, w) in weighted {
+        match prov {
+            crate::feedback::Provenance::AutoCalibrate(_) => auto += w,
+            crate::feedback::Provenance::External { .. } => external += w,
+            _ => humanish += w,
+        }
+    }
+    auto.min(1.0) + external.min(EXTERNAL_WEIGHT_CAP) + humanish
+}
+
 /// Compute the weight of a single feedback entry based on provenance and recency.
 fn verdict_weight(entry: &FeedbackEntry) -> f64 {
     let provenance_weight = match &entry.provenance {
@@ -136,34 +158,19 @@ pub fn calibrate(
             continue;
         }
 
-        // Compute weighted verdict scores with provenance-specific caps:
-        //   auto_*  capped at 1.0   (AutoCalibrate is now disabled by default)
-        //   external_* capped at EXTERNAL_WEIGHT_CAP (issue #97 — bound flood)
-        //   humanish (Human + PostFix + Unknown) uncapped
-        let mut auto_tp_weight: f64 = 0.0;
-        let mut external_tp_weight: f64 = 0.0;
-        let mut humanish_tp_weight: f64 = 0.0;
-        for e in similar.iter().filter(|e| e.verdict == Verdict::Tp || e.verdict == Verdict::Partial) {
-            match &e.provenance {
-                crate::feedback::Provenance::AutoCalibrate(_) => auto_tp_weight += verdict_weight(e),
-                crate::feedback::Provenance::External { .. } => external_tp_weight += verdict_weight(e),
-                _ => humanish_tp_weight += verdict_weight(e),
-            }
-        }
-        let tp_weight = auto_tp_weight.min(1.0) + external_tp_weight.min(EXTERNAL_WEIGHT_CAP) + humanish_tp_weight;
-
-        // Strict FP weight (drives full suppression)
-        let mut auto_fp_weight: f64 = 0.0;
-        let mut external_fp_weight: f64 = 0.0;
-        let mut humanish_fp_weight: f64 = 0.0;
-        for e in similar.iter().filter(|e| e.verdict == Verdict::Fp) {
-            match &e.provenance {
-                crate::feedback::Provenance::AutoCalibrate(_) => auto_fp_weight += verdict_weight(e),
-                crate::feedback::Provenance::External { .. } => external_fp_weight += verdict_weight(e),
-                _ => humanish_fp_weight += verdict_weight(e),
-            }
-        }
-        let fp_weight = auto_fp_weight.min(1.0) + external_fp_weight.min(EXTERNAL_WEIGHT_CAP) + humanish_fp_weight;
+        // Provenance-bucketed, per-bucket-capped weights. See `accumulate_capped`.
+        let tp_weight = accumulate_capped(
+            similar
+                .iter()
+                .filter(|e| matches!(e.verdict, Verdict::Tp | Verdict::Partial))
+                .map(|e| (&e.provenance, verdict_weight(e))),
+        );
+        let fp_weight = accumulate_capped(
+            similar
+                .iter()
+                .filter(|e| e.verdict == Verdict::Fp)
+                .map(|e| (&e.provenance, verdict_weight(e))),
+        );
 
         // Wontfix weight — retained only for trace diagnostics. Wontfix no longer
         // contributes to soft or full suppression (see inertness rationale below).
@@ -378,34 +385,20 @@ pub fn calibrate_with_index(
             continue;
         }
 
-        // Same cap scheme as the Jaccard path (see above) — External weights
-        // (scaled by similarity here) are capped at EXTERNAL_WEIGHT_CAP.
-        let mut auto_tp_weight: f64 = 0.0;
-        let mut external_tp_weight: f64 = 0.0;
-        let mut humanish_tp_weight: f64 = 0.0;
-        for s in similar.iter().filter(|s| s.entry.verdict == Verdict::Tp || s.entry.verdict == Verdict::Partial) {
-            let w = verdict_weight(&s.entry) * s.similarity as f64;
-            match &s.entry.provenance {
-                crate::feedback::Provenance::AutoCalibrate(_) => auto_tp_weight += w,
-                crate::feedback::Provenance::External { .. } => external_tp_weight += w,
-                _ => humanish_tp_weight += w,
-            }
-        }
-        let tp_weight = auto_tp_weight.min(1.0) + external_tp_weight.min(EXTERNAL_WEIGHT_CAP) + humanish_tp_weight;
-
-        // Strict FP weight (drives full suppression)
-        let mut auto_fp_weight: f64 = 0.0;
-        let mut external_fp_weight: f64 = 0.0;
-        let mut humanish_fp_weight: f64 = 0.0;
-        for s in similar.iter().filter(|s| s.entry.verdict == Verdict::Fp) {
-            let w = verdict_weight(&s.entry) * s.similarity as f64;
-            match &s.entry.provenance {
-                crate::feedback::Provenance::AutoCalibrate(_) => auto_fp_weight += w,
-                crate::feedback::Provenance::External { .. } => external_fp_weight += w,
-                _ => humanish_fp_weight += w,
-            }
-        }
-        let fp_weight = auto_fp_weight.min(1.0) + external_fp_weight.min(EXTERNAL_WEIGHT_CAP) + humanish_fp_weight;
+        // Provenance-bucketed, per-bucket-capped weights. Weights here are
+        // scaled by embedding similarity before bucketing.
+        let tp_weight = accumulate_capped(
+            similar
+                .iter()
+                .filter(|s| matches!(s.entry.verdict, Verdict::Tp | Verdict::Partial))
+                .map(|s| (&s.entry.provenance, verdict_weight(&s.entry) * s.similarity as f64)),
+        );
+        let fp_weight = accumulate_capped(
+            similar
+                .iter()
+                .filter(|s| s.entry.verdict == Verdict::Fp)
+                .map(|s| (&s.entry.provenance, verdict_weight(&s.entry) * s.similarity as f64)),
+        );
 
         // Wontfix weight — retained only for trace diagnostics. Wontfix no longer
         // contributes to soft or full suppression (see inertness rationale below).
@@ -2196,6 +2189,36 @@ mod tests {
             (2.95..=3.05).contains(&trace.fp_weight),
             "3 fresh Human FPs should give fp_weight ≈ 3.0 (got {})",
             trace.fp_weight
+        );
+    }
+
+    #[test]
+    fn external_cap_applies_in_calibrate_with_index_path() {
+        // CodeRabbit-flagged: all the unit cap tests hit `calibrate()` (the
+        // Jaccard path). `calibrate_with_index()` duplicates the cap math and
+        // could silently diverge. `build_jaccard_only` sidesteps the embedding-
+        // model download so this test is fast and hermetic.
+        let dir = tempfile::TempDir::new().unwrap();
+        let store = crate::feedback::FeedbackStore::new(dir.path().join("fb.jsonl"));
+        for _ in 0..10 {
+            store.record(&external_tp(0)).unwrap();
+        }
+        let mut index = crate::feedback_index::FeedbackIndex::build_jaccard_only(&store).unwrap();
+        let config = CalibratorConfig {
+            embedding_similarity_threshold: 0.0,
+            ..Default::default()
+        };
+        let finding = FindingBuilder::new()
+            .title("SQL injection")
+            .category("security")
+            .build();
+        let result = calibrate_with_index(vec![finding], &mut index, &config);
+        let trace = result.traces.last().expect("expected trace");
+        assert!(
+            (trace.tp_weight - EXTERNAL_WEIGHT_CAP).abs() < 1e-3,
+            "calibrate_with_index must also cap External; got tp_weight={} (cap={})",
+            trace.tp_weight,
+            EXTERNAL_WEIGHT_CAP
         );
     }
 }

--- a/src/feedback.rs
+++ b/src/feedback.rs
@@ -176,6 +176,16 @@ impl FeedbackStore {
     pub fn record(&self, entry: &FeedbackEntry) -> anyhow::Result<()> {
         use anyhow::Context;
         use std::io::Write;
+        // Issue #100: OpenOptions::create(true) only creates the file, not
+        // its parent. Direct callers (tests, daemon, future paths) that bypass
+        // run_feedback's pre-create step would otherwise hit ENOENT.
+        if let Some(parent) = self.path.parent() {
+            if !parent.as_os_str().is_empty() {
+                std::fs::create_dir_all(parent).with_context(|| {
+                    format!("Failed to create feedback parent dir: {}", parent.display())
+                })?;
+            }
+        }
         let mut file = std::fs::OpenOptions::new()
             .create(true)
             .append(true)
@@ -540,6 +550,51 @@ mod tests {
             provenance: Provenance::Human,
         };
         assert_eq!(entry.provenance, Provenance::Human);
+    }
+
+    // Issue #100: FeedbackStore::record must create the parent directory if it
+    // doesn't exist. Direct callers (tests, daemon, future entry points) that
+    // bypass `run_feedback`'s pre-create step would otherwise hit ENOENT on a
+    // fresh install or alternate QUORUM_HOME.
+    #[test]
+    fn record_creates_missing_parent_directory() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("missing").join("nested").join("feedback.jsonl");
+        assert!(
+            !path.parent().unwrap().exists(),
+            "precondition: parent dir must not pre-exist"
+        );
+        let store = FeedbackStore::new(path.clone());
+        store
+            .record(&sample_entry(Verdict::Tp))
+            .expect("record must succeed even if parent dir is missing");
+        assert!(path.exists(), "feedback file must be created");
+        assert_eq!(store.load_all().unwrap().len(), 1);
+    }
+
+    #[test]
+    fn record_appends_without_truncating() {
+        let (store, _dir) = test_store();
+        store.record(&sample_entry(Verdict::Tp)).unwrap();
+        store.record(&sample_entry(Verdict::Fp)).unwrap();
+        assert_eq!(store.load_all().unwrap().len(), 2);
+    }
+
+    #[test]
+    fn record_returns_err_on_unwritable_parent() {
+        let dir = TempDir::new().unwrap();
+        let blocker = dir.path().join("blocker");
+        std::fs::write(&blocker, b"i am a file not a dir").unwrap();
+        let path = blocker.join("subdir").join("feedback.jsonl");
+        let store = FeedbackStore::new(path);
+        let err = store
+            .record(&sample_entry(Verdict::Tp))
+            .expect_err("record must fail when parent cannot be created");
+        let has_io_cause = err.chain().any(|e| e.downcast_ref::<std::io::Error>().is_some());
+        assert!(
+            has_io_cause,
+            "error chain must include io::Error (got: {err:#})"
+        );
     }
 
     #[test]

--- a/src/feedback.rs
+++ b/src/feedback.rs
@@ -179,12 +179,10 @@ impl FeedbackStore {
         // Issue #100: OpenOptions::create(true) only creates the file, not
         // its parent. Direct callers (tests, daemon, future paths) that bypass
         // run_feedback's pre-create step would otherwise hit ENOENT.
-        if let Some(parent) = self.path.parent() {
-            if !parent.as_os_str().is_empty() {
-                std::fs::create_dir_all(parent).with_context(|| {
-                    format!("Failed to create feedback parent dir: {}", parent.display())
-                })?;
-            }
+        if let Some(parent) = self.path.parent().filter(|p| !p.as_os_str().is_empty()) {
+            std::fs::create_dir_all(parent).with_context(|| {
+                format!("Failed to create feedback parent dir: {}", parent.display())
+            })?;
         }
         let mut file = std::fs::OpenOptions::new()
             .create(true)


### PR DESCRIPTION
## Summary

Two small fixes bundled from the post-#95 external-feedback triage.

- **#97** — cap the global External-provenance contribution to any single finding's TP/FP accumulator at `EXTERNAL_WEIGHT_CAP = 1.4` (≈ 2 fresh External TPs = 1 Human TP). Prevents a misbehaving or compromised external review agent from flooding verdicts and dominating calibration. Cap is global across agents (one pool for pal + third-opinion + ...), not per-agent. Applied symmetrically to both calibrate() code paths: Jaccard-similar (\`calibrate\`) and embedding-similar (\`calibrate_with_index\`). Full suppression (\`fp_weight >= 1.5\`) is now unreachable via External alone — it requires humanish FP corroboration. Auto and Humanish buckets are unchanged.
- **#100** — \`FeedbackStore::record\` now creates the feedback file's parent directory (\`create_dir_all\`) before opening the file. Matters for any caller that bypasses \`run_feedback\`'s pre-create step: tests, daemon paths, future entry points, or fresh installs with alternate \`QUORUM_HOME\`.

## Test plan

- [x] 6 new calibrator cap tests: TP/FP buckets capped at \`EXTERNAL_WEIGHT_CAP\`, single-External below cap passes through at 0.7, humanish bucket uncapped (5 Human TP + 5 PostFix TP ≈ 12.5), cap global across agents (50 pal + 50 third-opinion caps at 1.4), empty-External is a no-op.
- [x] 3 new feedback record tests: creates missing parent, appends without truncating, error chain includes \`io::Error\` on unwritable parent (walks \`err.chain()\`, no string matching).
- [x] \`external_fp_accumulation_thresholds\` updated: n=3 now Soft (was Full pre-cap), n=100 row locks in "flood cannot reach Full".
- [x] All 1483 unit tests pass (baseline 1475 + 8 net new).
- [x] All 1527 full-suite tests pass with \`--test-threads=1\`.
- [x] \`cargo clippy --bin quorum -- -D warnings\` clean on changed files.
- [x] Release build clean.

## Quorum verdicts recorded

7 findings from the self-review — all pre-existing, none introduced by this diff. Triaged and recorded with reasons:

| Finding | File | Verdict | Issue |
|---|---|---|---|
| rename NotFound misclassified as benign race | feedback.rs | tp | #101 (new) |
| concurrent record() can corrupt JSONL | feedback.rs | tp | #91 |
| load_all drops malformed rows silently | feedback.rs | tp | #92 |
| drain_inbox complexity 22 | feedback.rs | partial | — |
| calibrate complexity 27 | calibrator.rs | tp | #21 |
| calibrate_with_index complexity 27 | calibrator.rs | tp | #21 |
| silent-error-conversion on .ok() | calibrator.rs | partial | — |

Closes #97, closes #98, closes #99, closes #100.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * External provenance contributions are now limited by a global cap in calibration weight calculations.

* **Bug Fixes**
  * Feedback storage now ensures missing parent directories are created before appending, preventing write failures.

* **Documentation**
  * Added a test plan covering calibration capping behavior and feedback storage edge cases.

* **Tests**
  * Expanded tests for weight-capping scenarios, cross-path calibration behavior, directory-creation, append semantics, and error propagation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->