### PR TITLE
feat(calibrate): fuzzy title matching in corpus join (#207)

### DIFF
--- a/docs/plans/2026-05-04-fuzzy-title-matching-design.md
+++ b/docs/plans/2026-05-04-fuzzy-title-matching-design.md
@@ -1,0 +1,88 @@
+# Fuzzy Title Matching in Calibrate Corpus Join — Design
+
+## Problem
+
+`quorum calibrate` joins `feedback.jsonl` with `calibrator_traces.jsonl` on
+`(finding_title, file_path)`. LLM-generated finding titles are non-deterministic
+across review runs, so the same issue gets different titles each time.
+
+Current join rate: 329/2,492 (13%). Root cause: 1,603 unique feedback titles have
+no exact match in traces.
+
+## Evidence
+
+Title variation patterns observed:
+- **Backtick formatting**: `Atomic JSON writer uses a fixed .tmp filename` vs
+  `Atomic JSON writer uses a fixed \`.tmp\` filename` (51 titles)
+- **Rule-name prefix**: `Empty .expect() message` vs
+  `expect-empty-message: Empty \`.expect()\` message`
+- **Sentence extension**: `Reset can race with visit processing` vs
+  `Reset can race with visit processing and lose the cleaned state`
+- **Rephrasing**: `Background LLM judge tasks are not tracked` vs
+  `Detached LLM judge tasks are never tracked or cancelled`
+
+Jaccard score distribution (best match per unmatched feedback title):
+- `>= 0.5`: 202 titles (12.6%) — spot-check shows mostly correct
+- `0.35-0.5`: 136 titles — noisy, many false matches
+- `< 0.35`: 1,265 titles — genuinely different issues
+
+## Design: Tiered Matching
+
+Match feedback to traces in priority order, stopping at first match:
+
+| Tier | Strategy | Precision | Expected Recovery |
+|------|----------|-----------|-------------------|
+| 1 | Raw exact `(title, file_path)` | Highest | Current 329 |
+| 2 | Normalized exact `(norm_title, file_path)` | Very high | +50-80 |
+| 3 | Fuzzy same-file (Jaccard >= 0.5, margin >= 0.1) | High | +80-120 |
+| 4 | Normalized exact title-only (legacy fallback) | Medium | +20-40 |
+
+**Deferred to v2**: Cross-file fuzzy (tier 5) — higher false-match risk, violates
+the `title_only_blocked_when_file_scoped_exists` anti-contamination invariant.
+
+### Title Normalization
+
+```
+fn normalize_title(raw: &str) -> String:
+    1. Strip rule-name prefix: regex ^[a-z][a-z0-9-]+:\s*
+    2. Lowercase
+    3. Replace punctuation except _ with spaces
+    4. Collapse whitespace
+    5. Trim
+```
+
+### Token Jaccard
+
+```
+fn token_jaccard(a: &str, b: &str) -> f64:
+    tokens_a = normalize_title(a).split_whitespace().collect::<HashSet>()
+    tokens_b = normalize_title(b).split_whitespace().collect::<HashSet>()
+    |intersection| / |union|
+```
+
+### Fuzzy Match Acceptance
+
+A fuzzy match is accepted only when:
+1. Best Jaccard score >= 0.5 (configurable constant, not user-facing)
+2. Best score exceeds second-best by >= 0.1 (ambiguity margin)
+3. Both tokens sets are non-empty
+
+### Observability
+
+Log match strategy counts via `tracing::info`:
+- `exact_raw`, `exact_normalized`, `fuzzy_same_file`, `normalized_title_only`
+- `ambiguous_skipped`, `below_threshold`, `unmatched`
+
+### Invariants Preserved
+
+- `title_only_blocked_when_file_scoped_exists` — normalized title-only fallback
+  (tier 4) still blocked when file-scoped traces exist for the same normalized title
+- Ambiguous keys (duplicate traces for same join key) still removed
+- Wontfix/unknown verdicts still filtered
+- Negative weights still clamped to zero
+
+## Reviewed By
+
+GPT-5.4 (2026-05-04): Endorsed tiered approach. Key additions: normalized-exact
+tier before Jaccard, same-file fuzzy before cross-file, best-vs-second margin
+framing, punctuation normalization (not just backticks), match strategy logging.

--- a/docs/plans/2026-05-04-fuzzy-title-matching.md
+++ b/docs/plans/2026-05-04-fuzzy-title-matching.md
@@ -1,0 +1,541 @@
+# Fuzzy Title Matching Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Improve `quorum calibrate` corpus join rate from 13% to ~25% by adding normalized exact matching and fuzzy token Jaccard matching to `join_feedback_and_traces`.
+
+**Architecture:** Add `normalize_title()` and `token_jaccard()` helper functions, then restructure the join in `join_feedback_and_traces` to attempt 4 tiers of matching in priority order. All changes confined to `src/calibrate.rs`.
+
+**Tech Stack:** Rust, serde_json, std collections. No new dependencies.
+
+---
+
+### Task 1: Add `normalize_title` function
+
+**Files:**
+- Modify: `src/calibrate.rs` (add function after imports, before `join_feedback_and_traces`)
+
+**Step 1: Write failing tests for normalize_title**
+
+```rust
+#[test]
+fn normalize_strips_backticks() {
+    assert_eq!(
+        normalize_title("uses a fixed `.tmp` filename"),
+        "uses a fixed tmp filename"
+    );
+}
+
+#[test]
+fn normalize_strips_rule_prefix() {
+    assert_eq!(
+        normalize_title("expect-empty-message: Empty .expect() message"),
+        "empty expect message"
+    );
+}
+
+#[test]
+fn normalize_lowercases_and_collapses_whitespace() {
+    assert_eq!(
+        normalize_title("  Missing  Error  Context  "),
+        "missing error context"
+    );
+}
+
+#[test]
+fn normalize_preserves_underscores() {
+    assert_eq!(
+        normalize_title("unwrap_or_default() silently drops errors"),
+        "unwrap_or_default silently drops errors"
+    );
+}
+
+#[test]
+fn normalize_handles_empty_and_prefix_only() {
+    assert_eq!(normalize_title(""), "");
+    assert_eq!(normalize_title("rule-name: "), "");
+}
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `cargo test --lib normalize_ -- --nocapture 2>&1 | head -30`
+Expected: FAIL — `normalize_title` not found
+
+**Step 3: Write minimal implementation**
+
+```rust
+/// Normalize a finding title for fuzzy comparison.
+///
+/// Strips rule-name prefixes, backticks, punctuation (except `_`),
+/// lowercases, and collapses whitespace.
+fn normalize_title(raw: &str) -> String {
+    let stripped = if let Some(rest) = raw.strip_prefix(|_: char| false) {
+        raw
+    } else {
+        raw
+    };
+    // Strip "rule-name: " prefix (lowercase-kebab-case followed by colon+space)
+    let after_prefix = strip_rule_prefix(stripped);
+    // Replace non-alphanumeric-non-underscore with space, lowercase, collapse
+    let normalized: String = after_prefix
+        .chars()
+        .map(|c| {
+            if c.is_alphanumeric() || c == '_' {
+                c.to_ascii_lowercase()
+            } else {
+                ' '
+            }
+        })
+        .collect();
+    // Collapse whitespace and trim
+    normalized.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+fn strip_rule_prefix(s: &str) -> &str {
+    // Match ^[a-z][a-z0-9-]+:\s*
+    let bytes = s.as_bytes();
+    if bytes.is_empty() || !bytes[0].is_ascii_lowercase() {
+        return s;
+    }
+    let mut colon_pos = None;
+    for (i, &b) in bytes.iter().enumerate().skip(1) {
+        if b == b':' {
+            colon_pos = Some(i);
+            break;
+        }
+        if !(b.is_ascii_lowercase() || b.is_ascii_digit() || b == b'-') {
+            return s;
+        }
+    }
+    match colon_pos {
+        Some(pos) if pos >= 2 => {
+            // Skip colon and any following whitespace
+            let rest = &s[pos + 1..];
+            rest.trim_start()
+        }
+        _ => s,
+    }
+}
+```
+
+**Step 4: Run tests to verify they pass**
+
+Run: `cargo test --lib normalize_ -- --nocapture`
+Expected: PASS (5 tests)
+
+**Step 5: Commit**
+
+```bash
+git add src/calibrate.rs
+git commit -m "feat(calibrate): add normalize_title for fuzzy matching (#207)"
+```
+
+---
+
+### Task 2: Add `token_jaccard` function
+
+**Files:**
+- Modify: `src/calibrate.rs`
+
+**Step 1: Write failing tests**
+
+```rust
+#[test]
+fn jaccard_identical_titles() {
+    let j = token_jaccard("missing error context", "missing error context");
+    assert!((j - 1.0).abs() < 1e-9);
+}
+
+#[test]
+fn jaccard_disjoint_titles() {
+    let j = token_jaccard("sql injection risk", "memory leak detected");
+    assert!(j < 0.01);
+}
+
+#[test]
+fn jaccard_partial_overlap() {
+    // "empty expect message" vs "empty expect message provide context"
+    // intersection=3, union=5, J=0.6
+    let j = token_jaccard(
+        "empty expect message",
+        "empty expect message provide context",
+    );
+    assert!((j - 0.6).abs() < 0.01);
+}
+
+#[test]
+fn jaccard_empty_returns_zero() {
+    assert!((token_jaccard("", "something")).abs() < 1e-9);
+    assert!((token_jaccard("something", "")).abs() < 1e-9);
+    assert!((token_jaccard("", "")).abs() < 1e-9);
+}
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `cargo test --lib jaccard_ -- --nocapture 2>&1 | head -20`
+Expected: FAIL — `token_jaccard` not found
+
+**Step 3: Write minimal implementation**
+
+```rust
+/// Compute token Jaccard similarity between two pre-normalized title strings.
+fn token_jaccard(a: &str, b: &str) -> f64 {
+    let set_a: HashSet<&str> = a.split_whitespace().collect();
+    let set_b: HashSet<&str> = b.split_whitespace().collect();
+    let union_size = set_a.union(&set_b).count();
+    if union_size == 0 {
+        return 0.0;
+    }
+    let intersection_size = set_a.intersection(&set_b).count();
+    intersection_size as f64 / union_size as f64
+}
+```
+
+**Step 4: Run tests to verify they pass**
+
+Run: `cargo test --lib jaccard_ -- --nocapture`
+Expected: PASS (4 tests)
+
+**Step 5: Commit**
+
+```bash
+git add src/calibrate.rs
+git commit -m "feat(calibrate): add token_jaccard similarity (#207)"
+```
+
+---
+
+### Task 3: Add normalized exact matching (Tier 2)
+
+**Files:**
+- Modify: `src/calibrate.rs`
+
+**Step 1: Write failing test**
+
+```rust
+#[test]
+fn normalized_exact_matches_backtick_difference() {
+    let feedback = vec![make_feedback("uses a fixed .tmp filename", "tp", "src/a.rs")];
+    let traces = vec![make_trace(
+        "uses a fixed `.tmp` filename",
+        2.0, 0.3, Some("src/a.rs"),
+    )];
+    let samples = join_feedback_and_traces(&feedback, &traces);
+    assert_eq!(samples.len(), 1, "normalized exact should match backtick variants");
+}
+
+#[test]
+fn normalized_exact_matches_rule_prefix() {
+    let feedback = vec![make_feedback("Empty .expect() message", "fp", "src/b.rs")];
+    let traces = vec![make_trace(
+        "expect-empty-message: Empty `.expect()` message",
+        0.2, 1.5, Some("src/b.rs"),
+    )];
+    let samples = join_feedback_and_traces(&feedback, &traces);
+    assert_eq!(samples.len(), 1, "normalized exact should match rule-prefix variants");
+}
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `cargo test --lib normalized_exact -- --nocapture`
+Expected: FAIL — no match found
+
+**Step 3: Implement normalized exact index in join**
+
+Add a `norm_trace_map: HashMap<(String, String), (f64, f64)>` built from `normalize_title(title)` + `file_path`. In the feedback loop, after raw exact miss, try `norm_trace_map.get(&(normalize_title(&title), fp))`.
+
+**Step 4: Run tests to verify they pass**
+
+Run: `cargo test --lib -- --nocapture 2>&1 | tail -5`
+Expected: ALL PASS (existing + new)
+
+**Step 5: Commit**
+
+```bash
+git add src/calibrate.rs
+git commit -m "feat(calibrate): tier-2 normalized exact matching (#207)"
+```
+
+---
+
+### Task 4: Add fuzzy same-file matching (Tier 3)
+
+**Files:**
+- Modify: `src/calibrate.rs`
+
+**Step 1: Write failing tests**
+
+```rust
+#[test]
+fn fuzzy_same_file_matches_extended_title() {
+    // Title with extra words appended — Jaccard ~0.6, same file
+    let feedback = vec![make_feedback(
+        "Reset can race with visit processing",
+        "tp", "src/visit.rs",
+    )];
+    let traces = vec![make_trace(
+        "Reset can race with visit processing and lose the cleaned state",
+        2.0, 0.5, Some("src/visit.rs"),
+    )];
+    let samples = join_feedback_and_traces(&feedback, &traces);
+    assert_eq!(samples.len(), 1, "fuzzy same-file should match extended title");
+}
+
+#[test]
+fn fuzzy_same_file_rejects_below_threshold() {
+    // Jaccard well below 0.5
+    let feedback = vec![make_feedback("API key leak", "tp", "src/a.rs")];
+    let traces = vec![make_trace(
+        "Database connection pool exhaustion under load",
+        2.0, 0.5, Some("src/a.rs"),
+    )];
+    let samples = join_feedback_and_traces(&feedback, &traces);
+    assert!(samples.is_empty(), "below-threshold fuzzy should not match");
+}
+
+#[test]
+fn fuzzy_same_file_rejects_ambiguous() {
+    // Two traces in same file with similar Jaccard to the feedback title
+    let feedback = vec![make_feedback(
+        "error handling is missing",
+        "tp", "src/a.rs",
+    )];
+    let traces = vec![
+        make_trace("error handling is missing for IO", 2.0, 0.5, Some("src/a.rs")),
+        make_trace("error handling is missing for parse", 1.0, 0.8, Some("src/a.rs")),
+    ];
+    let samples = join_feedback_and_traces(&feedback, &traces);
+    assert!(samples.is_empty(), "ambiguous fuzzy matches should be skipped");
+}
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `cargo test --lib fuzzy_same_file -- --nocapture`
+Expected: FAIL
+
+**Step 3: Implement fuzzy same-file matching**
+
+After tier 1 (raw exact) and tier 2 (normalized exact) miss, scan all traces with the same `file_path`. Compute `token_jaccard(normalize_title(fb_title), normalize_title(trace_title))`. Accept if best >= 0.5 and best - second_best >= 0.1.
+
+Constants:
+```rust
+const FUZZY_THRESHOLD: f64 = 0.5;
+const FUZZY_AMBIGUITY_MARGIN: f64 = 0.1;
+```
+
+Build a `file_to_traces: HashMap<String, Vec<(String, (f64, f64))>>` index mapping file_path to `(normalized_title, weights)` for fuzzy lookup.
+
+**Step 4: Run tests to verify they pass**
+
+Run: `cargo test --lib -- --nocapture 2>&1 | tail -5`
+Expected: ALL PASS
+
+**Step 5: Commit**
+
+```bash
+git add src/calibrate.rs
+git commit -m "feat(calibrate): tier-3 fuzzy same-file Jaccard matching (#207)"
+```
+
+---
+
+### Task 5: Add normalized title-only fallback (Tier 4)
+
+**Files:**
+- Modify: `src/calibrate.rs`
+
+**Step 1: Write failing test**
+
+```rust
+#[test]
+fn normalized_title_only_fallback_matches() {
+    // Old trace without file_path, title differs by backticks
+    let feedback = vec![make_feedback("fixed .tmp filename", "tp", "src/a.rs")];
+    let traces = vec![make_trace("fixed `.tmp` filename", 1.5, 0.5, None)];
+    let samples = join_feedback_and_traces(&feedback, &traces);
+    assert_eq!(samples.len(), 1, "normalized title-only fallback should match");
+}
+
+#[test]
+fn normalized_title_only_blocked_when_file_scoped_exists() {
+    // Same invariant as existing test but with normalized titles
+    let feedback = vec![make_feedback("fixed .tmp filename", "tp", "src/b.rs")];
+    let traces = vec![
+        make_trace("fixed `.tmp` filename", 2.5, 0.3, Some("src/a.rs")),
+        make_trace("fixed `.tmp` filename", 0.1, 1.8, None),
+    ];
+    let samples = join_feedback_and_traces(&feedback, &traces);
+    assert!(samples.is_empty(),
+        "normalized title-only fallback blocked when file-scoped traces exist");
+}
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `cargo test --lib normalized_title_only -- --nocapture`
+Expected: FAIL
+
+**Step 3: Implement normalized title-only index**
+
+Add `norm_title_only_map: HashMap<String, (f64, f64)>` keyed by `normalize_title(title)` for traces without `file_path`. Apply the same `titles_with_file_scoped` guard using normalized titles.
+
+**Step 4: Run tests to verify they pass**
+
+Run: `cargo test --lib -- --nocapture 2>&1 | tail -5`
+Expected: ALL PASS
+
+**Step 5: Commit**
+
+```bash
+git add src/calibrate.rs
+git commit -m "feat(calibrate): tier-4 normalized title-only fallback (#207)"
+```
+
+---
+
+### Task 6: Add match strategy logging
+
+**Files:**
+- Modify: `src/calibrate.rs`
+
+**Step 1: Write failing test**
+
+```rust
+#[test]
+fn join_returns_match_stats() {
+    let feedback = vec![
+        make_feedback("SQL injection", "tp", "src/db.rs"),
+        make_feedback("uses a fixed .tmp filename", "fp", "src/a.rs"),
+        make_feedback("no match at all xyz", "tp", "src/c.rs"),
+    ];
+    let traces = vec![
+        make_trace("SQL injection", 2.0, 0.3, Some("src/db.rs")),
+        make_trace("uses a fixed `.tmp` filename", 0.2, 1.5, Some("src/a.rs")),
+    ];
+    let (samples, stats) = join_feedback_and_traces(&feedback, &traces);
+    assert_eq!(samples.len(), 2);
+    assert_eq!(stats.exact_raw, 1);
+    assert_eq!(stats.exact_normalized, 1);
+    assert!(stats.unmatched >= 1);
+}
+```
+
+**Step 2: Run tests to verify they fail**
+
+Expected: FAIL — return type changed
+
+**Step 3: Add JoinStats struct, update return type**
+
+```rust
+#[derive(Debug, Default)]
+pub struct JoinStats {
+    pub exact_raw: usize,
+    pub exact_normalized: usize,
+    pub fuzzy_same_file: usize,
+    pub normalized_title_only: usize,
+    pub ambiguous_skipped: usize,
+    pub below_threshold: usize,
+    pub unmatched: usize,
+}
+
+pub fn join_feedback_and_traces(
+    feedback: &[serde_json::Value],
+    traces: &[serde_json::Value],
+) -> (Vec<(f64, bool)>, JoinStats) {
+```
+
+Update all call sites (only `src/main.rs::run_calibrate`) and existing tests to destructure the new return type.
+
+**Step 4: Run tests to verify they pass**
+
+Run: `cargo test --lib -- --nocapture 2>&1 | tail -5`
+Expected: ALL PASS
+
+**Step 5: Update `run_calibrate` in main.rs to log stats**
+
+Add `tracing::info!` and a human-readable stderr summary after join.
+
+**Step 6: Commit**
+
+```bash
+git add src/calibrate.rs src/main.rs
+git commit -m "feat(calibrate): add JoinStats observability for match tiers (#207)"
+```
+
+---
+
+### Task 7: Update `run_calibrate` display and verify end-to-end
+
+**Files:**
+- Modify: `src/main.rs` (update `run_calibrate` to print JoinStats summary)
+
+**Step 1: Write failing test**
+
+```rust
+// In calibrate.rs — integration-level test with all 4 tiers exercised
+#[test]
+fn all_four_tiers_exercised() {
+    let feedback = vec![
+        // Tier 1: raw exact
+        make_feedback("SQL injection", "tp", "src/db.rs"),
+        // Tier 2: normalized exact (backtick diff)
+        make_feedback("fixed .tmp filename", "fp", "src/a.rs"),
+        // Tier 3: fuzzy same-file (extended title)
+        make_feedback("reset can race with processing", "tp", "src/v.rs"),
+        // Tier 4: normalized title-only (old trace, no file_path)
+        make_feedback("missing error context", "fp", "src/z.rs"),
+        // No match
+        make_feedback("completely unrelated xyz", "tp", "src/q.rs"),
+    ];
+    let traces = vec![
+        make_trace("SQL injection", 2.0, 0.3, Some("src/db.rs")),
+        make_trace("fixed `.tmp` filename", 0.2, 1.5, Some("src/a.rs")),
+        make_trace("reset can race with processing and lose state", 1.5, 0.5, Some("src/v.rs")),
+        make_trace("missing error context", 0.8, 1.0, None),
+    ];
+    let (samples, stats) = join_feedback_and_traces(&feedback, &traces);
+    assert_eq!(samples.len(), 4, "4 of 5 should match");
+    assert_eq!(stats.exact_raw, 1);
+    assert_eq!(stats.exact_normalized, 1);
+    assert_eq!(stats.fuzzy_same_file, 1);
+    assert_eq!(stats.normalized_title_only, 1);
+    assert_eq!(stats.unmatched, 1);
+}
+```
+
+**Step 2: Run test to verify it fails**
+
+Expected: depends on implementation order — may already pass if tasks 1-6 are complete
+
+**Step 3: Wire JoinStats display in main.rs**
+
+```rust
+eprintln!("\nJoin strategy breakdown:");
+eprintln!("  exact (raw):        {}", stats.exact_raw);
+eprintln!("  exact (normalized): {}", stats.exact_normalized);
+eprintln!("  fuzzy (same-file):  {}", stats.fuzzy_same_file);
+eprintln!("  title-only (norm):  {}", stats.normalized_title_only);
+eprintln!("  ambiguous skipped:  {}", stats.ambiguous_skipped);
+eprintln!("  unmatched:          {}", stats.unmatched);
+```
+
+**Step 4: Run full test suite**
+
+Run: `cargo test --bin quorum`
+Expected: ALL PASS
+
+**Step 5: Run `quorum calibrate` against real data**
+
+Run: `cargo run -- calibrate`
+Expected: Join rate significantly improved, stats displayed
+
+**Step 6: Commit**
+
+```bash
+git add src/calibrate.rs src/main.rs
+git commit -m "feat(calibrate): end-to-end fuzzy title matching (#207)"
+```

--- a/src/calibrate.rs
+++ b/src/calibrate.rs
@@ -9,6 +9,65 @@ use std::collections::{HashMap, HashSet};
 use crate::metrics;
 use crate::threshold_config::{PathThreshold, ThresholdConfig};
 
+/// Minimum token Jaccard similarity for fuzzy title matching.
+const FUZZY_THRESHOLD: f64 = 0.5;
+
+/// Minimum margin between best and second-best Jaccard score.
+const FUZZY_AMBIGUITY_MARGIN: f64 = 0.1;
+
+fn normalize_title(raw: &str) -> String {
+    let after_prefix = strip_rule_prefix(raw);
+    let normalized: String = after_prefix
+        .chars()
+        .map(|c| {
+            if c.is_alphanumeric() || c == '_' {
+                c.to_lowercase().next().unwrap_or(c)
+            } else {
+                ' '
+            }
+        })
+        .collect();
+    normalized.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+fn strip_rule_prefix(s: &str) -> &str {
+    let bytes = s.as_bytes();
+    if bytes.is_empty() || !bytes[0].is_ascii_lowercase() {
+        return s;
+    }
+    let mut colon_pos = None;
+    let mut has_hyphen = false;
+    for (i, &b) in bytes.iter().enumerate().skip(1) {
+        if b == b':' {
+            colon_pos = Some(i);
+            break;
+        }
+        if b == b'-' {
+            has_hyphen = true;
+        } else if !(b.is_ascii_lowercase() || b.is_ascii_digit()) {
+            return s;
+        }
+    }
+    match colon_pos {
+        Some(pos) if pos >= 2 && has_hyphen => {
+            let rest = &s[pos + 1..];
+            rest.trim_start()
+        }
+        _ => s,
+    }
+}
+
+fn token_jaccard(a: &str, b: &str) -> f64 {
+    let set_a: HashSet<&str> = a.split_whitespace().collect();
+    let set_b: HashSet<&str> = b.split_whitespace().collect();
+    let union_size = set_a.union(&set_b).count();
+    if union_size == 0 {
+        return 0.0;
+    }
+    let intersection_size = set_a.intersection(&set_b).count();
+    intersection_size as f64 / union_size as f64
+}
+
 /// Minimum total samples required before computing any threshold.
 const MIN_TOTAL_SAMPLES: usize = 20;
 
@@ -382,6 +441,86 @@ mod tests {
         assert!(
             (0.0..=1.0).contains(&score),
             "negative weights should be clamped, got score {score}"
+        );
+    }
+
+    // --- normalize_title tests ---
+
+    #[test]
+    fn normalize_strips_backticks() {
+        assert_eq!(
+            normalize_title("uses a fixed `.tmp` filename"),
+            "uses a fixed tmp filename"
+        );
+    }
+
+    #[test]
+    fn normalize_strips_rule_prefix() {
+        assert_eq!(
+            normalize_title("expect-empty-message: Empty .expect() message"),
+            "empty expect message"
+        );
+    }
+
+    #[test]
+    fn normalize_lowercases_and_collapses_whitespace() {
+        assert_eq!(
+            normalize_title("  Missing  Error  Context  "),
+            "missing error context"
+        );
+    }
+
+    #[test]
+    fn normalize_preserves_underscores() {
+        assert_eq!(
+            normalize_title("unwrap_or_default() silently drops errors"),
+            "unwrap_or_default silently drops errors"
+        );
+    }
+
+    #[test]
+    fn normalize_handles_empty_and_prefix_only() {
+        assert_eq!(normalize_title(""), "");
+        assert_eq!(normalize_title("rule-name: "), "");
+    }
+
+    #[test]
+    fn normalize_no_prefix_when_uppercase_start() {
+        assert_eq!(normalize_title("SQL injection risk"), "sql injection risk");
+    }
+
+    #[test]
+    fn normalize_no_prefix_when_no_hyphen() {
+        assert_eq!(
+            normalize_title("http: connection refused"),
+            "http connection refused"
+        );
+    }
+
+    #[test]
+    fn normalize_no_prefix_when_short() {
+        assert_eq!(normalize_title("a-b: rest"), "rest");
+        assert_eq!(normalize_title("a: rest"), "a rest");
+    }
+
+    #[test]
+    fn normalize_multiple_backticks_and_parens() {
+        assert_eq!(
+            normalize_title("`foo()` calls `bar()` via `baz`"),
+            "foo calls bar via baz"
+        );
+    }
+
+    #[test]
+    fn normalize_numeric_rule_prefix() {
+        assert_eq!(normalize_title("rule-42: something"), "something");
+    }
+
+    #[test]
+    fn normalize_colon_mid_sentence_not_stripped() {
+        assert_eq!(
+            normalize_title("Warning: something bad"),
+            "warning something bad"
         );
     }
 

--- a/src/calibrate.rs
+++ b/src/calibrate.rs
@@ -444,6 +444,51 @@ mod tests {
         );
     }
 
+    // --- token_jaccard tests ---
+
+    #[test]
+    fn jaccard_identical_titles() {
+        let j = token_jaccard("missing error context", "missing error context");
+        assert!((j - 1.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn jaccard_disjoint_titles() {
+        let j = token_jaccard("sql injection risk", "memory leak detected");
+        assert!(j < 0.01);
+    }
+
+    #[test]
+    fn jaccard_partial_overlap() {
+        let j = token_jaccard(
+            "empty expect message",
+            "empty expect message provide context",
+        );
+        assert!((j - 0.6).abs() < 0.01, "3/5 = 0.6, got {j}");
+    }
+
+    #[test]
+    fn jaccard_empty_returns_zero() {
+        assert!(token_jaccard("", "something").abs() < 1e-9);
+        assert!(token_jaccard("something", "").abs() < 1e-9);
+        assert!(token_jaccard("", "").abs() < 1e-9);
+    }
+
+    #[test]
+    fn jaccard_duplicate_tokens_ignored() {
+        assert!((token_jaccard("the the the", "the") - 1.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn jaccard_single_token_match() {
+        assert!((token_jaccard("error", "error") - 1.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn jaccard_single_token_no_match() {
+        assert!(token_jaccard("error", "warning") < 0.01);
+    }
+
     // --- normalize_title tests ---
 
     #[test]

--- a/src/calibrate.rs
+++ b/src/calibrate.rs
@@ -285,6 +285,8 @@ pub fn join_feedback_and_traces(
                         stats.ambiguous_skipped += 1;
                         continue;
                     }
+                } else if !candidates.is_empty() {
+                    stats.below_threshold += 1;
                 }
             }
         }
@@ -315,6 +317,7 @@ pub fn join_feedback_and_traces(
         raw_title_only = stats.raw_title_only,
         normalized_title_only = stats.normalized_title_only,
         ambiguous_skipped = stats.ambiguous_skipped,
+        below_threshold = stats.below_threshold,
         unmatched = stats.unmatched,
         "join strategy breakdown"
     );
@@ -889,7 +892,8 @@ mod tests {
         let total_classified = stats.exact_raw + stats.exact_normalized
             + stats.fuzzy_same_file + stats.raw_title_only
             + stats.normalized_title_only
-            + stats.ambiguous_skipped + stats.unmatched;
+            + stats.ambiguous_skipped + stats.below_threshold
+            + stats.unmatched;
         // 3 eligible (tp, fp, tp) — wontfix filtered before classification
         assert_eq!(total_classified, 3, "every eligible entry must be classified");
         assert_eq!(samples.len(), 2);

--- a/src/calibrate.rs
+++ b/src/calibrate.rs
@@ -74,27 +74,56 @@ const MIN_TOTAL_SAMPLES: usize = 20;
 /// Minimum minority-class count per path (FP for suppress, TP for boost).
 const MIN_MINORITY_CLASS: usize = 10;
 
+#[derive(Debug, Default)]
+pub struct JoinStats {
+    pub exact_raw: usize,
+    pub exact_normalized: usize,
+    pub fuzzy_same_file: usize,
+    pub raw_title_only: usize,
+    pub normalized_title_only: usize,
+    pub ambiguous_skipped: usize,
+    pub below_threshold: usize,
+    pub unmatched: usize,
+}
+
 /// Join feedback verdicts with calibrator trace entries to produce labeled
 /// score samples for PR curve analysis.
 ///
-/// Join key: `(finding_title, file_path)`. Ambiguous keys (duplicate trace
-/// entries for the same key) are removed entirely with a warning. Wontfix
-/// verdicts are filtered out. `tp`/`partial` map to positive labels; `fp`
-/// maps to negative.
+/// Matching tiers (in priority order, first match wins):
+/// 1. Raw exact `(finding_title, file_path)`
+/// 2. Normalized exact `(normalize_title(finding_title), file_path)`
+/// 3. Fuzzy same-file: token Jaccard >= 0.5 with margin >= 0.1
+/// 4. Normalized exact title-only (legacy fallback for pre-file_path traces)
 ///
-/// Score: `tp_weight / (tp_weight + fp_weight)`. Entries where the total is
-/// zero are skipped (no signal).
+/// Ambiguous keys (duplicate trace entries for the same key) are removed.
+/// Wontfix verdicts are filtered out. `tp`/`partial` -> positive; `fp` -> negative.
+/// Score: `tp_weight / (tp_weight + fp_weight)`.
 pub fn join_feedback_and_traces(
     feedback: &[serde_json::Value],
     traces: &[serde_json::Value],
-) -> Vec<(f64, bool)> {
-    // Primary lookup: (finding_title, file_path) -> (tp_weight, fp_weight)
-    let mut trace_map: HashMap<(String, String), (f64, f64)> = HashMap::new();
-    let mut ambiguous: HashSet<(String, String)> = HashSet::new();
-    // Fallback: title-only lookup for pre-file_path trace entries
-    let mut title_only_map: HashMap<String, (f64, f64)> = HashMap::new();
-    let mut title_only_ambiguous: HashSet<String> = HashSet::new();
-    let mut titles_with_file_scoped: HashSet<String> = HashSet::new();
+) -> (Vec<(f64, bool)>, JoinStats) {
+    // Tier 1: raw exact (title, file_path)
+    let mut raw_map: HashMap<(String, String), (f64, f64)> = HashMap::new();
+    let mut raw_ambiguous: HashSet<(String, String)> = HashSet::new();
+
+    // Tier 2: normalized exact (norm_title, file_path)
+    let mut norm_map: HashMap<(String, String), (f64, f64)> = HashMap::new();
+    let mut norm_ambiguous: HashSet<(String, String)> = HashSet::new();
+
+    // Tier 3: fuzzy same-file: file_path -> Vec<(norm_title, weights)>
+    let mut file_traces: HashMap<String, Vec<(String, (f64, f64))>> = HashMap::new();
+
+    // Tier 4: normalized title-only (for traces without file_path)
+    let mut norm_title_only: HashMap<String, (f64, f64)> = HashMap::new();
+    let mut norm_title_only_ambiguous: HashSet<String> = HashSet::new();
+
+    // Raw title-only (existing behavior preserved)
+    let mut raw_title_only: HashMap<String, (f64, f64)> = HashMap::new();
+    let mut raw_title_only_ambiguous: HashSet<String> = HashSet::new();
+
+    // Track which normalized titles have file-scoped traces
+    let mut norm_titles_with_file_scoped: HashSet<String> = HashSet::new();
+    let mut raw_titles_with_file_scoped: HashSet<String> = HashSet::new();
 
     for t in traces {
         let title = t["finding_title"].as_str().unwrap_or("").to_string();
@@ -104,72 +133,205 @@ pub fn join_feedback_and_traces(
         let fp = t["file_path"].as_str().unwrap_or("").to_string();
         let tp_w = t["tp_weight"].as_f64().unwrap_or(0.0).max(0.0);
         let fp_w = t["fp_weight"].as_f64().unwrap_or(0.0).max(0.0);
+        let norm = normalize_title(&title);
 
         if fp.is_empty() {
-            // Pre-file_path trace entry: title-only index
-            match title_only_map.entry(title.clone()) {
+            // Title-only trace (legacy, no file_path)
+            match raw_title_only.entry(title.clone()) {
                 std::collections::hash_map::Entry::Occupied(_) => {
-                    title_only_ambiguous.insert(title);
+                    raw_title_only_ambiguous.insert(title.clone());
                 }
                 std::collections::hash_map::Entry::Vacant(e) => {
                     e.insert((tp_w, fp_w));
+                }
+            }
+            if !norm.is_empty() {
+                match norm_title_only.entry(norm) {
+                    std::collections::hash_map::Entry::Occupied(_) => {
+                        norm_title_only_ambiguous.insert(normalize_title(&title));
+                    }
+                    std::collections::hash_map::Entry::Vacant(e) => {
+                        e.insert((tp_w, fp_w));
+                    }
                 }
             }
         } else {
-            titles_with_file_scoped.insert(title.clone());
-            let key = (title, fp);
-            match trace_map.entry(key.clone()) {
+            raw_titles_with_file_scoped.insert(title.clone());
+            if !norm.is_empty() {
+                norm_titles_with_file_scoped.insert(norm.clone());
+            }
+
+            // Tier 1: raw exact
+            let raw_key = (title, fp.clone());
+            match raw_map.entry(raw_key.clone()) {
                 std::collections::hash_map::Entry::Occupied(_) => {
-                    ambiguous.insert(key);
+                    raw_ambiguous.insert(raw_key);
                 }
                 std::collections::hash_map::Entry::Vacant(e) => {
                     e.insert((tp_w, fp_w));
                 }
             }
+
+            // Tier 2: normalized exact
+            if !norm.is_empty() {
+                let norm_key = (norm.clone(), fp.clone());
+                match norm_map.entry(norm_key.clone()) {
+                    std::collections::hash_map::Entry::Occupied(_) => {
+                        norm_ambiguous.insert(norm_key);
+                    }
+                    std::collections::hash_map::Entry::Vacant(e) => {
+                        e.insert((tp_w, fp_w));
+                    }
+                }
+            }
+
+            // Tier 3: file -> normalized traces for fuzzy
+            if !norm.is_empty() {
+                file_traces.entry(fp).or_default().push((norm, (tp_w, fp_w)));
+            }
         }
     }
-    for key in &ambiguous {
-        trace_map.remove(key);
+
+    // Clean up ambiguous entries
+    for key in &raw_ambiguous {
+        raw_map.remove(key);
         tracing::warn!(
             title = %key.0,
             file_path = %key.1,
             "duplicate trace key -- skipping ambiguous entry"
         );
     }
-    for key in &title_only_ambiguous {
-        title_only_map.remove(key);
+    for key in &norm_ambiguous {
+        norm_map.remove(key);
     }
-    for title in &titles_with_file_scoped {
-        title_only_map.remove(title);
+    for key in &raw_title_only_ambiguous {
+        raw_title_only.remove(key);
+    }
+    for key in &norm_title_only_ambiguous {
+        norm_title_only.remove(key);
+    }
+
+    // Block title-only fallback when file-scoped traces exist for that title
+    for title in &raw_titles_with_file_scoped {
+        raw_title_only.remove(title);
+    }
+    for norm in &norm_titles_with_file_scoped {
+        norm_title_only.remove(norm);
     }
 
     let mut samples = Vec::new();
+    let mut stats = JoinStats::default();
+
     for f in feedback {
         let verdict = f["verdict"].as_str().unwrap_or("");
         let is_positive = match verdict {
             "tp" | "partial" => true,
             "fp" => false,
-            _ => continue, // skip wontfix, unknown, context_misleading
+            _ => continue,
         };
         let title = f["finding_title"].as_str().unwrap_or("").to_string();
         if title.is_empty() {
             continue;
         }
         let fp = f["file_path"].as_str().unwrap_or("").to_string();
-        let weights = trace_map
-            .get(&(title.clone(), fp))
-            .or_else(|| title_only_map.get(&title));
-        if let Some((tp_w, fp_w)) = weights {
-            let total = tp_w + fp_w;
-            if total > 0.0 {
-                let score = tp_w / total;
-                if score.is_finite() {
-                    samples.push((score, is_positive));
+        let norm = normalize_title(&title);
+
+        // Tier 1: raw exact (title, file_path)
+        if let Some(weights) = raw_map.get(&(title.clone(), fp.clone())) {
+            if push_sample(&mut samples, weights, is_positive) {
+                stats.exact_raw += 1;
+                continue;
+            }
+        }
+
+        // Tier 2: normalized exact (norm_title, file_path)
+        if !norm.is_empty() {
+            if let Some(weights) = norm_map.get(&(norm.clone(), fp.clone())) {
+                if push_sample(&mut samples, weights, is_positive) {
+                    stats.exact_normalized += 1;
+                    continue;
                 }
             }
         }
+
+        // Tier 3: fuzzy same-file
+        if !norm.is_empty() && !fp.is_empty() {
+            if let Some(candidates) = file_traces.get(&fp) {
+                let mut best_score = 0.0_f64;
+                let mut second_best = 0.0_f64;
+                let mut best_weights: Option<&(f64, f64)> = None;
+
+                for (cand_norm, weights) in candidates {
+                    let j = token_jaccard(&norm, cand_norm);
+                    if j > best_score {
+                        second_best = best_score;
+                        best_score = j;
+                        best_weights = Some(weights);
+                    } else if j > second_best {
+                        second_best = j;
+                    }
+                }
+
+                if best_score >= FUZZY_THRESHOLD {
+                    let margin = best_score - second_best;
+                    if margin >= FUZZY_AMBIGUITY_MARGIN {
+                        if let Some(weights) = best_weights {
+                            if push_sample(&mut samples, weights, is_positive) {
+                                stats.fuzzy_same_file += 1;
+                                continue;
+                            }
+                        }
+                    } else {
+                        stats.ambiguous_skipped += 1;
+                        continue;
+                    }
+                }
+            }
+        }
+
+        // Tier 4: title-only fallback (raw first, then normalized)
+        if let Some(weights) = raw_title_only.get(&title) {
+            if push_sample(&mut samples, weights, is_positive) {
+                stats.raw_title_only += 1;
+                continue;
+            }
+        }
+        if !norm.is_empty() {
+            if let Some(weights) = norm_title_only.get(&norm) {
+                if push_sample(&mut samples, weights, is_positive) {
+                    stats.normalized_title_only += 1;
+                    continue;
+                }
+            }
+        }
+
+        stats.unmatched += 1;
     }
-    samples
+
+    tracing::info!(
+        exact_raw = stats.exact_raw,
+        exact_normalized = stats.exact_normalized,
+        fuzzy_same_file = stats.fuzzy_same_file,
+        raw_title_only = stats.raw_title_only,
+        normalized_title_only = stats.normalized_title_only,
+        ambiguous_skipped = stats.ambiguous_skipped,
+        unmatched = stats.unmatched,
+        "join strategy breakdown"
+    );
+
+    (samples, stats)
+}
+
+fn push_sample(samples: &mut Vec<(f64, bool)>, weights: &(f64, f64), is_positive: bool) -> bool {
+    let total = weights.0 + weights.1;
+    if total > 0.0 {
+        let score = weights.0 / total;
+        if score.is_finite() {
+            samples.push((score, is_positive));
+            return true;
+        }
+    }
+    false
 }
 
 /// Compute suppress and boost thresholds from labeled score samples.
@@ -287,11 +449,9 @@ mod tests {
             make_trace("SQL injection", 2.5, 0.3, Some("src/db.rs")),
             make_trace("Unused var", 0.1, 1.8, Some("src/main.rs")),
         ];
-        let samples = join_feedback_and_traces(&feedback, &traces);
+        let (samples, _stats) = join_feedback_and_traces(&feedback, &traces);
         assert_eq!(samples.len(), 2);
-        // SQL injection: score = 2.5/(2.5+0.3) ~ 0.893, label = true
         assert!(samples.iter().any(|(s, l)| *l && (*s - 0.893).abs() < 0.01));
-        // Unused var: score = 0.1/(0.1+1.8) ~ 0.053, label = false
         assert!(samples.iter().any(|(s, l)| !*l && (*s - 0.053).abs() < 0.01));
     }
 
@@ -299,7 +459,7 @@ mod tests {
     fn wontfix_entries_are_skipped() {
         let feedback = vec![make_feedback("Style issue", "wontfix", "src/x.rs")];
         let traces = vec![make_trace("Style issue", 0.5, 0.5, Some("src/x.rs"))];
-        let samples = join_feedback_and_traces(&feedback, &traces);
+        let (samples, _stats) = join_feedback_and_traces(&feedback, &traces);
         assert!(samples.is_empty(), "wontfix should be excluded");
     }
 
@@ -371,7 +531,7 @@ mod tests {
             make_trace("SQL injection", 2.5, 0.3, None), // no file_path
             make_trace("Unused var", 0.1, 1.8, None),    // no file_path
         ];
-        let samples = join_feedback_and_traces(&feedback, &traces);
+        let (samples, _stats) = join_feedback_and_traces(&feedback, &traces);
         assert_eq!(samples.len(), 2, "title-only fallback should match");
     }
 
@@ -383,7 +543,7 @@ mod tests {
             make_trace("Bug", 2.5, 0.3, None),
             make_trace("Bug", 0.1, 1.8, None), // duplicate title-only
         ];
-        let samples = join_feedback_and_traces(&feedback, &traces);
+        let (samples, _stats) = join_feedback_and_traces(&feedback, &traces);
         assert!(samples.is_empty(), "ambiguous title-only keys should be skipped");
     }
 
@@ -396,10 +556,9 @@ mod tests {
             make_trace("Bug", 2.5, 0.3, Some("src/a.rs")), // primary match
             make_trace("Bug", 0.1, 1.8, None),              // title-only fallback
         ];
-        let samples = join_feedback_and_traces(&feedback, &traces);
+        let (samples, _stats) = join_feedback_and_traces(&feedback, &traces);
         assert_eq!(samples.len(), 1);
         let (score, _) = samples[0];
-        // Should use the primary match: 2.5/(2.5+0.3) ~ 0.893
         assert!((score - 0.893).abs() < 0.01, "should use primary key match, got {score}");
     }
 
@@ -412,7 +571,7 @@ mod tests {
             make_trace("Bug", 2.5, 0.3, Some("src/a.rs")), // file-scoped for different file
             make_trace("Bug", 0.1, 1.8, None),              // title-only
         ];
-        let samples = join_feedback_and_traces(&feedback, &traces);
+        let (samples, _stats) = join_feedback_and_traces(&feedback, &traces);
         assert!(
             samples.is_empty(),
             "title-only fallback should be blocked when file-scoped traces exist for same title"
@@ -426,7 +585,7 @@ mod tests {
             make_trace("SQL injection", 2.5, 0.3, Some("src/db.rs")),
             make_trace("SQL injection", 0.1, 1.8, Some("src/db.rs")), // duplicate key
         ];
-        let samples = join_feedback_and_traces(&feedback, &traces);
+        let (samples, _stats) = join_feedback_and_traces(&feedback, &traces);
         assert!(samples.is_empty(), "ambiguous join keys should be skipped");
     }
 
@@ -434,14 +593,306 @@ mod tests {
     fn negative_weights_clamped_to_zero() {
         let feedback = vec![make_feedback("Bug", "tp", "src/a.rs")];
         let traces = vec![make_trace("Bug", -1.0, 2.0, Some("src/a.rs"))];
-        let samples = join_feedback_and_traces(&feedback, &traces);
+        let (samples, _stats) = join_feedback_and_traces(&feedback, &traces);
         assert_eq!(samples.len(), 1);
         let (score, _) = samples[0];
-        // tp_weight clamped to 0.0, so score = 0.0/2.0 = 0.0
         assert!(
             (0.0..=1.0).contains(&score),
             "negative weights should be clamped, got score {score}"
         );
+    }
+
+    // --- tier 2: normalized exact ---
+
+    #[test]
+    fn normalized_exact_matches_backtick_difference() {
+        let feedback = vec![make_feedback("uses a fixed .tmp filename", "tp", "src/a.rs")];
+        let traces = vec![make_trace(
+            "uses a fixed `.tmp` filename",
+            2.0, 0.3, Some("src/a.rs"),
+        )];
+        let (samples, stats) = join_feedback_and_traces(&feedback, &traces);
+        assert_eq!(samples.len(), 1, "normalized exact should match backtick variants");
+        assert_eq!(stats.exact_normalized, 1);
+    }
+
+    #[test]
+    fn normalized_exact_matches_rule_prefix() {
+        let feedback = vec![make_feedback("Empty .expect() message", "fp", "src/b.rs")];
+        let traces = vec![make_trace(
+            "expect-empty-message: Empty `.expect()` message",
+            0.2, 1.5, Some("src/b.rs"),
+        )];
+        let (samples, stats) = join_feedback_and_traces(&feedback, &traces);
+        assert_eq!(samples.len(), 1, "normalized exact should match rule-prefix variants");
+        assert_eq!(stats.exact_normalized, 1);
+    }
+
+    #[test]
+    fn normalized_exact_does_not_override_raw_exact() {
+        let feedback = vec![make_feedback("Bug", "tp", "src/a.rs")];
+        let traces = vec![make_trace("Bug", 2.0, 0.3, Some("src/a.rs"))];
+        let (_samples, stats) = join_feedback_and_traces(&feedback, &traces);
+        assert_eq!(stats.exact_raw, 1);
+        assert_eq!(stats.exact_normalized, 0);
+    }
+
+    #[test]
+    fn normalized_exact_different_file_no_match() {
+        let feedback = vec![make_feedback("uses a fixed .tmp filename", "tp", "src/a.rs")];
+        let traces = vec![make_trace(
+            "uses a fixed `.tmp` filename",
+            2.0, 0.3, Some("src/b.rs"),
+        )];
+        let (samples, stats) = join_feedback_and_traces(&feedback, &traces);
+        assert!(samples.is_empty(), "different file should not match");
+        assert_eq!(stats.unmatched, 1);
+    }
+
+    // --- tier 3: fuzzy same-file ---
+
+    #[test]
+    fn fuzzy_same_file_matches_extended_title() {
+        let feedback = vec![make_feedback(
+            "Reset can race with visit processing",
+            "tp", "src/visit.rs",
+        )];
+        let traces = vec![make_trace(
+            "Reset can race with visit processing and lose the cleaned state",
+            2.0, 0.5, Some("src/visit.rs"),
+        )];
+        let (samples, stats) = join_feedback_and_traces(&feedback, &traces);
+        assert_eq!(samples.len(), 1, "fuzzy same-file should match extended title");
+        assert_eq!(stats.fuzzy_same_file, 1);
+    }
+
+    #[test]
+    fn fuzzy_same_file_rejects_below_threshold() {
+        let feedback = vec![make_feedback("API key leak", "tp", "src/a.rs")];
+        let traces = vec![make_trace(
+            "Database connection pool exhaustion under load",
+            2.0, 0.5, Some("src/a.rs"),
+        )];
+        let (samples, _stats) = join_feedback_and_traces(&feedback, &traces);
+        assert!(samples.is_empty(), "below-threshold fuzzy should not match");
+    }
+
+    #[test]
+    fn fuzzy_same_file_rejects_ambiguous() {
+        let feedback = vec![make_feedback(
+            "error handling is missing",
+            "tp", "src/a.rs",
+        )];
+        let traces = vec![
+            make_trace("error handling is missing for IO", 2.0, 0.5, Some("src/a.rs")),
+            make_trace("error handling is missing for parse", 1.0, 0.8, Some("src/a.rs")),
+        ];
+        let (samples, stats) = join_feedback_and_traces(&feedback, &traces);
+        assert!(samples.is_empty(), "ambiguous fuzzy matches should be skipped");
+        assert!(stats.ambiguous_skipped >= 1);
+    }
+
+    #[test]
+    fn fuzzy_same_file_accepts_clear_winner() {
+        let feedback = vec![make_feedback(
+            "error handling is missing",
+            "tp", "src/a.rs",
+        )];
+        let traces = vec![
+            make_trace("error handling is missing for IO operations", 2.0, 0.5, Some("src/a.rs")),
+            make_trace("something completely different xyz abc", 1.0, 0.8, Some("src/a.rs")),
+        ];
+        let (samples, stats) = join_feedback_and_traces(&feedback, &traces);
+        assert_eq!(samples.len(), 1, "clear winner should match");
+        assert_eq!(stats.fuzzy_same_file, 1);
+    }
+
+    #[test]
+    fn fuzzy_same_file_different_file_no_match() {
+        let feedback = vec![make_feedback(
+            "Reset can race with visit processing",
+            "tp", "src/a.rs",
+        )];
+        let traces = vec![make_trace(
+            "Reset can race with visit processing and lose state",
+            2.0, 0.5, Some("src/b.rs"),
+        )];
+        let (samples, _stats) = join_feedback_and_traces(&feedback, &traces);
+        assert!(samples.is_empty(), "fuzzy is file-scoped");
+    }
+
+    #[test]
+    fn fuzzy_exactly_at_threshold() {
+        // 3 shared tokens, 3 unique = 3/6 = 0.5 exactly
+        let feedback = vec![make_feedback("alpha beta gamma", "tp", "src/a.rs")];
+        let traces = vec![make_trace(
+            "alpha beta gamma delta epsilon zeta",
+            2.0, 0.5, Some("src/a.rs"),
+        )];
+        let (samples, stats) = join_feedback_and_traces(&feedback, &traces);
+        assert_eq!(samples.len(), 1, ">= 0.5 is inclusive");
+        assert_eq!(stats.fuzzy_same_file, 1);
+    }
+
+    #[test]
+    fn fuzzy_just_below_threshold() {
+        // 2 shared, 3 unique = 2/5 = 0.4
+        let feedback = vec![make_feedback("alpha beta", "tp", "src/a.rs")];
+        let traces = vec![make_trace(
+            "alpha beta gamma delta epsilon",
+            2.0, 0.5, Some("src/a.rs"),
+        )];
+        let (samples, _stats) = join_feedback_and_traces(&feedback, &traces);
+        assert!(samples.is_empty(), "0.4 < 0.5 should be rejected");
+    }
+
+    #[test]
+    fn fuzzy_margin_exactly_at_boundary() {
+        // best=0.6, second=0.5, margin=0.1 exactly
+        // "a b c" vs "a b c d e": 3/5=0.6
+        // "a b c" vs "a b d e f": 2/6=0.33 — need to pick values carefully
+        // Let's use: fb="a b c d e f", trace1="a b c d e f g h i j" (6/10=0.6),
+        //            trace2="a b c d e k l m n o" (5/10=0.5)
+        let feedback = vec![make_feedback("a b c d e f", "tp", "src/a.rs")];
+        let traces = vec![
+            make_trace("a b c d e f g h i j", 2.0, 0.5, Some("src/a.rs")),
+            make_trace("a b c d e k l m n o", 1.0, 0.8, Some("src/a.rs")),
+        ];
+        let (samples, stats) = join_feedback_and_traces(&feedback, &traces);
+        assert_eq!(samples.len(), 1, ">= 0.1 margin is inclusive");
+        assert_eq!(stats.fuzzy_same_file, 1);
+    }
+
+    #[test]
+    fn fuzzy_margin_just_below_boundary() {
+        // Need margin < 0.1. e.g. best=0.55, second=0.50 -> margin=0.05
+        // fb="a b c d e f g h i j k" (11 tokens)
+        // trace1: share 6 of 11 => add 5 unique = 6/16 ≈ 0.375 — too low
+        // Simpler: pick exact Jaccard values
+        // fb="a b c d e", trace1="a b c d e f g" (5/7≈0.71),
+        //                 trace2="a b c d e f h" (5/7≈0.71) — too close
+        // fb="a b c d e f", trace1="a b c d e f g h" (6/8=0.75),
+        //                   trace2="a b c d e f g i" (6/8=0.75) — same
+        // The trick: make second-best close. Let me try:
+        // fb="a b c", trace1="a b c d" (3/4=0.75), trace2="a b c d e" (3/5=0.6)
+        // margin = 0.15 — too much. Need them closer.
+        // fb="a b c d", trace1="a b c d e" (4/5=0.8), trace2="a b c d e f" (4/6≈0.67)
+        // margin = 0.13 — still > 0.1
+        // fb="a b c d e f g", trace1="a b c d e f g h i" (7/9≈0.78),
+        //                     trace2="a b c d e f g h j" (7/9≈0.78) — same
+        // Simpler approach: just use pre-normalized strings that give exact values
+        // fb = "a b", trace1 = "a b c" (2/3=0.67), trace2 = "a b d" (2/3=0.67) margin=0
+        let feedback = vec![make_feedback("a b", "tp", "src/a.rs")];
+        let traces = vec![
+            make_trace("a b c", 2.0, 0.5, Some("src/a.rs")),
+            make_trace("a b d", 1.0, 0.8, Some("src/a.rs")),
+        ];
+        let (samples, stats) = join_feedback_and_traces(&feedback, &traces);
+        assert!(samples.is_empty(), "margin 0.0 < 0.1 should be rejected");
+        assert!(stats.ambiguous_skipped >= 1);
+    }
+
+    #[test]
+    fn fuzzy_single_trace_in_file_no_margin_needed() {
+        // Only one trace in file, Jaccard >= 0.5
+        let feedback = vec![make_feedback(
+            "error handling is missing",
+            "tp", "src/a.rs",
+        )];
+        let traces = vec![make_trace(
+            "error handling is missing for IO operations",
+            2.0, 0.5, Some("src/a.rs"),
+        )];
+        let (samples, stats) = join_feedback_and_traces(&feedback, &traces);
+        assert_eq!(samples.len(), 1, "single trace, margin trivially satisfied");
+        assert_eq!(stats.fuzzy_same_file, 1);
+    }
+
+    // --- tier 4: normalized title-only ---
+
+    #[test]
+    fn normalized_title_only_fallback_matches() {
+        let feedback = vec![make_feedback("fixed .tmp filename", "tp", "src/a.rs")];
+        let traces = vec![make_trace("fixed `.tmp` filename", 1.5, 0.5, None)];
+        let (samples, stats) = join_feedback_and_traces(&feedback, &traces);
+        assert_eq!(samples.len(), 1, "normalized title-only fallback should match");
+        assert_eq!(stats.normalized_title_only, 1);
+    }
+
+    #[test]
+    fn normalized_title_only_blocked_when_file_scoped_exists() {
+        let feedback = vec![make_feedback("fixed .tmp filename", "tp", "src/b.rs")];
+        let traces = vec![
+            make_trace("fixed `.tmp` filename", 2.5, 0.3, Some("src/a.rs")),
+            make_trace("fixed `.tmp` filename", 0.1, 1.8, None),
+        ];
+        let (samples, _stats) = join_feedback_and_traces(&feedback, &traces);
+        assert!(samples.is_empty(),
+            "normalized title-only fallback blocked when file-scoped traces exist");
+    }
+
+    #[test]
+    fn title_only_not_attempted_after_fuzzy_match() {
+        let feedback = vec![make_feedback(
+            "error handling is missing",
+            "tp", "src/a.rs",
+        )];
+        let traces = vec![
+            make_trace("error handling is missing for IO operations", 2.0, 0.5, Some("src/a.rs")),
+            make_trace("error handling is missing", 1.0, 0.8, None),
+        ];
+        let (samples, stats) = join_feedback_and_traces(&feedback, &traces);
+        assert_eq!(samples.len(), 1);
+        assert_eq!(stats.fuzzy_same_file, 1);
+        assert_eq!(stats.normalized_title_only, 0);
+    }
+
+    // --- cross-tier + JoinStats ---
+
+    #[test]
+    fn all_four_tiers_exercised() {
+        let feedback = vec![
+            make_feedback("SQL injection", "tp", "src/db.rs"),
+            make_feedback("fixed .tmp filename", "fp", "src/a.rs"),
+            make_feedback("reset can race with processing", "tp", "src/v.rs"),
+            make_feedback("missing error context", "fp", "src/z.rs"),
+            make_feedback("completely unrelated xyz", "tp", "src/q.rs"),
+        ];
+        let traces = vec![
+            make_trace("SQL injection", 2.0, 0.3, Some("src/db.rs")),
+            make_trace("fixed `.tmp` filename", 0.2, 1.5, Some("src/a.rs")),
+            make_trace("reset can race with processing and lose state", 1.5, 0.5, Some("src/v.rs")),
+            make_trace("missing error context", 0.8, 1.0, None),
+        ];
+        let (samples, stats) = join_feedback_and_traces(&feedback, &traces);
+        assert_eq!(samples.len(), 4, "4 of 5 should match");
+        assert_eq!(stats.exact_raw, 1);
+        assert_eq!(stats.exact_normalized, 1);
+        assert_eq!(stats.fuzzy_same_file, 1);
+        assert_eq!(stats.raw_title_only, 1);
+        assert_eq!(stats.unmatched, 1);
+    }
+
+    #[test]
+    fn stats_sum_equals_eligible_feedback_count() {
+        let feedback = vec![
+            make_feedback("SQL injection", "tp", "src/db.rs"),
+            make_feedback("fixed .tmp filename", "fp", "src/a.rs"),
+            make_feedback("no match xyz", "tp", "src/q.rs"),
+            make_feedback("wontfix item", "wontfix", "src/w.rs"),
+        ];
+        let traces = vec![
+            make_trace("SQL injection", 2.0, 0.3, Some("src/db.rs")),
+            make_trace("fixed `.tmp` filename", 0.2, 1.5, Some("src/a.rs")),
+        ];
+        let (samples, stats) = join_feedback_and_traces(&feedback, &traces);
+        let total_classified = stats.exact_raw + stats.exact_normalized
+            + stats.fuzzy_same_file + stats.raw_title_only
+            + stats.normalized_title_only
+            + stats.ambiguous_skipped + stats.unmatched;
+        // 3 eligible (tp, fp, tp) — wontfix filtered before classification
+        assert_eq!(total_classified, 3, "every eligible entry must be classified");
+        assert_eq!(samples.len(), 2);
     }
 
     // --- token_jaccard tests ---
@@ -578,9 +1029,7 @@ mod tests {
         // Verify the join handles this gracefully without panicking.
         let feedback = vec![make_feedback("Bug", "tp", "src/a.rs")];
         let traces = vec![make_trace("Bug", f64::INFINITY, 0.1, Some("src/a.rs"))];
-        let samples = join_feedback_and_traces(&feedback, &traces);
-        // tp_weight becomes 0.0 (JSON null), fp_weight is 0.1.
-        // total = 0.1 > 0.0, so score = 0.0 / 0.1 = 0.0.
+        let (samples, _stats) = join_feedback_and_traces(&feedback, &traces);
         assert_eq!(samples.len(), 1);
         let (score, label) = samples[0];
         assert!(

--- a/src/calibrate.rs
+++ b/src/calibrate.rs
@@ -17,16 +17,14 @@ const FUZZY_AMBIGUITY_MARGIN: f64 = 0.1;
 
 fn normalize_title(raw: &str) -> String {
     let after_prefix = strip_rule_prefix(raw);
-    let normalized: String = after_prefix
-        .chars()
-        .map(|c| {
-            if c.is_alphanumeric() || c == '_' {
-                c.to_lowercase().next().unwrap_or(c)
-            } else {
-                ' '
-            }
-        })
-        .collect();
+    let normalized: String = after_prefix.chars().fold(String::new(), |mut acc, c| {
+        if c.is_alphanumeric() || c == '_' {
+            acc.extend(c.to_lowercase());
+        } else {
+            acc.push(' ');
+        }
+        acc
+    });
     normalized.split_whitespace().collect::<Vec<_>>().join(" ")
 }
 
@@ -256,6 +254,7 @@ pub fn join_feedback_and_traces(
         }
 
         // Tier 3: fuzzy same-file
+        let mut fuzzy_below_threshold = false;
         if !norm.is_empty() && !fp.is_empty() {
             if let Some(candidates) = file_traces.get(&fp) {
                 let mut best_score = 0.0_f64;
@@ -287,7 +286,7 @@ pub fn join_feedback_and_traces(
                         continue;
                     }
                 } else if !candidates.is_empty() {
-                    stats.below_threshold += 1;
+                    fuzzy_below_threshold = true;
                 }
             }
         }
@@ -308,7 +307,11 @@ pub fn join_feedback_and_traces(
             }
         }
 
-        stats.unmatched += 1;
+        if fuzzy_below_threshold {
+            stats.below_threshold += 1;
+        } else {
+            stats.unmatched += 1;
+        }
     }
 
     tracing::info!(

--- a/src/calibrate.rs
+++ b/src/calibrate.rs
@@ -146,9 +146,10 @@ pub fn join_feedback_and_traces(
                 }
             }
             if !norm.is_empty() {
+                let norm_for_ambiguous = norm.clone();
                 match norm_title_only.entry(norm) {
                     std::collections::hash_map::Entry::Occupied(_) => {
-                        norm_title_only_ambiguous.insert(normalize_title(&title));
+                        norm_title_only_ambiguous.insert(norm_for_ambiguous);
                     }
                     std::collections::hash_map::Entry::Vacant(e) => {
                         e.insert((tp_w, fp_w));

--- a/src/main.rs
+++ b/src/main.rs
@@ -1882,6 +1882,7 @@ fn run_calibrate(opts: cli::CalibrateOpts) -> i32 {
     eprintln!("  title-only (raw):   {}", join_stats.raw_title_only);
     eprintln!("  title-only (norm):  {}", join_stats.normalized_title_only);
     eprintln!("  ambiguous skipped:  {}", join_stats.ambiguous_skipped);
+    eprintln!("  below threshold:    {}", join_stats.below_threshold);
     eprintln!("  unmatched:          {}", join_stats.unmatched);
 
     let config = quorum::calibrate::compute_thresholds(

--- a/src/main.rs
+++ b/src/main.rs
@@ -1865,7 +1865,7 @@ fn run_calibrate(opts: cli::CalibrateOpts) -> i32 {
         traces.len(),
     );
 
-    let samples = quorum::calibrate::join_feedback_and_traces(&feedback, &traces);
+    let (samples, join_stats) = quorum::calibrate::join_feedback_and_traces(&feedback, &traces);
     let positives = samples.iter().filter(|(_, l)| *l).count();
     let negatives = samples.len() - positives;
 
@@ -1875,6 +1875,14 @@ fn run_calibrate(opts: cli::CalibrateOpts) -> i32 {
         positives,
         negatives,
     );
+    eprintln!("\nJoin strategy breakdown:");
+    eprintln!("  exact (raw):        {}", join_stats.exact_raw);
+    eprintln!("  exact (normalized): {}", join_stats.exact_normalized);
+    eprintln!("  fuzzy (same-file):  {}", join_stats.fuzzy_same_file);
+    eprintln!("  title-only (raw):   {}", join_stats.raw_title_only);
+    eprintln!("  title-only (norm):  {}", join_stats.normalized_title_only);
+    eprintln!("  ambiguous skipped:  {}", join_stats.ambiguous_skipped);
+    eprintln!("  unmatched:          {}", join_stats.unmatched);
 
     let config = quorum::calibrate::compute_thresholds(
         &samples,


### PR DESCRIPTION
## Summary

- Add tiered title matching to `join_feedback_and_traces` replacing single-tier exact join
- **Tier 1**: Raw exact `(title, file_path)` — unchanged behavior
- **Tier 2**: Normalized exact — strips backticks, `rule-name:` prefixes, punctuation (except `_`), lowercases, collapses whitespace
- **Tier 3**: Fuzzy same-file — token Jaccard >= 0.5 with best-vs-second margin >= 0.1
- **Tier 4**: Title-only fallback (raw then normalized) with anti-contamination guard preserved
- Add `JoinStats` return type with per-tier counters displayed during `quorum calibrate`
- Rule-prefix stripping requires a hyphen to avoid false positives on common words like `http:`
- Unicode-safe lowercasing (`c.to_lowercase()` not `to_ascii_lowercase()`)

Expected join rate improvement: 13% -> ~25% (329 -> 530+ samples).

## Design Review

- GPT-5.4 reviewed the approach and recommended the tiered structure, normalized-exact tier before Jaccard, and best-vs-second margin framing
- Testing antipatterns expert caught 2 bugs before code was written: Unicode casing asymmetry and rule-prefix false positives

## Test Plan

- [x] 26 new tests (76 total in calibrate module, 1212 total)
- [x] 11 normalize_title tests (backticks, prefixes, underscores, edge cases)
- [x] 7 token_jaccard tests (identity, disjoint, partial, empty, boundary)
- [x] 4 tier-2 tests (backtick recovery, prefix recovery, priority, file-path required)
- [x] 8 tier-3 tests (accept, reject, ambiguity, boundary at 0.5/0.1)
- [x] 3 tier-4 tests (normalized fallback, anti-contamination, short-circuit)
- [x] 2 cross-tier tests (all tiers exercised, accounting identity)
- [x] All existing regression tests updated for new return type
- [x] Clippy clean, release build succeeds

Closes #207

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Multi‑tier fuzzy title matching to improve corpus joins: exact, normalized, same‑file fuzzy, and title‑only fallback, with gating to avoid conflicting file‑scoped matches.
  * Join strategy breakdown reporting showing counts per match tier plus skipped/unmatched categories.

* **Documentation**
  * Added design and implementation plans detailing normalization, fuzzy scoring, acceptance criteria, and observability.

* **Tests**
  * Added tests for normalization, Jaccard scoring, thresholds/margins, ambiguity handling, and title‑only gating.

* **Bug Fixes**
  * Improved robustness for malformed/invalid weights and non‑actionable verdicts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->