### PR TITLE
fix(grounding): activate grounding via prompt + remove false-demotion fallback

### DIFF
--- a/src/grounding.rs
+++ b/src/grounding.rs
@@ -44,14 +44,8 @@ pub fn extract_identifiers(text: &str) -> Vec<&str> {
         .collect()
 }
 
-/// Extract identifiers from finding title first; fall back to description
-/// if the title yields nothing.
-pub fn extract_identifiers_from_finding_text<'a>(title: &'a str, description: &'a str) -> Vec<&'a str> {
-    let mut ids = extract_identifiers(title);
-    if ids.is_empty() {
-        ids = extract_identifiers(description);
-    }
-    ids
+pub fn extract_identifiers_from_finding_text<'a>(title: &'a str, _description: &'a str) -> Vec<&'a str> {
+    extract_identifiers(title)
 }
 
 /// Result of grounding verification for a single finding.
@@ -256,12 +250,12 @@ mod tests {
     }
 
     #[test]
-    fn extracts_from_description_too() {
+    fn no_title_ids_returns_empty_even_with_description_ids() {
         let ids = extract_identifiers_from_finding_text(
             "Missing error handling",
             "The function `process_data` at line 42 swallows the error",
         );
-        assert_eq!(ids, vec!["process_data"]);
+        assert!(ids.is_empty(), "description identifiers should not be used as fallback");
     }
 
     #[test]
@@ -623,5 +617,24 @@ mod tests {
         let result = verify_grounding(&f, sample_source());
         assert_eq!(result.status, GroundingStatus::LineOutOfRange);
         assert_eq!(result.severity_change, Some(Severity::Medium));
+    }
+
+    #[test]
+    fn no_backtick_in_title_returns_not_checked_even_with_description_ids() {
+        let source = "fn extract_imported_names(text: &str) -> Vec<String> {\n    vec![]\n}\n";
+        let f = FindingBuilder::new()
+            .title("Rust grouped import parsing breaks on nested braces")
+            .description("`extract_imported_names` parses `use a::{b::{C, D}, e::F};` incorrectly")
+            .source(Source::Llm("gpt-5.4".into()))
+            .lines(1, 3)
+            .severity(Severity::Medium)
+            .build();
+        let result = verify_grounding(&f, source);
+        assert_eq!(
+            result.status,
+            GroundingStatus::NotChecked,
+            "title has no backticked IDs; description fallback should not cause SymbolNotFound"
+        );
+        assert!(result.severity_change.is_none(), "severity should not change");
     }
 }

--- a/src/llm_client.rs
+++ b/src/llm_client.rs
@@ -1095,7 +1095,7 @@ impl OpenAiClient {
             "\n",
             "<response_format>\n",
             "Return a JSON array. Each element has these fields:\n",
-            "- title (string, <=80 chars): concise summary of the issue.\n",
+            "- title (string, <=80 chars): concise summary. Reference the specific function, variable, or type involved using backtick-quoted names (e.g. \"`process_data` swallows errors\"). This enables automated verification that cited symbols exist in the source.\n",
             "- description (string): what the defect is, why it matters, and the conditions under which it manifests.\n",
             "- severity (string): one of critical, high, medium, low, info.\n",
             "- category (string): one of the categories listed above.\n",
@@ -2835,6 +2835,16 @@ mod tests {
         assert!(
             !is_transient_transport_error(&decode_err),
             "decode errors must NOT be classified transient (#146)"
+        );
+    }
+
+    #[test]
+    fn system_prompt_instructs_backticked_symbol_names_in_titles() {
+        let prompt = OpenAiClient::system_prompt();
+        assert!(
+            prompt.contains("backtick"),
+            "system prompt must instruct LLMs to include backticked symbol names in titles \
+             so AST grounding can verify cited identifiers exist in source"
         );
     }
 }

--- a/src/llm_client.rs
+++ b/src/llm_client.rs
@@ -2842,9 +2842,9 @@ mod tests {
     fn system_prompt_instructs_backticked_symbol_names_in_titles() {
         let prompt = OpenAiClient::system_prompt();
         assert!(
-            prompt.contains("backtick"),
-            "system prompt must instruct LLMs to include backticked symbol names in titles \
-             so AST grounding can verify cited identifiers exist in source"
+            prompt.contains("title (string, <=80 chars)")
+                && prompt.contains("backtick-quoted names"),
+            "system prompt must require backtick-quoted symbol names in finding titles"
         );
     }
 }

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -717,16 +717,14 @@ pub async fn review_file(
     let merged = grounding::apply_grounding(merged, source, grounding_disabled);
     {
         let gc = grounding::count_grounding_outcomes(&merged);
-        if gc.verified + gc.symbol_not_found + gc.line_out_of_range > 0 {
-            tracing::info!(
-                phase = "grounding",
-                verified = gc.verified,
-                symbol_not_found = gc.symbol_not_found,
-                line_out_of_range = gc.line_out_of_range,
-                not_checked = gc.not_checked,
-                "grounding pass complete"
-            );
-        }
+        tracing::info!(
+            phase = "grounding",
+            verified = gc.verified,
+            symbol_not_found = gc.symbol_not_found,
+            line_out_of_range = gc.line_out_of_range,
+            not_checked = gc.not_checked,
+            "grounding pass complete"
+        );
     }
 
     // Calibrate using feedback precedent (prefer FeedbackIndex for semantic matching)
@@ -1101,16 +1099,14 @@ pub async fn review_file_llm_only(
     let merged = grounding::apply_grounding(merged, source, grounding_disabled);
     {
         let gc = grounding::count_grounding_outcomes(&merged);
-        if gc.verified + gc.symbol_not_found + gc.line_out_of_range > 0 {
-            tracing::info!(
-                phase = "grounding",
-                verified = gc.verified,
-                symbol_not_found = gc.symbol_not_found,
-                line_out_of_range = gc.line_out_of_range,
-                not_checked = gc.not_checked,
-                "grounding pass complete"
-            );
-        }
+        tracing::info!(
+            phase = "grounding",
+            verified = gc.verified,
+            symbol_not_found = gc.symbol_not_found,
+            line_out_of_range = gc.line_out_of_range,
+            not_checked = gc.not_checked,
+            "grounding pass complete"
+        );
     }
 
     // Calibrate


### PR DESCRIPTION
## Summary

Three fixes that make AST symbol-existence grounding actually work end-to-end:

- **Remove description fallback** from `extract_identifiers_from_finding_text` — when titles had no backticked IDs, fallback to description extracted explanatory code examples that failed ALL-match, producing spurious `SymbolNotFound` demotions instead of `NotChecked`
- **Add backtick instruction to system prompt** — the `<response_format>` title spec now tells LLMs to include backtick-quoted symbol names (e.g. `` `process_data` swallows errors ``), which is what grounding needs to actually fire
- **Always-log grounding trace** — removed the guard that skipped trace emission when all findings were `not_checked`, so the all-silent scenario is visible in traces

### Evidence

Live review after the fix shows grounding working:
```
grounding pass complete: verified=2, symbol_not_found=0, line_out_of_range=0, not_checked=2
```
LLM findings now have backticked titles like `` `extract_identifiers` drops real symbols `` and both verified successfully against source.

## Test plan

- [x] RED test: `system_prompt_instructs_backticked_symbol_names_in_titles` — fails before prompt change
- [x] GREEN: prompt updated, test passes
- [x] RED test: `no_title_ids_returns_empty_even_with_description_ids` — validates fallback removal
- [x] RED test: `no_backtick_in_title_returns_not_checked_even_with_description_ids` — end-to-end grounding behavior
- [x] Full suite: 1205 passed, 0 failed
- [x] `cargo clippy` clean (no new warnings)
- [x] `cargo build --release` succeeds
- [x] Live review on `src/grounding.rs` confirms verified findings with backticked titles

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Grounding now extracts identifiers from finding titles only; findings without title identifiers are marked as unverified instead of falling back to descriptions.
  * AI prompt updated to require backtick-quoted symbol names in finding titles for precise references.
  * Grounding pass logging now always emits complete grounding counters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->