### PR TITLE
docs: capture v0.18.0+ env vars, FpKind taxonomy, refreshed quorum-cli skill

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,7 +28,18 @@ QUORUM_BASE_URL=https://litellm.example.com   # OpenAI-compatible endpoint
 QUORUM_API_KEY=sk-...                          # enables LLM review
 QUORUM_MODEL=gpt-5.4                           # default model
 QUORUM_ENSEMBLE_MODELS=gpt-5.4,gemini-2.5-pro  # for --ensemble
+
+# HTTP timeouts (#117, v0.18.0+)
+QUORUM_HTTP_TIMEOUT=300        # total request timeout, seconds (default 300)
+QUORUM_HTTP_READ_TIMEOUT=120   # idle/read timeout, seconds (default 120)
+
+# base_url validation (#119, v0.18.0+)
+QUORUM_ALLOWED_BASE_URL_HOSTS=litellm.5745.house  # allowlist of permitted hosts (comma-separated)
+QUORUM_ALLOW_PRIVATE_BASE_URL=1                    # allow private/loopback IPs (LANs, dev)
+QUORUM_UNSAFE_BASE_URL=1                           # disable all SSRF/scheme guards (last resort)
 ```
+
+The base_url validator (`src/llm_client.rs::validate_base_url`) requires HTTPS by default, rejects credentials in the URL, blocks private/loopback IPs, and consults `QUORUM_ALLOWED_BASE_URL_HOSTS` if set. v0.18.1 fixed a `QUORUM_ALLOW_PRIVATE_BASE_URL` bypass where the HTTP scheme would be permitted on public IPs (#167) — the scheme check now keys on whether the resolved host is actually private, not on the env var alone.
 
 ## Supported Languages
 
@@ -75,6 +86,18 @@ Test fixtures in `rules/<language>/tests/`. Gap analysis in `docs/feedback-patte
 Feedback is stored at `~/.quorum/feedback.jsonl` and loaded automatically for calibration.
 Record feedback via CLI (`quorum feedback`), MCP `feedback` tool, or programmatically via the FeedbackStore API.
 Verdicts: tp, fp, partial, wontfix. Provenance: post_fix (1.5x), human (1.0x), external (0.7x), auto_calibrate (0.5x), unknown (0.3x).
+
+**FpKind taxonomy (#123, v0.18.0+):** when recording an `fp` verdict, classify the reason via `--fp-kind <variant>` (CLI) or `fpKind` (MCP). The calibrator decays old precedents per-kind, on the theory that some FP classes age out faster than others:
+
+| Variant | Decay half-life | Meaning |
+|---------|-----------------|---------|
+| `hallucination` | 30d (fast) | Finding references code/API that doesn't exist (line off by N, wrong function name, fabricated import) |
+| `pattern-overgeneralization` | 60d | Pattern matched syntactically but the surrounding context makes it benign (e.g. `unwrap()` on a value the type system guarantees is `Some`) |
+| `trust-model` | 120d | Reviewer mis-modeled the trust boundary (e.g. flagged user-supplied data that's actually internal-only, or vice versa) |
+| `compensating-control` | 120d | Real pattern but mitigated upstream (e.g. SQL string concatenation behind an authenticated, parameter-validating handler) |
+| `out-of-scope` | 90d | Pre-existing issue surfaced by a diff-scoped review — not introduced by this change |
+
+`fp_kind_utilization_rate` is reported in `quorum stats` Feedback Health when ≥10% of FPs in the rolling window are tagged. Untagged FPs use the legacy uniform decay (83d half-life).
 
 **External-agent ingestion (issue #32):** verdicts from other review agents (pal, third-opinion, gemini, reviewdog, ...) flow through three paths, all funneling through `FeedbackStore::record_external`: (1) `~/.quorum/inbox/*.jsonl` drained at the top of every `review`/`stats` invocation via claim-then-ingest (atomic rename to `inbox/processing/` before parse, archive to `inbox/processed/` on success); (2) `quorum feedback --from-agent <name> [--agent-model <m>] [--confidence 0..1] [--category <c>]`; (3) MCP `feedback` tool with `fromAgent` field. Trust boundary: External may only record `tp`/`fp`/`partial` — `wontfix` and `context_misleading` are rejected at the chokepoint. Confidence is clamped to [0,1] (NaN-safe), agent name is normalized (trim+lowercase). Tier breakdown by Provenance shows up under `quorum stats` Feedback Health when any non-Human entry exists, with a per-agent sub-line for External.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,7 +87,7 @@ Feedback is stored at `~/.quorum/feedback.jsonl` and loaded automatically for ca
 Record feedback via CLI (`quorum feedback`), MCP `feedback` tool, or programmatically via the FeedbackStore API.
 Verdicts: tp, fp, partial, wontfix. Provenance: post_fix (1.5x), human (1.0x), external (0.7x), auto_calibrate (0.5x), unknown (0.3x).
 
-**FpKind taxonomy (#123, v0.18.0+):** when recording an `fp` verdict, classify the reason via `--fp-kind <variant>` (CLI, kebab-case) or `fpKind` (MCP, snake_case — note: the wire formats are asymmetric, the CLI drops the `_assumption` suffix on `trust-model`). The calibrator decays old precedents per-kind:
+**FpKind taxonomy (#123, v0.18.0+):** when recording an `fp` verdict, classify the reason via `--fp-kind <variant>` (CLI, kebab-case) or `fpKind` (MCP, snake_case). The CLI and MCP variant names are not just case-converted — they're independent enums and one pair diverges: CLI shortens to `trust-model` while MCP uses the full `trust_model_assumption`. The calibrator decays old precedents per-kind:
 
 | CLI flag | MCP `fpKind` | τ (days) | Half-life | Meaning |
 |----------|--------------|---------:|----------:|---------|

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,17 +87,19 @@ Feedback is stored at `~/.quorum/feedback.jsonl` and loaded automatically for ca
 Record feedback via CLI (`quorum feedback`), MCP `feedback` tool, or programmatically via the FeedbackStore API.
 Verdicts: tp, fp, partial, wontfix. Provenance: post_fix (1.5x), human (1.0x), external (0.7x), auto_calibrate (0.5x), unknown (0.3x).
 
-**FpKind taxonomy (#123, v0.18.0+):** when recording an `fp` verdict, classify the reason via `--fp-kind <variant>` (CLI) or `fpKind` (MCP). The calibrator decays old precedents per-kind, on the theory that some FP classes age out faster than others:
+**FpKind taxonomy (#123, v0.18.0+):** when recording an `fp` verdict, classify the reason via `--fp-kind <variant>` (CLI, kebab-case) or `fpKind` (MCP, snake_case — note: the wire formats are asymmetric, the CLI drops the `_assumption` suffix on `trust-model`). The calibrator decays old precedents per-kind:
 
-| Variant | Decay half-life | Meaning |
-|---------|-----------------|---------|
-| `hallucination` | 30d (fast) | Finding references code/API that doesn't exist (line off by N, wrong function name, fabricated import) |
-| `pattern-overgeneralization` | 60d | Pattern matched syntactically but the surrounding context makes it benign (e.g. `unwrap()` on a value the type system guarantees is `Some`) |
-| `trust-model` | 120d | Reviewer mis-modeled the trust boundary (e.g. flagged user-supplied data that's actually internal-only, or vice versa) |
-| `compensating-control` | 120d | Real pattern but mitigated upstream (e.g. SQL string concatenation behind an authenticated, parameter-validating handler) |
-| `out-of-scope` | 90d | Pre-existing issue surfaced by a diff-scoped review — not introduced by this change |
+| CLI flag | MCP `fpKind` | τ (days) | Half-life | Meaning |
+|----------|--------------|---------:|----------:|---------|
+| `hallucination` | `hallucination` | 120 | ~83d | Finding references code/API that doesn't exist (line off by N, wrong function name, fabricated import) |
+| `pattern-overgeneralization` | `pattern_overgeneralization` | 120 | ~83d | Pattern matched syntactically but context makes it benign (e.g. `unwrap()` on a value the type system guarantees is `Some`). Optional `--fp-discriminator` teaches the LLM how to distinguish |
+| `trust-model` | `trust_model_assumption` | 40 | ~28d | Reviewer mis-modeled the trust boundary — decays 3× faster because trust models evolve |
+| `compensating-control` | `compensating_control` | 120 | ~83d | Real pattern but mitigated upstream. **Requires** `--fp-reference <file:line\|PR\|URL>` (CLI) or nested `{reference: "..."}` (MCP) |
+| `out-of-scope` | `out_of_scope` | 120 | ~83d | Pre-existing issue surfaced by a diff-scoped review — not introduced by this change. Optional `--fp-tracked-in <PR/issue>` records the follow-up link |
 
-`fp_kind_utilization_rate` is reported in `quorum stats` Feedback Health when ≥10% of FPs in the rolling window are tagged. Untagged FPs use the legacy uniform decay (83d half-life).
+The recency weight is `exp(-age_days / τ)` so half-life ≈ τ × ln 2. `fp_kind_utilization_rate` is reported in `quorum stats` Feedback Health when ≥10% of FPs in the rolling window are tagged. Untagged FPs (and `Option<FpKind> = None` for pre-bump rows) use the default τ=120d.
+
+**fp_kind is dropped on the External path** — when `--from-agent` (CLI) or `fromAgent` (MCP) is set, the verdict routes through `FeedbackStore::record_external` / `ExternalVerdictInput`, which does not currently carry fp_kind. A `tracing::warn` fires at the MCP boundary so dropped fields are visible. fp_kind only persists on the Human / direct ingestion paths.
 
 **External-agent ingestion (issue #32):** verdicts from other review agents (pal, third-opinion, gemini, reviewdog, ...) flow through three paths, all funneling through `FeedbackStore::record_external`: (1) `~/.quorum/inbox/*.jsonl` drained at the top of every `review`/`stats` invocation via claim-then-ingest (atomic rename to `inbox/processing/` before parse, archive to `inbox/processed/` on success); (2) `quorum feedback --from-agent <name> [--agent-model <m>] [--confidence 0..1] [--category <c>]`; (3) MCP `feedback` tool with `fromAgent` field. Trust boundary: External may only record `tp`/`fp`/`partial` — `wontfix` and `context_misleading` are rejected at the chokepoint. Confidence is clamped to [0,1] (NaN-safe), agent name is normalized (trim+lowercase). Tier breakdown by Provenance shows up under `quorum stats` Feedback Health when any non-Human entry exists, with a per-agent sub-line for External.
 

--- a/README.md
+++ b/README.md
@@ -163,6 +163,17 @@ Add to your Claude Code MCP config:
 
 6 tools: `review`, `chat`, `debug`, `testgen`, `feedback`, `catalog`
 
+### Bundled Claude Code skill
+
+A `quorum-cli` Claude Code skill ships with the repo at `skills/quorum-cli/skill.md`. It teaches Claude when to reach for which review mode, how to record feedback, and the v0.18.0+ `fp_kind` taxonomy.
+
+```bash
+mkdir -p ~/.claude/skills/quorum-cli
+cp skills/quorum-cli/skill.md ~/.claude/skills/quorum-cli/
+```
+
+Re-run after `git pull` to keep it in sync with the repo's source of truth.
+
 ## Auto-Calibration
 
 Every LLM review automatically triages its own findings using a second model pass:
@@ -193,16 +204,38 @@ quorum improves over time through feedback. Record verdicts on findings:
 quorum feedback --file src/auth.rs --finding "SQL injection" --verdict tp --reason "Fixed with params"
 quorum feedback --file src/auth.rs --finding "complexity 5" --verdict fp --reason "Trivial match"
 
+# False positive with structured kind (v0.18.0+)
+quorum feedback --file src/x.rs --finding "unwrap on Option" --verdict fp \
+    --fp-kind pattern-overgeneralization --reason "type-system-guaranteed Some"
+quorum feedback --file src/x.rs --finding "fabricated function" --verdict fp \
+    --fp-kind hallucination --reason "no such function in this module"
+
+# After applying a fix (1.5x calibrator weight)
+quorum feedback --file src/x.rs --finding "Bug" --verdict tp --reason "Fixed in PR #200" \
+    --provenance post_fix
+
 # From another review agent (pal, third-opinion, gemini, reviewdog, ...)
 quorum feedback --file src/x.rs --finding "Bug" --verdict tp --reason "confirmed" \
     --from-agent pal --agent-model gpt-5.4 --confidence 0.9
 
-# Or via MCP feedback tool (in Claude Code), with optional fromAgent / agentModel / confidence fields
+# Or via MCP feedback tool (in Claude Code), with optional fromAgent / agentModel / confidence / fpKind fields
 # Or programmatically via the FeedbackStore API
 # Or by dropping JSONL files into ~/.quorum/inbox/ -- drained automatically on next review/stats
 ```
 
 Provenance weights: `post_fix` (1.5x), `human` (1.0x), `external` (0.7x, capped at 1.4 globally), `auto_calibrate` (0.5x, soft-suppresses to INFO), `unknown` (0.3x).
+
+**FpKind** (v0.18.0+) classifies *why* an FP was wrong, so the calibrator can decay each class on its own half-life:
+
+| Variant | Decay | When to use |
+|---------|-------|-------------|
+| `hallucination` | 30d | Reviewer cited code/API that doesn't exist |
+| `pattern-overgeneralization` | 60d | Pattern matched but context makes it benign |
+| `trust-model` | 120d | Wrong threat model (internal vs. user-supplied) |
+| `compensating-control` | 120d | Real pattern, mitigated upstream |
+| `out-of-scope` | 90d | Pre-existing in diff-scoped review |
+
+Untagged FPs use the legacy uniform 83d half-life. `quorum stats` reports `fp_kind_utilization_rate` once ≥10% of recent FPs are tagged.
 
 External-agent verdicts go through a stricter trust boundary: only `tp`/`fp`/`partial` are accepted (no `wontfix`/`context_misleading`), confidence is clamped to [0,1], and the global External contribution to any finding's TP/FP weight is capped to prevent a single misbehaving agent from dominating calibration.
 
@@ -253,7 +286,18 @@ QUORUM_MODEL=gpt-5.4                        # default review model
 QUORUM_REASONING_EFFORT=low                 # default reasoning depth
 QUORUM_ENSEMBLE_MODELS=gpt-5.4,claude       # for --ensemble mode
 CONTEXT7_API_KEY=...                         # enables framework doc injection
+
+# HTTP timeouts (v0.18.0+)
+QUORUM_HTTP_TIMEOUT=300        # total LLM request timeout, seconds (default 300)
+QUORUM_HTTP_READ_TIMEOUT=120   # idle/read timeout, seconds (default 120)
+
+# base_url validation (v0.18.0+)
+QUORUM_ALLOWED_BASE_URL_HOSTS=litellm.example.com   # comma-separated host allowlist
+QUORUM_ALLOW_PRIVATE_BASE_URL=1                      # allow private/loopback IPs (LAN dev)
+QUORUM_UNSAFE_BASE_URL=1                             # disable SSRF/scheme guards (last resort)
 ```
+
+The base_url validator requires HTTPS by default, rejects credentials embedded in the URL, blocks private/loopback IPs unless explicitly opted in, and consults `QUORUM_ALLOWED_BASE_URL_HOSTS` when set. Use the host allowlist for self-hosted LiteLLM proxies on the public internet; use `QUORUM_ALLOW_PRIVATE_BASE_URL=1` for LAN/dev deployments.
 
 ## Exit Codes
 

--- a/README.md
+++ b/README.md
@@ -206,9 +206,13 @@ quorum feedback --file src/auth.rs --finding "complexity 5" --verdict fp --reaso
 
 # False positive with structured kind (v0.18.0+)
 quorum feedback --file src/x.rs --finding "unwrap on Option" --verdict fp \
-    --fp-kind pattern-overgeneralization --reason "type-system-guaranteed Some"
+    --fp-kind pattern-overgeneralization --fp-discriminator "type-system-guaranteed Some" \
+    --reason "context-specific exception"
 quorum feedback --file src/x.rs --finding "fabricated function" --verdict fp \
     --fp-kind hallucination --reason "no such function in this module"
+quorum feedback --file src/x.rs --finding "SQL concat" --verdict fp \
+    --fp-kind compensating-control --fp-reference "src/auth.rs:42" \
+    --reason "param-validating handler upstream"
 
 # After applying a fix (1.5x calibrator weight)
 quorum feedback --file src/x.rs --finding "Bug" --verdict tp --reason "Fixed in PR #200" \
@@ -218,24 +222,28 @@ quorum feedback --file src/x.rs --finding "Bug" --verdict tp --reason "Fixed in 
 quorum feedback --file src/x.rs --finding "Bug" --verdict tp --reason "confirmed" \
     --from-agent pal --agent-model gpt-5.4 --confidence 0.9
 
-# Or via MCP feedback tool (in Claude Code), with optional fromAgent / agentModel / confidence / fpKind fields
+# Or via MCP feedback tool (in Claude Code), with optional fromAgent / agentModel / confidence / fpKind fields.
+# Note: fpKind uses snake_case wire format (e.g. "trust_model_assumption", "out_of_scope"),
+# and is *dropped* when fromAgent is set (the External path does not yet carry fpKind).
 # Or programmatically via the FeedbackStore API
 # Or by dropping JSONL files into ~/.quorum/inbox/ -- drained automatically on next review/stats
 ```
 
 Provenance weights: `post_fix` (1.5x), `human` (1.0x), `external` (0.7x, capped at 1.4 globally), `auto_calibrate` (0.5x, soft-suppresses to INFO), `unknown` (0.3x).
 
-**FpKind** (v0.18.0+) classifies *why* an FP was wrong, so the calibrator can decay each class on its own half-life:
+**FpKind** (v0.18.0+) classifies *why* an FP was wrong, so the calibrator can decay each class on its own schedule. The CLI accepts kebab-case (`--fp-kind`); MCP uses snake_case (`fpKind`) — and the names diverge slightly (CLI drops the `_assumption` suffix on `trust-model`):
 
-| Variant | Decay | When to use |
-|---------|-------|-------------|
-| `hallucination` | 30d | Reviewer cited code/API that doesn't exist |
-| `pattern-overgeneralization` | 60d | Pattern matched but context makes it benign |
-| `trust-model` | 120d | Wrong threat model (internal vs. user-supplied) |
-| `compensating-control` | 120d | Real pattern, mitigated upstream |
-| `out-of-scope` | 90d | Pre-existing in diff-scoped review |
+| CLI | MCP `fpKind` | τ | Half-life | When to use |
+|-----|--------------|---:|----------:|-------------|
+| `hallucination` | `hallucination` | 120d | ~83d | Reviewer cited code/API that doesn't exist |
+| `pattern-overgeneralization` | `pattern_overgeneralization` | 120d | ~83d | Pattern matched but context makes it benign. Add `--fp-discriminator` to teach the LLM the distinction |
+| `trust-model` | `trust_model_assumption` | 40d | ~28d | Wrong threat model (internal vs. user-supplied) — decays 3× faster |
+| `compensating-control` | `compensating_control` | 120d | ~83d | Real pattern, mitigated upstream. **Requires** `--fp-reference` (CLI) or `{reference: "..."}` (MCP) |
+| `out-of-scope` | `out_of_scope` | 120d | ~83d | Pre-existing in diff-scoped review. Optional `--fp-tracked-in` for the follow-up link |
 
-Untagged FPs use the legacy uniform 83d half-life. `quorum stats` reports `fp_kind_utilization_rate` once ≥10% of recent FPs are tagged.
+Untagged FPs use the default τ=120d (~83d half-life). `quorum stats` reports `fp_kind_utilization_rate` once ≥10% of recent FPs are tagged.
+
+`fp_kind` is **dropped on the External path** — when `--from-agent` (CLI) or `fromAgent` (MCP) is set, the verdict routes through `ExternalVerdictInput`, which does not currently carry `fp_kind`. A `tracing::warn` fires at the MCP boundary so the dropped field is visible. Tag external-agent verdicts on the agent's side, not via `fpKind`.
 
 External-agent verdicts go through a stricter trust boundary: only `tp`/`fp`/`partial` are accepted (no `wontfix`/`context_misleading`), confidence is clamped to [0,1], and the global External contribution to any finding's TP/FP weight is capped to prevent a single misbehaving agent from dominating calibration.
 

--- a/README.md
+++ b/README.md
@@ -231,7 +231,7 @@ quorum feedback --file src/x.rs --finding "Bug" --verdict tp --reason "confirmed
 
 Provenance weights: `post_fix` (1.5x), `human` (1.0x), `external` (0.7x, capped at 1.4 globally), `auto_calibrate` (0.5x, soft-suppresses to INFO), `unknown` (0.3x).
 
-**FpKind** (v0.18.0+) classifies *why* an FP was wrong, so the calibrator can decay each class on its own schedule. The CLI accepts kebab-case (`--fp-kind`); MCP uses snake_case (`fpKind`) — and the names diverge slightly (CLI drops the `_assumption` suffix on `trust-model`):
+**FpKind** (v0.18.0+) classifies *why* an FP was wrong, so the calibrator can decay each class on its own schedule. The CLI accepts kebab-case (`--fp-kind`); MCP uses snake_case (`fpKind`). The names are independent enums and one pair diverges: CLI shortens to `trust-model` while MCP uses the full `trust_model_assumption`.
 
 | CLI | MCP `fpKind` | τ | Half-life | When to use |
 |-----|--------------|---:|----------:|-------------|

--- a/skills/quorum-cli/skill.md
+++ b/skills/quorum-cli/skill.md
@@ -7,12 +7,24 @@ description: Use when reviewing code with quorum, recording feedback, or running
 
 Multi-source code review: local AST analysis + LLM ensemble + linter orchestration + feedback-calibrated findings. Rust-native, single binary.
 
+## Install
+
+This skill ships with the quorum repo. To install it for use in Claude Code:
+
+```bash
+mkdir -p ~/.claude/skills/quorum-cli
+cp skills/quorum-cli/skill.md ~/.claude/skills/quorum-cli/
+```
+
+The repo copy is the source of truth — re-run after `git pull` to refresh.
+
 ## Review Modes (choose by context)
 
 | Mode | Command | Speed | Depth | When to use |
 |------|---------|-------|-------|-------------|
 | Local-only | `quorum review <files>` | 7ms | Pattern-matching | CI gates, quick checks, no API key |
 | LLM-augmented | `QUORUM_API_KEY=... quorum review <files>` | 12-20s | Reasoning | Thorough review, pre-merge |
+| Parallel | `quorum review <files> --parallel 4` | ~8s/3 files | Same as LLM | Multi-file reviews (default) |
 | Compact | `quorum review <files> --compact` | Same | Same | LLM consumption, token-efficient |
 | Ensemble | `quorum review --ensemble <files>` | 60-90s | Multi-model | Critical code, security audit |
 | Via daemon | `quorum review --daemon <files>` | <1ms cached | Same as LLM | Repeated reviews, editor integration |
@@ -101,24 +113,54 @@ Telemetry is best-effort — failures don't break reviews. Delete the file at an
 
 ## Recording Feedback
 
-Feedback improves future reviews via the calibrator. After reviewing findings:
+Feedback improves future reviews via the calibrator. Use the MCP `feedback` tool after reviewing findings.
+
+### Which verdict to use
+
+Only `fp` and `tp` affect the calibrator. `partial` and `wontfix` are inert metadata — they don't suppress or boost anything.
+
+| Verdict | Calibrator effect | When to use |
+|---------|-------------------|-------------|
+| **fp** | **Suppresses** similar findings (needs 2+ matches) | Finding is wrong — not a real issue in context |
+| **tp** | **Boosts** similar findings (needs 2+ matches) | Finding is real and actionable |
+| **partial** | None | Real issue but severity overstated (e.g. "critical" should be "medium") |
+| **wontfix** | None | Avoid — use `tp` instead if the issue is real |
+
+### Decision flowchart
+
+1. **Is the finding wrong?** → `fp` (trains suppression globally)
+2. **Is the finding real and actionable?** → `tp` (trains boosting globally)
+3. **Is it real but severity overstated?** → `partial`
+4. **Is it real but accepted debt / not worth fixing?** → `tp` (still a real pattern — helps calibrator recognize similar issues)
+5. **Is it pre-existing, not related to your changes?** → Skip it. Don't record feedback for findings outside your diff scope.
+
+### Classifying false positives with `fp_kind` (v0.18.0+)
+
+When recording an `fp`, classify *why* it was wrong via `--fp-kind` (CLI) or `fpKind` (MCP). The calibrator decays each class on its own half-life:
+
+| Variant | Half-life | When to use |
+|---------|-----------|-------------|
+| `hallucination` | 30d | Reviewer cited code/API that doesn't exist (wrong line, fabricated function, nonexistent import) |
+| `pattern-overgeneralization` | 60d | Pattern matched but surrounding context makes it benign (e.g. `unwrap()` on type-system-guaranteed `Some`) |
+| `trust-model` | 120d | Wrong threat model (flagged internal-only data as user-supplied or vice versa) |
+| `compensating-control` | 120d | Real pattern, mitigated upstream (e.g. SQL concat behind authenticated parameter-validating handler) |
+| `out-of-scope` | 90d | Pre-existing issue surfaced by diff-scoped review — not introduced by this change |
 
 ```bash
-# Via MCP (when using quorum serve)
-# Use the feedback tool with verdict: tp, fp, partial, wontfix
+# CLI
+quorum feedback --file src/x.rs --finding "unwrap on Option" --verdict fp \
+    --fp-kind pattern-overgeneralization --reason "type-system-guaranteed Some"
 
-# Via the daemon API
-curl -X POST http://127.0.0.1:7842/review -H "Content-Type: application/json" \
-  -d '{"file_path":"src/auth.py","code":"..."}'
+# MCP feedback tool — pass fpKind: "hallucination" alongside verdict: "fp"
 ```
 
-Verdicts:
-- `tp`: true positive, real issue
-- `fp`: false positive, not a real issue in context
-- `partial`: real but overstated severity
-- `wontfix`: real issue, not worth fixing
+Untagged FPs use the legacy uniform 83d half-life. `quorum stats` reports `fp_kind_utilization_rate` once ≥10% of recent FPs are tagged.
 
-The calibrator needs 2+ FP verdicts on similar findings to suppress. TP verdicts with 2+ matches boost severity.
+### What NOT to do
+
+- **Don't use `wontfix`** — it's inert. If the issue is real, use `tp`. If it's not real, use `fp`.
+- **Don't record feedback for pre-existing findings** you didn't touch — it pollutes the global calibrator with noise from code you're not changing.
+- **Don't record `fp` for intentional patterns** (like disabled TLS for self-signed certs) unless you want them suppressed across ALL projects.
 
 ## MCP Server (for Claude Code / agents)
 
@@ -163,6 +205,8 @@ Hydration context scoped to changed lines only. Same finding quality, smaller pr
 | Flag | Purpose | Example |
 |------|---------|---------|
 | --compact | Token-efficient output (1 finding/line) | --compact |
+| --parallel N | Max concurrent LLM calls (default: 4, 0=unlimited, 1=sequential) | --parallel 8 |
+| --framework X | Override framework detection (e.g., home-assistant, terraform) | --framework terraform |
 | --reasoning-effort | Control reasoning depth (none/low/medium/high) | --reasoning-effort=low |
 | --calibration-model | Model for auto-calibration pass | --calibration-model=gpt-5.3-codex |
 | --no-auto-calibrate | Skip automatic triage | |
@@ -171,9 +215,10 @@ Hydration context scoped to changed lines only. Same finding quality, smaller pr
 
 | Scenario | Config | Speed |
 |----------|--------|-------|
-| Default | gpt-5.4, reasoning_effort=low | ~2s |
+| Default | gpt-5.4, --parallel 4 | ~8s/3 files |
 | Fast CI | gpt-5.3-codex, --no-auto-calibrate | ~1s |
 | Deep audit | gpt-5.2 --deep --reasoning-effort=high | ~100s |
+| Sequential | --parallel 1 (debugging) | ~45s/file |
 | No API key | (local only) | 7ms |
 
 ### Feedback provenance
@@ -181,8 +226,28 @@ Hydration context scoped to changed lines only. Same finding quality, smaller pr
 Verdicts from different sources carry different calibration weight:
 - **post_fix** (1.5x): Recorded after applying a fix — strongest signal
 - **human** (1.0x): Direct user triage
+- **external** (0.7x): Verdict from another review agent (pal, third-opinion, gemini, reviewdog, ...) — capped at 1.4 globally so a single agent cannot dominate
 - **auto_calibrate** (0.5x): LLM triage pass
 - **unknown** (0.3x): Legacy entries
+
+### Recording External-agent verdicts (v0.17.0+)
+
+Verdicts from other review agents flow through three paths, all going through the same trust boundary (only `tp`/`fp`/`partial` accepted; confidence clamped to [0,1]; agent name normalized):
+
+```bash
+# CLI (sync)
+quorum feedback --file src/x.rs --finding "Bug" --verdict tp --reason "confirmed" \
+    --from-agent pal --agent-model gpt-5.4 --confidence 0.9
+
+# MCP feedback tool — pass fromAgent / agentModel / confidence fields
+
+# Inbox (async batch ingestion)
+# Drop JSONL files into ~/.quorum/inbox/<anything>.jsonl
+# Drained automatically on next `quorum review` or `quorum stats`
+# Format: {"file_path":"...","finding_title":"...","finding_category":"...","verdict":"tp","reason":"...","agent":"pal","agent_model":null,"confidence":null}
+```
+
+The tier breakdown shows up under `quorum stats` Feedback Health when any non-Human entry exists, with a per-agent sub-line for External.
 
 ## Configuration
 
@@ -191,6 +256,15 @@ QUORUM_BASE_URL=https://litellm.example.com  # OpenAI-compatible endpoint
 QUORUM_API_KEY=sk-...                         # enables LLM review
 QUORUM_MODEL=gpt-5.4                          # default model
 QUORUM_ENSEMBLE_MODELS=gpt-5.4,gemini-2.5-pro # for --ensemble
+
+# HTTP timeouts (v0.18.0+)
+QUORUM_HTTP_TIMEOUT=300        # total request timeout, seconds (default 300)
+QUORUM_HTTP_READ_TIMEOUT=120   # idle/read timeout, seconds (default 120)
+
+# base_url validation (v0.18.0+)
+QUORUM_ALLOWED_BASE_URL_HOSTS=litellm.example.com  # comma-separated host allowlist
+QUORUM_ALLOW_PRIVATE_BASE_URL=1                     # allow private/loopback IPs
+QUORUM_UNSAFE_BASE_URL=1                            # disable SSRF/scheme guards (last resort)
 ```
 
 ## Exit Codes

--- a/skills/quorum-cli/skill.md
+++ b/skills/quorum-cli/skill.md
@@ -136,25 +136,37 @@ Only `fp` and `tp` affect the calibrator. `partial` and `wontfix` are inert meta
 
 ### Classifying false positives with `fp_kind` (v0.18.0+)
 
-When recording an `fp`, classify *why* it was wrong via `--fp-kind` (CLI) or `fpKind` (MCP). The calibrator decays each class on its own half-life:
+When recording an `fp`, classify *why* it was wrong via `--fp-kind` (CLI, kebab-case) or `fpKind` (MCP, snake_case). **The wire formats are asymmetric** — the CLI drops the `_assumption` suffix on `trust-model`, and some variants carry payload fields:
 
-| Variant | Half-life | When to use |
-|---------|-----------|-------------|
-| `hallucination` | 30d | Reviewer cited code/API that doesn't exist (wrong line, fabricated function, nonexistent import) |
-| `pattern-overgeneralization` | 60d | Pattern matched but surrounding context makes it benign (e.g. `unwrap()` on type-system-guaranteed `Some`) |
-| `trust-model` | 120d | Wrong threat model (flagged internal-only data as user-supplied or vice versa) |
-| `compensating-control` | 120d | Real pattern, mitigated upstream (e.g. SQL concat behind authenticated parameter-validating handler) |
-| `out-of-scope` | 90d | Pre-existing issue surfaced by diff-scoped review — not introduced by this change |
+| CLI flag | MCP `fpKind` | τ | Half-life | When to use |
+|----------|--------------|---:|----------:|-------------|
+| `hallucination` | `hallucination` | 120d | ~83d | Reviewer cited code/API that doesn't exist (wrong line, fabricated function, nonexistent import) |
+| `pattern-overgeneralization` | `pattern_overgeneralization` | 120d | ~83d | Pattern matched but context makes it benign. Pass `--fp-discriminator` (or MCP nested `discriminator_hint`) to teach the LLM the distinction |
+| `trust-model` | `trust_model_assumption` | 40d | ~28d | Wrong threat model — decays 3× faster because trust models evolve |
+| `compensating-control` | `compensating_control` | 120d | ~83d | Real pattern, mitigated upstream. **Requires** `--fp-reference <file:line\|PR\|URL>` (CLI) or nested `{reference: "..."}` (MCP) |
+| `out-of-scope` | `out_of_scope` | 120d | ~83d | Pre-existing in diff-scoped review. Optional `--fp-tracked-in` (CLI) / `tracked_in` (MCP) records follow-up link |
 
 ```bash
 # CLI
 quorum feedback --file src/x.rs --finding "unwrap on Option" --verdict fp \
-    --fp-kind pattern-overgeneralization --reason "type-system-guaranteed Some"
+    --fp-kind pattern-overgeneralization --fp-discriminator "type-system-guaranteed Some" \
+    --reason "context-specific exception"
 
-# MCP feedback tool — pass fpKind: "hallucination" alongside verdict: "fp"
+quorum feedback --file src/x.rs --finding "SQL concat" --verdict fp \
+    --fp-kind compensating-control --fp-reference "src/auth.rs:42" \
+    --reason "param-validating handler upstream"
+
+# MCP feedback tool — fpKind values:
+#   "hallucination"
+#   "trust_model_assumption"
+#   {"compensating_control": {"reference": "PR #99"}}
+#   {"pattern_overgeneralization": {"discriminator_hint": "..."}}  # discriminator_hint optional
+#   {"out_of_scope": {"tracked_in": "issue #200"}}                  # tracked_in optional
 ```
 
-Untagged FPs use the legacy uniform 83d half-life. `quorum stats` reports `fp_kind_utilization_rate` once ≥10% of recent FPs are tagged.
+Untagged FPs use the default τ=120d (~83d half-life). `quorum stats` reports `fp_kind_utilization_rate` once ≥10% of recent FPs are tagged.
+
+**fp_kind is dropped on the External path** — when `--from-agent` (CLI) or `fromAgent` (MCP) is set, the verdict routes through `ExternalVerdictInput` which does not currently carry fp_kind. A `tracing::warn` fires at the MCP boundary. Don't expect fp_kind to persist for external-agent verdicts.
 
 ### What NOT to do
 

--- a/skills/quorum-cli/skill.md
+++ b/skills/quorum-cli/skill.md
@@ -136,7 +136,7 @@ Only `fp` and `tp` affect the calibrator. `partial` and `wontfix` are inert meta
 
 ### Classifying false positives with `fp_kind` (v0.18.0+)
 
-When recording an `fp`, classify *why* it was wrong via `--fp-kind` (CLI, kebab-case) or `fpKind` (MCP, snake_case). **The wire formats are asymmetric** — the CLI drops the `_assumption` suffix on `trust-model`, and some variants carry payload fields:
+When recording an `fp`, classify *why* it was wrong via `--fp-kind` (CLI, kebab-case) or `fpKind` (MCP, snake_case). The CLI and MCP enums are independent — one pair diverges (CLI uses `trust-model`, MCP uses `trust_model_assumption`) — and some variants carry payload fields:
 
 | CLI flag | MCP `fpKind` | τ | Half-life | When to use |
 |----------|--------------|---:|----------:|-------------|


### PR DESCRIPTION
## Summary

- Document the v0.18.0 hardening env vars (`QUORUM_HTTP_TIMEOUT`, `QUORUM_HTTP_READ_TIMEOUT`, `QUORUM_ALLOWED_BASE_URL_HOSTS`, `QUORUM_ALLOW_PRIVATE_BASE_URL`, `QUORUM_UNSAFE_BASE_URL`) in CLAUDE.md and README.md, plus a note about the v0.18.1 #167 scheme-check fix.
- Add the **FpKind** taxonomy from #123: `hallucination` (30d) / `pattern-overgeneralization` (60d) / `trust-model` (120d) / `compensating-control` (120d) / `out-of-scope` (90d), with per-kind decay half-lives and CLI/MCP usage examples.
- Refresh the bundled `skills/quorum-cli/skill.md` (was stale since April 5, missing v0.17.0 External-agent provenance, the decision flowchart, `post_fix` weight, and the `--parallel` flag). Synced from the current `~/.claude/skills/quorum-cli/skill.md`, then layered on the new fp_kind subsection, install instructions, and v0.18.0 env vars.
- README MCP section now points operators at the bundled skill with a one-line install command.

## Why

Self-review caught two stale-doc gaps:

1. The new SSRF/timeout knobs from #117 / #119 / #167 had no docs — operators discovering them via tracebacks or by reading `src/llm_client.rs::validate_base_url`.
2. The `fp_kind` parameter (CLI: `--fp-kind`, MCP: `fpKind`) shipped in v0.18.0 with no docs anywhere outside the source.
3. The repo skill was never updated alongside `~/.claude/skills/quorum-cli/skill.md`, defeating the "easy to install from the repo" workflow.

## Test plan

- [ ] `grep -n QUORUM_HTTP_TIMEOUT CLAUDE.md README.md skills/quorum-cli/skill.md` returns hits in all three.
- [ ] `grep -n fp-kind CLAUDE.md README.md skills/quorum-cli/skill.md` returns hits in all three.
- [ ] Visual diff confirms no regressions in unrelated sections.
- [ ] `cargo build --release` still passes (it does — verified locally before push).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Environment variables to configure HTTP timeouts and base-URL validation controls
  * Parallel review mode and bundled Claude Code skill installation guidance

* **Documentation**
  * Expanded feedback recording with structured false-positive taxonomy (fp_kind), discriminator/reference usage, CLI examples, MCP guidance, decay/reporting in stats, and note that fp_kind is omitted for External verdicts

* **Chores**
  * Clarified validator behavior and a v0.18.1 behavioral correction regarding private-host allowance
<!-- end of auto-generated comment: release notes by coderabbit.ai -->