### PR TITLE
fix(cli): hardening sweep — review file-required + run_context stdout errors (#89, #84, #79)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,10 @@
 name = "quorum"
 version = "0.17.1"
 edition = "2024"
+# `if let` chains used in src/cli_io.rs and src/context/cli.rs stabilized
+# in Rust 1.88. Edition 2024 already requires 1.85+, but document the
+# actual minimum explicitly.
+rust-version = "1.88"
 description = "Multi-source code review: LLM ensemble + local AST analysis + linter orchestration"
 license = "MIT"
 repository = "https://github.com/jsnyder/quorum"

--- a/docs/plans/v0.17.2-antipattern-review.md
+++ b/docs/plans/v0.17.2-antipattern-review.md
@@ -1,0 +1,85 @@
+# v0.17.2 CLI Hardening — Pre-RED Antipattern Audit
+
+**Scope:** Test strategy review for issues #89, #79, #84, BEFORE any tests are written.
+**Verdict at-a-glance:** #89 GO-WITH-CHANGES, #79 GO-WITH-CHANGES (re-frame as regression guard), #84 GO-WITH-CHANGES (split unit + thin integration).
+
+---
+
+## Issue #89 — `quorum review` accepts zero files — **GO-WITH-CHANGES**
+
+**Current state confirmed:** `src/cli/mod.rs:285-289` — `ReviewOpts.files: Vec<PathBuf>` has no `num_args`/`required` constraint. Bug is live.
+
+**Plan:** subprocess test via `assert_cmd`, run `quorum review` with no args, assert non-zero exit + stderr contains required-files message.
+
+**Findings:**
+
+- **(AP#5 Slow) (AP#3 Wrong shape):** Subprocess is appropriate here — clap's `required = true` only fires during `Parser::parse_from()`, and we want to verify the assembled binary's behavior. In-process via `Cli::try_parse_from(["quorum", "review"])` is **faster and equally valid**. **Recommend: prefer in-process `try_parse_from` for the core "no files rejected" assertion; keep at most ONE subprocess smoke test for exit-code wiring.** Mixing both is fine; pure-subprocess wastes ~200ms per case.
+- **(AP#5 Brittle assertion on internals):** Do NOT match clap's exact error text ("the following required arguments were not provided"). Clap minor-version bumps reword it. **Use `err.kind() == ErrorKind::MissingRequiredArgument`** for in-process; for subprocess use a loose substring like `"FILES"` or `"required"`, not the full sentence.
+- **(AP#1 Happy-path bias):** Plan covers only the zero-args case. **Add boundary cases:**
+  1. `quorum review` (zero files) → MissingRequiredArgument
+  2. `quorum review nonexistent.rs` (one bad file) → existing path (sanity / delimiter)
+  3. `quorum review --json` (zero files, with a flag that should NOT bypass requirement) → still MissingRequiredArgument. This catches the "I used `required_unless_present_any` too aggressively" mutation.
+- **(AP#9 Mutation testing):** Adding `num_args = 1..` without `required = true` would still allow zero args. Test #1 above kills that mutant. Good.
+- **(AP#4 Always-passing / RED check):** Today `Vec<PathBuf>` happily parses to empty. Test #1 will fail today → genuine RED. Confirmed.
+
+**Adjusted test count:** 2 in-process unit tests (`try_parse_from`) + 1 subprocess smoke = **3 tests**.
+
+---
+
+## Issue #79 — `--source` + `--all` together — **GO-WITH-CHANGES (re-frame)**
+
+**Current state confirmed:** `src/cli/mod.rs:135-156` — `ContextIndexOpts` AND `ContextRefreshOpts` already have bidirectional `conflicts_with` annotations. **The bug appears already fixed.** The issue body's "silently prefers --all" claim does not match the current code.
+
+**Findings:**
+
+- **(AP#10 Bug-to-test discipline) (AP#13 Bad rep from ignorance):** Frame the PR commit + test as **"regression guard for #79 (already fixed by prior conflicts_with work)"**, not "fix for #79". Otherwise reviewers will look for a code change that doesn't exist and lose trust in the PR narrative.
+- **(AP#4 Always-passing):** This test will pass on `main` today — that violates strict RED-GREEN. **Mitigation:** include a temporary commit on the branch that *removes* one `conflicts_with` annotation to prove the test fails, then revert before merge. OR document in the test body: `// Regression guard: passes on current main; protects against future removal of conflicts_with.` The second is cheaper; recommend that.
+- **(AP#5 Brittle assertion):** Clap emits `ErrorKind::ArgumentConflict` for `conflicts_with` violations. Assert on the kind, not on the error string mentioning `--source` or `--all` by name (clap formats these consistently today but it's still implementation detail).
+- **(AP#1 Happy-path / coverage):** Plan covers `index --source X --all`. **Add the symmetric `refresh` case** (separate struct, separate annotation — independent regression risk). Also cover one positive case per command (`index --all` alone, `index --source x` alone) to ensure the conflict rule isn't over-tightened. That's 4 cases for #79.
+- **(AP#5 Slow):** Pure clap argument-parsing — **all in-process via `Cli::try_parse_from`**. No subprocess justified.
+
+**Adjusted test count:** 4 in-process unit tests (2 conflict + 2 positive sanity) = **4 tests**.
+
+---
+
+## Issue #84 — silent stdout write errors — **GO-WITH-CHANGES**
+
+**Current state confirmed:** `src/main.rs:399-410` — three `let _ = handle.write_all(...)` calls plus `let _ = handle.flush()`. EIO/ENOSPC silently swallowed.
+
+**Plan:** extract `write_cmd_output(handle, out) -> i32`, unit-test with `FailingWriter`.
+
+**Findings:**
+
+- **(AP#19 Over-mocking / mock-the-mock):** A `FailingWriter` that returns `io::ErrorKind::BrokenPipe` is **not** mock-the-mock — it's a legitimate test double for the `Write` trait boundary. The behavior under test is the helper's *branching on `ErrorKind`*, which is real production logic. **Pass.** The risk would be if the test asserted "FailingWriter::write was called" — don't do that; assert on the helper's return value (exit code) and on what was written to a captured stderr buffer.
+- **(AP#5 / AP#19 Pure-unit vs end-to-end):** The pure-unit test of `write_cmd_output` does NOT prove `run_context` *calls* the helper. A trivial mutation — `run_context` keeps its inline `let _ =` block and never invokes `write_cmd_output` — would leave all unit tests green. **Recommend: add ONE thin integration test** that runs `quorum context list` (or any command with deterministic stdout) with stdout piped to a closed pipe (`Stdio::null()` won't trigger BrokenPipe; need an actually-closed reader — easiest path: pipe to `head -c 0` via shell, or use `assert_cmd` + drop the child stdout reader early). Assert exit code is 0 (BrokenPipe is expected), no panic. This catches "forgot to wire helper into run_context".
+- **(AP#1 Happy-path bias / AP#9 Mutation):** Plan lists 3 cases (BrokenPipe, EIO, success). **Add a 4th: flush() error.** The current code calls `flush()` after writes; if the helper handles `write_all` errors but ignores `flush` errors, EIO-on-flush is still silent. A `FailingWriter` configured to succeed on writes but fail on flush kills that mutant. Also consider: **partial-write** (write_all returns Ok but only after multiple chunks) — `write_all` handles short writes internally so this is moot, skip.
+- **(AP#5 Brittle assertion):** Capturing stderr from a unit test is awkward in Rust. Two options: (a) refactor helper signature to `write_cmd_output(out_handle: &mut impl Write, err_handle: &mut impl Write, ...) -> i32` — pure, fully testable, no globals. **Strongly recommend (a).** (b) use a global capture crate. (a) is cleaner and makes the helper trivially unit-testable without filesystem or process state.
+- **(AP#6 Fixture deps):** None. Pure in-memory writers. Good.
+- **(AP#4 RED check):** Today the swallowed EIO returns 0; new test asserts 1. Genuine RED. Confirmed.
+- **(AP#2 Assertion-free):** Verify each `FailingWriter` test asserts BOTH return value AND stderr buffer contents (for non-BrokenPipe cases). A test that only asserts exit code passes against a mutation that drops the `eprintln!`.
+
+**Adjusted test count:** 4 in-process unit tests (BrokenPipe, EIO-on-write, EIO-on-flush, success) + 1 subprocess integration (helper actually wired into `run_context`) = **5 tests**.
+
+---
+
+## Cross-cutting recommendations
+
+1. **(AP#11 TDD-as-religion):** For #79's "already-fixed" case, don't fake a RED phase by introducing-then-reverting the bug. Document it as a regression guard in the test name itself: `#[test] fn regression_guard_79_index_source_all_conflict()`. Honesty > ritual.
+2. **(AP#7 Flaky):** None of the planned tests touch network, time, or `$HOME`. The subprocess BrokenPipe test for #84 is the only flake risk — make sure to use `Command::stdout(Stdio::piped())` and explicitly drop the reader; do NOT rely on `| head` which introduces a shell dependency.
+3. **(AP#15 Snapshot abuse):** None planned. Verified clean.
+4. **(AP#14 AI-generated smells):** If any test is drafted by Copilot/Claude, manually verify each `expect()` is meaningful (not `expect(result.is_ok()).to_be(true)` boilerplate). Specifically check stderr-content assertions are substring-based, not full-string equality on clap output.
+
+---
+
+## Final test inventory
+
+| Issue | In-process unit | Subprocess integration | Total |
+|-------|----------------|------------------------|-------|
+| #89   | 2              | 1                      | 3     |
+| #79   | 4              | 0                      | 4     |
+| #84   | 4              | 1                      | 5     |
+| **Total** | **10**     | **2**                  | **12** |
+
+Subprocess ratio 2/12 = 17% — consistent with the project's existing honeycomb-leaning shape (most CLI behavior tested via `try_parse_from` + helper unit tests, with thin subprocess smoke tests for binary wiring). No ice-cream-cone risk.
+
+**Proceed to RED phase** with the adjustments above.

--- a/docs/plans/v0.17.2-cli-hardening-tests.md
+++ b/docs/plans/v0.17.2-cli-hardening-tests.md
@@ -1,0 +1,341 @@
+# v0.17.2 CLI Hardening — TDD Test Plan
+
+Branch: `fix/cli-hardening` (worktree `.worktrees/cli-hardening`)
+Scope: 3 small, independent CLI correctness fixes (issues #89, #79, #84).
+
+## Pre-flight findings (read before writing tests)
+
+| Issue | Reported behavior | Actual (verified in tree) |
+|-------|-------------------|---------------------------|
+| #89 | `quorum review` (no files) parses + silently no-ops | `src/main.rs:509-513` already short-circuits: `if opts.files.is_empty() { eprintln!("Error: No files specified"); return 3; }` — but no test pins this. Bug as filed is partially fixed; we're writing a regression test. |
+| #79 | `--source X --all` silently prefers `--all` | `src/cli/mod.rs:135-153` already has `#[arg(long, conflicts_with = "all")]` on both `ContextIndexOpts` and `ContextRefreshOpts`. Bug already fixed; we're writing a regression test. |
+| #84 | stdout write errors swallowed in `run_context` | Confirmed at `src/main.rs:404-411`. `let _ = handle.write_all(...)` discards EIO/ENOSPC alongside BrokenPipe. RED test required. |
+
+Implication: only #84 needs a real RED-then-GREEN cycle. #89 and #79 get **regression tests** — they should pass on first run if the existing fixes work, and would fail if anyone reverts. State this honestly in commits.
+
+---
+
+## Issue #89 — `quorum review` rejects zero files
+
+### Test 1: `review_with_no_files_exits_nonzero`
+- **File:** `tests/cli_review_requires_files.rs` (new)
+- **Asserts:** exit status is non-zero (NOT zero). No assumption about specific code (3 today, clap-2 if `num_args=1..` is added later).
+- **Why minimal:** the bug surface is "exit 0 with no work done". One assertion: exit code is non-zero. Don't constrain to 3 — leaves room for the `num_args=1..` fix style without breaking the test.
+- **Run:** `cargo test --test cli_review_requires_files review_with_no_files_exits_nonzero`
+
+```rust
+use assert_cmd::Command;
+use tempfile::TempDir;
+
+#[test]
+fn review_with_no_files_exits_nonzero() {
+    let home = TempDir::new().unwrap();
+    let qhome = home.path().join(".quorum");
+    std::fs::create_dir_all(&qhome).unwrap();
+    Command::cargo_bin("quorum")
+        .unwrap()
+        .env("QUORUM_HOME", qhome.as_os_str())
+        .env_remove("QUORUM_API_KEY")
+        .arg("review")
+        .assert()
+        .failure(); // any non-zero exit
+}
+```
+
+- **Expected RED (today):** PASSES (handler already returns 3). This is a regression test, not a true RED.
+- **Expected GREEN:** still passes after either fix style (`num_args=1..` in clap → exit 2; explicit handler check → exit 3).
+
+### Test 2: `review_with_no_files_emits_diagnostic_to_stderr`
+- **File:** same.
+- **Asserts:** stderr is non-empty AND contains a substring like `"file"` (case-insensitive). Avoid pinning the exact message ("No files specified" vs clap's "required arguments not provided") — both are acceptable diagnostics.
+- **Why minimal:** "silently no-ops" is the bug; this asserts the user gets *some* feedback.
+- **Run:** same target.
+
+```rust
+#[test]
+fn review_with_no_files_emits_diagnostic_to_stderr() {
+    let home = TempDir::new().unwrap();
+    let qhome = home.path().join(".quorum");
+    std::fs::create_dir_all(&qhome).unwrap();
+    let assert = Command::cargo_bin("quorum")
+        .unwrap()
+        .env("QUORUM_HOME", qhome.as_os_str())
+        .env_remove("QUORUM_API_KEY")
+        .arg("review")
+        .assert()
+        .failure();
+    let stderr = String::from_utf8_lossy(&assert.get_output().stderr).to_lowercase();
+    assert!(
+        stderr.contains("file"),
+        "stderr must mention 'file' so user knows what's missing; got: {stderr}"
+    );
+}
+```
+
+- **Expected RED:** PASSES today (handler prints "Error: No files specified").
+- **Expected GREEN:** unchanged.
+
+### Test 3 (positive control): `review_with_one_nonexistent_file_does_not_trigger_no_files_path`
+- **File:** same.
+- **Asserts:** running with one (even bogus) path does NOT produce the "no files" stderr. Pins that the empty-list check only fires on truly empty input.
+- **Why minimal:** prevents a future fix from over-zealously rejecting `review /tmp/missing.rs`.
+- **Run:** same target.
+
+```rust
+#[test]
+fn review_with_one_arg_does_not_emit_no_files_diagnostic() {
+    let home = TempDir::new().unwrap();
+    let qhome = home.path().join(".quorum");
+    std::fs::create_dir_all(&qhome).unwrap();
+    let assert = Command::cargo_bin("quorum")
+        .unwrap()
+        .env("QUORUM_HOME", qhome.as_os_str())
+        .env_remove("QUORUM_API_KEY")
+        .args(["review", "/definitely/does/not/exist.rs"])
+        .assert();
+    let stderr = String::from_utf8_lossy(&assert.get_output().stderr);
+    assert!(
+        !stderr.to_lowercase().contains("no files specified"),
+        "single-file invocation must not trigger empty-files branch; got: {stderr}"
+    );
+}
+```
+
+---
+
+## Issue #79 — `--source` and `--all` mutually exclusive
+
+### Test 1: `context_index_rejects_source_and_all_together`
+- **File:** `tests/cli_context_source_all_conflict.rs` (new)
+- **Asserts:** `quorum context index --source foo --all` exits non-zero.
+- **Why minimal:** any clap conflict produces non-zero; the contract is "user gets an error, not a silent preference". Don't pin the clap error format.
+- **Run:** `cargo test --test cli_context_source_all_conflict context_index_rejects_source_and_all_together`
+
+```rust
+use assert_cmd::Command;
+use tempfile::TempDir;
+
+fn quorum(home: &std::path::Path) -> Command {
+    let qhome = home.join(".quorum");
+    std::fs::create_dir_all(&qhome).unwrap();
+    let mut cmd = Command::cargo_bin("quorum").unwrap();
+    cmd.env("QUORUM_HOME", qhome.as_os_str())
+        .env_remove("QUORUM_API_KEY");
+    cmd
+}
+
+#[test]
+fn context_index_rejects_source_and_all_together() {
+    let home = TempDir::new().unwrap();
+    quorum(home.path())
+        .args(["context", "index", "--source", "foo", "--all"])
+        .assert()
+        .failure();
+}
+```
+
+- **Expected RED:** PASSES today (`conflicts_with` already wired). Regression test.
+- **Expected GREEN:** unchanged.
+
+### Test 2: `context_refresh_rejects_source_and_all_together`
+- Same pattern, `refresh` subcommand. One behavior per test.
+
+```rust
+#[test]
+fn context_refresh_rejects_source_and_all_together() {
+    let home = TempDir::new().unwrap();
+    quorum(home.path())
+        .args(["context", "refresh", "--source", "foo", "--all"])
+        .assert()
+        .failure();
+}
+```
+
+### Test 3: `context_index_with_only_source_succeeds_at_parse`
+- **Asserts:** `--source foo` alone parses (may still fail later for "source not registered", but that's exit code from the handler, not clap).
+- **Asserts on:** stderr does NOT contain `"cannot be used with"` / `"conflict"`. We want to prove the conflict only fires when BOTH are present.
+- **Why minimal:** prevents a regression where someone tightens the constraint to forbid `--source` alone.
+
+```rust
+#[test]
+fn context_index_with_only_source_does_not_trigger_clap_conflict() {
+    let home = TempDir::new().unwrap();
+    let assert = quorum(home.path())
+        .args(["context", "index", "--source", "nonexistent"])
+        .assert();
+    let stderr = String::from_utf8_lossy(&assert.get_output().stderr).to_lowercase();
+    assert!(
+        !stderr.contains("cannot be used with"),
+        "single-flag invocation must not trip clap conflict; got: {stderr}"
+    );
+}
+```
+
+---
+
+## Issue #84 — stdout write errors propagate (non-BrokenPipe)
+
+This is the only true RED test. Strategy: extract a pure helper, unit-test it with a `FailingWriter` mock.
+
+### Refactor target
+
+Create `src/cli_io.rs` with:
+
+```rust
+use std::io::{self, Write};
+
+pub struct CmdRender<'a> {
+    pub stdout: &'a str,
+    pub warnings: &'a [String],
+    pub doctor_failed: Option<bool>,
+}
+
+/// Write rendered output to `out`, emit warnings to `err`. Returns process exit code.
+/// - BrokenPipe on `out` -> exit 0 (downstream consumer closed early)
+/// - Other I/O error on `out` -> print "error: failed to write output: <e>" to `err`, exit 1
+/// - Success -> exit 0, or 1 if doctor_failed == Some(true)
+pub fn write_cmd_output<W: Write, E: Write>(
+    out: &mut W,
+    err: &mut E,
+    render: &CmdRender<'_>,
+) -> i32 { /* ... */ }
+```
+
+`run_context`'s `Ok(out)` arm becomes a single call to `write_cmd_output(&mut stdout.lock(), &mut io::stderr().lock(), &render)`.
+
+### Test 1: `broken_pipe_returns_zero_and_emits_no_error`
+- **File:** `src/cli_io.rs` inline `#[cfg(test)] mod tests`.
+- **Asserts:** when writer returns `ErrorKind::BrokenPipe`, return value is 0 AND stderr buffer is empty.
+- **Why minimal:** BrokenPipe is the documented "user piped to `head`" case — exit 0 silently is the contract.
+- **Run:** `cargo test --lib cli_io::tests::broken_pipe_returns_zero`
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::{self, Write};
+
+    struct FailingWriter { kind: io::ErrorKind }
+    impl Write for FailingWriter {
+        fn write(&mut self, _: &[u8]) -> io::Result<usize> {
+            Err(io::Error::new(self.kind, "simulated"))
+        }
+        fn flush(&mut self) -> io::Result<()> { Ok(()) }
+    }
+
+    #[test]
+    fn broken_pipe_returns_zero_and_emits_no_error() {
+        let mut out = FailingWriter { kind: io::ErrorKind::BrokenPipe };
+        let mut err: Vec<u8> = Vec::new();
+        let render = CmdRender { stdout: "hello", warnings: &[], doctor_failed: None };
+        let code = write_cmd_output(&mut out, &mut err, &render);
+        assert_eq!(code, 0);
+        assert!(err.is_empty(), "BrokenPipe must not emit stderr; got: {:?}", String::from_utf8_lossy(&err));
+    }
+}
+```
+- **Expected RED:** the helper does not exist yet → compile error. After scaffolding the helper to mirror current behavior (`let _ = ...`), this test PASSES (silent on all errors).
+
+### Test 2: `non_broken_pipe_io_error_returns_one_and_prints_to_stderr`
+- **Asserts:** for `ErrorKind::Other` (proxy for EIO/ENOSPC), return value is 1 AND stderr contains the substring `"failed to write"`.
+- **Why minimal:** this is THE bug. EIO must not be swallowed.
+
+```rust
+#[test]
+fn non_broken_pipe_io_error_returns_one_and_prints_to_stderr() {
+    let mut out = FailingWriter { kind: io::ErrorKind::Other };
+    let mut err: Vec<u8> = Vec::new();
+    let render = CmdRender { stdout: "hello", warnings: &[], doctor_failed: None };
+    let code = write_cmd_output(&mut out, &mut err, &render);
+    assert_eq!(code, 1, "non-BrokenPipe I/O error must yield exit 1");
+    let s = String::from_utf8_lossy(&err);
+    assert!(s.contains("failed to write"), "stderr must explain the failure; got: {s}");
+}
+```
+- **Expected RED:** with the naive `let _ = ...` scaffold, returns 0 and stderr is empty → assertion on exit code fires first. This is the failing test that drives the fix.
+- **Expected GREEN:** match on `e.kind()`: BrokenPipe → continue silently; else → write diagnostic + return 1.
+
+### Test 3: `successful_write_returns_doctor_exit_code`
+- **Asserts:** with a Vec<u8> writer (success path), `doctor_failed: Some(true)` → returns 1; `Some(false)` or `None` → returns 0.
+- **Why minimal:** pins the doctor-exit interaction so the refactor doesn't regress issue #73.
+
+```rust
+#[test]
+fn successful_write_with_doctor_failed_true_returns_one() {
+    let mut out: Vec<u8> = Vec::new();
+    let mut err: Vec<u8> = Vec::new();
+    let render = CmdRender { stdout: "ok\n", warnings: &[], doctor_failed: Some(true) };
+    assert_eq!(write_cmd_output(&mut out, &mut err, &render), 1);
+}
+
+#[test]
+fn successful_write_with_no_doctor_status_returns_zero() {
+    let mut out: Vec<u8> = Vec::new();
+    let mut err: Vec<u8> = Vec::new();
+    let render = CmdRender { stdout: "ok\n", warnings: &[], doctor_failed: None };
+    assert_eq!(write_cmd_output(&mut out, &mut err, &render), 0);
+}
+```
+
+### Test 4: `flush_error_is_treated_like_write_error`
+- **Asserts:** if `write_all` succeeds but `flush` returns non-BrokenPipe error, return 1 with stderr diagnostic.
+- **Why minimal:** flush errors hit the same data-loss surface (e.g. `tee` partial write); current code swallows them too.
+
+```rust
+struct FlushFailingWriter { kind: io::ErrorKind }
+impl Write for FlushFailingWriter {
+    fn write(&mut self, b: &[u8]) -> io::Result<usize> { Ok(b.len()) }
+    fn flush(&mut self) -> io::Result<()> { Err(io::Error::new(self.kind, "simulated")) }
+}
+
+#[test]
+fn flush_error_non_broken_pipe_returns_one() {
+    let mut out = FlushFailingWriter { kind: io::ErrorKind::Other };
+    let mut err: Vec<u8> = Vec::new();
+    let render = CmdRender { stdout: "hello", warnings: &[], doctor_failed: None };
+    assert_eq!(write_cmd_output(&mut out, &mut err, &render), 1);
+}
+
+#[test]
+fn flush_error_broken_pipe_returns_zero() {
+    let mut out = FlushFailingWriter { kind: io::ErrorKind::BrokenPipe };
+    let mut err: Vec<u8> = Vec::new();
+    let render = CmdRender { stdout: "hello", warnings: &[], doctor_failed: None };
+    assert_eq!(write_cmd_output(&mut out, &mut err, &render), 0);
+}
+```
+
+---
+
+## Recommended TDD Ordering
+
+1. **Issue #84 first** (only true RED-GREEN). Sequence:
+   1. Write `src/cli_io.rs` with the function signature + `todo!()` body. Add `mod cli_io;` to `src/main.rs`.
+   2. Add the 6 unit tests above. Run `cargo test --lib cli_io` → all fail (panic from `todo!()`).
+   3. Implement naive scaffold (`let _ = out.write_all(...)`) → BrokenPipe + success tests pass; the EIO test fails (RED on the actual bug).
+   4. Implement the kind-match (BrokenPipe → silent; else → write to err + return 1) → all pass (GREEN).
+   5. Replace the inline block in `run_context` with a call to `write_cmd_output`. Run `cargo test` to confirm no regressions across `cli_inbox_drain.rs`, `context_cli.rs`, `doctor_exit_code.rs`.
+2. **Issue #89 second.** Add the 3 `assert_cmd` tests. They should pass immediately (handler already short-circuits). Commit as `test: pin regression for empty-files review (#89)`.
+3. **Issue #79 third.** Add the 3 conflict tests. They should pass immediately. Commit as `test: pin regression for --source/--all clap conflict (#79)`.
+
+If during step 2 or 3 a test fails, the underlying fix is missing → reopen the issue.
+
+---
+
+## Antipatterns avoided
+
+- **No assertion on clap-internal error strings.** Tests check `.failure()` (non-zero) and substring matches on user-visible language only.
+- **No multi-behavior test names.** Each test names exactly one observable property.
+- **No mocking stdlib for its own sake.** `FailingWriter` represents "the OS returned EIO" — a meaningful collaborator; without it we can't test the error branch in-process.
+- **No coupling to exit codes 2 vs 3.** Tests use `.failure()` so either fix style for #89 (clap `num_args=1..` which exits 2, or handler check which exits 3) keeps the test green.
+- **No production-binary tests for the pure logic.** #84's helper is unit-tested in-process; only #89 and #79, which exercise clap, use `assert_cmd`.
+- **No `--no-auto-calibrate` / `QUORUM_API_KEY` leakage.** Tests `env_remove("QUORUM_API_KEY")` and set a temp `QUORUM_HOME` so they don't touch the user's feedback log or hit the network.
+- **Honest commit messages.** #89 and #79 are labeled "regression test", not "fix" — reviewers know we found the bugs already addressed.
+
+---
+
+## Out of scope
+
+- Performance / timing assertions (none of these fixes change perf).
+- Cross-platform stdout behavior (Windows pipe semantics differ; CI runs Linux/macOS — fine for now).
+- Removing the `let _ = handle.flush()` pattern elsewhere in the codebase. Audit-only; not part of this batch.

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -841,4 +841,29 @@ mod tests {
             res.err().map(|e| e.kind())
         );
     }
+
+    #[test]
+    fn regression_guard_79_refresh_with_only_source_parses() {
+        // ContextRefreshOpts is a separate clap surface from ContextIndexOpts;
+        // mirror the index positive-controls so a future over-tightening of
+        // refresh's flags is caught (CodeRabbit PR #106).
+        use clap::Parser;
+        let res = Args::try_parse_from(["quorum", "context", "refresh", "--source", "foo"]);
+        assert!(
+            res.is_ok(),
+            "single-flag invocation must parse; got {:?}",
+            res.err().map(|e| e.kind())
+        );
+    }
+
+    #[test]
+    fn regression_guard_79_refresh_with_only_all_parses() {
+        use clap::Parser;
+        let res = Args::try_parse_from(["quorum", "context", "refresh", "--all"]);
+        assert!(
+            res.is_ok(),
+            "single-flag invocation must parse; got {:?}",
+            res.err().map(|e| e.kind())
+        );
+    }
 }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -284,6 +284,12 @@ pub struct DaemonOpts {
 #[derive(Parser)]
 pub struct ReviewOpts {
     /// Files to review
+    // Issue #89: at least one file is required. Without this, clap accepted
+    // an empty list and the handler later short-circuited with exit 3 — but
+    // that's a usage error (exit 2) and the contract belongs at the parsing
+    // layer so the user gets clap's standard "required arguments" message
+    // and `--help` hint.
+    #[arg(required = true, num_args = 1..)]
     pub files: Vec<PathBuf>,
 
     /// Output as JSON (auto-detected when piped)
@@ -736,5 +742,103 @@ mod tests {
             }
             _ => panic!("Expected Stats command"),
         }
+    }
+
+    // --- Issue #89: review subcommand requires at least one file -----------
+    //
+    // Pre-fix, `Vec<PathBuf>` parsed an empty list silently and the handler
+    // short-circuited with exit 3 — but the contract belongs at the clap
+    // layer (standard usage error, exit 2, clap-formatted message). Asserting
+    // on the typed `ErrorKind` is robust to clap's wording changes.
+
+    #[test]
+    fn review_with_no_files_yields_missing_required_argument() {
+        use clap::Parser;
+        let res = Args::try_parse_from(["quorum", "review"]);
+        let err = res.err().expect("review with zero files must fail to parse");
+        assert_eq!(
+            err.kind(),
+            clap::error::ErrorKind::MissingRequiredArgument,
+            "expected MissingRequiredArgument; got {:?}",
+            err.kind()
+        );
+    }
+
+    #[test]
+    fn review_with_json_flag_and_no_files_still_requires_files() {
+        // --json must NOT bypass the required-files rule. This guards against
+        // an over-aggressive `required_unless_present_any = ["json"]` style
+        // fix that would re-introduce the silent-no-op surface.
+        use clap::Parser;
+        let res = Args::try_parse_from(["quorum", "review", "--json"]);
+        let err = res.err().expect("--json without files must still fail");
+        assert_eq!(err.kind(), clap::error::ErrorKind::MissingRequiredArgument);
+    }
+
+    #[test]
+    fn review_with_one_file_parses_successfully() {
+        // Positive control: pins that the constraint only fires on the truly
+        // empty case, not on every invocation.
+        use clap::Parser;
+        let args = Args::parse_from(["quorum", "review", "/tmp/x.rs"]);
+        match args.command {
+            Command::Review(opts) => assert_eq!(opts.files.len(), 1),
+            _ => panic!("Expected Review command"),
+        }
+    }
+
+    // --- Issue #79 regression guards ---------------------------------------
+    //
+    // ContextIndexOpts and ContextRefreshOpts already declare
+    // `conflicts_with` for --source/--all (src/cli/mod.rs:135-156). These
+    // tests exist to prevent silent regression of that fix; they pass on
+    // current main and would fail if the annotation is dropped.
+
+    #[test]
+    fn regression_guard_79_index_rejects_source_and_all() {
+        use clap::Parser;
+        let res = Args::try_parse_from([
+            "quorum", "context", "index", "--source", "foo", "--all",
+        ]);
+        let err = res.err().expect("index with both --source and --all must fail");
+        assert_eq!(
+            err.kind(),
+            clap::error::ErrorKind::ArgumentConflict,
+            "expected ArgumentConflict; got {:?}",
+            err.kind()
+        );
+    }
+
+    #[test]
+    fn regression_guard_79_refresh_rejects_source_and_all() {
+        use clap::Parser;
+        let res = Args::try_parse_from([
+            "quorum", "context", "refresh", "--source", "foo", "--all",
+        ]);
+        let err = res.err().expect("refresh with both --source and --all must fail");
+        assert_eq!(err.kind(), clap::error::ErrorKind::ArgumentConflict);
+    }
+
+    #[test]
+    fn regression_guard_79_index_with_only_source_parses() {
+        // Positive control: --source alone must NOT trip the conflict rule.
+        use clap::Parser;
+        let res = Args::try_parse_from(["quorum", "context", "index", "--source", "foo"]);
+        assert!(
+            res.is_ok(),
+            "single-flag invocation must parse; got {:?}",
+            res.err().map(|e| e.kind())
+        );
+    }
+
+    #[test]
+    fn regression_guard_79_index_with_only_all_parses() {
+        use clap::Parser;
+        let res = Args::try_parse_from(["quorum", "context", "index", "--all"]);
+        assert!(
+            res.is_ok(),
+            "single-flag invocation must parse; got {:?}",
+            res.err().map(|e| e.kind())
+        );
     }
 }

--- a/src/cli_io.rs
+++ b/src/cli_io.rs
@@ -31,29 +31,41 @@ pub fn write_cmd_output<W: Write, E: Write>(
     err: &mut E,
     cmd: &CmdOutput,
 ) -> i32 {
+    // Capture the exit code from the first stdout error (if any) but do NOT
+    // return early — warnings still need to reach stderr regardless of the
+    // stdout state. The pre-extraction inline code in `run_context` had this
+    // property (warnings were emitted via `eprintln!` after `let _ = …` on
+    // stdout); preserving it keeps the CLI contract stable. CodeRabbit
+    // PR #106 caught the regression where an early return hid warnings on
+    // BrokenPipe / EIO.
+    let mut early_exit: Option<i32> = None;
+
     if !cmd.stdout.is_empty() {
         if let Err(e) = out.write_all(cmd.stdout.as_bytes()) {
-            return classify(&e, err);
-        }
-        if !cmd.stdout.ends_with('\n')
+            early_exit = Some(classify(&e, err));
+        } else if !cmd.stdout.ends_with('\n')
             && let Err(e) = out.write_all(b"\n")
         {
-            return classify(&e, err);
+            early_exit = Some(classify(&e, err));
         }
     }
-    if let Err(e) = out.flush() {
-        return classify(&e, err);
+    if early_exit.is_none()
+        && let Err(e) = out.flush()
+    {
+        early_exit = Some(classify(&e, err));
     }
     for w in &cmd.warnings {
         // err is the diagnostic channel; if it itself fails there's nothing
         // useful to do.
         let _ = writeln!(err, "{}", w);
     }
-    if cmd.doctor_failed.unwrap_or(false) {
-        1
-    } else {
-        0
-    }
+    early_exit.unwrap_or_else(|| {
+        if cmd.doctor_failed.unwrap_or(false) {
+            1
+        } else {
+            0
+        }
+    })
 }
 
 /// Map an I/O error from the stdout channel into an exit code, emitting a
@@ -245,6 +257,60 @@ mod tests {
         assert_eq!(
             s, "first\nsecond\n",
             "warnings must be one-per-line on stderr; got: {s:?}"
+        );
+    }
+
+    #[test]
+    fn warnings_are_emitted_even_when_stdout_write_fails() {
+        // CodeRabbit PR #106: returning early from classify() hid warnings on
+        // the error path. Pin the contract: warnings always reach stderr,
+        // independent of stdout state.
+        let mut out = WriteFailingWriter {
+            kind: io::ErrorKind::Other,
+        };
+        let mut err: Vec<u8> = Vec::new();
+        let cmd = CmdOutput {
+            stdout: "hello".into(),
+            warnings: vec!["important warning".into()],
+            ..Default::default()
+        };
+        let code = write_cmd_output(&mut out, &mut err, &cmd);
+        assert_eq!(code, 1, "non-BrokenPipe stdout error must still yield 1");
+        let s = String::from_utf8_lossy(&err);
+        assert!(
+            s.contains("failed to write"),
+            "stderr must contain the write-error diagnostic; got: {s}"
+        );
+        assert!(
+            s.contains("important warning"),
+            "stderr must still contain the warning even when stdout failed; got: {s}"
+        );
+    }
+
+    #[test]
+    fn warnings_are_emitted_even_on_broken_pipe() {
+        // BrokenPipe is the silent-success path, but warnings must still reach
+        // stderr — they are diagnostic info, not part of the rendered output
+        // that the broken-pipe consumer rejected.
+        let mut out = WriteFailingWriter {
+            kind: io::ErrorKind::BrokenPipe,
+        };
+        let mut err: Vec<u8> = Vec::new();
+        let cmd = CmdOutput {
+            stdout: "hello".into(),
+            warnings: vec!["still important".into()],
+            ..Default::default()
+        };
+        let code = write_cmd_output(&mut out, &mut err, &cmd);
+        assert_eq!(code, 0);
+        let s = String::from_utf8_lossy(&err);
+        assert!(
+            !s.contains("failed to write"),
+            "BrokenPipe must not emit the write-error diagnostic; got: {s}"
+        );
+        assert!(
+            s.contains("still important"),
+            "warnings must reach stderr on BrokenPipe; got: {s}"
         );
     }
 

--- a/src/cli_io.rs
+++ b/src/cli_io.rs
@@ -35,10 +35,10 @@ pub fn write_cmd_output<W: Write, E: Write>(
         if let Err(e) = out.write_all(cmd.stdout.as_bytes()) {
             return classify(&e, err);
         }
-        if !cmd.stdout.ends_with('\n') {
-            if let Err(e) = out.write_all(b"\n") {
-                return classify(&e, err);
-            }
+        if !cmd.stdout.ends_with('\n')
+            && let Err(e) = out.write_all(b"\n")
+        {
+            return classify(&e, err);
         }
     }
     if let Err(e) = out.flush() {

--- a/src/cli_io.rs
+++ b/src/cli_io.rs
@@ -1,0 +1,261 @@
+//! Stdio shim for command handlers.
+//!
+//! `write_cmd_output` is the centralized exit-code rule for `quorum context …`
+//! (and any future subcommand that returns a `CmdOutput`). It exists so the
+//! pipe-handling logic is testable without touching real stdio.
+//!
+//! Issue #84: previous inline implementation in `run_context` swallowed every
+//! `write_all`/`flush` error with `let _ = …`. That was correct for `BrokenPipe`
+//! (the user piped to `head` and closed the reader early — exit 0 is fine) but
+//! silently hid `EIO` / `ENOSPC`, so a redirect to a failing filesystem looked
+//! successful. We now distinguish the two.
+
+use std::io::{self, Write};
+
+use crate::context::cli::CmdOutput;
+
+/// Write a command's rendered stdout + warnings, returning the process exit
+/// code.
+///
+/// Contract:
+/// - `BrokenPipe` on `out` (write or flush) → exit 0, no diagnostic. The
+///   downstream consumer chose to stop reading; that is not a failure.
+/// - Any other I/O error on `out` → write `error: failed to write output: {e}`
+///   to `err` and return 1. This surfaces `EIO`/`ENOSPC`/etc.
+/// - On success, return 1 if `cmd.doctor_failed == Some(true)`, else 0.
+///
+/// Errors writing to `err` (the diagnostic channel) are themselves swallowed
+/// — there is no useful recovery if both stdout and stderr are broken.
+pub fn write_cmd_output<W: Write, E: Write>(
+    out: &mut W,
+    err: &mut E,
+    cmd: &CmdOutput,
+) -> i32 {
+    if !cmd.stdout.is_empty() {
+        if let Err(e) = out.write_all(cmd.stdout.as_bytes()) {
+            return classify(&e, err);
+        }
+        if !cmd.stdout.ends_with('\n') {
+            if let Err(e) = out.write_all(b"\n") {
+                return classify(&e, err);
+            }
+        }
+    }
+    if let Err(e) = out.flush() {
+        return classify(&e, err);
+    }
+    for w in &cmd.warnings {
+        // err is the diagnostic channel; if it itself fails there's nothing
+        // useful to do.
+        let _ = writeln!(err, "{}", w);
+    }
+    if cmd.doctor_failed.unwrap_or(false) {
+        1
+    } else {
+        0
+    }
+}
+
+/// Map an I/O error from the stdout channel into an exit code, emitting a
+/// diagnostic to `err` for non-`BrokenPipe` cases.
+fn classify<E: Write>(e: &io::Error, err: &mut E) -> i32 {
+    if e.kind() == io::ErrorKind::BrokenPipe {
+        0
+    } else {
+        let _ = writeln!(err, "error: failed to write output: {}", e);
+        1
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io;
+
+    /// Test double: returns the configured `ErrorKind` from every `write` and
+    /// reports `flush` as success. Models EIO/ENOSPC/BrokenPipe on the write
+    /// path.
+    struct WriteFailingWriter {
+        kind: io::ErrorKind,
+    }
+    impl Write for WriteFailingWriter {
+        fn write(&mut self, _buf: &[u8]) -> io::Result<usize> {
+            Err(io::Error::new(self.kind, "simulated write failure"))
+        }
+        fn flush(&mut self) -> io::Result<()> {
+            Ok(())
+        }
+    }
+
+    /// Test double: writes succeed; flush returns the configured `ErrorKind`.
+    /// Models `tee`-style pipelines that fail only on flush.
+    struct FlushFailingWriter {
+        kind: io::ErrorKind,
+    }
+    impl Write for FlushFailingWriter {
+        fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+            Ok(buf.len())
+        }
+        fn flush(&mut self) -> io::Result<()> {
+            Err(io::Error::new(self.kind, "simulated flush failure"))
+        }
+    }
+
+    fn cmd_with_stdout(s: &str) -> CmdOutput {
+        CmdOutput {
+            stdout: s.into(),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn broken_pipe_on_write_returns_zero_and_emits_no_error() {
+        let mut out = WriteFailingWriter {
+            kind: io::ErrorKind::BrokenPipe,
+        };
+        let mut err: Vec<u8> = Vec::new();
+        let cmd = cmd_with_stdout("hello");
+        let code = write_cmd_output(&mut out, &mut err, &cmd);
+        assert_eq!(code, 0, "BrokenPipe must yield exit 0");
+        assert!(
+            err.is_empty(),
+            "BrokenPipe must not emit a diagnostic; got: {:?}",
+            String::from_utf8_lossy(&err)
+        );
+    }
+
+    #[test]
+    fn non_broken_pipe_write_error_returns_one_and_prints_to_stderr() {
+        // Issue #84: this is the bug being fixed. Pre-fix, the Ok arm of
+        // run_context silently dropped EIO and exited 0. Now we expect 1.
+        let mut out = WriteFailingWriter {
+            kind: io::ErrorKind::Other,
+        };
+        let mut err: Vec<u8> = Vec::new();
+        let cmd = cmd_with_stdout("hello");
+        let code = write_cmd_output(&mut out, &mut err, &cmd);
+        assert_eq!(code, 1, "non-BrokenPipe I/O error must yield exit 1");
+        let s = String::from_utf8_lossy(&err);
+        assert!(
+            s.contains("failed to write"),
+            "stderr must explain the failure to the user; got: {s}"
+        );
+    }
+
+    #[test]
+    fn flush_error_non_broken_pipe_returns_one() {
+        // Mirror of the write-path EIO test for flush. Pre-fix, flush errors
+        // were silently dropped via `let _ = handle.flush();`. Now we expect
+        // the same surface as a write failure.
+        let mut out = FlushFailingWriter {
+            kind: io::ErrorKind::Other,
+        };
+        let mut err: Vec<u8> = Vec::new();
+        let cmd = cmd_with_stdout("hello");
+        let code = write_cmd_output(&mut out, &mut err, &cmd);
+        assert_eq!(code, 1, "flush EIO must yield exit 1");
+        let s = String::from_utf8_lossy(&err);
+        assert!(
+            s.contains("failed to write"),
+            "flush failure stderr must explain the failure; got: {s}"
+        );
+    }
+
+    #[test]
+    fn flush_error_broken_pipe_returns_zero() {
+        let mut out = FlushFailingWriter {
+            kind: io::ErrorKind::BrokenPipe,
+        };
+        let mut err: Vec<u8> = Vec::new();
+        let cmd = cmd_with_stdout("hello");
+        let code = write_cmd_output(&mut out, &mut err, &cmd);
+        assert_eq!(code, 0, "BrokenPipe on flush must still be silent");
+        assert!(err.is_empty(), "BrokenPipe must not emit a diagnostic");
+    }
+
+    #[test]
+    fn successful_write_with_doctor_failed_true_returns_one() {
+        // Pins the exit-code interaction with issue #73 (typed doctor result).
+        let mut out: Vec<u8> = Vec::new();
+        let mut err: Vec<u8> = Vec::new();
+        let cmd = CmdOutput {
+            stdout: "ok\n".into(),
+            doctor_failed: Some(true),
+            ..Default::default()
+        };
+        assert_eq!(write_cmd_output(&mut out, &mut err, &cmd), 1);
+        assert!(err.is_empty(), "doctor-failed alone must not emit stderr");
+    }
+
+    #[test]
+    fn successful_write_with_no_doctor_status_returns_zero() {
+        let mut out: Vec<u8> = Vec::new();
+        let mut err: Vec<u8> = Vec::new();
+        let cmd = CmdOutput {
+            stdout: "ok\n".into(),
+            doctor_failed: None,
+            ..Default::default()
+        };
+        assert_eq!(write_cmd_output(&mut out, &mut err, &cmd), 0);
+        assert_eq!(
+            std::str::from_utf8(&out).unwrap(),
+            "ok\n",
+            "rendered stdout must be written verbatim"
+        );
+        assert!(err.is_empty());
+    }
+
+    #[test]
+    fn appends_trailing_newline_when_stdout_lacks_one() {
+        // run_context's prior contract: write a trailing \n if non-empty stdout
+        // does not end with one. Pin this so the helper extraction doesn't drop
+        // it.
+        let mut out: Vec<u8> = Vec::new();
+        let mut err: Vec<u8> = Vec::new();
+        let cmd = cmd_with_stdout("no-newline");
+        write_cmd_output(&mut out, &mut err, &cmd);
+        let s = std::str::from_utf8(&out).unwrap();
+        assert!(
+            s.ends_with('\n'),
+            "trailing newline must be appended; got: {s:?}"
+        );
+        assert_eq!(s, "no-newline\n");
+    }
+
+    #[test]
+    fn does_not_append_extra_newline_when_present() {
+        let mut out: Vec<u8> = Vec::new();
+        let mut err: Vec<u8> = Vec::new();
+        let cmd = cmd_with_stdout("has-newline\n");
+        write_cmd_output(&mut out, &mut err, &cmd);
+        assert_eq!(std::str::from_utf8(&out).unwrap(), "has-newline\n");
+    }
+
+    #[test]
+    fn warnings_are_written_to_err_one_per_line() {
+        let mut out: Vec<u8> = Vec::new();
+        let mut err: Vec<u8> = Vec::new();
+        let cmd = CmdOutput {
+            stdout: "ok\n".into(),
+            warnings: vec!["first".into(), "second".into()],
+            ..Default::default()
+        };
+        write_cmd_output(&mut out, &mut err, &cmd);
+        let s = std::str::from_utf8(&err).unwrap();
+        assert_eq!(
+            s, "first\nsecond\n",
+            "warnings must be one-per-line on stderr; got: {s:?}"
+        );
+    }
+
+    #[test]
+    fn empty_stdout_writes_nothing_no_trailing_newline() {
+        // Match prior contract: `if !out.stdout.is_empty() && !ends_with('\n')`.
+        // An empty stdout produces no output at all.
+        let mut out: Vec<u8> = Vec::new();
+        let mut err: Vec<u8> = Vec::new();
+        let cmd = cmd_with_stdout("");
+        write_cmd_output(&mut out, &mut err, &cmd);
+        assert!(out.is_empty(), "empty stdout must produce no bytes");
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -495,10 +495,9 @@ fn deep_tool_root(file_path: &std::path::Path) -> std::path::PathBuf {
 }
 
 fn run_review(opts: cli::ReviewOpts) -> i32 {
-    if opts.files.is_empty() {
-        eprintln!("Error: No files specified");
-        return 3;
-    }
+    // The empty-files case is now rejected at the clap layer via
+    // `#[arg(required = true, num_args = 1..)]` on `ReviewOpts.files`
+    // (issue #89). The redundant handler-level guard was removed.
 
     // Initialize structured tracing if --trace flag or QUORUM_TRACE=1 env var
     let trace_enabled = opts.trace || std::env::var("QUORUM_TRACE").map(|v| v == "1").unwrap_or(false);

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,7 @@ mod cache;
 mod calibrator;
 mod calibrator_trace;
 mod cli;
+mod cli_io;
 mod config;
 mod context;
 mod context_enrichment;
@@ -290,7 +291,6 @@ fn run_context(opts: cli::ContextOpts) -> i32 {
         IndexArgs, ListArgs, ListFormat, ProdDeps, PruneArgs, QueryArgs, QueryFormat,
         RefreshArgs, SourceSelector,
     };
-    use std::io::Write;
 
     // Map `--source X` / `--all` / neither into a SourceSelector. The default
     // when both are absent is `All` to match the handler's natural semantics
@@ -394,27 +394,15 @@ fn run_context(opts: cli::ContextOpts) -> i32 {
 
     match run_context_cmd(&cmd, &deps) {
         Ok(out) => {
-            // Match the signal-safe stdout pattern used elsewhere: write via
-            // a locked handle and flush. We deliberately ignore write errors
-            // (e.g. BrokenPipe from `| head`) so exit code reflects the
-            // handler result rather than the downstream consumer.
+            // Centralized stdout handling lives in `cli_io::write_cmd_output`:
+            // BrokenPipe stays silent (downstream consumer closed early) but
+            // EIO/ENOSPC etc. are surfaced to stderr with exit 1 (issue #84).
+            // doctor_failed propagation preserved (issue #73).
             let stdout = std::io::stdout();
-            let mut handle = stdout.lock();
-            let _ = handle.write_all(out.stdout.as_bytes());
-            if !out.stdout.is_empty() && !out.stdout.ends_with('\n') {
-                let _ = handle.write_all(b"\n");
-            }
-            let _ = handle.flush();
-            for w in &out.warnings {
-                eprintln!("{}", w);
-            }
-            // `doctor` populates `CmdOutput.doctor_failed` with the typed
-            // result of the any-fail computation; non-doctor commands leave
-            // it as `None` so this branch is a no-op for them (issue #73).
-            if out.doctor_failed.unwrap_or(false) {
-                return 1;
-            }
-            0
+            let stderr = std::io::stderr();
+            let mut out_handle = stdout.lock();
+            let mut err_handle = stderr.lock();
+            cli_io::write_cmd_output(&mut out_handle, &mut err_handle, &out)
         }
         Err(e) => {
             eprintln!("error: {}", e);

--- a/tests/cli_context_stdout_handling.rs
+++ b/tests/cli_context_stdout_handling.rs
@@ -25,9 +25,9 @@ fn quorum_bin() -> std::path::PathBuf {
 /// the real `write_cmd_output` path. The child must exit 0 (not panic, not 1).
 #[test]
 fn context_list_with_closed_stdout_exits_zero() {
-    let home = TempDir::new().unwrap();
+    let home = TempDir::new().expect("failed to create temp dir for QUORUM_HOME");
     let qhome = home.path().join(".quorum");
-    std::fs::create_dir_all(&qhome).unwrap();
+    std::fs::create_dir_all(&qhome).expect("failed to create .quorum directory");
 
     let mut child = Command::new(quorum_bin())
         .env("QUORUM_HOME", qhome.as_os_str())
@@ -73,9 +73,9 @@ fn context_list_with_closed_stdout_exits_zero() {
 /// not over-eagerly translating success into errors.
 #[test]
 fn context_list_with_open_stdout_exits_zero_and_writes_to_stdout() {
-    let home = TempDir::new().unwrap();
+    let home = TempDir::new().expect("failed to create temp dir for QUORUM_HOME");
     let qhome = home.path().join(".quorum");
-    std::fs::create_dir_all(&qhome).unwrap();
+    std::fs::create_dir_all(&qhome).expect("failed to create .quorum directory");
 
     let mut child = Command::new(quorum_bin())
         .env("QUORUM_HOME", qhome.as_os_str())

--- a/tests/cli_context_stdout_handling.rs
+++ b/tests/cli_context_stdout_handling.rs
@@ -36,13 +36,13 @@ fn context_list_with_closed_stdout_exits_zero() {
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
         .spawn()
-        .expect("spawn quorum");
+        .expect("failed to spawn quorum binary");
 
     // Drop the stdout pipe immediately. The child's first write_all should
     // see EPIPE -> the helper translates to exit 0 silently.
     drop(child.stdout.take());
 
-    let status = child.wait().expect("wait");
+    let status = child.wait().expect("failed to wait for quorum child");
     assert!(
         status.success(),
         "BrokenPipe on stdout must yield exit 0; got {status:?}"
@@ -66,7 +66,7 @@ fn context_list_with_open_stdout_exits_zero_and_writes_to_stdout() {
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
         .spawn()
-        .expect("spawn quorum");
+        .expect("failed to spawn quorum binary");
 
     // Drain stdout to EOF so the child can flush successfully.
     let mut stdout_buf = Vec::new();
@@ -75,15 +75,15 @@ fn context_list_with_open_stdout_exits_zero_and_writes_to_stdout() {
         .take()
         .unwrap()
         .read_to_end(&mut stdout_buf)
-        .expect("read stdout");
+        .expect("failed to drain quorum stdout");
     let mut stderr_buf = Vec::new();
     child
         .stderr
         .take()
         .unwrap()
         .read_to_end(&mut stderr_buf)
-        .expect("read stderr");
-    let status = child.wait().expect("wait");
+        .expect("failed to drain quorum stderr");
+    let status = child.wait().expect("failed to wait for quorum child");
 
     assert!(status.success(), "successful list must exit 0; got {status:?}");
     let stderr = String::from_utf8_lossy(&stderr_buf);

--- a/tests/cli_context_stdout_handling.rs
+++ b/tests/cli_context_stdout_handling.rs
@@ -1,0 +1,98 @@
+//! Integration tests for `run_context`'s stdout handling (issue #84).
+//!
+//! These prove the binary actually invokes `cli_io::write_cmd_output`. The
+//! pure unit tests in `src/cli_io.rs` cover the helper's branching logic;
+//! this file kills the "forgot to wire helper" mutation by running the real
+//! binary and observing end-to-end behavior.
+
+use std::io::Read;
+use std::process::{Command, Stdio};
+use tempfile::TempDir;
+
+fn quorum_bin() -> std::path::PathBuf {
+    // Same env var assert_cmd uses; cargo sets it for the integration target.
+    let mut path = std::path::PathBuf::from(env!("CARGO_BIN_EXE_quorum"));
+    if !path.exists() {
+        // Fall back to assert_cmd's lookup if the env var isn't honored on
+        // some toolchains.
+        path = assert_cmd::cargo::cargo_bin("quorum");
+    }
+    path
+}
+
+/// Run `quorum context list` with stdout piped to a reader that closes
+/// immediately. This forces a `BrokenPipe` on the child's stdout, exercising
+/// the real `write_cmd_output` path. The child must exit 0 (not panic, not 1).
+#[test]
+fn context_list_with_closed_stdout_exits_zero() {
+    let home = TempDir::new().unwrap();
+    let qhome = home.path().join(".quorum");
+    std::fs::create_dir_all(&qhome).unwrap();
+
+    let mut child = Command::new(quorum_bin())
+        .env("QUORUM_HOME", qhome.as_os_str())
+        .env_remove("QUORUM_API_KEY")
+        .args(["context", "list"])
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn quorum");
+
+    // Drop the stdout pipe immediately. The child's first write_all should
+    // see EPIPE -> the helper translates to exit 0 silently.
+    drop(child.stdout.take());
+
+    let status = child.wait().expect("wait");
+    assert!(
+        status.success(),
+        "BrokenPipe on stdout must yield exit 0; got {status:?}"
+    );
+}
+
+/// Sanity: with stdout fully consumed, `context list` exits 0 and writes
+/// nothing to stderr (no warnings on a fresh QUORUM_HOME). This is the
+/// "happy path" companion to the BrokenPipe test — proves the helper is
+/// not over-eagerly translating success into errors.
+#[test]
+fn context_list_with_open_stdout_exits_zero_and_writes_to_stdout() {
+    let home = TempDir::new().unwrap();
+    let qhome = home.path().join(".quorum");
+    std::fs::create_dir_all(&qhome).unwrap();
+
+    let mut child = Command::new(quorum_bin())
+        .env("QUORUM_HOME", qhome.as_os_str())
+        .env_remove("QUORUM_API_KEY")
+        .args(["context", "list"])
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn quorum");
+
+    // Drain stdout to EOF so the child can flush successfully.
+    let mut stdout_buf = Vec::new();
+    child
+        .stdout
+        .take()
+        .unwrap()
+        .read_to_end(&mut stdout_buf)
+        .expect("read stdout");
+    let mut stderr_buf = Vec::new();
+    child
+        .stderr
+        .take()
+        .unwrap()
+        .read_to_end(&mut stderr_buf)
+        .expect("read stderr");
+    let status = child.wait().expect("wait");
+
+    assert!(status.success(), "successful list must exit 0; got {status:?}");
+    let stderr = String::from_utf8_lossy(&stderr_buf);
+    assert!(
+        !stderr.contains("failed to write"),
+        "happy path must not emit write-error diagnostic; got: {stderr}"
+    );
+    // Don't pin exact stdout content — `context list` formatting is a moving
+    // target. Just ensure something was written, proving the helper is wired
+    // and not silently dropping output.
+    let _ = stdout_buf;
+}

--- a/tests/cli_context_stdout_handling.rs
+++ b/tests/cli_context_stdout_handling.rs
@@ -42,6 +42,24 @@ fn context_list_with_closed_stdout_exits_zero() {
     // see EPIPE -> the helper translates to exit 0 silently.
     drop(child.stdout.take());
 
+    // Drain stderr so the child can flush + exit; also lets us assert that
+    // the BrokenPipe path does NOT emit the "failed to write output:"
+    // diagnostic (which would be a regression of the helper's classify rule).
+    // CodeRabbit PR #106 noted the original test didn't catch a regression
+    // where classify() mistakenly wrote on BrokenPipe.
+    let mut stderr_buf = Vec::new();
+    child
+        .stderr
+        .take()
+        .unwrap()
+        .read_to_end(&mut stderr_buf)
+        .expect("failed to drain quorum stderr");
+    let stderr = String::from_utf8_lossy(&stderr_buf);
+    assert!(
+        !stderr.contains("failed to write"),
+        "BrokenPipe must not emit the write-error diagnostic; got stderr: {stderr}"
+    );
+
     let status = child.wait().expect("failed to wait for quorum child");
     assert!(
         status.success(),
@@ -91,8 +109,11 @@ fn context_list_with_open_stdout_exits_zero_and_writes_to_stdout() {
         !stderr.contains("failed to write"),
         "happy path must not emit write-error diagnostic; got: {stderr}"
     );
-    // Don't pin exact stdout content — `context list` formatting is a moving
-    // target. Just ensure something was written, proving the helper is wired
-    // and not silently dropping output.
-    let _ = stdout_buf;
+    // Pin that the helper actually wrote something (CodeRabbit PR #106). A
+    // mutation that drops the `out.write_all(cmd.stdout.as_bytes())` call
+    // would still pass an exit-code-only assertion.
+    assert!(
+        !stdout_buf.is_empty(),
+        "context list must produce stdout output; got empty buffer"
+    );
 }

--- a/tests/cli_context_stdout_handling.rs
+++ b/tests/cli_context_stdout_handling.rs
@@ -67,10 +67,13 @@ fn context_list_with_closed_stdout_exits_zero() {
     );
 }
 
-/// Sanity: with stdout fully consumed, `context list` exits 0 and writes
-/// nothing to stderr (no warnings on a fresh QUORUM_HOME). This is the
-/// "happy path" companion to the BrokenPipe test — proves the helper is
-/// not over-eagerly translating success into errors.
+/// Sanity: with stdout fully consumed, `context list` exits 0 and does not
+/// emit a write-error diagnostic on stderr. (stderr may legitimately contain
+/// a warning on a fresh QUORUM_HOME — e.g. "sources.toml not found" — which
+/// the helper routes there per contract; the assertion below only forbids
+/// the specific "failed to write" diagnostic.) This is the "happy path"
+/// companion to the BrokenPipe test — proves the helper is not over-eagerly
+/// translating success into errors.
 #[test]
 fn context_list_with_open_stdout_exits_zero_and_writes_to_stdout() {
     let home = TempDir::new().expect("failed to create temp dir for QUORUM_HOME");


### PR DESCRIPTION
## Summary

Three small CLI/diagnostic fixes from quorum self-review on the external-feedback branch. Bundled because they all live in `src/main.rs` / `src/cli/mod.rs` and share the same TDD/test-style.

| Issue | Severity | Type |
|-------|----------|------|
| #84   | HIGH (correctness) | Real bug — stdout write errors silently dropped |
| #89   | HIGH (correctness) | Real bug — clap accepts zero files for `review` |
| #79   | HIGH (correctness) | Already fixed by prior `conflicts_with` work — added regression guards |

Plans recorded in `docs/plans/v0.17.2-cli-hardening-tests.md` (test plan) and `docs/plans/v0.17.2-antipattern-review.md` (pre-RED antipattern audit).

## #84 — non-BrokenPipe stdout write errors silently dropped

**Bug.** `run_context`'s success arm used `let _ = handle.write_all(...)` followed by `let _ = handle.flush()`. The intent was to swallow `BrokenPipe` (downstream `| head`-style consumers closing the reader early — exit 0 is fine). But the same `let _ =` also masked `EIO` and `ENOSPC` from a redirect to a failing filesystem, so the command exited 0 even though it didn't deliver its output. Automation treated those failures as success.

**Fix.** Extract `cli_io::write_cmd_output(out, err, cmd) -> i32`. The helper:

- Returns 0 silently on `BrokenPipe` (write or flush).
- Returns 1 with `error: failed to write output: {e}` on stderr for any other I/O error.
- Preserves the issue #73 contract for `doctor_failed`.
- Preserves the trailing-newline rule and the "warnings on stderr, one per line" behavior.

`run_context`'s 14-line inline block becomes a single helper call.

**Tests** (12 total for #84):
- 10 in-process unit tests with `WriteFailingWriter` / `FlushFailingWriter` doubles cover the helper's branching: BrokenPipe-on-write, EIO-on-write, BrokenPipe-on-flush, EIO-on-flush, doctor_failed propagation, newline appending, warnings routing, empty-stdout no-op.
- 2 subprocess integration tests (`tests/cli_context_stdout_handling.rs`) prove `run_context` actually invokes the helper — without them, a "forgot to wire helper into run_context" mutation would leave every unit test green.

## #89 — `quorum review` accepted zero files

**Bug.** `ReviewOpts.files: Vec<PathBuf>` had no `required` constraint. `quorum review` (with zero files) parsed successfully and the handler short-circuited with `eprintln!("Error: No files specified"); return 3`. That's a usage error (exit 2), not a tool error (exit 3) — and the contract belongs at the parsing layer so the user gets clap's standard message + a `--help` hint.

**Fix.** `#[arg(required = true, num_args = 1..)]` on `ReviewOpts.files`. Removed the now-dead handler-level guard.

**Tests:** 3 in-process tests via `Args::try_parse_from` + `ErrorKind::MissingRequiredArgument`:
- zero files → MissingRequiredArgument
- `--json` + zero files still requires files (catches `required_unless_present_any = ['json']` style mutations)
- one file parses (positive control)

## #79 — `--source X --all` regression guard

**Status.** Already fixed in the tree. `ContextIndexOpts` and `ContextRefreshOpts` declare bidirectional `conflicts_with` (`src/cli/mod.rs:135-156`). Closing #79 here adds 4 regression guards that pass on current main and would fail if the annotation is dropped:
- `index --source X --all` → ArgumentConflict
- `refresh --source X --all` → ArgumentConflict
- `index --source X` alone → Ok (positive control)
- `index --all` alone → Ok (positive control)

Tests are honestly named `regression_guard_79_*` so reviewers don't look for a code change that doesn't exist.

## Verification

- 1507 unit tests pass (was 1490 — 17 new: 10 cli_io + 3 #89 + 4 #79)
- 49 integration tests pass across 11 test files (2 new: #84 wiring tests)
- `cargo build --release` clean
- `cargo clippy --bin quorum` clean on changed files (one collapsible-if fix in `cli_io.rs`)
- `quorum review` self-review on the diff: 0 findings on production code; 1 LOW (test `.expect()` messages) addressed in commit 67ebe4c

## Test plan

- [x] cargo test --bin quorum
- [x] cargo test (integration)
- [x] cargo build --release
- [x] cargo clippy --bin quorum
- [x] quorum review on src/cli_io.rs, src/main.rs run_context excerpt, src/cli/mod.rs ReviewOpts excerpt
- [x] Recorded post_fix feedback for the LOW expect-empty-message finding

Closes #89
Closes #84
Closes #79

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * CLI now silently ignores broken-pipe stdout writes, reports other write/flush errors with clear diagnostics, and sets exit codes consistently.
  * Argument parsing enforces required files and mutual-exclusion flags at parse time, preventing runtime handler errors.

* **Tests**
  * Added unit and integration tests covering stdout/stderr write/flush behavior, exit-code interactions, and argument-parsing regressions.

* **Documentation**
  * Added test-strategy and TDD plans guiding CLI hardening and regression coverage.

* **Chores**
  * Declared minimum Rust toolchain version (1.88).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->