### PR TITLE
fix(pipeline): convert acquire_llm_permit + review fns to async (#81)

### DIFF
--- a/docs/plans/2026-04-25-issue-81-async-permit.md
+++ b/docs/plans/2026-04-25-issue-81-async-permit.md
@@ -1,0 +1,629 @@
+# Issue #81 — Async permit acquisition (deadlock fix)
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:test-driven-development for each task. Write the failing test, watch it fail for the documented reason, write minimal code, watch it pass, commit.
+
+**Goal:** Eliminate the cross-runtime deadlock in `pipeline::acquire_llm_permit` by converting permit acquisition (and the three review functions that call it) from sync-with-runtime-detection to async-throughout.
+
+**Architecture:** Replace the `MultiThread`/`CurrentThread` runtime-flavor switch (which uses `block_in_place` on multi-thread and `std::thread::scope` + a fresh runtime + `join()` on current-thread) with a single `async fn` that simply `.await`s `Semaphore::acquire_owned`. The current-thread `join()` is the deadlock root cause — when the calling runtime owns the permit holder, blocking its only worker at `join()` prevents the holder from ever running, and the spawned helper runtime awaits forever. Removing the cross-runtime blocking dance eliminates the deadlock by construction. The three callers (`review_file`, `review_source`, `review_file_llm_only`) become `async fn`; downstream call sites either `.await` directly (CLI serial, daemon, MCP handler — all already in async contexts) or wrap in `Handle::current().block_on(async { ... })` inside the existing `spawn_blocking` thread (CLI parallel — `block_on` on a blocking-pool thread is safe per Tokio docs).
+
+**Tech Stack:** Rust 1.88, Tokio (async runtime + Semaphore), `async_trait` (already in use for `ServerHandler`), `#[tokio::test]` for regression coverage.
+
+**Out of scope (will be filed as follow-ups):**
+- Offloading the sync `LlmReviewer::review` (~12-20s reqwest::blocking call) into `spawn_blocking` to free the runtime worker. Pre-existing concern — this PR doesn't make it worse.
+- `review_file_llm_only` doesn't use the `context7_skip_reason` helper that `review_file` uses. Drift, not a deadlock issue.
+
+---
+
+## Task 1: RED — current-thread regression test (proves the deadlock)
+
+**Files:**
+- Modify: `src/pipeline.rs` (test module at the bottom — append a new test fn)
+
+**Why this test:** The existing `acquire_llm_permit_does_not_panic_inside_current_thread_runtime` only proves "doesn't panic" with a 1-permit-available semaphore. It does NOT exercise contention. The bug only manifests when the permit is *held by another task on the same current-thread runtime*. We need a test that reproduces that exact shape AND fails at runtime against the buggy code (not just at compile time).
+
+**Two-phase RED (per testing-antipatterns review):** First demonstrate the bug at runtime against the current SYNC API via a `spawn_blocking` shim — this gives a *runtime* failure (timeout) that proves the deadlock exists. Then post-fix, the test (with the shim removed) compiles and passes against the new ASYNC API.
+
+**Step 1a: Write the runtime-RED test (shimmed against current sync API)**
+
+Append to the existing `mod tests` (after the `acquire_llm_permit_does_not_panic_inside_multi_thread_runtime` test):
+
+```rust
+    /// Issue #81 regression: on a current-thread runtime, if the permit
+    /// holder is another task on the same runtime, the OLD synchronous
+    /// `acquire_llm_permit` deadlocks (it blocks the runtime worker at
+    /// `std::thread::scope.join()`, so the holder can never run and
+    /// release). Post-fix, async acquisition cooperatively yields and
+    /// the holder runs to completion.
+    ///
+    /// Uses `tokio::sync::Notify` (not `sleep`) for a deterministic
+    /// happens-before between holder.acquired and waiter.start —
+    /// avoids timing flakiness on slow CI.
+    #[tokio::test(flavor = "current_thread")]
+    async fn acquire_llm_permit_does_not_deadlock_under_contention_on_current_thread() {
+        use std::sync::Arc;
+        use std::time::Duration;
+        use tokio::sync::{Notify, Semaphore};
+
+        let sem = Arc::new(Semaphore::new(1));
+        let opt = Some(sem.clone());
+        let waiter_started = Arc::new(Notify::new());
+
+        // Holder: takes the only permit, waits for the waiter to be
+        // observably parked on acquire (Notify), then drops the permit.
+        let holder_sem = sem.clone();
+        let holder_signal = waiter_started.clone();
+        let holder = async move {
+            let _h = holder_sem.acquire_owned().await.unwrap();
+            holder_signal.notified().await;
+            // permit dropped at scope exit — waiter unparks
+        };
+
+        // Waiter: notifies "I'm about to acquire" then awaits permit.
+        // Pre-fix, this deadlocks: the waiter runs first under
+        // tokio::join!, so notify_one happens, but the SYNC
+        // acquire_llm_permit blocks the only worker at join() and the
+        // holder can never run.
+        let waiter_signal = waiter_started.clone();
+        let waiter = async move {
+            // Yield once so the holder gets the permit before we ask.
+            tokio::task::yield_now().await;
+            waiter_signal.notify_one();
+            acquire_llm_permit(&opt).await
+        };
+
+        // Wrap in a 5s timeout so a regression manifests as a fast
+        // test failure, not a hung CI job. Capture the waiter's
+        // result so the failure message is unambiguous.
+        let result = tokio::time::timeout(
+            Duration::from_secs(5),
+            async { tokio::join!(holder, waiter) },
+        )
+        .await;
+
+        let (_, waiter_permit) = result
+            .expect("deadlock regression: tokio::join! on current-thread \
+                     runtime did not complete within 5s — issue #81");
+        assert!(
+            waiter_permit.is_some(),
+            "waiter must receive a permit once the holder releases"
+        );
+    }
+```
+
+**Step 1b: Demonstrate runtime RED against current sync code (temporary shim)**
+
+The above test calls `acquire_llm_permit(&opt).await` — invalid against the current SYNC signature. To prove the test catches the runtime bug (not just the type system), temporarily replace that call inside the test body with a `spawn_blocking` shim that drives the SYNC API from a blocking-pool thread:
+
+```rust
+        // TEMPORARY SHIM (Task 2 removes): drive the current SYNC
+        // acquire_llm_permit from spawn_blocking so the test compiles.
+        let waiter = async move {
+            tokio::task::yield_now().await;
+            waiter_signal.notify_one();
+            tokio::task::spawn_blocking(move || acquire_llm_permit(&opt))
+                .await
+                .unwrap()
+        };
+```
+
+Run the test against the current sync code with this shim:
+
+```bash
+cargo test --bin quorum -- acquire_llm_permit_does_not_deadlock_under_contention_on_current_thread --nocapture
+```
+
+Expected: TIMEOUT FAILURE within 5s. The panic message should be:
+> deadlock regression: tokio::join! on current-thread runtime did not complete within 5s — issue #81
+
+This is the **runtime RED** — proves the deadlock exists, not just that the contract changed.
+
+**Step 1c: Revert the shim**
+
+After observing the timeout failure, REVERT the `spawn_blocking` shim — restore the direct `acquire_llm_permit(&opt).await` call. The test now does not compile against the sync code (Task 2 fixes that). Do not commit the shimmed version.
+
+**Step 2: Verify compile-fail against current code (final RED state)**
+
+Run: `cargo test --bin quorum -- acquire_llm_permit_does_not_deadlock_under_contention_on_current_thread`
+
+Expected: compile error — `.await` on a non-future. This is the documented RED for the new contract; runtime RED already established in Step 1b.
+
+**Step 3: Commit (RED checkpoint)**
+
+```bash
+git add src/pipeline.rs
+git commit -m "test(pipeline): add deadlock regression for issue #81
+
+Reproduces the cross-task deadlock on a current-thread runtime
+where the permit holder is another task on the same runtime.
+RED: does not compile against the current sync acquire_llm_permit
+(intentional - the test asserts the post-fix async contract).
+"
+```
+
+---
+
+## Task 2: GREEN — convert `acquire_llm_permit` to async
+
+**Files:**
+- Modify: `src/pipeline.rs:75-128` (function + docstring)
+
+**Step 1: Replace the function**
+
+Find the existing `fn acquire_llm_permit(...)` block (with the `MultiThread`/`_` match) and replace the whole thing — docstring included — with:
+
+```rust
+/// Acquire a semaphore permit if configured, awaiting cooperatively.
+///
+/// Returns an owned permit that is released on drop (RAII). When the
+/// semaphore is `None`, returns `None` immediately (no throttling).
+///
+/// Issue #81: pre-fix this was a sync helper that branched on the
+/// current Tokio runtime flavor — `block_in_place` on multi-thread,
+/// `std::thread::scope` + fresh runtime on current-thread. The
+/// current-thread branch deadlocked when the permit holder was
+/// another task on the *same* runtime: `join()` blocked the only
+/// worker, the holder never ran to release, the helper runtime
+/// awaited forever. The async shape eliminates that class of bug
+/// by construction — we just `.await` and let the runtime that
+/// owns the holder make progress.
+///
+/// Closed-semaphore (`acquire_owned` returns `Err`) degrades to
+/// `None`, mirroring the prior contract for "throttling can't
+/// work, don't crash the caller".
+async fn acquire_llm_permit(
+    sem: &Option<std::sync::Arc<tokio::sync::Semaphore>>,
+) -> Option<tokio::sync::OwnedSemaphorePermit> {
+    sem.as_ref()?.clone().acquire_owned().await.ok()
+}
+```
+
+The previous `use tokio::runtime::{Handle, RuntimeFlavor};` import inside the function disappears (it was the only consumer).
+
+**Step 2: Run the regression test**
+
+Run: `cargo test --bin quorum -- acquire_llm_permit_does_not_deadlock_under_contention_on_current_thread`
+
+Expected: still does not compile — callers of `acquire_llm_permit` are now using `.await` on a non-future site (the two call sites at lines ~561 and ~857 inside SYNC functions). This is correct; Task 3 fixes that.
+
+---
+
+## Task 3: GREEN — convert `review_file`, `review_source`, `review_file_llm_only` to async
+
+**Files:**
+- Modify: `src/pipeline.rs:323` (`pub fn review_file` → `pub async fn review_file`)
+- Modify: `src/pipeline.rs:561` (call site: `acquire_llm_permit(...)` → `acquire_llm_permit(...).await`)
+- Modify: `src/pipeline.rs:709` (`pub fn review_source` → `pub async fn review_source`)
+- Modify: `src/pipeline.rs:722` (`review_file(...)` → `review_file(...).await`)
+- Modify: `src/pipeline.rs:748` (`pub fn review_file_llm_only` → `pub async fn review_file_llm_only`)
+- Modify: `src/pipeline.rs:857` (call site: `acquire_llm_permit(...)` → `acquire_llm_permit(...).await`)
+
+**Step 1: Apply the six edits.** Mechanical: add `async` to the three `pub fn`, add `.await` to the three call sites. No body restructuring.
+
+**Step 2: Run the regression test**
+
+Run: `cargo test --bin quorum -- acquire_llm_permit_does_not_deadlock_under_contention_on_current_thread`
+
+Expected: still does not compile — main.rs and mcp/handler.rs and http_server.rs callers now see async functions. Task 4 wires those.
+
+**Step 3: Run cargo check to see all call-site breakage at once**
+
+Run: `cargo check --bin quorum 2>&1 | grep -E "error\[|^error:" | head -40`
+
+Expected output: errors at the call sites in `main.rs`, `mcp/handler.rs`, `http_server.rs`, plus the existing test sites in `pipeline.rs` (deep-review etc.). Use this list as the work-set for Task 4.
+
+---
+
+## Task 4: GREEN — wire all call sites
+
+**Files (in order of fix):**
+- Modify: `src/http_server.rs:118` (already in `async fn review`, just add `.await`)
+- Modify: `src/mcp/handler.rs:88` (`fn handle_review` → `async fn handle_review`, add `.await` at the `pipeline::review_source` call, update the dispatch in `handle_call_tool_request` at line ~378 to `.await` the changed handler)
+- Modify: `src/main.rs:855` (serial path: add `.await` directly — already in async fn main)
+- Modify: `src/main.rs:865` (serial path: add `.await` to `review_file_llm_only`)
+- Modify: `src/main.rs:916-980` (parallel path: wrap the existing `rt.spawn_blocking(move || ... review_source(...) ...)` so the body uses `tokio::runtime::Handle::current().block_on(async move { review_source(...).await })`)
+- Modify: existing test sites in `src/pipeline.rs:950, 1194, 1207, 1216, 1229, 1233, 1318` (these tests call `review_source`/`review_file` synchronously; convert each to `#[tokio::test]` with `.await` — flavor=multi_thread by default works fine here)
+- Modify: `src/context/phase6_integration_tests.rs:283, 311` (similar conversion)
+
+**Step 1: Fix daemon and MCP handler (smallest delta)**
+
+For `src/http_server.rs` line 118 area:
+
+```rust
+let result = pipeline::review_source(
+    std::path::Path::new(&req.file_path),
+    &req.code,
+    lang,
+    state.llm_reviewer.as_deref(),
+    &pipeline_cfg,
+    Some(&state.parse_cache),
+)
+.await
+.map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, format!("Review error: {}", e)))?;
+```
+
+For `src/mcp/handler.rs`:
+
+1. Change `fn handle_review` → `async fn handle_review`.
+2. Add `.await` after the `pipeline::review_source(...)` call inside.
+3. In `handle_call_tool_request` (line ~378), change `self.handle_review(tool)` → `self.handle_review(tool).await`.
+
+**Step 2: Fix CLI serial path (`main.rs:855` and `:865`)**
+
+```rust
+let review_result = if let Some(l) = lang {
+    pipeline::review_source(
+        file_path, &source, l, llm_reviewer, &pipeline_cfg, Some(&parse_cache),
+    ).await
+} else {
+    eprintln!("Note: No AST support for {}, using LLM-only review", file_path.display());
+    pipeline::review_file_llm_only(
+        file_path, &source, llm_reviewer, &pipeline_cfg,
+    ).await
+};
+```
+
+(Both at line ~855 and again at the second copy near line ~963.)
+
+**Step 3: Fix CLI parallel path (`main.rs:916-980`)**
+
+Inside the `rt.spawn_blocking(move || { ... })` closure body, the inner sync call:
+
+```rust
+let review_result = if let Some(l) = lang {
+    pipeline::review_source(&file_path, &source, l, llm_reviewer, &pipeline_cfg, Some(&parse_cache))
+} else {
+    pipeline::review_file_llm_only(&file_path, &source, llm_reviewer, &pipeline_cfg)
+};
+```
+
+becomes:
+
+```rust
+let handle = tokio::runtime::Handle::current();
+let review_result = handle.block_on(async {
+    if let Some(l) = lang {
+        pipeline::review_source(&file_path, &source, l, llm_reviewer, &pipeline_cfg, Some(&parse_cache)).await
+    } else {
+        pipeline::review_file_llm_only(&file_path, &source, llm_reviewer, &pipeline_cfg).await
+    }
+});
+```
+
+The deep-review path inside the same closure does NOT call our async functions (it uses `agent::agent_loop` which stays sync), so it's unchanged.
+
+**Add a brief inline comment justifying `block_on` inside `spawn_blocking`:**
+
+```rust
+// `spawn_blocking` runs on Tokio's blocking pool, NOT a runtime
+// worker, so `Handle::block_on` here is sound (per Tokio docs).
+// We deliberately keep the parsing/AST CPU work out of runtime
+// workers by retaining the spawn_blocking shell.
+```
+
+**Step 4: Convert pipeline.rs and phase6 tests**
+
+Each of these tests calls the now-async fns. Three-line change per test:
+- `#[test]` → `#[tokio::test(flavor = "multi_thread", worker_threads = 1)]`
+  (Default `#[tokio::test]` is current-thread, which can change cooperative-scheduling semantics for tests that previously assumed sync execution order. Pinning multi-thread/1-worker preserves sequential semantics while supporting `block_in_place`-style operations downstream.)
+- `fn ...()` → `async fn ...()`
+- Wrap test body call: `review_source(...)` → `review_source(...).await`
+
+Sites to update:
+- `src/pipeline.rs`: tests at lines 950, 1194, 1207, 1216, 1229, 1233, 1318 (use `cargo check --bin quorum` to enumerate exactly).
+- `src/context/phase6_integration_tests.rs`: lines 283, 311.
+
+**Step 4b: Add MCP handler async-dispatch regression test**
+
+The MCP handler change (`fn handle_review` → `async fn handle_review`, plus `.await` in `handle_call_tool_request`) is mechanical but high-leverage — that dispatch path was untested for async behavior. Add to `src/mcp/handler.rs` test module:
+
+```rust
+    /// Issue #81 followup: handle_review is now async; the dispatch
+    /// in handle_call_tool_request awaits it. This test exercises
+    /// the full handler -> async pipeline surface end-to-end through
+    /// the MCP tool boundary, asserting we don't reintroduce sync
+    /// dispatch in a future refactor.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn handle_review_is_async_and_dispatches_through_call_tool() {
+        // Build a handler with a no-op LLM reviewer (None) so the
+        // pipeline runs local-only — fast, no network.
+        let tmpdir = tempfile::tempdir().unwrap();
+        let store = std::sync::Arc::new(crate::feedback::FeedbackStore::new(
+            tmpdir.path().join("feedback.jsonl"),
+        ));
+        let handler = QuorumHandler {
+            llm_reviewer: None,
+            feedback_store: store,
+            config: crate::config::Config {
+                model: "test".to_string(),
+                ..Default::default()
+            },
+            parse_cache: std::sync::Arc::new(crate::cache::ParseCache::new(8)),
+        };
+
+        // A trivial Rust source so AST parsing runs without findings.
+        let params = ReviewTool {
+            file_path: "trivial.rs".to_string(),
+            code: "fn main() {}".to_string(),
+            focus: None,
+        };
+        let result = handler.handle_review(params).await;
+        assert!(result.is_ok(), "handle_review must succeed: {:?}", result.err());
+    }
+```
+
+(Adapt the `QuorumHandler { ... }` literal to match the actual fields — `cargo check` will tell you.)
+
+**Step 5: Verify regression test compiles AND passes**
+
+Run: `cargo test --bin quorum -- acquire_llm_permit_does_not_deadlock_under_contention_on_current_thread --nocapture`
+
+Expected: PASS. The test body executes on a current-thread runtime with `tokio::join!(holder, waiter)`, both tasks complete within 5s, no deadlock.
+
+**Step 6: Verify the broader test suite still compiles + passes**
+
+Run: `cargo test --bin quorum 2>&1 | tail -10`
+
+Expected: all passing (modulo the known fastembed cache flake when running concurrently with main worktree — if you see those 3 failures, rerun with `--test-threads=1`).
+
+**Step 7: Commit (GREEN checkpoint)**
+
+```bash
+git add -u
+git commit -m "fix(pipeline): convert acquire_llm_permit + review fns to async (#81)
+
+Eliminates the current-thread runtime deadlock by removing the
+runtime-flavor switch and the std::thread::scope + fresh-runtime
++ join() dance. Now: just .await Semaphore::acquire_owned().
+
+Public API change: review_file, review_source, review_file_llm_only
+are now async fn. Callers updated in lockstep:
+
+  - src/main.rs serial path: .await directly
+  - src/main.rs parallel path: spawn_blocking still owns the
+    CPU-heavy work; Handle::current().block_on(async { ... })
+    drives the now-async review fns inside the blocking-pool
+    thread (safe per Tokio: blocking pool != runtime worker)
+  - src/http_server.rs: .await directly (already async)
+  - src/mcp/handler.rs: handle_review is now async fn; the
+    handle_call_tool_request dispatch awaits it
+  - test sites: converted to #[tokio::test]
+
+Regression test (added in prior commit) now passes: holder +
+waiter via tokio::join! on a current-thread runtime, semaphore
+of 1, completes within 5s where previously it hung.
+"
+```
+
+---
+
+## Task 5: Defensive coverage — flavor matrix + cancellation
+
+**Files:**
+- Modify: `src/pipeline.rs` (test module — add three more tests)
+
+**Step 1: Update the existing `does_not_panic_inside_*` tests to use the async signature**
+
+The two existing `acquire_llm_permit_does_not_panic_inside_*` tests at lines ~1013 and ~1029 already use `#[tokio::test]`. Their bodies call `acquire_llm_permit(&sem)` synchronously — change to `acquire_llm_permit(&sem).await`. (May already be done as part of Task 4 — `cargo test` will tell you.)
+
+**Step 2: Update the no-runtime test**
+
+The test `acquire_llm_permit_does_not_panic_outside_tokio_runtime` at line ~985 is `#[test]` (no runtime). Post-fix, calling an async fn outside a runtime won't panic — it just returns a future that's never polled. Replace the test body with one that explicitly verifies "no runtime ⇒ caller must build one to drive it":
+
+```rust
+    /// Issue #58 followup: with the async-permit shape, the helper
+    /// no longer cares about runtime presence — building a fresh
+    /// current-thread runtime to drive the future is the caller's
+    /// responsibility. The function is still safe to *call* from
+    /// non-runtime code (returns a future, no panic).
+    #[test]
+    fn acquire_llm_permit_returns_future_outside_tokio_runtime() {
+        use std::sync::Arc;
+        use tokio::sync::Semaphore;
+        let sem = Some(Arc::new(Semaphore::new(1)));
+        // Just constructing the future must not panic. We don't
+        // poll it — that's the caller's job once they have a runtime.
+        let _fut = acquire_llm_permit(&sem);
+        // Drop without polling is safe.
+    }
+```
+
+**Step 3: Add a cancellation-safety test**
+
+Append to the test module:
+
+```rust
+    /// When a waiter on `acquire_llm_permit` is dropped (cancelled)
+    /// before the permit becomes available, no permit is leaked and
+    /// later acquisitions still work. This is the standard async
+    /// cancellation guarantee — verifies we haven't accidentally
+    /// broken it.
+    #[tokio::test(flavor = "current_thread")]
+    async fn acquire_llm_permit_cancellation_does_not_leak() {
+        use std::sync::Arc;
+        use std::time::Duration;
+        use tokio::sync::Semaphore;
+
+        let sem = Arc::new(Semaphore::new(1));
+        let opt = Some(sem.clone());
+
+        // Hold the only permit until we explicitly drop below.
+        let holder = sem.clone().acquire_owned().await.unwrap();
+
+        // Spawn a waiter and immediately abort it.
+        let opt_clone = opt.clone();
+        let waiter = tokio::spawn(async move {
+            acquire_llm_permit(&opt_clone).await
+        });
+        // Give the waiter a chance to start awaiting.
+        tokio::task::yield_now().await;
+        waiter.abort();
+        let _ = waiter.await; // join the cancelled task
+
+        // Available permits unchanged — still 0 because the holder
+        // is alive. Drop the holder to release.
+        assert_eq!(sem.available_permits(), 0);
+        drop(holder);
+
+        // Next acquirer must succeed; 2s bound is generous for
+        // slow CI but tight enough to flag a regression.
+        let permit = tokio::time::timeout(
+            Duration::from_secs(2),
+            acquire_llm_permit(&opt),
+        )
+        .await
+        .expect("should not time out after holder release");
+        assert!(permit.is_some());
+    }
+```
+
+**Step 4: Add a multi-thread flavor regression test (defensive matrix coverage)**
+
+```rust
+    /// Same contention pattern as the current-thread regression but
+    /// on a multi-thread runtime. Documents that the fix preserves
+    /// production behavior (the path that already worked).
+    /// Uses Notify for deterministic happens-before, mirroring the
+    /// current-thread test.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn acquire_llm_permit_does_not_deadlock_under_contention_on_multi_thread() {
+        use std::sync::Arc;
+        use std::time::Duration;
+        use tokio::sync::{Notify, Semaphore};
+
+        let sem = Arc::new(Semaphore::new(1));
+        let opt = Some(sem.clone());
+        let waiter_started = Arc::new(Notify::new());
+
+        let holder_sem = sem.clone();
+        let holder_signal = waiter_started.clone();
+        let holder = async move {
+            let _h = holder_sem.acquire_owned().await.unwrap();
+            holder_signal.notified().await;
+        };
+        let waiter_signal = waiter_started.clone();
+        let waiter = async move {
+            tokio::task::yield_now().await;
+            waiter_signal.notify_one();
+            acquire_llm_permit(&opt).await
+        };
+
+        let result = tokio::time::timeout(
+            Duration::from_secs(5),
+            async {
+                let (_, w) = tokio::join!(holder, waiter);
+                w
+            },
+        )
+        .await
+        .expect("multi-thread contention timed out");
+        assert!(result.is_some(), "waiter should receive a permit");
+    }
+
+    /// Closed-semaphore degrades to None (mirrors no-throttle
+    /// contract). Cheap mutation-killer: any change that turns the
+    /// `.ok()` into an unwrap or removes the `?` would fail this.
+    #[tokio::test(flavor = "current_thread")]
+    async fn acquire_llm_permit_returns_none_when_semaphore_is_closed() {
+        use std::sync::Arc;
+        use tokio::sync::Semaphore;
+        let sem = Arc::new(Semaphore::new(1));
+        sem.close();
+        let opt = Some(sem);
+        assert!(acquire_llm_permit(&opt).await.is_none());
+    }
+```
+
+**Step 5: Run all four targeted tests**
+
+```bash
+cargo test --bin quorum -- acquire_llm_permit_does_not_panic_outside_tokio_runtime \
+                          acquire_llm_permit_does_not_panic_inside_current_thread_runtime \
+                          acquire_llm_permit_does_not_panic_inside_multi_thread_runtime \
+                          acquire_llm_permit_does_not_deadlock_under_contention_on_current_thread \
+                          acquire_llm_permit_does_not_deadlock_under_contention_on_multi_thread \
+                          acquire_llm_permit_cancellation_does_not_leak \
+                          acquire_llm_permit_returns_future_outside_tokio_runtime
+```
+
+Expected: all pass. (If `acquire_llm_permit_does_not_panic_outside_tokio_runtime` still exists from before — it should be deleted in Step 2 since we replaced it with `acquire_llm_permit_returns_future_outside_tokio_runtime`.)
+
+**Step 6: Commit**
+
+```bash
+git add src/pipeline.rs
+git commit -m "test(pipeline): cancellation safety + multi-thread flavor coverage
+
+Three additional regressions:
+- acquire_llm_permit_returns_future_outside_tokio_runtime: replaces
+  the panic-check; the async shape returns a future, no runtime
+  needed to construct it.
+- acquire_llm_permit_cancellation_does_not_leak: aborted waiter does
+  not corrupt semaphore state; subsequent acquire still works.
+- acquire_llm_permit_does_not_deadlock_under_contention_on_multi_thread:
+  documents that production behavior is preserved on the path that
+  already worked.
+"
+```
+
+---
+
+## Task 6: Verification (Phase 5)
+
+**Step 1: Full test suite**
+
+```bash
+cargo test --bin quorum 2>&1 | tail -5
+```
+
+Expected: `test result: ok. <N> passed; 0 failed; 1 ignored`. If you see fastembed flake (3 failures involving `embeddings::tests::similar_texts_have_high_cosine` etc.), rerun with `--test-threads=1` — those are infrastructure flake from concurrent fastembed cache lock contention, not a regression from this PR.
+
+**Step 2: Clippy**
+
+```bash
+cargo clippy --bin quorum -- -D warnings 2>&1 | tail -10
+```
+
+Expected: clean.
+
+**Step 3: Release build**
+
+```bash
+cargo build --release --bin quorum 2>&1 | tail -3
+```
+
+Expected: `Finished release ...`.
+
+**Step 4: Smoke test the MCP path**
+
+```bash
+QUORUM_API_KEY=dummy ./target/release/quorum serve <<EOF | head -5
+{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"smoke","version":"0"}}}
+EOF
+```
+
+Expected: a JSON `initialize` response (no panic, no hang).
+
+---
+
+## Risks / antipatterns avoided
+
+- **No "test the mock"**: the regression tests exercise real `tokio::sync::Semaphore` + real `tokio::join!` + real `tokio::sync::Notify` — no permit fakery, no fake runtimes.
+- **Two-phase RED (compile + runtime)**: Task 1b demonstrates the deadlock at runtime against the current SYNC code via a temporary `spawn_blocking` shim — proves the test catches the bug, not just the contract change. Step 1c reverts the shim before commit.
+- **Deterministic synchronization**: `tokio::sync::Notify` provides a happens-before signal between holder and waiter, replacing brittle `sleep(10ms)` timing windows. Slow-CI proof.
+- **No mocked runtime**: tests use `#[tokio::test(flavor = "current_thread")]` to actually run on the formerly-deadlocking flavor. This is the test that proves the bug is gone.
+- **Single-failure-reason per test**: Task 1's outer timeout `.expect()` and inner `assert!(waiter_permit.is_some())` are distinct branches with distinct messages — no assertion roulette.
+- **No bypassed cancellation**: Task 5 explicitly tests `tokio::spawn` + `abort()` to confirm the standard async cancellation guarantee survives.
+- **Mutation-killer for closed semaphore**: explicit `acquire_llm_permit_returns_none_when_semaphore_is_closed` test covers the `?` and `.ok()` branches that would otherwise be implicit.
+- **Bulk-conversion safety**: `#[tokio::test]` sites pin `flavor = "multi_thread", worker_threads = 1` rather than relying on the current-thread default, preserving sequential semantics for tests that previously assumed sync execution order.
+- **MCP-dispatch regression**: explicit test for `handle_review` async dispatch through `handle_call_tool_request` — covers the riskiest call-site change.
+- **Bounded scope**: `LlmReviewer::review` async-hygiene (worker-blocking concern) and the `review_file_llm_only` Context7 helper drift are filed as follow-up issues, not bundled here.
+
+## Plan revisions log
+
+- **Round 1 (test-planning + antipattern reviews):**
+  - Replaced `sleep(10ms)` timing window with `tokio::sync::Notify` deterministic handshake (Tasks 1, 5).
+  - Added two-phase RED: runtime-fail demonstration via `spawn_blocking` shim before contract change (Task 1b).
+  - Bumped cancellation post-release timeout from 500ms → 2s (slow-CI tolerance).
+  - Added `acquire_llm_permit_returns_none_when_semaphore_is_closed` mutation-killer (Task 5).
+  - Pinned `#[tokio::test]` bulk conversions to `multi_thread, worker_threads = 1` instead of default current-thread (Task 4).
+  - Added MCP `handle_review` async-dispatch regression test (Task 4b).

--- a/docs/plans/2026-04-25-issue-81-async-permit.md
+++ b/docs/plans/2026-04-25-issue-81-async-permit.md
@@ -378,13 +378,41 @@ of 1, completes within 5s where previously it hung.
 **Files:**
 - Modify: `src/pipeline.rs` (test module — add three more tests)
 
-**Step 1: Update the existing `does_not_panic_inside_*` tests to use the async signature**
+**Step 1: Replace the panic-check tests with happy-path tests on each flavor**
 
-The two existing `acquire_llm_permit_does_not_panic_inside_*` tests at lines ~1013 and ~1029 already use `#[tokio::test]`. Their bodies call `acquire_llm_permit(&sem)` synchronously — change to `acquire_llm_permit(&sem).await`. (May already be done as part of Task 4 — `cargo test` will tell you.)
+The two existing `acquire_llm_permit_does_not_panic_inside_*_runtime` tests wrap a SYNC call in `catch_unwind` to assert "doesn't panic". Post-fix the function is async: calling it returns a future (cheap to construct), so the panic check is no longer meaningful. DELETE them and append happy-path replacements:
 
-**Step 2: Update the no-runtime test**
+```rust
+    #[tokio::test(flavor = "current_thread")]
+    async fn acquire_llm_permit_returns_some_when_permit_available_on_current_thread() {
+        // Issue #71/#81: confirm the happy path works on a
+        // current-thread runtime — the formerly-deadlocking flavor.
+        let sem = Some(std::sync::Arc::new(tokio::sync::Semaphore::new(1)));
+        let permit = acquire_llm_permit(&sem).await;
+        assert!(permit.is_some());
+    }
 
-The test `acquire_llm_permit_does_not_panic_outside_tokio_runtime` at line ~985 is `#[test]` (no runtime). Post-fix, calling an async fn outside a runtime won't panic — it just returns a future that's never polled. Replace the test body with one that explicitly verifies "no runtime ⇒ caller must build one to drive it":
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn acquire_llm_permit_returns_some_when_permit_available_on_multi_thread() {
+        let sem = Some(std::sync::Arc::new(tokio::sync::Semaphore::new(1)));
+        let permit = acquire_llm_permit(&sem).await;
+        assert!(permit.is_some());
+    }
+```
+
+The pre-fix `acquire_llm_permit_returns_none_when_no_semaphore` test must be converted from `#[test]` (sync) to `#[tokio::test(flavor = "current_thread")]` (async with `.await`):
+
+```rust
+    #[tokio::test(flavor = "current_thread")]
+    async fn acquire_llm_permit_returns_none_when_no_semaphore() {
+        let result = acquire_llm_permit(&None).await;
+        assert!(result.is_none());
+    }
+```
+
+**Step 2: Replace the no-runtime panic test**
+
+The test `acquire_llm_permit_does_not_panic_outside_tokio_runtime` is `#[test]` (no runtime). Post-fix, calling an async fn outside a runtime won't panic — it just returns a future that's never polled. DELETE it and append:
 
 ```rust
     /// Issue #58 followup: with the async-permit shape, the helper
@@ -394,9 +422,7 @@ The test `acquire_llm_permit_does_not_panic_outside_tokio_runtime` at line ~985 
     /// non-runtime code (returns a future, no panic).
     #[test]
     fn acquire_llm_permit_returns_future_outside_tokio_runtime() {
-        use std::sync::Arc;
-        use tokio::sync::Semaphore;
-        let sem = Some(Arc::new(Semaphore::new(1)));
+        let sem = Some(std::sync::Arc::new(tokio::sync::Semaphore::new(1)));
         // Just constructing the future must not panic. We don't
         // poll it — that's the caller's job once they have a runtime.
         let _fut = acquire_llm_permit(&sem);

--- a/docs/plans/2026-04-25-issue-81-async-permit.md
+++ b/docs/plans/2026-04-25-issue-81-async-permit.md
@@ -510,19 +510,15 @@ Append to the test module:
     }
 ```
 
-**Step 5: Run all four targeted tests**
+**Step 5: Run all targeted tests**
+
+The two pre-fix `..._does_not_panic_inside_*_runtime` tests used `catch_unwind` on the SYNC call; post-fix the function returns a future (cheap to construct), so the panic check is no longer meaningful. Step 2 above replaced them with `..._returns_some_when_permit_available_on_*` (happy-path on each flavor) and `..._returns_future_outside_tokio_runtime` (no-runtime construction). The full post-fix test list — exactly what the binary has — runs via the prefix filter:
 
 ```bash
-cargo test --bin quorum -- acquire_llm_permit_does_not_panic_outside_tokio_runtime \
-                          acquire_llm_permit_does_not_panic_inside_current_thread_runtime \
-                          acquire_llm_permit_does_not_panic_inside_multi_thread_runtime \
-                          acquire_llm_permit_does_not_deadlock_under_contention_on_current_thread \
-                          acquire_llm_permit_does_not_deadlock_under_contention_on_multi_thread \
-                          acquire_llm_permit_cancellation_does_not_leak \
-                          acquire_llm_permit_returns_future_outside_tokio_runtime
+cargo test --bin quorum -- acquire_llm_permit
 ```
 
-Expected: all pass. (If `acquire_llm_permit_does_not_panic_outside_tokio_runtime` still exists from before — it should be deleted in Step 2 since we replaced it with `acquire_llm_permit_returns_future_outside_tokio_runtime`.)
+Expected names (8 total): `acquire_llm_permit_returns_future_outside_tokio_runtime`, `acquire_llm_permit_returns_none_when_no_semaphore`, `acquire_llm_permit_returns_some_when_permit_available_on_current_thread`, `acquire_llm_permit_returns_some_when_permit_available_on_multi_thread`, `acquire_llm_permit_returns_none_when_semaphore_is_closed`, `acquire_llm_permit_does_not_deadlock_under_contention_on_current_thread`, `acquire_llm_permit_does_not_deadlock_under_contention_on_multi_thread`, `acquire_llm_permit_cancellation_does_not_leak`. All must pass.
 
 **Step 6: Commit**
 

--- a/docs/plans/2026-04-25-issue-81-async-permit.md
+++ b/docs/plans/2026-04-25-issue-81-async-permit.md
@@ -583,7 +583,7 @@ Expected: a JSON `initialize` response (no panic, no hang).
 ## Risks / antipatterns avoided
 
 - **No "test the mock"**: the regression tests exercise real `tokio::sync::Semaphore` + real `tokio::join!` + real `tokio::sync::Notify` — no permit fakery, no fake runtimes.
-- **Two-phase RED (compile + runtime)**: Task 1b demonstrates the deadlock at runtime against the current SYNC code via a temporary `spawn_blocking` shim — proves the test catches the bug, not just the contract change. Step 1c reverts the shim before commit.
+- **Compile-fail RED (with documented runtime-RED limitation)**: Task 1b demonstrates the test fails to compile against the current SYNC signature — rustc itself suggests "consider making `fn acquire_llm_permit` asynchronous", which IS the fix. The original plan called for an additional runtime-RED via a `spawn_blocking` shim, but on closer analysis that shim does NOT reproduce the deadlock (`spawn_blocking` runs on the blocking pool, not a runtime worker, so the holder still gets polled). A faithful runtime-RED would require sync `acquire_llm_permit` to block worker X *directly*, which would also hang Tokio's timeout future itself — `std::thread::spawn` + condvar harness would be needed to detect it, which is significant complexity for a one-shot demonstration. Compile-fail RED + the issue's reproduction analysis accepted as sufficient.
 - **Deterministic synchronization**: `tokio::sync::Notify` provides a happens-before signal between holder and waiter, replacing brittle `sleep(10ms)` timing windows. Slow-CI proof.
 - **No mocked runtime**: tests use `#[tokio::test(flavor = "current_thread")]` to actually run on the formerly-deadlocking flavor. This is the test that proves the bug is gone.
 - **Single-failure-reason per test**: Task 1's outer timeout `.expect()` and inner `assert!(waiter_permit.is_some())` are distinct branches with distinct messages — no assertion roulette.
@@ -597,7 +597,7 @@ Expected: a JSON `initialize` response (no panic, no hang).
 
 - **Round 1 (test-planning + antipattern reviews):**
   - Replaced `sleep(10ms)` timing window with `tokio::sync::Notify` deterministic handshake (Tasks 1, 5).
-  - Added two-phase RED: runtime-fail demonstration via `spawn_blocking` shim before contract change (Task 1b).
+  - Initially added two-phase RED (runtime-fail demonstration via `spawn_blocking` shim before contract change in Task 1b); subsequently dropped after analysis showed the shim does NOT reproduce the deadlock (blocking pool ≠ runtime worker, so the holder still gets polled). Compile-fail RED + reproduction analysis accepted as sufficient.
   - Bumped cancellation post-release timeout from 500ms → 2s (slow-CI tolerance).
   - Added `acquire_llm_permit_returns_none_when_semaphore_is_closed` mutation-killer (Task 5).
   - Pinned `#[tokio::test]` bulk conversions to `multi_thread, worker_threads = 1` instead of default current-thread (Task 4).

--- a/docs/plans/2026-04-25-issue-81-async-permit.md
+++ b/docs/plans/2026-04-25-issue-81-async-permit.md
@@ -90,42 +90,17 @@ Append to the existing `mod tests` (after the `acquire_llm_permit_does_not_panic
     }
 ```
 
-**Step 1b: Demonstrate runtime RED against current sync code (temporary shim)**
+**Step 1b: Verify the test fails to compile against current sync code (RED)**
 
-The above test calls `acquire_llm_permit(&opt).await` — invalid against the current SYNC signature. To prove the test catches the runtime bug (not just the type system), temporarily replace that call inside the test body with a `spawn_blocking` shim that drives the SYNC API from a blocking-pool thread:
-
-```rust
-        // TEMPORARY SHIM (Task 2 removes): drive the current SYNC
-        // acquire_llm_permit from spawn_blocking so the test compiles.
-        let waiter = async move {
-            tokio::task::yield_now().await;
-            waiter_signal.notify_one();
-            tokio::task::spawn_blocking(move || acquire_llm_permit(&opt))
-                .await
-                .unwrap()
-        };
-```
-
-Run the test against the current sync code with this shim:
+The test calls `acquire_llm_permit(&opt).await`, which is invalid against the current SYNC signature. Run:
 
 ```bash
-cargo test --bin quorum -- acquire_llm_permit_does_not_deadlock_under_contention_on_current_thread --nocapture
+cargo test --bin quorum -- acquire_llm_permit_does_not_deadlock_under_contention_on_current_thread
 ```
 
-Expected: TIMEOUT FAILURE within 5s. The panic message should be:
-> deadlock regression: tokio::join! on current-thread runtime did not complete within 5s — issue #81
+Expected: compile error E0277 with rustc's diagnostic literally suggesting "consider making `fn acquire_llm_permit` asynchronous". This is the strongest possible compile-time RED: the compiler points at exactly the fix.
 
-This is the **runtime RED** — proves the deadlock exists, not just that the contract changed.
-
-**Step 1c: Revert the shim**
-
-After observing the timeout failure, REVERT the `spawn_blocking` shim — restore the direct `acquire_llm_permit(&opt).await` call. The test now does not compile against the sync code (Task 2 fixes that). Do not commit the shimmed version.
-
-**Step 2: Verify compile-fail against current code (final RED state)**
-
-Run: `cargo test --bin quorum -- acquire_llm_permit_does_not_deadlock_under_contention_on_current_thread`
-
-Expected: compile error — `.await` on a non-future. This is the documented RED for the new contract; runtime RED already established in Step 1b.
+**Note on runtime RED:** The original plan included a `spawn_blocking` shim to demonstrate runtime failure. That doesn't work — `spawn_blocking` dispatches to the blocking pool (separate from runtime workers), so worker X stays free to poll the holder, which can release the permit cleanly. The actual production deadlock requires sync `acquire_llm_permit` to block worker X *directly* (which `review_file` did inline from `#[tokio::main]` — but only on current-thread flavors). A test that does that would hang Tokio's timeout future itself (no worker to poll it) and require `std::thread::spawn` + condvar harness to detect, which is significant complexity for a one-shot demonstration. The compile-fail RED + the issue's reproduction analysis are accepted as sufficient.
 
 **Step 3: Commit (RED checkpoint)**
 

--- a/docs/plans/2026-04-25-issue-81-async-permit.md
+++ b/docs/plans/2026-04-25-issue-81-async-permit.md
@@ -19,11 +19,13 @@
 **Files:**
 - Modify: `src/pipeline.rs` (test module at the bottom — append a new test fn)
 
-**Why this test:** The existing `acquire_llm_permit_does_not_panic_inside_current_thread_runtime` only proves "doesn't panic" with a 1-permit-available semaphore. It does NOT exercise contention. The bug only manifests when the permit is *held by another task on the same current-thread runtime*. We need a test that reproduces that exact shape AND fails at runtime against the buggy code (not just at compile time).
+**Why this test:** The existing `acquire_llm_permit_does_not_panic_inside_current_thread_runtime` only proves "doesn't panic" with a 1-permit-available semaphore. It does NOT exercise contention. The bug only manifests when the permit is *held by another task on the same current-thread runtime*. We need a test that reproduces that exact shape.
 
-**Two-phase RED (per testing-antipatterns review):** First demonstrate the bug at runtime against the current SYNC API via a `spawn_blocking` shim — this gives a *runtime* failure (timeout) that proves the deadlock exists. Then post-fix, the test (with the shim removed) compiles and passes against the new ASYNC API.
+**Compile-fail RED (the strongest available signal):** The test below calls `.await` on `acquire_llm_permit`, which is invalid against the current SYNC signature. This produces compile error E0277 with rustc itself suggesting "consider making `fn acquire_llm_permit` asynchronous" — the compiler points at exactly the Task 2 fix. Step 1b verifies the failure mode.
 
-**Step 1a: Write the runtime-RED test (shimmed against current sync API)**
+The original plan called for an additional runtime-RED via a `spawn_blocking` shim, but on closer analysis (see Step 1b note) the shim does NOT reproduce the deadlock — `spawn_blocking` runs on the blocking pool, not the runtime worker, so the holder still gets polled. A faithful runtime-RED would require sync `acquire_llm_permit` to block worker X *directly*, which would also hang Tokio's timeout future itself; `std::thread::spawn` + condvar harness would be needed to detect it, which is significant complexity for a one-shot demonstration. Compile-fail RED + the issue's reproduction analysis are accepted as sufficient.
+
+**Step 1a: Write the test**
 
 Append to the existing `mod tests` (after the `acquire_llm_permit_does_not_panic_inside_multi_thread_runtime` test):
 

--- a/src/context/phase6_integration_tests.rs
+++ b/src/context/phase6_integration_tests.rs
@@ -268,8 +268,8 @@ fn retriever_errored_flag_is_false_when_retriever_returns_zero_hits() {
     );
 }
 
-#[test]
-fn end_to_end_review_with_context_injection_logs_telemetry() {
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn end_to_end_review_with_context_injection_logs_telemetry() {
     // End-to-end wiring check: a pipeline configured with a real
     // `ContextInjector` (backed by the mini-rust fixture index) must produce
     // a `FileReviewResult` whose `context_telemetry` is non-default, and
@@ -316,6 +316,7 @@ fn end_to_end_review_with_context_injection_logs_telemetry() {
         Some(&llm),
         &config,
     )
+    .await
     .unwrap();
 
     let tele = result

--- a/src/http_server.rs
+++ b/src/http_server.rs
@@ -123,6 +123,7 @@ async fn review(
         &pipeline_cfg,
         Some(&state.parse_cache),
     )
+    .await
     .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, format!("Review error: {}", e)))?;
 
     let cache_hit = state.parse_cache.stats().hits > cache_before;

--- a/src/main.rs
+++ b/src/main.rs
@@ -116,7 +116,7 @@ async fn main() -> anyhow::Result<()> {
     match args.command {
         cli::Command::Review(opts) => {
             drain_agent_inbox();
-            let exit_code = run_review(opts);
+            let exit_code = run_review(opts).await;
             std::process::exit(exit_code);
         }
         cli::Command::Stats(opts) => {
@@ -494,7 +494,7 @@ fn deep_tool_root(file_path: &std::path::Path) -> std::path::PathBuf {
     pipeline::find_project_root(file_path)
 }
 
-fn run_review(opts: cli::ReviewOpts) -> i32 {
+async fn run_review(opts: cli::ReviewOpts) -> i32 {
     // The empty-files case is now rejected at the clap layer via
     // `#[arg(required = true, num_args = 1..)]` on `ReviewOpts.files`
     // (issue #89). The redundant handler-level guard was removed.
@@ -860,6 +860,7 @@ fn run_review(opts: cli::ReviewOpts) -> i32 {
                     &pipeline_cfg,
                     Some(&parse_cache),
                 )
+                .await
             } else {
                 eprintln!("Note: No AST support for {}, using LLM-only review", file_path.display());
                 pipeline::review_file_llm_only(
@@ -868,6 +869,7 @@ fn run_review(opts: cli::ReviewOpts) -> i32 {
                     llm_reviewer,
                     &pipeline_cfg,
                 )
+                .await
             };
             match review_result {
                 Ok(mut result) => {
@@ -959,13 +961,23 @@ fn run_review(opts: cli::ReviewOpts) -> i32 {
                 // Standard review path
                 let llm_reviewer: Option<&dyn pipeline::LlmReviewer> = llm_client.as_deref().map(|c| c as _);
                 let parse_cache = cache::ParseCache::new(128);
-                let review_result = if let Some(l) = lang {
-                    pipeline::review_source(
-                        &file_path, &source, l, llm_reviewer, &pipeline_cfg, Some(&parse_cache))
-                } else {
-                    pipeline::review_file_llm_only(
-                        &file_path, &source, llm_reviewer, &pipeline_cfg)
-                };
+                // `spawn_blocking` runs on Tokio's blocking pool (separate from
+                // runtime workers), so `Handle::block_on` here is sound per
+                // Tokio docs. We deliberately keep the parsing/AST CPU work
+                // inside the spawn_blocking shell and just bridge into the
+                // now-async review fns; issue #81.
+                let handle = tokio::runtime::Handle::current();
+                let review_result = handle.block_on(async {
+                    if let Some(l) = lang {
+                        pipeline::review_source(
+                            &file_path, &source, l, llm_reviewer, &pipeline_cfg, Some(&parse_cache))
+                            .await
+                    } else {
+                        pipeline::review_file_llm_only(
+                            &file_path, &source, llm_reviewer, &pipeline_cfg)
+                            .await
+                    }
+                });
 
                 match review_result {
                     Ok(mut result) => {
@@ -985,7 +997,7 @@ fn run_review(opts: cli::ReviewOpts) -> i32 {
         type ParResult = (pipeline::FileReviewResult, Vec<(crate::finding::Finding, suppress::SuppressionRule)>);
         let mut indexed_results: Vec<Option<ParResult>> = vec![None; opts.files.len()];
         for handle in handles {
-            match tokio::task::block_in_place(|| rt.block_on(handle)) {
+            match handle.await {
                 Ok((idx, Ok(result))) => { indexed_results[idx] = Some(result); }
                 Ok((idx, Err(e))) => {
                     eprintln!("Error: Review failed for {}: {}", opts.files[idx].display(), e);

--- a/src/mcp/handler.rs
+++ b/src/mcp/handler.rs
@@ -84,7 +84,7 @@ impl QuorumHandler {
         })
     }
 
-    fn handle_review(&self, params: ReviewTool) -> Result<CallToolResult, String> {
+    async fn handle_review(&self, params: ReviewTool) -> Result<CallToolResult, String> {
         let lang = Language::from_path(std::path::Path::new(&params.file_path))
             .ok_or_else(|| format!("Unsupported file type: {}", params.file_path))?;
 
@@ -101,6 +101,7 @@ impl QuorumHandler {
             &pipeline_cfg,
             Some(&self.parse_cache),
         )
+        .await
         .map_err(|e| format!("Review error: {}", e))?;
 
         let json = serde_json::to_string_pretty(&result.findings)
@@ -375,7 +376,7 @@ impl ServerHandler for QuorumHandler {
             "review" => {
                 let tool: ReviewTool = serde_json::from_value(args_value)
                     .map_err(|e| CallToolError::from_message(format!("Invalid parameters: {}", e)))?;
-                self.handle_review(tool)
+                self.handle_review(tool).await
             }
             "feedback" => {
                 let tool: FeedbackTool = serde_json::from_value(args_value)
@@ -413,8 +414,8 @@ impl ServerHandler for QuorumHandler {
 mod tests {
     use super::*;
 
-    #[test]
-    fn review_handler_parses_clean_rust() {
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn review_handler_parses_clean_rust() {
         let handler = QuorumHandler {
             config: Config {
                 base_url: "https://example.com".into(),
@@ -432,13 +433,13 @@ mod tests {
             focus: None,
         };
 
-        let result = handler.handle_review(params).unwrap();
+        let result = handler.handle_review(params).await.unwrap();
         // Clean code should produce empty findings or minor ones
         assert!(!result.content.is_empty());
     }
 
-    #[test]
-    fn review_handler_finds_insecure_python() {
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn review_handler_finds_insecure_python() {
         let handler = QuorumHandler {
             config: Config {
                 base_url: "https://example.com".into(),
@@ -456,7 +457,7 @@ mod tests {
             focus: Some("security".into()),
         };
 
-        let result = handler.handle_review(params).unwrap();
+        let result = handler.handle_review(params).await.unwrap();
         let text = &result.content[0];
         // Should contain eval finding in the JSON output
         let text_str = serde_json::to_string(text).unwrap();
@@ -690,8 +691,8 @@ mod tests {
         assert!(text.contains("Python"));
     }
 
-    #[test]
-    fn review_handler_rejects_unsupported_extension() {
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn review_handler_rejects_unsupported_extension() {
         let handler = QuorumHandler {
             config: Config {
                 base_url: "https://example.com".into(),
@@ -709,7 +710,7 @@ mod tests {
             focus: None,
         };
 
-        assert!(handler.handle_review(params).is_err());
+        assert!(handler.handle_review(params).await.is_err());
     }
 
     // -- Chat, Debug, Testgen: require LLM --
@@ -834,8 +835,8 @@ mod tests {
 
     // -- Cache integration --
 
-    #[test]
-    fn review_populates_parse_cache() {
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn review_populates_parse_cache() {
         let cache = Arc::new(ParseCache::new(10));
         let handler = QuorumHandler {
             config: Config {
@@ -853,7 +854,7 @@ mod tests {
             file_path: "test.rs".into(),
             focus: None,
         };
-        handler.handle_review(params).unwrap();
+        handler.handle_review(params).await.unwrap();
         assert_eq!(cache.stats().misses, 1, "First review should be a cache miss");
 
         // Second review with same code should hit cache
@@ -862,7 +863,7 @@ mod tests {
             file_path: "test.rs".into(),
             focus: None,
         };
-        handler.handle_review(params2).unwrap();
+        handler.handle_review(params2).await.unwrap();
         assert_eq!(cache.stats().hits, 1, "Second review should be a cache hit");
     }
 

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -1039,6 +1039,66 @@ mod tests {
         );
     }
 
+    /// Issue #81 regression: on a current-thread runtime, if the permit
+    /// holder is another task on the same runtime, the OLD synchronous
+    /// `acquire_llm_permit` deadlocks (it blocks the runtime worker at
+    /// `std::thread::scope.join()`, so the holder can never run and
+    /// release). Post-fix, async acquisition cooperatively yields and
+    /// the holder runs to completion.
+    ///
+    /// Uses `tokio::sync::Notify` (not `sleep`) for a deterministic
+    /// happens-before between holder.acquired and waiter.start —
+    /// avoids timing flakiness on slow CI.
+    #[tokio::test(flavor = "current_thread")]
+    async fn acquire_llm_permit_does_not_deadlock_under_contention_on_current_thread() {
+        use std::sync::Arc;
+        use std::time::Duration;
+        use tokio::sync::{Notify, Semaphore};
+
+        let sem = Arc::new(Semaphore::new(1));
+        let opt = Some(sem.clone());
+        let waiter_started = Arc::new(Notify::new());
+
+        // Holder: takes the only permit, waits for the waiter to be
+        // observably parked on acquire (Notify), then drops the permit.
+        let holder_sem = sem.clone();
+        let holder_signal = waiter_started.clone();
+        let holder = async move {
+            let _h = holder_sem.acquire_owned().await.unwrap();
+            holder_signal.notified().await;
+            // permit dropped at scope exit — waiter unparks
+        };
+
+        // Waiter: yields once so the holder grabs the permit, signals
+        // "I'm about to acquire", then awaits permit. Pre-fix, this
+        // deadlocks: the SYNC acquire_llm_permit blocks the only worker
+        // at join() and the holder can never run to release.
+        let waiter_signal = waiter_started.clone();
+        let waiter = async move {
+            tokio::task::yield_now().await;
+            waiter_signal.notify_one();
+            acquire_llm_permit(&opt).await
+        };
+
+        // Wrap in a 5s timeout so a regression manifests as a fast
+        // test failure, not a hung CI job. Capture the waiter's
+        // result so the failure message is unambiguous.
+        let result = tokio::time::timeout(
+            Duration::from_secs(5),
+            async { tokio::join!(holder, waiter) },
+        )
+        .await;
+
+        let (_, waiter_permit) = result.expect(
+            "deadlock regression: tokio::join! on current-thread \
+             runtime did not complete within 5s — issue #81",
+        );
+        assert!(
+            waiter_permit.is_some(),
+            "waiter must receive a permit once the holder releases"
+        );
+    }
+
     // -- Complexity threshold default --
 
     #[test]

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -74,57 +74,27 @@ fn write_calibrator_traces(
     }
 }
 
-/// Acquire a semaphore permit if configured. Returns an owned permit
-/// that is released on drop (RAII).
+/// Acquire a semaphore permit if configured, awaiting cooperatively.
 ///
-/// This is a *synchronous* function that may be called from any of:
-/// `spawn_blocking` threads, plain sync callers with no runtime, or
-/// from inside an async context (via deeply-nested sync wrappers).
-/// To handle all three without panicking we mirror the runtime-flavor
-/// pattern from `llm_client::block_on_async` (issue #71):
+/// Returns an owned permit that is released on drop (RAII). When the
+/// semaphore is `None`, returns `None` immediately (no throttling).
+/// A closed semaphore (`acquire_owned` returns `Err`) also degrades
+/// to `None`, mirroring the prior contract for "throttling can't
+/// work, don't crash the caller".
 ///
-/// - `MultiThread` runtime: use `block_in_place` + `Handle::block_on`
-///   so the worker can pick up other tasks while we wait.
-/// - `CurrentThread` (or any future flavor where `block_in_place` is
-///   disallowed): drive the future on a dedicated OS thread with its
-///   own current-thread runtime. We can't reuse the calling runtime
-///   (`block_on` panics inside an async context) and `block_in_place`
-///   is not allowed there either, so we hand the work off to a fresh
-///   executor. Throttling still works because the new runtime awaits
-///   the same `Arc<Semaphore>`.
-/// - No runtime at all (issue #58): degrade to `None`. Throttling
-///   can't work without a runtime, but the caller (lazy sync wiring,
-///   embedders, tests) shouldn't crash — same observable behavior as
-///   the no-semaphore path.
-///
-/// Degrades to `None` (rather than panicking) on: no semaphore
-/// configured, semaphore closed, no runtime, or a transient failure
-/// to build the fallback runtime.
-fn acquire_llm_permit(sem: &Option<std::sync::Arc<tokio::sync::Semaphore>>) -> Option<tokio::sync::OwnedSemaphorePermit> {
-    use tokio::runtime::{Handle, RuntimeFlavor};
-    let sem = sem.as_ref()?.clone();
-    let handle = Handle::try_current().ok()?;
-    match handle.runtime_flavor() {
-        RuntimeFlavor::MultiThread => {
-            tokio::task::block_in_place(|| handle.block_on(sem.acquire_owned()).ok())
-        }
-        // CurrentThread or any future flavor where block_in_place is
-        // disallowed: drive on a separate thread with its own runtime.
-        // Throttling still works (the new runtime awaits the same
-        // semaphore arc) and we don't re-enter the calling runtime.
-        _ => std::thread::scope(|s| {
-            s.spawn(|| {
-                let rt = tokio::runtime::Builder::new_current_thread()
-                    .enable_all()
-                    .build()
-                    .ok()?;
-                rt.block_on(sem.acquire_owned()).ok()
-            })
-            .join()
-            .ok()
-            .flatten()
-        }),
-    }
+/// Issue #81: pre-fix this was a sync helper that branched on the
+/// current Tokio runtime flavor — `block_in_place` on multi-thread,
+/// `std::thread::scope` + a fresh current-thread runtime + `join()`
+/// on current-thread. The current-thread branch deadlocked when the
+/// permit holder was another task on the *same* runtime: `join()`
+/// blocked the only worker, the holder never ran to release, and
+/// the spawned helper runtime awaited forever. The async shape
+/// eliminates that class of bug by construction — we just `.await`
+/// and let the runtime that owns the holder make progress.
+async fn acquire_llm_permit(
+    sem: &Option<std::sync::Arc<tokio::sync::Semaphore>>,
+) -> Option<tokio::sync::OwnedSemaphorePermit> {
+    sem.as_ref()?.clone().acquire_owned().await.ok()
 }
 
 /// Trait for LLM review — allows testing with fake implementations.
@@ -320,7 +290,7 @@ fn query_feedback_precedents(
 }
 
 /// Run the full review pipeline on a single file.
-pub fn review_file(
+pub async fn review_file(
     file_path: &Path,
     source: &str,
     lang: Language,
@@ -556,9 +526,12 @@ pub fn review_file(
         let prompt = review::build_review_prompt(&req);
 
         for model in &pipeline_config.models {
-            let _span = tracing::info_span!("phase.llm_call", model = %model, file = %file_str).entered();
             let t0 = std::time::Instant::now();
-            let _permit = acquire_llm_permit(&pipeline_config.semaphore);
+            // EnteredSpan is !Send, so it must not cross an `.await`.
+            // The span only scopes the tracing events inside the match
+            // arms below — `acquire_llm_permit` emits no events itself.
+            let _permit = acquire_llm_permit(&pipeline_config.semaphore).await;
+            let _span = tracing::info_span!("phase.llm_call", model = %model, file = %file_str).entered();
             match reviewer.review(&prompt, model) {
                 Ok(resp) => {
                     let (prompt_tok, completion_tok, cached_tok) = resp.usage.as_ref()
@@ -706,7 +679,7 @@ pub fn find_project_root(file_path: &Path) -> std::path::PathBuf {
 }
 
 /// Higher-level entry point: parses source (with optional cache) then runs review_file.
-pub fn review_source(
+pub async fn review_source(
     file_path: &Path,
     source: &str,
     lang: Language,
@@ -719,7 +692,7 @@ pub fn review_source(
     } else {
         parser::parse(source, lang)?
     };
-    review_file(file_path, source, lang, &tree, llm, pipeline_config)
+    review_file(file_path, source, lang, &tree, llm, pipeline_config).await
 }
 
 fn lang_name(lang: Language) -> &'static str {
@@ -745,7 +718,7 @@ fn lang_name_from_path(path: &Path) -> String {
 
 /// LLM-only review for files without tree-sitter support.
 /// Skips local AST analysis but still does LLM review, calibration, and auto-calibration.
-pub fn review_file_llm_only(
+pub async fn review_file_llm_only(
     file_path: &Path,
     source: &str,
     llm: Option<&dyn LlmReviewer>,
@@ -854,7 +827,7 @@ pub fn review_file_llm_only(
 
             let prompt = review::build_review_prompt(&req);
             for model in &pipeline_config.models {
-                let _permit = acquire_llm_permit(&pipeline_config.semaphore);
+                let _permit = acquire_llm_permit(&pipeline_config.semaphore).await;
                 match reviewer.review(&prompt, model) {
                     Ok(resp) => {
                         if let Some(u) = &resp.usage {
@@ -941,13 +914,13 @@ mod tests {
 
     use crate::test_support::fakes::FakeReviewer;
 
-    fn parse_and_review(source: &str, lang: Language, llm: Option<&dyn LlmReviewer>, models: Vec<String>) -> FileReviewResult {
+    async fn parse_and_review(source: &str, lang: Language, llm: Option<&dyn LlmReviewer>, models: Vec<String>) -> FileReviewResult {
         let tree = parser::parse(source, lang).unwrap();
         let config = PipelineConfig {
             models,
             ..Default::default()
         };
-        review_file(Path::new("test.rs"), source, lang, &tree, llm, &config).unwrap()
+        review_file(Path::new("test.rs"), source, lang, &tree, llm, &config).await.unwrap()
     }
 
     #[test]
@@ -981,62 +954,133 @@ mod tests {
         assert_eq!(context7_skip_reason(&cfg), Some("init failed"));
     }
 
+    /// Issue #58 followup: with the async-permit shape, the helper
+    /// no longer cares about runtime presence — building a fresh
+    /// current-thread runtime to drive the future is the caller's
+    /// responsibility. The function is still safe to *call* from
+    /// non-runtime code (returns a future, no panic on construction).
     #[test]
-    fn acquire_llm_permit_does_not_panic_outside_tokio_runtime() {
-        // Issue #58: acquire_llm_permit calls Handle::current() which
-        // panics if no Tokio runtime exists. Callers that lazily wire a
-        // Pipeline from a sync context (e.g., embedders, tests) would
-        // crash on the first throttled review. Degrade to "no permit"
-        // instead — same observable behavior as the no-semaphore path.
+    fn acquire_llm_permit_returns_future_outside_tokio_runtime() {
         let sem = Some(std::sync::Arc::new(tokio::sync::Semaphore::new(1)));
-        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-            acquire_llm_permit(&sem)
-        }));
-        assert!(
-            result.is_ok(),
-            "acquire_llm_permit panicked outside Tokio runtime: {:?}",
-            result.err()
-        );
-        // None is acceptable here: throttling can't work without a runtime,
-        // so we degrade rather than crash.
-        let permit = result.unwrap();
-        let _ = permit;
+        // Constructing the future must not panic. We don't poll it —
+        // that's the caller's job once they have a runtime.
+        let _fut = acquire_llm_permit(&sem);
     }
 
-    #[test]
-    fn acquire_llm_permit_returns_none_when_no_semaphore() {
-        let result = acquire_llm_permit(&None);
+    #[tokio::test(flavor = "current_thread")]
+    async fn acquire_llm_permit_returns_none_when_no_semaphore() {
+        let result = acquire_llm_permit(&None).await;
         assert!(result.is_none());
     }
 
     #[tokio::test(flavor = "current_thread")]
-    async fn acquire_llm_permit_does_not_panic_inside_current_thread_runtime() {
-        // Issue #71: handle.block_on(...) panics inside an async
-        // execution context ("Cannot start a runtime from within a
-        // runtime"). Mirror block_on_async's RuntimeFlavor pattern.
+    async fn acquire_llm_permit_returns_some_when_permit_available_on_current_thread() {
+        // Issue #71/#81: confirm the happy path works on a
+        // current-thread runtime — the formerly-deadlocking flavor.
         let sem = Some(std::sync::Arc::new(tokio::sync::Semaphore::new(1)));
-        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-            acquire_llm_permit(&sem)
-        }));
-        assert!(
-            result.is_ok(),
-            "acquire_llm_permit panicked inside current_thread runtime: {:?}",
-            result.err()
-        );
+        let permit = acquire_llm_permit(&sem).await;
+        assert!(permit.is_some());
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn acquire_llm_permit_does_not_panic_inside_multi_thread_runtime() {
+    async fn acquire_llm_permit_returns_some_when_permit_available_on_multi_thread() {
         // Multi-thread coverage so the fix isn't current_thread-specific.
         let sem = Some(std::sync::Arc::new(tokio::sync::Semaphore::new(1)));
-        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-            acquire_llm_permit(&sem)
-        }));
-        assert!(
-            result.is_ok(),
-            "acquire_llm_permit panicked inside multi_thread runtime: {:?}",
-            result.err()
-        );
+        let permit = acquire_llm_permit(&sem).await;
+        assert!(permit.is_some());
+    }
+
+    /// Closed-semaphore degrades to None (mirrors no-throttle
+    /// contract). Cheap mutation-killer: any change that turns the
+    /// `.ok()` into an unwrap or removes the `?` would fail this.
+    #[tokio::test(flavor = "current_thread")]
+    async fn acquire_llm_permit_returns_none_when_semaphore_is_closed() {
+        let sem = std::sync::Arc::new(tokio::sync::Semaphore::new(1));
+        sem.close();
+        let opt = Some(sem);
+        assert!(acquire_llm_permit(&opt).await.is_none());
+    }
+
+    /// When a waiter on `acquire_llm_permit` is dropped (cancelled)
+    /// before the permit becomes available, no permit is leaked and
+    /// later acquisitions still work. Standard async cancellation
+    /// guarantee — verifies we haven't accidentally broken it.
+    #[tokio::test(flavor = "current_thread")]
+    async fn acquire_llm_permit_cancellation_does_not_leak() {
+        use std::sync::Arc;
+        use std::time::Duration;
+        use tokio::sync::Semaphore;
+
+        let sem = Arc::new(Semaphore::new(1));
+        let opt = Some(sem.clone());
+
+        // Hold the only permit until we explicitly drop below.
+        let holder = sem.clone().acquire_owned().await.unwrap();
+
+        // Spawn a waiter and immediately abort it.
+        let opt_clone = opt.clone();
+        let waiter = tokio::spawn(async move {
+            acquire_llm_permit(&opt_clone).await
+        });
+        // Give the waiter a chance to start awaiting.
+        tokio::task::yield_now().await;
+        waiter.abort();
+        let _ = waiter.await; // join the cancelled task
+
+        // Available permits unchanged — still 0 because the holder
+        // is alive. Drop the holder to release.
+        assert_eq!(sem.available_permits(), 0);
+        drop(holder);
+
+        // Next acquirer must succeed; 2s bound is generous for
+        // slow CI but tight enough to flag a regression.
+        let permit = tokio::time::timeout(
+            Duration::from_secs(2),
+            acquire_llm_permit(&opt),
+        )
+        .await
+        .expect("should not time out after holder release");
+        assert!(permit.is_some());
+    }
+
+    /// Same contention pattern as the current-thread regression but
+    /// on a multi-thread runtime. Documents that the fix preserves
+    /// production behavior (the path that already worked).
+    /// Uses Notify for deterministic happens-before, mirroring the
+    /// current-thread test.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn acquire_llm_permit_does_not_deadlock_under_contention_on_multi_thread() {
+        use std::sync::Arc;
+        use std::time::Duration;
+        use tokio::sync::{Notify, Semaphore};
+
+        let sem = Arc::new(Semaphore::new(1));
+        let opt = Some(sem.clone());
+        let waiter_started = Arc::new(Notify::new());
+
+        let holder_sem = sem.clone();
+        let holder_signal = waiter_started.clone();
+        let holder = async move {
+            let _h = holder_sem.acquire_owned().await.unwrap();
+            holder_signal.notified().await;
+        };
+        let waiter_signal = waiter_started.clone();
+        let waiter = async move {
+            tokio::task::yield_now().await;
+            waiter_signal.notify_one();
+            acquire_llm_permit(&opt).await
+        };
+
+        let result = tokio::time::timeout(
+            Duration::from_secs(5),
+            async {
+                let (_, w) = tokio::join!(holder, waiter);
+                w
+            },
+        )
+        .await
+        .expect("multi-thread contention timed out");
+        assert!(result.is_some(), "waiter should receive a permit");
     }
 
     /// Issue #81 regression: on a current-thread runtime, if the permit
@@ -1106,10 +1150,10 @@ mod tests {
         assert_eq!(PipelineConfig::default().complexity_threshold, 10);
     }
 
-    #[test]
-    fn pipeline_default_does_not_flag_cc_six_function() {
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn pipeline_default_does_not_flag_cc_six_function() {
         let source = "fn moderate(a: bool, b: bool, c: bool) {\n    if a {\n        if b {\n            if c {\n                for i in 0..10 {\n                    if i > 5 { break; }\n                }\n            }\n        }\n    }\n}\n";
-        let result = parse_and_review(source, Language::Rust, None, vec![]);
+        let result = parse_and_review(source, Language::Rust, None, vec![]).await;
         assert!(
             !result.findings.iter().any(|f| f.category == "complexity"),
             "CC=6 should not flag at default threshold=10"
@@ -1118,34 +1162,34 @@ mod tests {
 
     // -- Local-only mode --
 
-    #[test]
-    fn pipeline_local_only_no_llm() {
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn pipeline_local_only_no_llm() {
         let source = "fn simple() -> i32 { 42 }";
-        let result = parse_and_review(source, Language::Rust, None, vec![]);
+        let result = parse_and_review(source, Language::Rust, None, vec![]).await;
         // Simple function: no findings expected
         assert!(result.findings.is_empty());
     }
 
-    #[test]
-    fn pipeline_local_finds_complexity() {
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn pipeline_local_finds_complexity() {
         // CC=11: 10 decision points + 1 baseline. Must exceed default threshold (10).
         let source = "fn complex(a: bool, b: bool, c: bool, d: bool, e: bool) {\n    if a { return; }\n    if b { return; }\n    if c { return; }\n    if d { return; }\n    if e { return; }\n    for i in 0..10 {\n        if i > 5 { break; }\n        while i < 3 { break; }\n        match i { 0 => {}, 1 => {}, _ => {} }\n    }\n}\n";
-        let result = parse_and_review(source, Language::Rust, None, vec![]);
+        let result = parse_and_review(source, Language::Rust, None, vec![]).await;
         assert!(!result.findings.is_empty());
         assert!(result.findings.iter().any(|f| f.category == "complexity"));
     }
 
-    #[test]
-    fn pipeline_local_finds_insecure() {
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn pipeline_local_finds_insecure() {
         let source = "def run(code):\n    eval(code)\n";
-        let result = parse_and_review(source, Language::Python, None, vec![]);
+        let result = parse_and_review(source, Language::Python, None, vec![]).await;
         assert!(result.findings.iter().any(|f| f.category == "security"));
     }
 
     // -- With LLM --
 
-    #[test]
-    fn pipeline_llm_findings_merged_with_local() {
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn pipeline_llm_findings_merged_with_local() {
         let source = "def run(code):\n    eval(code)\n";
         let llm_response = r#"[{"title":"Dangerous eval","description":"eval is dangerous","severity":"critical","category":"security","line_start":2,"line_end":2}]"#;
         let llm = FakeReviewer::always(llm_response);
@@ -1153,53 +1197,53 @@ mod tests {
             source, Language::Python,
             Some(&llm),
             vec!["gpt-5.4".into()],
-        );
+        ).await;
         // Should have findings from both local and LLM, merged
         assert!(!result.findings.is_empty());
         assert!(result.findings.iter().any(|f| matches!(&f.source, Source::LocalAst)));
     }
 
-    #[test]
-    fn pipeline_llm_empty_response() {
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn pipeline_llm_empty_response() {
         let source = "fn safe() -> i32 { 42 }";
         let llm = FakeReviewer::always("[]");
         let result = parse_and_review(
             source, Language::Rust,
             Some(&llm),
             vec!["gpt-5.4".into()],
-        );
+        ).await;
         assert!(result.findings.is_empty());
     }
 
-    #[test]
-    fn pipeline_llm_failure_degrades_gracefully() {
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn pipeline_llm_failure_degrades_gracefully() {
         let source = "fn safe() -> i32 { 42 }";
         let llm = FakeReviewer::failing("network error");
         let result = parse_and_review(
             source, Language::Rust,
             Some(&llm),
             vec!["gpt-5.4".into()],
-        );
+        ).await;
         // LLM failure should not crash; local results still work
         assert!(result.findings.is_empty());
     }
 
-    #[test]
-    fn pipeline_llm_malformed_response_degrades_gracefully() {
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn pipeline_llm_malformed_response_degrades_gracefully() {
         let source = "fn safe() -> i32 { 42 }";
         let llm = FakeReviewer::always("not valid json");
         let result = parse_and_review(
             source, Language::Rust,
             Some(&llm),
             vec!["gpt-5.4".into()],
-        );
+        ).await;
         assert!(result.findings.is_empty());
     }
 
     // -- Multi-model ensemble --
 
-    #[test]
-    fn pipeline_ensemble_multiple_models() {
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn pipeline_ensemble_multiple_models() {
         let source = "fn x() -> i32 { 42 }";
         let llm_response = r#"[{"title":"Style issue","description":"Consider naming","severity":"info","category":"style","line_start":1,"line_end":1}]"#;
         let llm = FakeReviewer::always(llm_response);
@@ -1207,7 +1251,7 @@ mod tests {
             source, Language::Rust,
             Some(&llm),
             vec!["gpt-5.4".into(), "claude".into()],
-        );
+        ).await;
         // Same response from both models should be deduped
         assert!(!result.findings.is_empty());
         // Should be merged (not duplicated)
@@ -1219,8 +1263,8 @@ mod tests {
 
     // -- Secret redaction --
 
-    #[test]
-    fn pipeline_redacts_secrets_before_llm() {
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn pipeline_redacts_secrets_before_llm() {
         let source = "API_KEY = \"sk-proj-secret123456\"\nfn main() {}";
         let llm = FakeReviewer::always("[]");
         // We can't directly verify the prompt content through the FakeLlmReviewer,
@@ -1233,33 +1277,33 @@ mod tests {
             source, Language::Rust,
             Some(&llm),
             vec!["gpt-5.4".into()],
-        );
+        ).await;
         // Pipeline completes without panic — redaction doesn't affect local analysis
         assert!(result.file_path == "test.rs");
     }
 
-    #[test]
-    fn pipeline_file_path_in_result() {
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn pipeline_file_path_in_result() {
         let source = "fn x() {}";
-        let result = parse_and_review(source, Language::Rust, None, vec![]);
+        let result = parse_and_review(source, Language::Rust, None, vec![]).await;
         assert_eq!(result.file_path, "test.rs");
     }
 
     // -- Cache integration --
 
-    #[test]
-    fn review_source_without_cache() {
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn review_source_without_cache() {
         let source = "fn simple() -> i32 { 42 }";
         let config = PipelineConfig::default();
         let result = review_source(
             Path::new("test.rs"), source, Language::Rust,
             None, &config, None,
-        ).unwrap();
+        ).await.unwrap();
         assert!(result.findings.is_empty());
     }
 
-    #[test]
-    fn review_source_with_cache_populates_cache() {
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn review_source_with_cache_populates_cache() {
         let cache = crate::cache::ParseCache::new(10);
         let source = "fn simple() -> i32 { 42 }";
         let config = PipelineConfig::default();
@@ -1267,7 +1311,7 @@ mod tests {
         let _result = review_source(
             Path::new("test.rs"), source, Language::Rust,
             None, &config, Some(&cache),
-        ).unwrap();
+        ).await.unwrap();
 
         assert_eq!(cache.stats().misses, 1);
         assert_eq!(cache.stats().hits, 0);
@@ -1276,24 +1320,24 @@ mod tests {
         let _result2 = review_source(
             Path::new("test.rs"), source, Language::Rust,
             None, &config, Some(&cache),
-        ).unwrap();
+        ).await.unwrap();
 
         assert_eq!(cache.stats().hits, 1);
     }
 
-    #[test]
-    fn review_source_cache_different_files() {
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn review_source_cache_different_files() {
         let cache = crate::cache::ParseCache::new(10);
         let config = PipelineConfig::default();
 
         review_source(
             Path::new("a.rs"), "fn a() {}", Language::Rust,
             None, &config, Some(&cache),
-        ).unwrap();
+        ).await.unwrap();
         review_source(
             Path::new("b.rs"), "fn b() {}", Language::Rust,
             None, &config, Some(&cache),
-        ).unwrap();
+        ).await.unwrap();
 
         assert_eq!(cache.stats().misses, 2);
         assert_eq!(cache.stats().size, 2);
@@ -1352,11 +1396,12 @@ mod tests {
         assert_eq!(cfg.semaphore.as_ref().unwrap().available_permits(), 4);
     }
 
-    #[test]
-    fn review_file_works_with_semaphore() {
-        let rt = tokio::runtime::Runtime::new().unwrap();
-        let _guard = rt.enter();
-
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn review_file_works_with_semaphore() {
+        // Pre-#81: this test built its own Runtime + entered it because
+        // review_file was sync and acquire_llm_permit needed a runtime
+        // context. Post-#81: review_file is async, the #[tokio::test]
+        // runtime drives it directly.
         let sem = std::sync::Arc::new(tokio::sync::Semaphore::new(2));
         let cfg = PipelineConfig {
             models: vec!["test-model".into()],
@@ -1378,7 +1423,7 @@ mod tests {
         let result = review_file(
             std::path::Path::new("test.rs"), source, Language::Rust, &tree,
             Some(&EmptyReviewer), &cfg,
-        );
+        ).await;
         assert!(result.is_ok());
     }
 }


### PR DESCRIPTION
## Summary

- Eliminates the cross-runtime deadlock in `pipeline::acquire_llm_permit` (issue #81). Pre-fix the helper synchronously branched on the calling Tokio runtime flavor; the current-thread branch deadlocked when the permit holder was another task on the *same* runtime (the `std::thread::scope` `join()` blocked the only worker, the holder never ran to release, and the spawned helper runtime awaited forever).
- Post-fix `acquire_llm_permit` is `async fn`: `sem.as_ref()?.clone().acquire_owned().await.ok()`. No runtime detection, no thread spawning, no blocking. Awaiting cooperatively yields to the runtime that owns the holder; deadlock vanishes by construction.
- **Public API change:** `pipeline::review_file`, `review_source`, `review_file_llm_only` are now `pub async fn`. All call sites updated in lockstep (CLI serial path `.await`s directly; CLI parallel path keeps the `spawn_blocking` shell so CPU-heavy parsing stays off runtime workers, with `Handle::current().block_on(async { ... })` inside the closure to bridge sync-context blocking-pool threads into the async pipeline; MCP `handle_review` is now `async fn`; HTTP daemon `.await`s).

## Evidence

- `cargo test --bin quorum`: 1526 passed, 1 ignored (1 suite, 6.95s).
- `cargo test` (full suite incl. integration): 1575 passed, 1 ignored (12 suites, 112s).
- `cargo clippy --bin quorum`: 206 warnings, ZERO new vs main (pre-existing project debt: empty-line-after-doc-comment, collapsible-if, etc.).
- `cargo build --release --bin quorum`: 1m 49s, clean.
- Smoke: `quorum version` → 0.17.3; `quorum review src/pipeline.rs --compact` produces findings; `quorum serve` returns valid `initialize` response.

## Tests added

- `acquire_llm_permit_does_not_deadlock_under_contention_on_current_thread` — actively exercises the formerly-deadlocking flavor with `tokio::sync::Notify` deterministic handshake (no `sleep` timing windows), holder + waiter via `tokio::join!`, 5s timeout floor.
- `acquire_llm_permit_does_not_deadlock_under_contention_on_multi_thread` — defensive matrix coverage; documents production behavior preserved.
- `acquire_llm_permit_cancellation_does_not_leak` — aborted waiter does not corrupt semaphore state; subsequent acquire still works (2s post-release tolerance for slow CI).
- `acquire_llm_permit_returns_none_when_semaphore_is_closed` — mutation-killer for the `?` and `.ok()` branches.
- `acquire_llm_permit_returns_some_when_permit_available_on_*` — happy path on both flavors.
- Replaced obsolete `acquire_llm_permit_does_not_panic_*` tests (pre-fix used `catch_unwind` on a sync call; post-fix the function returns a future that's cheap to construct, so the panic check is no longer meaningful).
- Bulk-converted ~15 `#[test]` sites to `#[tokio::test(flavor = "multi_thread", worker_threads = 1)]` — pinned flavor preserves sequential semantics for tests that previously assumed sync execution order. (Default `#[tokio::test]` is current-thread, which can change cooperative-scheduling behavior.)

## Process

- Plan committed first ([docs/plans/2026-04-25-issue-81-async-permit.md](./docs/plans/2026-04-25-issue-81-async-permit.md)) with explicit two-stage review: `test-planning-implementation` agent (acceptance coverage) + `testing-antipatterns-expert` agent (bias against compile-fail RED, sleep-based timing, assertion roulette). Plan revised before any test code was written: replaced `sleep(10ms)` windows with `Notify`-based handshake, bumped cancellation timeout from 500ms → 2s, added closed-semaphore mutation-killer, pinned `#[tokio::test]` flavor on bulk conversions.
- TDD: RED test (compile-fail against current sync signature, with rustc itself suggesting "consider making `fn acquire_llm_permit` asynchronous") committed BEFORE the implementation. Plan revision noted that the antipattern reviewer's suggested `spawn_blocking` shim runtime-RED would NOT actually reproduce the deadlock — `spawn_blocking` runs on the blocking pool, not the worker, so the holder still gets polled. Compile-fail RED accepted as sufficient.
- Quorum self-review on the diff: 22 total findings, 21 pre-existing (cyclomatic complexity, unwraps elsewhere, etc.), 1 in-diff (`block-on-in-async` at `main.rs:970-980`) recorded as `fp` — the ast-grep rule pattern-matches `block_on(async {...})` but cannot see the enclosing `spawn_blocking` closure; the call site is on a blocking-pool thread per Tokio docs.
- GPT-5.4 design review confirmed: async conversion is the right shape; `Handle::block_on` inside `spawn_blocking` is sound; `OwnedSemaphorePermit` across `.await` is fine.

## Out of scope (filed as follow-ups separately)

- `LlmReviewer::review` is still sync (`reqwest::blocking` ~12-20s); blocks one runtime worker during the LLM call. Pre-existing concern, not made worse here.
- `review_file_llm_only` doesn't use the `context7_skip_reason` helper that `review_file` uses. Drift, not a deadlock issue.

## Test plan

- [ ] CI green
- [ ] CodeRabbit review (comments addressed in subsequent commits if needed)
- [ ] No new clippy warnings vs main
- [ ] Regression test passes against post-fix code; would fail to compile against pre-fix sync signature

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevents cross-runtime deadlocks and ensures review work is properly awaited, improving stability under contention.

* **New Features / Improvements**
  * CLI, HTTP, and dispatch paths fully adopt async review flows and correctly await task completion.
  * LLM throttling/permit acquisition converted to async to avoid blocking behavior.

* **Tests**
  * Expanded async regression and integration tests for contention, cancellation/leak safety, closed-permit behavior, and telemetry.

* **Documentation**
  * Added a migration and verification plan for the async transition.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->