### PR TITLE
fix(cli): validate context add --name and cap context query --k (#135, #136)

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -122,6 +122,21 @@ pub fn validate_source_name(s: &str) -> Result<String, String> {
     Ok(s.to_string())
 }
 
+/// Validate `--k` for `quorum context query`. clap 4.5's
+/// `value_parser!(usize).range(...)` is unsupported (the ranged parser only
+/// takes primitive integer types like u64/i64), so we hand-roll the
+/// validator and keep the field type `Option<usize>` to avoid downstream
+/// type churn.
+pub fn validate_k(s: &str) -> Result<usize, String> {
+    let n: usize = s
+        .parse()
+        .map_err(|e| format!("--k must be a positive integer: {e}"))?;
+    if !(1..=100).contains(&n) {
+        return Err(format!("--k must be in 1..=100 (got {n})"));
+    }
+    Ok(n)
+}
+
 #[derive(Parser)]
 pub struct ContextAddOpts {
     /// Short unique name for the source (used as a directory key).
@@ -198,8 +213,8 @@ pub struct ContextQueryOpts {
     #[arg(long)]
     pub source: Option<String>,
 
-    /// Return up to this many chunks.
-    #[arg(long)]
+    /// Return up to this many chunks. Range: 1..=100.
+    #[arg(long, value_parser = validate_k)]
     pub k: Option<usize>,
 
     /// Include per-chunk scoring details.
@@ -1260,4 +1275,64 @@ mod tests {
         assert!(r.is_ok(), "64-char name (max allowed) must parse");
     }
 
+    // --- Issue #136: clap-layer validation for `--k` --------------------------
+    //
+    // `clap::value_parser!(usize).range(...)` is NOT supported in clap 4.5
+    // (the ranged parser only takes u64/i64-style integer types), so we use
+    // a custom `validate_k` value_parser and keep the field type
+    // `Option<usize>` to avoid downstream type churn.
+
+    #[test]
+    fn context_query_k_rejects_zero() {
+        use clap::Parser;
+        let r = Args::try_parse_from([
+            "quorum", "context", "query", "hello", "--k", "0",
+        ]);
+        assert!(r.is_err(), "--k 0 must be rejected (would produce empty results)");
+    }
+
+    #[test]
+    fn context_query_k_rejects_above_cap() {
+        use clap::Parser;
+        let r = Args::try_parse_from([
+            "quorum", "context", "query", "hello", "--k", "101",
+        ]);
+        assert!(r.is_err(), "--k 101 must be rejected (above 100 cap)");
+    }
+
+    #[test]
+    fn context_query_k_rejects_negative() {
+        use clap::Parser;
+        let r = Args::try_parse_from([
+            "quorum", "context", "query", "hello", "--k", "-1",
+        ]);
+        assert!(r.is_err(), "--k -1 must be rejected (not a usize)");
+    }
+
+    #[test]
+    fn context_query_k_accepts_in_range() {
+        use clap::Parser;
+        let r = Args::try_parse_from([
+            "quorum", "context", "query", "hello", "--k", "50",
+        ]);
+        assert!(r.is_ok(), "--k 50 must parse");
+    }
+
+    #[test]
+    fn context_query_k_accepts_one() {
+        use clap::Parser;
+        let r = Args::try_parse_from([
+            "quorum", "context", "query", "hello", "--k", "1",
+        ]);
+        assert!(r.is_ok(), "--k 1 must parse (lower bound)");
+    }
+
+    #[test]
+    fn context_query_k_accepts_hundred() {
+        use clap::Parser;
+        let r = Args::try_parse_from([
+            "quorum", "context", "query", "hello", "--k", "100",
+        ]);
+        assert!(r.is_ok(), "--k 100 must parse (upper bound)");
+    }
 }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -87,10 +87,46 @@ pub enum ContextCommand {
     Doctor(ContextDoctorOpts),
 }
 
+/// Validate `--name` (and any other "becomes a single directory component"
+/// argument). The value lands at `~/.quorum/sources/<name>/`, so it must be:
+///
+/// - 1..=64 ASCII chars from `[a-zA-Z0-9_-]`
+/// - not start with `.` (no hidden dirs, no `.`/`..` traversal)
+///
+/// This validator is the single source of truth shared by clap's
+/// `value_parser`, the `run_add` handler (defense-in-depth), and
+/// `SourcesConfig::append_source` (config-write boundary). It returns the
+/// owned `String` clap stores into the typed field.
+pub fn validate_source_name(s: &str) -> Result<String, String> {
+    if s.is_empty() {
+        return Err("--name must not be empty".into());
+    }
+    if s.len() > 64 {
+        return Err(format!(
+            "--name length must be 1..=64 (got {})",
+            s.len()
+        ));
+    }
+    if s.starts_with('.') {
+        return Err("--name must not start with '.'".into());
+    }
+    if !s
+        .chars()
+        .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-')
+    {
+        return Err(
+            "--name may only contain [a-zA-Z0-9_-] (no path separators, spaces, or unicode)"
+                .into(),
+        );
+    }
+    Ok(s.to_string())
+}
+
 #[derive(Parser)]
 pub struct ContextAddOpts {
     /// Short unique name for the source (used as a directory key).
-    #[arg(long)]
+    /// Must be 1..=64 chars from [a-zA-Z0-9_-] and not start with '.'.
+    #[arg(long, value_parser = validate_source_name)]
     pub name: String,
 
     /// Source kind: rust, typescript, javascript, python, go, terraform, service, docs.
@@ -1106,4 +1142,122 @@ mod tests {
             res.err().map(|e| e.kind())
         );
     }
+
+    // --- Issue #135: clap-layer validation for `--name` -----------------------
+    //
+    // The `--name` value becomes a single directory component under
+    // `~/.quorum/sources/<name>/`. Path-traversal characters, leading dots,
+    // and overlong values must be rejected at parse time; the handler also
+    // re-validates as defense-in-depth (see `src/context/cli.rs::run_add`).
+
+    #[test]
+    fn context_add_name_rejects_dotdot() {
+        use clap::Parser;
+        let r = Args::try_parse_from([
+            "quorum", "context", "add",
+            "--name", "../etc",
+            "--kind", "rust",
+            "--path", "/tmp/x",
+        ]);
+        assert!(r.is_err(), "../etc must be rejected at parse time");
+    }
+
+    #[test]
+    fn context_add_name_rejects_absolute() {
+        use clap::Parser;
+        let r = Args::try_parse_from([
+            "quorum", "context", "add",
+            "--name", "/etc/passwd",
+            "--kind", "rust",
+            "--path", "/tmp/x",
+        ]);
+        assert!(r.is_err());
+    }
+
+    #[test]
+    fn context_add_name_rejects_slash() {
+        use clap::Parser;
+        let r = Args::try_parse_from([
+            "quorum", "context", "add",
+            "--name", "a/b",
+            "--kind", "rust",
+            "--path", "/tmp/x",
+        ]);
+        assert!(r.is_err());
+    }
+
+    #[test]
+    fn context_add_name_rejects_backslash() {
+        use clap::Parser;
+        let r = Args::try_parse_from([
+            "quorum", "context", "add",
+            "--name", r"a\b",
+            "--kind", "rust",
+            "--path", "/tmp/x",
+        ]);
+        assert!(r.is_err());
+    }
+
+    #[test]
+    fn context_add_name_rejects_leading_dot() {
+        use clap::Parser;
+        let r = Args::try_parse_from([
+            "quorum", "context", "add",
+            "--name", ".hidden",
+            "--kind", "rust",
+            "--path", "/tmp/x",
+        ]);
+        assert!(r.is_err());
+    }
+
+    #[test]
+    fn context_add_name_rejects_overlong() {
+        use clap::Parser;
+        let long = "a".repeat(65);
+        let r = Args::try_parse_from([
+            "quorum", "context", "add",
+            "--name", &long,
+            "--kind", "rust",
+            "--path", "/tmp/x",
+        ]);
+        assert!(r.is_err());
+    }
+
+    #[test]
+    fn context_add_name_rejects_empty() {
+        use clap::Parser;
+        let r = Args::try_parse_from([
+            "quorum", "context", "add",
+            "--name", "",
+            "--kind", "rust",
+            "--path", "/tmp/x",
+        ]);
+        assert!(r.is_err());
+    }
+
+    #[test]
+    fn context_add_name_accepts_simple() {
+        use clap::Parser;
+        let r = Args::try_parse_from([
+            "quorum", "context", "add",
+            "--name", "my-source_1",
+            "--kind", "rust",
+            "--path", "/tmp/x",
+        ]);
+        assert!(r.is_ok(), "simple alnum/dash/underscore must parse: {:?}", r.err().map(|e| e.to_string()));
+    }
+
+    #[test]
+    fn context_add_name_accepts_64_chars() {
+        use clap::Parser;
+        let max_len = "a".repeat(64);
+        let r = Args::try_parse_from([
+            "quorum", "context", "add",
+            "--name", &max_len,
+            "--kind", "rust",
+            "--path", "/tmp/x",
+        ]);
+        assert!(r.is_ok(), "64-char name (max allowed) must parse");
+    }
+
 }

--- a/src/context/cli.rs
+++ b/src/context/cli.rs
@@ -614,10 +614,16 @@ fn run_init<D: ContextDeps>(deps: &D) -> Result<CmdOutput> {
 fn run_add<D: ContextDeps>(args: &AddArgs, deps: &D) -> Result<CmdOutput> {
     // Up-front validation: failing here means the on-disk file is never
     // touched, which is the cheapest way to satisfy the atomicity contract.
+    //
+    // Defense-in-depth (#135): re-run the strict allowlist validator from
+    // `crate::cli::validate_source_name`. clap's value_parser already gates
+    // the command-line surface, but every API caller that builds `AddArgs`
+    // directly (programmatic users, MCP wiring, tests) must hit the same
+    // gate before we touch the on-disk file or join `<home>/sources/<name>`
+    // anywhere downstream.
     let name = args.name.trim();
-    if name.is_empty() {
-        return Err(anyhow!("source name must not be empty"));
-    }
+    crate::cli::validate_source_name(name)
+        .map_err(|e| anyhow!("source name invalid: {e}"))?;
     let kind = SourceKind::parse_cli(&args.kind).ok_or_else(|| {
         anyhow!(
             "unknown kind '{}' (expected one of: rust, typescript, javascript, python, go, terraform, service, docs)",

--- a/src/context/cli_tests.rs
+++ b/src/context/cli_tests.rs
@@ -481,6 +481,10 @@ fn add_rejects_control_characters_in_user_strings() {
     run_context_cmd(&ContextCmd::Init, &deps).expect("init");
 
     // Newline in name would corrupt the TOML even after string escaping.
+    // After #135, a newline in `--name` is rejected by the stricter
+    // allowlist (`[a-zA-Z0-9_-]`) BEFORE the generic control-char branch
+    // fires, so the error message changes shape. Either path is correct;
+    // we just need the name to be rejected.
     let bad_name = AddArgs {
         name: "core\nlie".to_string(),
         kind: "rust".to_string(),
@@ -490,7 +494,11 @@ fn add_rejects_control_characters_in_user_strings() {
     };
     let err = run_context_cmd(&ContextCmd::Add(bad_name), &deps)
         .expect_err("control char in name must be rejected");
-    assert!(format!("{err}").contains("control character"));
+    let msg = format!("{err}");
+    assert!(
+        msg.to_lowercase().contains("name") || msg.contains("control character"),
+        "name with newline must be rejected (allowlist or control-char path): {msg}"
+    );
 
     // Same for url, rev, path, ignore glob.
     for args in [
@@ -530,6 +538,105 @@ fn add_rejects_control_characters_in_user_strings() {
             .expect_err("control char must be rejected");
         assert!(format!("{err}").contains("control character"));
     }
+}
+
+// --- Issue #135 defense-in-depth ------------------------------------------
+//
+// `validate_source_name` is also enforced at the clap value_parser layer
+// (see `src/cli/mod.rs`), but every API caller that constructs `AddArgs`
+// directly (programmatic users, tests, future MCP wiring) must hit the same
+// gate. A path-traversal name that bypasses clap MUST still be rejected by
+// the handler before any on-disk write happens — otherwise a future code
+// path that joins `<home>/sources/<name>` could escape the sources root.
+
+#[test]
+fn add_rejects_path_traversal_name_at_handler() {
+    let deps = TestDeps::new();
+    run_context_cmd(&ContextCmd::Init, &deps).expect("init");
+    let err = run_context_cmd(
+        &ContextCmd::Add(path_add_args("../etc", "rust", "/tmp/x")),
+        &deps,
+    )
+    .expect_err("../etc must be rejected by handler even if clap is bypassed");
+    let msg = format!("{err}").to_lowercase();
+    assert!(
+        msg.contains("name"),
+        "error must mention --name: {msg}"
+    );
+}
+
+#[test]
+fn add_rejects_slash_in_name_at_handler() {
+    let deps = TestDeps::new();
+    run_context_cmd(&ContextCmd::Init, &deps).expect("init");
+    let err = run_context_cmd(
+        &ContextCmd::Add(path_add_args("a/b", "rust", "/tmp/x")),
+        &deps,
+    )
+    .expect_err("path separator must be rejected by handler");
+    let msg = format!("{err}").to_lowercase();
+    assert!(msg.contains("name"));
+}
+
+#[test]
+fn add_rejects_leading_dot_at_handler() {
+    let deps = TestDeps::new();
+    run_context_cmd(&ContextCmd::Init, &deps).expect("init");
+    let err = run_context_cmd(
+        &ContextCmd::Add(path_add_args(".hidden", "rust", "/tmp/x")),
+        &deps,
+    )
+    .expect_err("leading dot must be rejected by handler");
+    let msg = format!("{err}").to_lowercase();
+    assert!(msg.contains("name"));
+}
+
+#[test]
+fn add_rejects_overlong_name_at_handler() {
+    let deps = TestDeps::new();
+    run_context_cmd(&ContextCmd::Init, &deps).expect("init");
+    let too_long = "a".repeat(65);
+    let err = run_context_cmd(
+        &ContextCmd::Add(path_add_args(&too_long, "rust", "/tmp/x")),
+        &deps,
+    )
+    .expect_err("65-char name must be rejected by handler");
+    let msg = format!("{err}").to_lowercase();
+    assert!(msg.contains("name"));
+}
+
+#[test]
+fn append_source_rejects_path_traversal_name() {
+    // SourcesConfig::append_source is the config-write boundary; even a
+    // hand-rolled SourceEntry constructed outside the CLI must be gated.
+    use super::config::{SourceEntry, SourceKind};
+    let deps = TestDeps::new();
+    run_context_cmd(&ContextCmd::Init, &deps).expect("init");
+    let path = deps.home_dir().join("sources.toml");
+    let entry = SourceEntry {
+        name: "../etc".to_string(),
+        kind: SourceKind::Rust,
+        location: SourceLocation::Path(PathBuf::from("/tmp/x")),
+        paths: Vec::new(),
+        weight: None,
+        ignore: Vec::new(),
+    };
+    let err = SourcesConfig::append_source(&path, &entry)
+        .expect_err("traversal name at config layer must be rejected");
+    let msg = format!("{err}").to_lowercase();
+    assert!(msg.contains("name"), "error must mention name: {msg}");
+}
+
+#[test]
+fn add_accepts_valid_name_at_handler() {
+    // Positive control: the validator must NOT regress on legit names.
+    let deps = TestDeps::new();
+    run_context_cmd(&ContextCmd::Init, &deps).expect("init");
+    run_context_cmd(
+        &ContextCmd::Add(path_add_args("my-app_1", "rust", "/tmp/x")),
+        &deps,
+    )
+    .expect("alnum/dash/underscore name must be accepted");
 }
 
 #[test]

--- a/src/context/config.rs
+++ b/src/context/config.rs
@@ -227,9 +227,14 @@ impl SourcesConfig {
     /// config. This preserves any hand edits, comments, and formatting in
     /// the `[context]` block and existing `[[source]]` entries.
     pub fn append_source(path: &Path, entry: &SourceEntry) -> Result<(), ConfigError> {
-        if entry.name.trim().is_empty() {
-            return Err(ConfigError::Invalid("source name must not be empty".into()));
-        }
+        // Defense-in-depth (#135): single source of truth for source-name
+        // validity lives in `crate::cli::validate_source_name`. The CLI
+        // gates `--name` at parse time and `run_add` re-checks; this is the
+        // last line of defense for any caller bypassing both (e.g. a
+        // future programmatic config writer or a hand-edited entry round-
+        // tripping through `from_str`).
+        crate::cli::validate_source_name(entry.name.trim())
+            .map_err(|e| ConfigError::Invalid(format!("source name invalid: {e}")))?;
         match &entry.location {
             SourceLocation::Path(p) => {
                 if p.as_os_str().is_empty() {


### PR DESCRIPTION
## Summary
- Validates `quorum context add --name` at parse time (allowlist `^[a-zA-Z0-9_-]{1,64}$`, no leading dot, no path separators) — closes #135
- Caps `quorum context query --k` at `1..=100` (custom validator since clap 4.5 `range()` doesn't support `usize`) — closes #136
- DRY: single `validate_source_name` shared across clap value_parser, `run_add`, and `SourcesConfig::append_source`

## Plan
`docs/plans/2026-04-30-self-review-bugfix-batch.md` — PR 1 section

## Implementation deviation (validated by review)
The plan suggested an additional `canonicalize+starts_with` defense-in-depth check at the handler. Skipped because the allowlist regex already rejects path separators / `..` / leading dots, and `run_add` only writes to `sources.toml` (never per-source dirs). The Phase 6 review confirmed: any name passing the allowlist cannot escape sources root via the `<home>/sources/<name>` join. Deviation stands.

## Tests
+21 tests (1637 → 1658). Inline in `src/cli/mod.rs` and `src/context/cli_tests.rs`.

## Pre-existing bugs surfaced during review (filed, not fixed in this PR)
- #149 — `ContextAddOpts.kind` accepts arbitrary strings (correctness)
- #150 — `ReviewOpts.parallel` unbounded usize, 0 == unlimited (perf)
- #151 — `append_source` read-modify-write race (concurrency)
- #152 — `render_source_fragment` drops `SourceEntry.paths` field on disk (correctness)

## Test plan
- [x] `cargo test --bin quorum` — 1658 passed, 0 failed
- [x] `cargo build --release` — clean
- [x] CodeRabbit review — 0 findings
- [x] Quorum self-review — 0 in-branch findings (12 pre-existing, 4 filed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Stricter validation for source names in `quorum context add --name` with improved error messages.
  * Added validation and range constraints (1–100) for the `--k` parameter in `quorum context query`.

* **Tests**
  * Expanded test coverage for invalid and boundary-case inputs across name and k parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->