### PR TITLE
feat(calibrator): trace provenance metadata + fuzzy ablation + JoinFilter

### DIFF
--- a/src/calibrate.rs
+++ b/src/calibrate.rs
@@ -9,6 +9,89 @@ use std::collections::{HashMap, HashSet};
 use crate::metrics;
 use crate::threshold_config::{PathThreshold, ThresholdConfig};
 
+/// Filters applied to traces before joining with feedback.
+///
+/// Default filter retains all traces (including legacy ones without provenance).
+/// Setting any positive filter (e.g. `quorum_version`) excludes legacy traces
+/// that lack provenance metadata.
+#[derive(Debug, Default)]
+pub struct JoinFilter {
+    /// Only include traces from this quorum version (e.g. `"0.18.4"`).
+    pub quorum_version: Option<String>,
+    /// When `true`, exclude traces where `provenance.dirty == Some(true)`.
+    pub clean_only: bool,
+    /// Only include traces from this repository.
+    pub repo: Option<String>,
+    /// Only include traces from this exact commit SHA.
+    pub commit_sha: Option<String>,
+    /// Only include traces from this run ID.
+    pub run_id: Option<String>,
+}
+
+impl JoinFilter {
+    /// Returns `true` when no positive filters are set (only `clean_only` can
+    /// be active). Legacy traces (without provenance) are retained by default.
+    fn is_default(&self) -> bool {
+        self.quorum_version.is_none()
+            && !self.clean_only
+            && self.repo.is_none()
+            && self.commit_sha.is_none()
+            && self.run_id.is_none()
+    }
+
+    /// Returns `true` if the trace passes this filter.
+    fn accepts(&self, trace: &serde_json::Value) -> bool {
+        let prov = trace.get("provenance");
+
+        // Legacy trace (provenance is null or missing)
+        let is_legacy = prov.is_none() || prov.is_some_and(|v| v.is_null());
+
+        if is_legacy {
+            // Default filter retains legacy; any positive filter excludes them.
+            return self.is_default();
+        }
+
+        let prov = prov.unwrap(); // safe: not legacy
+
+        if let Some(ref ver) = self.quorum_version {
+            let trace_ver = prov.get("quorum_version").and_then(|v| v.as_str());
+            if trace_ver != Some(ver.as_str()) {
+                return false;
+            }
+        }
+
+        if self.clean_only {
+            let dirty = prov.get("dirty").and_then(|v| v.as_bool()).unwrap_or(false);
+            if dirty {
+                return false;
+            }
+        }
+
+        if let Some(ref repo) = self.repo {
+            let trace_repo = prov.get("repo").and_then(|v| v.as_str());
+            if trace_repo != Some(repo.as_str()) {
+                return false;
+            }
+        }
+
+        if let Some(ref sha) = self.commit_sha {
+            let trace_sha = prov.get("commit_sha").and_then(|v| v.as_str());
+            if trace_sha != Some(sha.as_str()) {
+                return false;
+            }
+        }
+
+        if let Some(ref rid) = self.run_id {
+            let trace_rid = prov.get("run_id").and_then(|v| v.as_str());
+            if trace_rid != Some(rid.as_str()) {
+                return false;
+            }
+        }
+
+        true
+    }
+}
+
 /// Minimum token Jaccard similarity for fuzzy title matching.
 const FUZZY_THRESHOLD: f64 = 0.5;
 
@@ -100,6 +183,25 @@ pub fn join_feedback_and_traces(
     feedback: &[serde_json::Value],
     traces: &[serde_json::Value],
 ) -> (Vec<(f64, bool)>, JoinStats) {
+    join_feedback_and_traces_with_options(feedback, traces, &JoinFilter::default(), false)
+}
+
+/// Like [`join_feedback_and_traces`] but with additional controls:
+///
+/// - `filter`: pre-filters traces by provenance metadata before indexing.
+/// - `disable_fuzzy`: when `true`, skips tiers 2-4 (normalized exact, fuzzy
+///   same-file, normalized title-only). Only tier 1 (raw exact) and the raw
+///   title-only fallback are used.
+pub fn join_feedback_and_traces_with_options(
+    feedback: &[serde_json::Value],
+    traces: &[serde_json::Value],
+    filter: &JoinFilter,
+    disable_fuzzy: bool,
+) -> (Vec<(f64, bool)>, JoinStats) {
+    // Pre-filter traces by provenance metadata.
+    let filtered_traces: Vec<&serde_json::Value> =
+        traces.iter().filter(|t| filter.accepts(t)).collect();
+
     // Tier 1: raw exact (title, file_path)
     let mut raw_map: HashMap<(String, String), (f64, f64)> = HashMap::new();
     let mut raw_ambiguous: HashSet<(String, String)> = HashSet::new();
@@ -123,7 +225,7 @@ pub fn join_feedback_and_traces(
     let mut norm_titles_with_file_scoped: HashSet<String> = HashSet::new();
     let mut raw_titles_with_file_scoped: HashSet<String> = HashSet::new();
 
-    for t in traces {
+    for t in &filtered_traces {
         let title = t["finding_title"].as_str().unwrap_or("").to_string();
         if title.is_empty() {
             continue;
@@ -143,7 +245,7 @@ pub fn join_feedback_and_traces(
                     e.insert((tp_w, fp_w));
                 }
             }
-            if !norm.is_empty() {
+            if !disable_fuzzy && !norm.is_empty() {
                 let norm_for_ambiguous = norm.clone();
                 match norm_title_only.entry(norm) {
                     std::collections::hash_map::Entry::Occupied(_) => {
@@ -171,22 +273,24 @@ pub fn join_feedback_and_traces(
                 }
             }
 
-            // Tier 2: normalized exact
-            if !norm.is_empty() {
-                let norm_key = (norm.clone(), fp.clone());
-                match norm_map.entry(norm_key.clone()) {
-                    std::collections::hash_map::Entry::Occupied(_) => {
-                        norm_ambiguous.insert(norm_key);
-                    }
-                    std::collections::hash_map::Entry::Vacant(e) => {
-                        e.insert((tp_w, fp_w));
+            if !disable_fuzzy {
+                // Tier 2: normalized exact
+                if !norm.is_empty() {
+                    let norm_key = (norm.clone(), fp.clone());
+                    match norm_map.entry(norm_key.clone()) {
+                        std::collections::hash_map::Entry::Occupied(_) => {
+                            norm_ambiguous.insert(norm_key);
+                        }
+                        std::collections::hash_map::Entry::Vacant(e) => {
+                            e.insert((tp_w, fp_w));
+                        }
                     }
                 }
-            }
 
-            // Tier 3: file -> normalized traces for fuzzy
-            if !norm.is_empty() {
-                file_traces.entry(fp).or_default().push((norm, (tp_w, fp_w)));
+                // Tier 3: file -> normalized traces for fuzzy
+                if !norm.is_empty() {
+                    file_traces.entry(fp).or_default().push((norm, (tp_w, fp_w)));
+                }
             }
         }
     }
@@ -243,8 +347,8 @@ pub fn join_feedback_and_traces(
             }
         }
 
-        // Tier 2: normalized exact (norm_title, file_path)
-        if !norm.is_empty() {
+        // Tier 2: normalized exact (norm_title, file_path) -- skipped when fuzzy disabled
+        if !disable_fuzzy && !norm.is_empty() {
             if let Some(weights) = norm_map.get(&(norm.clone(), fp.clone())) {
                 if push_sample(&mut samples, weights, is_positive) {
                     stats.exact_normalized += 1;
@@ -253,9 +357,9 @@ pub fn join_feedback_and_traces(
             }
         }
 
-        // Tier 3: fuzzy same-file
+        // Tier 3: fuzzy same-file -- skipped when fuzzy disabled
         let mut fuzzy_below_threshold = false;
-        if !norm.is_empty() && !fp.is_empty() {
+        if !disable_fuzzy && !norm.is_empty() && !fp.is_empty() {
             if let Some(candidates) = file_traces.get(&fp) {
                 let mut best_score = 0.0_f64;
                 let mut second_best = 0.0_f64;
@@ -291,14 +395,14 @@ pub fn join_feedback_and_traces(
             }
         }
 
-        // Tier 4: title-only fallback (raw first, then normalized)
+        // Title-only fallback (raw first, then normalized -- normalized skipped when fuzzy disabled)
         if let Some(weights) = raw_title_only.get(&title) {
             if push_sample(&mut samples, weights, is_positive) {
                 stats.raw_title_only += 1;
                 continue;
             }
         }
-        if !norm.is_empty() {
+        if !disable_fuzzy && !norm.is_empty() {
             if let Some(weights) = norm_title_only.get(&norm) {
                 if push_sample(&mut samples, weights, is_positive) {
                     stats.normalized_title_only += 1;
@@ -1045,5 +1149,286 @@ mod tests {
             "INF weight serialized as JSON null should be treated as 0.0, got {score}"
         );
         assert!(label);
+    }
+
+    // --- Task 6: disable_fuzzy ablation ---
+
+    fn make_trace_with_provenance(
+        title: &str,
+        tp: f64,
+        fp: f64,
+        file_path: Option<&str>,
+        prov: Option<serde_json::Value>,
+    ) -> serde_json::Value {
+        let mut v = make_trace(title, tp, fp, file_path);
+        if let Some(p) = prov {
+            v["provenance"] = p;
+        }
+        v
+    }
+
+    #[test]
+    fn disable_fuzzy_skips_normalized_exact() {
+        // Without fuzzy disabled, normalized exact (tier 2) matches backtick variants.
+        // With fuzzy disabled, only raw exact (tier 1) is used -- no match.
+        let feedback = vec![make_feedback("uses a fixed .tmp filename", "tp", "src/a.rs")];
+        let traces = vec![make_trace(
+            "uses a fixed `.tmp` filename",
+            2.0, 0.3, Some("src/a.rs"),
+        )];
+
+        // Fuzzy enabled: should match via tier 2
+        let (samples, stats) = join_feedback_and_traces(&feedback, &traces);
+        assert_eq!(samples.len(), 1);
+        assert_eq!(stats.exact_normalized, 1);
+
+        // Fuzzy disabled: no match
+        let (samples, stats) = join_feedback_and_traces_with_options(
+            &feedback, &traces, &JoinFilter::default(), true,
+        );
+        assert!(samples.is_empty(), "fuzzy disabled should skip normalized exact");
+        assert_eq!(stats.exact_normalized, 0);
+        assert_eq!(stats.unmatched, 1);
+    }
+
+    #[test]
+    fn disable_fuzzy_skips_fuzzy_same_file() {
+        let feedback = vec![make_feedback(
+            "Reset can race with visit processing",
+            "tp", "src/visit.rs",
+        )];
+        let traces = vec![make_trace(
+            "Reset can race with visit processing and lose the cleaned state",
+            2.0, 0.5, Some("src/visit.rs"),
+        )];
+
+        // Fuzzy enabled: should match via tier 3
+        let (samples, stats) = join_feedback_and_traces(&feedback, &traces);
+        assert_eq!(samples.len(), 1);
+        assert_eq!(stats.fuzzy_same_file, 1);
+
+        // Fuzzy disabled: no match
+        let (samples, stats) = join_feedback_and_traces_with_options(
+            &feedback, &traces, &JoinFilter::default(), true,
+        );
+        assert!(samples.is_empty(), "fuzzy disabled should skip fuzzy same-file");
+        assert_eq!(stats.fuzzy_same_file, 0);
+    }
+
+    #[test]
+    fn disable_fuzzy_skips_normalized_title_only() {
+        let feedback = vec![make_feedback("fixed .tmp filename", "tp", "src/a.rs")];
+        let traces = vec![make_trace("fixed `.tmp` filename", 1.5, 0.5, None)];
+
+        // Fuzzy enabled: should match via tier 4 (normalized title-only)
+        let (samples, stats) = join_feedback_and_traces(&feedback, &traces);
+        assert_eq!(samples.len(), 1);
+        assert_eq!(stats.normalized_title_only, 1);
+
+        // Fuzzy disabled: no match (raw title-only doesn't match either since titles differ)
+        let (samples, stats) = join_feedback_and_traces_with_options(
+            &feedback, &traces, &JoinFilter::default(), true,
+        );
+        assert!(samples.is_empty(), "fuzzy disabled should skip normalized title-only");
+        assert_eq!(stats.normalized_title_only, 0);
+    }
+
+    #[test]
+    fn disable_fuzzy_preserves_raw_exact_and_raw_title_only() {
+        // Raw exact (tier 1) and raw title-only should still work when fuzzy is disabled.
+        let feedback = vec![
+            make_feedback("SQL injection", "tp", "src/db.rs"),
+            make_feedback("Unused var", "fp", "src/main.rs"),
+        ];
+        let traces = vec![
+            make_trace("SQL injection", 2.5, 0.3, Some("src/db.rs")), // tier 1
+            make_trace("Unused var", 0.1, 1.8, None),                  // raw title-only
+        ];
+        let (samples, stats) = join_feedback_and_traces_with_options(
+            &feedback, &traces, &JoinFilter::default(), true,
+        );
+        assert_eq!(samples.len(), 2);
+        assert_eq!(stats.exact_raw, 1);
+        assert_eq!(stats.raw_title_only, 1);
+    }
+
+    // --- Task 7: JoinFilter ---
+
+    #[test]
+    fn join_filter_default_retains_legacy_traces() {
+        // Default filter includes traces without provenance (legacy).
+        let feedback = vec![make_feedback("Bug", "tp", "src/a.rs")];
+        let traces = vec![make_trace("Bug", 2.0, 0.3, Some("src/a.rs"))]; // no provenance
+        let (samples, _stats) = join_feedback_and_traces_with_options(
+            &feedback, &traces, &JoinFilter::default(), false,
+        );
+        assert_eq!(samples.len(), 1, "default filter should retain legacy traces");
+    }
+
+    #[test]
+    fn join_filter_positive_excludes_legacy() {
+        // Setting quorum_version filter excludes traces without provenance.
+        let feedback = vec![make_feedback("Bug", "tp", "src/a.rs")];
+        let traces = vec![make_trace("Bug", 2.0, 0.3, Some("src/a.rs"))]; // no provenance
+        let filter = JoinFilter {
+            quorum_version: Some("0.18.4".to_string()),
+            ..Default::default()
+        };
+        let (samples, _stats) = join_feedback_and_traces_with_options(
+            &feedback, &traces, &filter, false,
+        );
+        assert!(samples.is_empty(), "positive filter should exclude legacy traces");
+    }
+
+    #[test]
+    fn join_filter_by_version() {
+        let feedback = vec![
+            make_feedback("Bug A", "tp", "src/a.rs"),
+            make_feedback("Bug B", "fp", "src/b.rs"),
+        ];
+        let traces = vec![
+            make_trace_with_provenance("Bug A", 2.0, 0.3, Some("src/a.rs"), Some(serde_json::json!({
+                "quorum_version": "0.18.4",
+                "repo": "quorum"
+            }))),
+            make_trace_with_provenance("Bug B", 0.1, 1.8, Some("src/b.rs"), Some(serde_json::json!({
+                "quorum_version": "0.18.3",
+                "repo": "quorum"
+            }))),
+        ];
+        let filter = JoinFilter {
+            quorum_version: Some("0.18.4".to_string()),
+            ..Default::default()
+        };
+        let (samples, stats) = join_feedback_and_traces_with_options(
+            &feedback, &traces, &filter, false,
+        );
+        assert_eq!(samples.len(), 1, "only version 0.18.4 trace should match");
+        assert_eq!(stats.exact_raw, 1);
+        // The matched sample should be the TP (Bug A)
+        assert!(samples[0].1, "matched sample should be positive (Bug A)");
+    }
+
+    #[test]
+    fn join_filter_clean_only() {
+        let feedback = vec![
+            make_feedback("Bug A", "tp", "src/a.rs"),
+            make_feedback("Bug B", "fp", "src/b.rs"),
+        ];
+        let traces = vec![
+            make_trace_with_provenance("Bug A", 2.0, 0.3, Some("src/a.rs"), Some(serde_json::json!({
+                "quorum_version": "0.18.4",
+                "dirty": false
+            }))),
+            make_trace_with_provenance("Bug B", 0.1, 1.8, Some("src/b.rs"), Some(serde_json::json!({
+                "quorum_version": "0.18.4",
+                "dirty": true
+            }))),
+        ];
+        let filter = JoinFilter {
+            clean_only: true,
+            ..Default::default()
+        };
+        let (samples, stats) = join_feedback_and_traces_with_options(
+            &feedback, &traces, &filter, false,
+        );
+        assert_eq!(samples.len(), 1, "dirty trace should be excluded");
+        assert_eq!(stats.exact_raw, 1);
+        assert!(samples[0].1, "matched sample should be positive (Bug A, clean)");
+    }
+
+    #[test]
+    fn join_filter_by_repo() {
+        let feedback = vec![
+            make_feedback("Bug A", "tp", "src/a.rs"),
+            make_feedback("Bug B", "fp", "src/b.rs"),
+        ];
+        let traces = vec![
+            make_trace_with_provenance("Bug A", 2.0, 0.3, Some("src/a.rs"), Some(serde_json::json!({
+                "repo": "quorum"
+            }))),
+            make_trace_with_provenance("Bug B", 0.1, 1.8, Some("src/b.rs"), Some(serde_json::json!({
+                "repo": "other-project"
+            }))),
+        ];
+        let filter = JoinFilter {
+            repo: Some("quorum".to_string()),
+            ..Default::default()
+        };
+        let (samples, _stats) = join_feedback_and_traces_with_options(
+            &feedback, &traces, &filter, false,
+        );
+        assert_eq!(samples.len(), 1, "only quorum-repo trace should match");
+        assert!(samples[0].1, "matched sample should be positive (Bug A)");
+    }
+
+    #[test]
+    fn join_filter_by_commit_sha() {
+        let feedback = vec![make_feedback("Bug", "tp", "src/a.rs")];
+        let traces = vec![
+            make_trace_with_provenance("Bug", 2.0, 0.3, Some("src/a.rs"), Some(serde_json::json!({
+                "commit_sha": "abc123"
+            }))),
+        ];
+        let filter = JoinFilter {
+            commit_sha: Some("def456".to_string()),
+            ..Default::default()
+        };
+        let (samples, _stats) = join_feedback_and_traces_with_options(
+            &feedback, &traces, &filter, false,
+        );
+        assert!(samples.is_empty(), "wrong commit_sha should exclude trace");
+    }
+
+    #[test]
+    fn join_filter_by_run_id() {
+        let feedback = vec![make_feedback("Bug", "tp", "src/a.rs")];
+        let traces = vec![
+            make_trace_with_provenance("Bug", 2.0, 0.3, Some("src/a.rs"), Some(serde_json::json!({
+                "run_id": "run-42"
+            }))),
+        ];
+        let filter = JoinFilter {
+            run_id: Some("run-42".to_string()),
+            ..Default::default()
+        };
+        let (samples, stats) = join_feedback_and_traces_with_options(
+            &feedback, &traces, &filter, false,
+        );
+        assert_eq!(samples.len(), 1, "matching run_id should pass");
+        assert_eq!(stats.exact_raw, 1);
+    }
+
+    #[test]
+    fn join_filter_combined_version_and_clean() {
+        let feedback = vec![
+            make_feedback("Bug A", "tp", "src/a.rs"),
+            make_feedback("Bug B", "fp", "src/b.rs"),
+            make_feedback("Bug C", "tp", "src/c.rs"),
+        ];
+        let traces = vec![
+            make_trace_with_provenance("Bug A", 2.0, 0.3, Some("src/a.rs"), Some(serde_json::json!({
+                "quorum_version": "0.18.4",
+                "dirty": false
+            }))),
+            make_trace_with_provenance("Bug B", 0.1, 1.8, Some("src/b.rs"), Some(serde_json::json!({
+                "quorum_version": "0.18.4",
+                "dirty": true
+            }))),
+            make_trace_with_provenance("Bug C", 1.0, 0.5, Some("src/c.rs"), Some(serde_json::json!({
+                "quorum_version": "0.18.3",
+                "dirty": false
+            }))),
+        ];
+        let filter = JoinFilter {
+            quorum_version: Some("0.18.4".to_string()),
+            clean_only: true,
+            ..Default::default()
+        };
+        let (samples, _stats) = join_feedback_and_traces_with_options(
+            &feedback, &traces, &filter, false,
+        );
+        assert_eq!(samples.len(), 1, "only Bug A passes both version + clean filter");
+        assert!(samples[0].1, "matched sample should be positive (Bug A)");
     }
 }

--- a/src/calibrate.rs
+++ b/src/calibrate.rs
@@ -18,7 +18,8 @@ use crate::threshold_config::{PathThreshold, ThresholdConfig};
 pub struct JoinFilter {
     /// Only include traces from this quorum version (e.g. `"0.18.4"`).
     pub quorum_version: Option<String>,
-    /// When `true`, exclude traces where `provenance.dirty == Some(true)`.
+    /// When `true`, only include traces with `provenance.dirty == Some(false)`.
+    /// Traces with unknown or missing dirty state are excluded.
     pub clean_only: bool,
     /// Only include traces from this repository.
     pub repo: Option<String>,

--- a/src/calibrate.rs
+++ b/src/calibrate.rs
@@ -29,8 +29,8 @@ pub struct JoinFilter {
 }
 
 impl JoinFilter {
-    /// Returns `true` when no positive filters are set (only `clean_only` can
-    /// be active). Legacy traces (without provenance) are retained by default.
+    /// Returns `true` when all filters are at their default values. Legacy
+    /// traces (without provenance) are retained only when this returns true.
     fn is_default(&self) -> bool {
         self.quorum_version.is_none()
             && !self.clean_only

--- a/src/calibrate.rs
+++ b/src/calibrate.rs
@@ -61,8 +61,8 @@ impl JoinFilter {
         }
 
         if self.clean_only {
-            let dirty = prov.get("dirty").and_then(|v| v.as_bool()).unwrap_or(false);
-            if dirty {
+            let dirty = prov.get("dirty").and_then(|v| v.as_bool());
+            if dirty != Some(false) {
                 return false;
             }
         }
@@ -1430,5 +1430,30 @@ mod tests {
         );
         assert_eq!(samples.len(), 1, "only Bug A passes both version + clean filter");
         assert!(samples[0].1, "matched sample should be positive (Bug A)");
+    }
+
+    #[test]
+    fn join_filter_clean_only_excludes_unknown_dirty() {
+        let feedback = vec![
+            make_feedback("Bug A", "tp", "src/a.rs"),
+            make_feedback("Bug B", "fp", "src/b.rs"),
+        ];
+        let traces = vec![
+            make_trace_with_provenance("Bug A", 2.0, 0.3, Some("src/a.rs"), Some(serde_json::json!({
+                "quorum_version": "0.18.4",
+                "dirty": false
+            }))),
+            make_trace_with_provenance("Bug B", 0.1, 1.8, Some("src/b.rs"), Some(serde_json::json!({
+                "quorum_version": "0.18.4"
+            }))),
+        ];
+        let filter = JoinFilter {
+            clean_only: true,
+            ..Default::default()
+        };
+        let (samples, _stats) = join_feedback_and_traces_with_options(
+            &feedback, &traces, &filter, false,
+        );
+        assert_eq!(samples.len(), 1, "trace with unknown dirty should be excluded by clean_only");
     }
 }

--- a/src/calibrator.rs
+++ b/src/calibrator.rs
@@ -96,6 +96,7 @@ fn make_no_match_trace(finding: &Finding, file_path: &str) -> crate::calibrator_
             crate::calibrator_trace::SeverityChangeReason::NoMatch,
         ),
         file_path: if file_path.is_empty() { None } else { Some(file_path.to_string()) },
+        provenance: None,
     }
 }
 
@@ -130,6 +131,7 @@ fn make_trace_entry(
         output_severity: finding.severity.clone(),
         severity_change_reason,
         file_path: if file_path.is_empty() { None } else { Some(file_path.to_string()) },
+        provenance: None,
     }
 }
 

--- a/src/calibrator.rs
+++ b/src/calibrator.rs
@@ -3713,4 +3713,32 @@ mod tests {
             "calibrate_with_index must stamp provenance from config",
         );
     }
+
+    #[test]
+    fn calibrate_attaches_provenance_on_decision_trace() {
+        let findings = vec![
+            FindingBuilder::new()
+                .title("SQL injection")
+                .category("security".into())
+                .severity(Severity::Medium)
+                .build(),
+        ];
+        let feedback = vec![
+            fb("SQL injection", "security", Verdict::Tp),
+            fb("SQL injection", "security", Verdict::Tp),
+        ];
+        let prov = crate::calibrator_trace::TraceProvenance {
+            run_id: Some("01JTEST_DECISION".into()),
+            ..Default::default()
+        };
+        let mut config = CalibratorConfig::default();
+        config.trace_provenance = Some(prov.clone());
+        let result = calibrate(findings, &feedback, &config, "src/db.rs");
+        assert_eq!(result.traces.len(), 1);
+        assert_eq!(
+            result.traces[0].provenance.as_ref(),
+            Some(&prov),
+            "decision-path trace must carry provenance from config",
+        );
+    }
 }

--- a/src/calibrator.rs
+++ b/src/calibrator.rs
@@ -45,6 +45,10 @@ pub struct CalibratorConfig {
     /// Intended for `QUORUM_FORCE_THRESHOLD` env var injection. `None` means
     /// use the individual suppress/boost thresholds.
     pub force_threshold: Option<f64>,
+    /// Provenance metadata stamped onto every `CalibratorTraceEntry` produced
+    /// during this calibration run. `None` means no provenance is attached
+    /// (backward-compatible default).
+    pub trace_provenance: Option<crate::calibrator_trace::TraceProvenance>,
 }
 
 impl Default for CalibratorConfig {
@@ -59,6 +63,7 @@ impl Default for CalibratorConfig {
             suppress_threshold: None,
             boost_threshold: None,
             force_threshold: None,
+            trace_provenance: None,
         }
     }
 }
@@ -431,7 +436,11 @@ pub fn calibrate(
     if filtered.is_empty() {
         // Track B: emit NoMatch traces so the eval harness sees per-finding
         // calibration outcomes even when the corpus is empty / fully filtered.
-        let traces = findings.iter().map(|f| make_no_match_trace(f, file_path)).collect();
+        let traces = findings.iter().map(|f| {
+            let mut t = make_no_match_trace(f, file_path);
+            t.provenance = config.trace_provenance.clone();
+            t
+        }).collect();
         return CalibrationResult {
             findings,
             suppressed: 0,
@@ -458,7 +467,9 @@ pub fn calibrate(
             .collect();
 
         if similar.is_empty() {
-            traces.push(make_no_match_trace(&finding, file_path));
+            let mut trace = make_no_match_trace(&finding, file_path);
+            trace.provenance = config.trace_provenance.clone();
+            traces.push(trace);
             output.push(finding);
             continue;
         }
@@ -521,7 +532,7 @@ pub fn calibrate(
             ));
         }
 
-        let decision = calibrate_core_decision(
+        let mut decision = calibrate_core_decision(
             &mut finding,
             config,
             tp_weight,
@@ -532,6 +543,7 @@ pub fn calibrate(
             input_severity,
             file_path,
         );
+        decision.trace.provenance = config.trace_provenance.clone();
         traces.push(decision.trace);
         if decision.suppressed {
             suppressed += 1;
@@ -606,7 +618,11 @@ pub fn calibrate_with_index(
     if index.is_empty() {
         // Track B: emit NoMatch traces so the eval harness sees per-finding
         // calibration outcomes even when the index is empty.
-        let traces = findings.iter().map(|f| make_no_match_trace(f, file_path)).collect();
+        let traces = findings.iter().map(|f| {
+            let mut t = make_no_match_trace(f, file_path);
+            t.provenance = config.trace_provenance.clone();
+            t
+        }).collect();
         return CalibrationResult { findings, suppressed: 0, boosted: 0, traces };
     }
 
@@ -664,7 +680,9 @@ pub fn calibrate_with_index(
             .collect();
 
         if similar.is_empty() {
-            traces.push(make_no_match_trace(&finding, file_path));
+            let mut trace = make_no_match_trace(&finding, file_path);
+            trace.provenance = config.trace_provenance.clone();
+            traces.push(trace);
             output.push(finding);
             continue;
         }
@@ -724,7 +742,7 @@ pub fn calibrate_with_index(
             ));
         }
 
-        let decision = calibrate_core_decision(
+        let mut decision = calibrate_core_decision(
             &mut finding,
             config,
             tp_weight,
@@ -735,6 +753,7 @@ pub fn calibrate_with_index(
             input_severity,
             file_path,
         );
+        decision.trace.provenance = config.trace_provenance.clone();
         traces.push(decision.trace);
         if decision.suppressed {
             suppressed += 1;
@@ -3619,6 +3638,73 @@ mod tests {
         assert!(
             !decision.boosted,
             "zero weights -> score=0.5, should not boost with threshold=0.6"
+        );
+    }
+
+    // --- Trace provenance stamping tests ---
+
+    #[test]
+    fn calibrate_attaches_provenance_to_traces() {
+        let findings = vec![
+            FindingBuilder::new()
+                .title("SQL injection")
+                .category("security".into())
+                .severity(Severity::Medium)
+                .build(),
+            FindingBuilder::new()
+                .title("Unused variable")
+                .category("quality".into())
+                .severity(Severity::Low)
+                .build(),
+        ];
+        let prov = crate::calibrator_trace::TraceProvenance {
+            quorum_version: Some("0.19.0-test".into()),
+            repo: Some("test-repo".into()),
+            run_id: Some("01JTEST_CAL".into()),
+            ..Default::default()
+        };
+        let mut config = CalibratorConfig::default();
+        config.trace_provenance = Some(prov.clone());
+        // Empty feedback: all traces take the NoMatch path.
+        let result = calibrate(findings, &[], &config, "test.rs");
+        assert_eq!(result.traces.len(), 2, "one trace per finding");
+        for trace in &result.traces {
+            assert_eq!(
+                trace.provenance.as_ref(),
+                Some(&prov),
+                "every trace must carry the config provenance; finding={}",
+                trace.finding_title,
+            );
+        }
+    }
+
+    #[test]
+    fn calibrate_with_index_attaches_provenance() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let store = crate::feedback::FeedbackStore::new(dir.path().join("fb.jsonl"));
+        // Empty store -> empty index -> NoMatch path in calibrate_with_index.
+        let mut index = crate::feedback_index::FeedbackIndex::build_jaccard_only(&store).unwrap();
+
+        let findings = vec![
+            FindingBuilder::new()
+                .title("Buffer overflow")
+                .category("security".into())
+                .severity(Severity::High)
+                .build(),
+        ];
+        let prov = crate::calibrator_trace::TraceProvenance {
+            quorum_version: Some("0.19.0-test".into()),
+            commit_sha: Some("deadbeef".into()),
+            ..Default::default()
+        };
+        let mut config = CalibratorConfig::default();
+        config.trace_provenance = Some(prov.clone());
+        let result = calibrate_with_index(findings, &mut index, &config, "buf.c");
+        assert_eq!(result.traces.len(), 1, "one trace per finding");
+        assert_eq!(
+            result.traces[0].provenance.as_ref(),
+            Some(&prov),
+            "calibrate_with_index must stamp provenance from config",
         );
     }
 }

--- a/src/calibrator.rs
+++ b/src/calibrator.rs
@@ -49,6 +49,11 @@ pub struct CalibratorConfig {
     /// during this calibration run. `None` means no provenance is attached
     /// (backward-compatible default).
     pub trace_provenance: Option<crate::calibrator_trace::TraceProvenance>,
+    /// Ablation flag: when `Some(true)`, the corpus join skips fuzzy matching
+    /// tiers (normalized exact, fuzzy same-file, normalized title-only) and
+    /// uses only raw exact + raw title-only fallback. `None` or `Some(false)`
+    /// keeps all tiers active (default).
+    pub disable_fuzzy_matching: Option<bool>,
 }
 
 impl Default for CalibratorConfig {
@@ -64,6 +69,7 @@ impl Default for CalibratorConfig {
             boost_threshold: None,
             force_threshold: None,
             trace_provenance: None,
+            disable_fuzzy_matching: None,
         }
     }
 }

--- a/src/calibrator_fingerprint.rs
+++ b/src/calibrator_fingerprint.rs
@@ -176,6 +176,7 @@ mod tests {
             output_severity: Severity::High,
             severity_change_reason: Some(SeverityChangeReason::Boosted),
             file_path: None,
+            provenance: None,
         }
     }
 

--- a/src/calibrator_trace.rs
+++ b/src/calibrator_trace.rs
@@ -38,6 +38,24 @@ pub enum SeverityChangeReason {
     NoMatch,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq)]
+pub struct TraceProvenance {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub quorum_version: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub repo: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub commit_sha: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub dirty: Option<bool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub review_model: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub run_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub timestamp: Option<String>,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CalibratorTraceEntry {
     pub finding_title: String,
@@ -59,6 +77,8 @@ pub struct CalibratorTraceEntry {
     /// `None` for backward-compat with pre-PR3 trace lines.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub file_path: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub provenance: Option<TraceProvenance>,
 }
 
 #[cfg(test)]
@@ -88,6 +108,7 @@ mod tests {
             output_severity: Severity::High,
             severity_change_reason: None,
             file_path: None,
+            provenance: None,
         };
         let json = serde_json::to_string(&trace).unwrap();
         assert!(json.contains("\"tp_weight\":2.5"));
@@ -110,6 +131,7 @@ mod tests {
             output_severity: Severity::Low,
             severity_change_reason: None,
             file_path: None,
+            provenance: None,
         };
         let json = serde_json::to_string(&trace).unwrap();
         assert!(json.contains("\"matched_precedents\":[]"));
@@ -148,6 +170,7 @@ mod tests {
             output_severity: Severity::Low,
             severity_change_reason: None,
             file_path: None,
+            provenance: None,
         };
         let json = serde_json::to_string(&trace).unwrap();
         assert!(!json.contains("severity_change_reason"),
@@ -185,6 +208,7 @@ mod tests {
             output_severity: Severity::Medium,
             severity_change_reason: None,
             file_path: Some("src/main.rs".to_string()),
+            provenance: None,
         };
         let json = serde_json::to_string(&trace).unwrap();
         assert!(json.contains("\"file_path\":\"src/main.rs\""));
@@ -197,5 +221,79 @@ mod tests {
         let json = r#"{"finding_title":"test","finding_category":"security","tp_weight":1.0,"fp_weight":0.5,"wontfix_weight":0.0,"full_suppress_weight":0.5,"soft_fp_weight":0.5,"matched_precedents":[],"action":null,"input_severity":"medium","output_severity":"medium"}"#;
         let trace: CalibratorTraceEntry = serde_json::from_str(json).unwrap();
         assert_eq!(trace.file_path, None, "old entries should parse with None file_path");
+    }
+
+    #[test]
+    fn trace_provenance_round_trips() {
+        let prov = TraceProvenance {
+            quorum_version: Some("0.19.0".into()),
+            repo: Some("quorum".into()),
+            commit_sha: Some("abc123def".into()),
+            dirty: Some(false),
+            review_model: Some("gpt-5.4".into()),
+            run_id: Some("01JTEST000".into()),
+            timestamp: Some("2026-05-05T12:00:00Z".into()),
+        };
+        let json = serde_json::to_string(&prov).unwrap();
+        let back: TraceProvenance = serde_json::from_str(&json).unwrap();
+        assert_eq!(prov, back);
+    }
+
+    #[test]
+    fn all_none_provenance_serializes_empty() {
+        let prov = TraceProvenance::default();
+        let json = serde_json::to_string(&prov).unwrap();
+        assert_eq!(json, "{}");
+    }
+
+    #[test]
+    fn trace_entry_with_provenance_nested_object() {
+        let trace = CalibratorTraceEntry {
+            finding_title: "test".into(),
+            finding_category: "security".into(),
+            tp_weight: 0.0, fp_weight: 0.0, wontfix_weight: 0.0,
+            full_suppress_weight: 0.0, soft_fp_weight: 0.0,
+            matched_precedents: vec![], action: None,
+            input_severity: Severity::Low, output_severity: Severity::Low,
+            severity_change_reason: None, file_path: None,
+            provenance: Some(TraceProvenance {
+                quorum_version: Some("0.19.0".into()),
+                ..Default::default()
+            }),
+        };
+        let json = serde_json::to_string(&trace).unwrap();
+        assert!(json.contains(r#""provenance":{"quorum_version":"0.19.0"}"#),
+            "provenance must be a nested object, got: {json}");
+    }
+
+    #[test]
+    fn old_trace_without_provenance_deserializes() {
+        let json = r#"{"finding_title":"x","finding_category":"y","tp_weight":0.0,"fp_weight":0.0,"wontfix_weight":0.0,"full_suppress_weight":0.0,"soft_fp_weight":0.0,"matched_precedents":[],"action":null,"input_severity":"low","output_severity":"low"}"#;
+        let trace: CalibratorTraceEntry = serde_json::from_str(json).unwrap();
+        assert!(trace.provenance.is_none());
+    }
+
+    #[test]
+    fn provenance_accepts_unknown_keys_for_forward_compat() {
+        let json = r#"{"quorum_version":"0.19.0","future_field":"value"}"#;
+        let prov: TraceProvenance = serde_json::from_str(json).unwrap();
+        assert_eq!(prov.quorum_version.as_deref(), Some("0.19.0"));
+    }
+
+    #[test]
+    fn provenance_omitted_when_none() {
+        let trace = CalibratorTraceEntry {
+            finding_title: "x".into(),
+            finding_category: "y".into(),
+            tp_weight: 0.0, fp_weight: 0.0, wontfix_weight: 0.0,
+            full_suppress_weight: 0.0, soft_fp_weight: 0.0,
+            matched_precedents: vec![], action: None,
+            input_severity: Severity::Low, output_severity: Severity::Low,
+            severity_change_reason: None, file_path: None,
+            provenance: None,
+        };
+        let json = serde_json::to_string(&trace).unwrap();
+        assert!(!json.contains("provenance"),
+            "None provenance must be omitted from JSON");
     }
 }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -267,6 +267,30 @@ pub struct CalibrateOpts {
     /// Target precision for boost path (default: 0.85, range 0.0-1.0)
     #[arg(long, default_value = "0.85")]
     pub boost_precision: f64,
+
+    /// Only include traces from this quorum version
+    #[arg(long)]
+    pub trace_version: Option<String>,
+
+    /// Only include traces from clean commits (dirty == false)
+    #[arg(long)]
+    pub clean_only: bool,
+
+    /// Only include traces from this repository
+    #[arg(long)]
+    pub trace_repo: Option<String>,
+
+    /// Only include traces from this commit SHA
+    #[arg(long)]
+    pub trace_commit: Option<String>,
+
+    /// Only include traces from this review run ID
+    #[arg(long)]
+    pub trace_run_id: Option<String>,
+
+    /// Disable fuzzy matching tiers (normalized + Jaccard); raw exact only
+    #[arg(long)]
+    pub disable_fuzzy: bool,
 }
 
 #[derive(Parser)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -741,8 +741,41 @@ async fn run_review(opts: cli::ReviewOpts) -> i32 {
         }
     };
 
+    // Generate run_id early so it can be shared between TraceProvenance
+    // and ReviewRecord (design constraint: same ULID for join key).
+    let run_id = review_log::ReviewRecord::new_ulid();
+
+    // Compute trace provenance ONCE before per-file fanout (design H3).
+    let trace_provenance = {
+        let first_file = opts.files.first().map(|p| p.as_path());
+        let repo = first_file.and_then(review_log::detect_repo);
+        let commit_sha = std::process::Command::new("git")
+            .args(["rev-parse", "HEAD"])
+            .output()
+            .ok()
+            .filter(|o| o.status.success())
+            .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string());
+        let dirty = std::process::Command::new("git")
+            .args(["status", "--porcelain"])
+            .output()
+            .ok()
+            .filter(|o| o.status.success())
+            .map(|o| !o.stdout.is_empty());
+
+        quorum::calibrator_trace::TraceProvenance {
+            quorum_version: Some(env!("CARGO_PKG_VERSION").into()),
+            repo,
+            commit_sha,
+            dirty,
+            review_model: models.first().cloned(),
+            run_id: Some(run_id.clone()),
+            timestamp: Some(chrono::Utc::now().to_rfc3339()),
+        }
+    };
+
     // Build calibrator config, loading data-driven thresholds if available.
     let mut calibrator_config = calibrator::CalibratorConfig::default();
+    calibrator_config.trace_provenance = Some(trace_provenance);
     let thresholds_path = qhome.join("calibrator_thresholds.toml");
     if let Some(tc) =
         quorum::threshold_config::ThresholdConfig::load_from(&thresholds_path.to_string_lossy())
@@ -1381,7 +1414,7 @@ async fn run_review(opts: cli::ReviewOpts) -> i32 {
         }
 
         let record = review_log::ReviewRecord {
-            run_id: review_log::ReviewRecord::new_ulid(),
+            run_id: run_id.clone(),
             timestamp: chrono::Utc::now(),
             quorum_version: env!("CARGO_PKG_VERSION").to_string(),
             repo,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1898,7 +1898,19 @@ fn run_calibrate(opts: cli::CalibrateOpts) -> i32 {
         traces.len(),
     );
 
-    let (samples, join_stats) = quorum::calibrate::join_feedback_and_traces(&feedback, &traces);
+    let filter = quorum::calibrate::JoinFilter {
+        quorum_version: opts.trace_version.clone(),
+        clean_only: opts.clean_only,
+        repo: opts.trace_repo.clone(),
+        commit_sha: opts.trace_commit.clone(),
+        run_id: opts.trace_run_id.clone(),
+    };
+    let disable_fuzzy = opts.disable_fuzzy
+        || std::env::var("QUORUM_DISABLE_FUZZY_MATCHING").is_ok();
+    let (samples, join_stats) =
+        quorum::calibrate::join_feedback_and_traces_with_options(
+            &feedback, &traces, &filter, disable_fuzzy,
+        );
     let positives = samples.iter().filter(|(_, l)| *l).count();
     let negatives = samples.len() - positives;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -749,13 +749,19 @@ async fn run_review(opts: cli::ReviewOpts) -> i32 {
     let trace_provenance = {
         let first_file = opts.files.first().map(|p| p.as_path());
         let repo = first_file.and_then(review_log::detect_repo);
+        let git_dir = first_file
+            .and_then(|p| p.parent())
+            .map(|p| p.to_path_buf())
+            .unwrap_or_else(|| std::env::current_dir().unwrap_or_default());
         let commit_sha = std::process::Command::new("git")
+            .current_dir(&git_dir)
             .args(["rev-parse", "HEAD"])
             .output()
             .ok()
             .filter(|o| o.status.success())
             .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string());
         let dirty = std::process::Command::new("git")
+            .current_dir(&git_dir)
             .args(["status", "--porcelain"])
             .output()
             .ok()
@@ -1906,7 +1912,10 @@ fn run_calibrate(opts: cli::CalibrateOpts) -> i32 {
         run_id: opts.trace_run_id.clone(),
     };
     let disable_fuzzy = opts.disable_fuzzy
-        || std::env::var("QUORUM_DISABLE_FUZZY_MATCHING").is_ok();
+        || std::env::var("QUORUM_DISABLE_FUZZY_MATCHING")
+            .ok()
+            .map(|v| matches!(v.as_str(), "1" | "true" | "yes" | "on"))
+            .unwrap_or(false);
     let (samples, join_stats) =
         quorum::calibrate::join_feedback_and_traces_with_options(
             &feedback, &traces, &filter, disable_fuzzy,


### PR DESCRIPTION
## Summary

Adds provenance metadata to calibrator traces so the corpus can be rebuilt, filtered, and compared across versions. Three capabilities:

- **TraceProvenance struct** — 7 optional fields (quorum_version, repo, commit_sha, dirty, review_model, run_id, timestamp) stamped on every `CalibratorTraceEntry`. Nested `Option<TraceProvenance>` (not `#[serde(flatten)]`) for forward-compatible schema. All 6 trace-construction sites in `calibrate()` / `calibrate_with_index()` now stamp provenance from `CalibratorConfig`.
- **JoinFilter** — corpus slicing by quorum_version, clean_only, repo, commit_sha, or run_id. Legacy traces (pre-provenance, `provenance: None`) are retained by default but excluded by any positive filter. `join_feedback_and_traces_with_options()` is the new entry point; the original function delegates to it.
- **Fuzzy ablation** — `--disable-fuzzy` flag (or `QUORUM_DISABLE_FUZZY_MATCHING` env var) skips tiers 2-4 in the corpus join for A/B testing the fuzzy matching from #207.

### Design decisions
- Provenance carried on `CalibratorConfig` to avoid function signature bloat
- No `#[serde(deny_unknown_fields)]` — project pattern is forward-compat (newer quorum writes fields older quorum doesn't know)
- `run_id` pre-generated as ULID before review fanout, shared between `TraceProvenance` and `ReviewRecord`
- Git info computed via `std::process::Command` (not internal `SystemGit` trait, which lives in unexported `context` module)

### Test coverage
- 7 new `TraceProvenance` serde tests (round-trip, empty serialization, nested shape, backward compat, forward compat, omit-when-None)
- 2 provenance-stamping integration tests (calibrate + calibrate_with_index paths)
- 4 fuzzy ablation tests (ablation flag skips fuzzy tiers, default enables fuzzy)
- 8 JoinFilter tests (all filter combinations + legacy trace semantics)
- 1212 bin + 724 lib tests pass

## Quorum self-review verdicts
- 2 TP (pre-existing: precision bounds, reasoning_effort validation)
- 6 FP out-of-scope (pre-existing complexity/pattern findings)
- 1 wontfix (run_calibrate complexity — added 10 lines to already-complex function)
- 0 in-branch bugs found

## Test plan
- [x] `cargo test --bin quorum` — 1212 passed
- [x] `cargo test --lib` — 724 passed
- [x] `cargo clippy` — 0 new warnings (163 pre-existing from Rust 1.94 clippy bump)
- [x] `cargo build --release` — success
- [x] Quorum self-review — all findings pre-existing, 9 feedback verdicts recorded

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Filter calibration traces by provenance (version, repo, commit SHA, run ID) and a clean-only option; legacy traces without provenance are preserved only when no filters are set.
  * CLI flags to supply provenance filters and to disable fuzzy matching tiers and fallback behavior.
  * Calibration now stamps traces with provenance (repo, commit, version, review model, run ID, timestamp) and reuses a single run ID per run.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->