### PR TITLE
feat(calibrate): backfill file_path on legacy traces

### DIFF
--- a/src/calibrate.rs
+++ b/src/calibrate.rs
@@ -1598,4 +1598,122 @@ mod tests {
         assert_eq!(stats.feedback_exact, 1);
         assert_eq!(stats.total_backfilled, 1);
     }
+
+    #[test]
+    fn backfill_skips_traces_with_existing_file_path() {
+        let feedback = vec![
+            serde_json::json!({
+                "finding_title": "SQL injection",
+                "file_path": "src/db.rs",
+                "verdict": "tp"
+            }),
+        ];
+        let mut traces = vec![
+            serde_json::json!({
+                "finding_title": "SQL injection",
+                "finding_category": "security",
+                "tp_weight": 1.0,
+                "fp_weight": 0.0,
+                "file_path": "src/other.rs"
+            }),
+        ];
+        let stats = backfill_file_paths(&mut traces, &feedback);
+        assert_eq!(traces[0]["file_path"].as_str(), Some("src/other.rs"));
+        assert_eq!(stats.already_present, 1);
+        assert_eq!(stats.total_backfilled, 0);
+    }
+
+    #[test]
+    fn backfill_leaves_ambiguous_as_null() {
+        let feedback = vec![
+            serde_json::json!({
+                "finding_title": "Use of unwrap()",
+                "file_path": "src/a.rs",
+                "verdict": "tp"
+            }),
+            serde_json::json!({
+                "finding_title": "Use of unwrap()",
+                "file_path": "src/b.rs",
+                "verdict": "fp"
+            }),
+        ];
+        let mut traces = vec![
+            serde_json::json!({
+                "finding_title": "Use of unwrap()",
+                "finding_category": "correctness",
+                "tp_weight": 1.0,
+                "fp_weight": 0.0
+            }),
+        ];
+        let stats = backfill_file_paths(&mut traces, &feedback);
+        // Should NOT have file_path set
+        let fp = traces[0].get("file_path");
+        assert!(
+            fp.is_none() || fp.unwrap().is_null() || fp.unwrap().as_str() == Some(""),
+            "ambiguous title should not be stamped, got: {:?}",
+            fp
+        );
+        assert_eq!(stats.ambiguous, 1);
+        assert_eq!(stats.total_backfilled, 0);
+    }
+
+    #[test]
+    fn backfill_uses_precedent_when_feedback_ambiguous() {
+        let feedback = vec![
+            serde_json::json!({
+                "finding_title": "Use of unwrap()",
+                "file_path": "src/a.rs",
+                "verdict": "tp"
+            }),
+            serde_json::json!({
+                "finding_title": "Use of unwrap()",
+                "file_path": "src/b.rs",
+                "verdict": "fp"
+            }),
+        ];
+        let mut traces = vec![
+            serde_json::json!({
+                "finding_title": "Use of unwrap()",
+                "finding_category": "correctness",
+                "tp_weight": 1.0,
+                "fp_weight": 0.0,
+                "matched_precedents": [
+                    {"finding_title": "unwrap risk", "file_path": "src/a.rs", "verdict": "tp"},
+                    {"finding_title": "unwrap again", "file_path": "src/a.rs", "verdict": "tp"}
+                ]
+            }),
+        ];
+        let stats = backfill_file_paths(&mut traces, &feedback);
+        assert_eq!(traces[0]["file_path"].as_str(), Some("src/a.rs"));
+        assert_eq!(stats.precedent_inferred, 1);
+        assert_eq!(stats.total_backfilled, 1);
+    }
+
+    #[test]
+    fn backfill_handles_empty_inputs() {
+        let mut empty_traces: Vec<serde_json::Value> = vec![];
+        let empty_feedback: Vec<serde_json::Value> = vec![];
+        let stats = backfill_file_paths(&mut empty_traces, &empty_feedback);
+        assert_eq!(stats, BackfillStats::default());
+    }
+
+    #[test]
+    fn backfill_skips_trace_with_missing_title() {
+        let feedback = vec![
+            serde_json::json!({
+                "finding_title": "A",
+                "file_path": "f.rs",
+                "verdict": "tp"
+            }),
+        ];
+        let mut traces = vec![
+            serde_json::json!({
+                "tp_weight": 1.0,
+                "fp_weight": 0.0
+            }),
+        ];
+        let stats = backfill_file_paths(&mut traces, &feedback);
+        assert_eq!(stats.no_match, 1);
+        assert_eq!(stats.total_backfilled, 0);
+    }
 }

--- a/src/calibrate.rs
+++ b/src/calibrate.rs
@@ -515,6 +515,119 @@ pub fn compute_thresholds(
     config
 }
 
+/// Stats from a `backfill_file_paths` run.
+#[derive(Debug, Default, PartialEq, Eq)]
+pub struct BackfillStats {
+    /// Traces that already had file_path (skipped).
+    pub already_present: usize,
+    /// Backfilled via unambiguous feedback title match.
+    pub feedback_exact: usize,
+    /// Backfilled via unambiguous normalized feedback title match.
+    pub feedback_normalized: usize,
+    /// Backfilled via unambiguous matched_precedents file_path.
+    pub precedent_inferred: usize,
+    /// Ambiguous (2+ candidate files) — left as null.
+    pub ambiguous: usize,
+    /// No signal found — left as null.
+    pub no_match: usize,
+    /// Total traces modified.
+    pub total_backfilled: usize,
+}
+
+/// Enrich legacy traces that lack `file_path` by cross-referencing the
+/// feedback corpus.
+pub fn backfill_file_paths(
+    traces: &mut [serde_json::Value],
+    feedback: &[serde_json::Value],
+) -> BackfillStats {
+    let mut exact_map: HashMap<String, HashSet<String>> = HashMap::new();
+    let mut norm_map: HashMap<String, HashSet<String>> = HashMap::new();
+
+    for f in feedback {
+        let title = f["finding_title"].as_str().unwrap_or("");
+        let fp = f["file_path"].as_str().unwrap_or("");
+        if title.is_empty() || fp.is_empty() {
+            continue;
+        }
+        exact_map
+            .entry(title.to_string())
+            .or_default()
+            .insert(fp.to_string());
+        let norm = normalize_title(title);
+        if !norm.is_empty() {
+            norm_map.entry(norm).or_default().insert(fp.to_string());
+        }
+    }
+
+    let mut stats = BackfillStats::default();
+
+    for trace in traces.iter_mut() {
+        let existing = trace.get("file_path").and_then(|v| v.as_str()).unwrap_or("");
+        if !existing.is_empty() {
+            stats.already_present += 1;
+            continue;
+        }
+
+        let title = trace["finding_title"].as_str().unwrap_or("").to_string();
+        if title.is_empty() {
+            stats.no_match += 1;
+            continue;
+        }
+
+        // Tier 1: exact title match
+        if let Some(files) = exact_map.get(&title) {
+            if files.len() == 1 {
+                let fp = files.iter().next().unwrap().clone();
+                trace["file_path"] = serde_json::Value::String(fp);
+                stats.feedback_exact += 1;
+                stats.total_backfilled += 1;
+                continue;
+            }
+        }
+
+        // Tier 2: normalized title match
+        let norm = normalize_title(&title);
+        if !norm.is_empty() {
+            if let Some(files) = norm_map.get(&norm) {
+                if files.len() == 1 {
+                    let fp = files.iter().next().unwrap().clone();
+                    trace["file_path"] = serde_json::Value::String(fp);
+                    stats.feedback_normalized += 1;
+                    stats.total_backfilled += 1;
+                    continue;
+                }
+            }
+        }
+
+        // Tier 3: precedent inference
+        if let Some(precs) = trace.get("matched_precedents").and_then(|v| v.as_array()) {
+            let prec_files: HashSet<&str> = precs
+                .iter()
+                .filter_map(|p| p["file_path"].as_str())
+                .filter(|s| !s.is_empty())
+                .collect();
+            if prec_files.len() == 1 {
+                let fp = prec_files.into_iter().next().unwrap().to_string();
+                trace["file_path"] = serde_json::Value::String(fp);
+                stats.precedent_inferred += 1;
+                stats.total_backfilled += 1;
+                continue;
+            }
+        }
+
+        // Determine whether it was ambiguous or truly no match
+        let had_exact = exact_map.get(&title).is_some_and(|f| f.len() > 1);
+        let had_norm = !norm.is_empty() && norm_map.get(&norm).is_some_and(|f| f.len() > 1);
+        if had_exact || had_norm {
+            stats.ambiguous += 1;
+        } else {
+            stats.no_match += 1;
+        }
+    }
+
+    stats
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1456,5 +1569,33 @@ mod tests {
             &feedback, &traces, &filter, false,
         );
         assert_eq!(samples.len(), 1, "trace with unknown dirty should be excluded by clean_only");
+    }
+
+    #[test]
+    fn backfill_stamps_file_path_from_unambiguous_feedback() {
+        let feedback = vec![
+            serde_json::json!({
+                "finding_title": "SQL injection risk",
+                "file_path": "src/db.rs",
+                "verdict": "tp"
+            }),
+            serde_json::json!({
+                "finding_title": "SQL injection risk",
+                "file_path": "src/db.rs",
+                "verdict": "fp"
+            }),
+        ];
+        let mut traces = vec![
+            serde_json::json!({
+                "finding_title": "SQL injection risk",
+                "finding_category": "security",
+                "tp_weight": 2.0,
+                "fp_weight": 0.5
+            }),
+        ];
+        let stats = backfill_file_paths(&mut traces, &feedback);
+        assert_eq!(traces[0]["file_path"].as_str(), Some("src/db.rs"));
+        assert_eq!(stats.feedback_exact, 1);
+        assert_eq!(stats.total_backfilled, 1);
     }
 }

--- a/src/calibrate.rs
+++ b/src/calibrate.rs
@@ -1716,4 +1716,28 @@ mod tests {
         assert_eq!(stats.no_match, 1);
         assert_eq!(stats.total_backfilled, 0);
     }
+
+    #[test]
+    fn backfill_falls_through_to_normalized_title() {
+        // Feedback has rule-prefixed title, trace has bare title
+        let feedback = vec![
+            serde_json::json!({
+                "finding_title": "bare-except-pass: Using bare except: pass",
+                "file_path": "src/handler.py",
+                "verdict": "tp"
+            }),
+        ];
+        let mut traces = vec![
+            serde_json::json!({
+                "finding_title": "Using bare except: pass",
+                "finding_category": "correctness",
+                "tp_weight": 1.0,
+                "fp_weight": 0.0
+            }),
+        ];
+        let stats = backfill_file_paths(&mut traces, &feedback);
+        assert_eq!(traces[0]["file_path"].as_str(), Some("src/handler.py"));
+        assert_eq!(stats.feedback_normalized, 1);
+        assert_eq!(stats.total_backfilled, 1);
+    }
 }

--- a/src/calibrate.rs
+++ b/src/calibrate.rs
@@ -1740,4 +1740,48 @@ mod tests {
         assert_eq!(stats.feedback_normalized, 1);
         assert_eq!(stats.total_backfilled, 1);
     }
+
+    #[test]
+    fn backfill_reports_correct_stats_and_mutations_on_mixed_corpus() {
+        let feedback = vec![
+            serde_json::json!({"finding_title": "A", "file_path": "f1.rs", "verdict": "tp"}),
+            serde_json::json!({"finding_title": "B", "file_path": "f2.rs", "verdict": "tp"}),
+            serde_json::json!({"finding_title": "C", "file_path": "f3.rs", "verdict": "tp"}),
+            serde_json::json!({"finding_title": "C", "file_path": "f4.rs", "verdict": "fp"}),
+        ];
+        let mut traces = vec![
+            // 0: Already has file_path -> skip
+            serde_json::json!({"finding_title": "A", "tp_weight": 1.0, "fp_weight": 0.0, "file_path": "f1.rs"}),
+            // 1: Exact match -> backfill to f2.rs
+            serde_json::json!({"finding_title": "B", "tp_weight": 1.0, "fp_weight": 0.0}),
+            // 2: Ambiguous (C -> f3.rs AND f4.rs)
+            serde_json::json!({"finding_title": "C", "tp_weight": 1.0, "fp_weight": 0.0}),
+            // 3: No match at all
+            serde_json::json!({"finding_title": "D", "tp_weight": 1.0, "fp_weight": 0.0}),
+        ];
+        let stats = backfill_file_paths(&mut traces, &feedback);
+
+        // Verify stats
+        assert_eq!(stats.already_present, 1);
+        assert_eq!(stats.feedback_exact, 1);
+        assert_eq!(stats.ambiguous, 1);
+        assert_eq!(stats.no_match, 1);
+        assert_eq!(stats.total_backfilled, 1);
+
+        // Verify actual mutations
+        assert_eq!(traces[0]["file_path"].as_str(), Some("f1.rs"), "unchanged");
+        assert_eq!(traces[1]["file_path"].as_str(), Some("f2.rs"), "backfilled");
+        assert!(
+            traces[2].get("file_path").is_none()
+                || traces[2]["file_path"].is_null()
+                || traces[2]["file_path"].as_str() == Some(""),
+            "ambiguous: should not be stamped"
+        );
+        assert!(
+            traces[3].get("file_path").is_none()
+                || traces[3]["file_path"].is_null()
+                || traces[3]["file_path"].as_str() == Some(""),
+            "no match: should not be stamped"
+        );
+    }
 }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -291,6 +291,10 @@ pub struct CalibrateOpts {
     /// Disable fuzzy matching tiers (normalized + Jaccard); raw exact only
     #[arg(long)]
     pub disable_fuzzy: bool,
+
+    /// Backfill file_path on legacy traces using feedback cross-reference
+    #[arg(long)]
+    pub backfill_paths: bool,
 }
 
 #[derive(Parser)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1934,7 +1934,14 @@ fn run_calibrate(opts: cli::CalibrateOpts) -> i32 {
         }
         eprintln!("Backup: {}", bak_path.display());
 
-        let tmp_path = traces_path.with_extension("jsonl.tmp");
+        let tmp_path = traces_path.with_file_name(format!(
+            "calibrator_traces.{}.{}.tmp",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_nanos())
+                .unwrap_or(0),
+        ));
         let mut out = match std::fs::File::create(&tmp_path) {
             Ok(f) => std::io::BufWriter::new(f),
             Err(e) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1904,6 +1904,60 @@ fn run_calibrate(opts: cli::CalibrateOpts) -> i32 {
         traces.len(),
     );
 
+    if opts.backfill_paths {
+        let mut traces_mut = traces;
+        let stats = quorum::calibrate::backfill_file_paths(&mut traces_mut, &feedback);
+        eprintln!("\nBackfill results:");
+        eprintln!("  already had file_path: {}", stats.already_present);
+        eprintln!("  feedback (exact):      {}", stats.feedback_exact);
+        eprintln!("  feedback (normalized): {}", stats.feedback_normalized);
+        eprintln!("  precedent inferred:    {}", stats.precedent_inferred);
+        eprintln!("  ambiguous (skipped):   {}", stats.ambiguous);
+        eprintln!("  no match (skipped):    {}", stats.no_match);
+        eprintln!("  total backfilled:      {}", stats.total_backfilled);
+
+        if stats.total_backfilled == 0 {
+            eprintln!("\nNo traces to backfill.");
+            return 0;
+        }
+
+        if opts.dry_run {
+            eprintln!("\n(dry run -- no files written)");
+            return 0;
+        }
+
+        // Atomic write: backup original, write new
+        let bak_path = traces_path.with_extension("jsonl.bak");
+        if let Err(e) = std::fs::copy(&traces_path, &bak_path) {
+            eprintln!("error: failed to create backup: {e}");
+            return 3;
+        }
+        eprintln!("Backup: {}", bak_path.display());
+
+        let tmp_path = traces_path.with_extension("jsonl.tmp");
+        let mut out = match std::fs::File::create(&tmp_path) {
+            Ok(f) => std::io::BufWriter::new(f),
+            Err(e) => {
+                eprintln!("error: failed to create temp file: {e}");
+                return 3;
+            }
+        };
+        use std::io::Write;
+        for t in &traces_mut {
+            if let Err(e) = writeln!(out, "{}", serde_json::to_string(t).unwrap()) {
+                eprintln!("error: write failed: {e}");
+                return 3;
+            }
+        }
+        drop(out);
+        if let Err(e) = std::fs::rename(&tmp_path, &traces_path) {
+            eprintln!("error: rename failed: {e}");
+            return 3;
+        }
+        eprintln!("Wrote {}", traces_path.display());
+        return 0;
+    }
+
     let filter = quorum::calibrate::JoinFilter {
         quorum_version: opts.trace_version.clone(),
         clean_only: opts.clean_only,

--- a/tests/calibrate_backfill.rs
+++ b/tests/calibrate_backfill.rs
@@ -27,6 +27,8 @@ fn calibrate_backfill_paths_dry_run() {
         .output()
         .unwrap();
 
+    assert!(output.status.success(), "should exit 0, stderr: {}", String::from_utf8_lossy(&output.stderr));
+
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(
         stderr.contains("total backfilled:"),

--- a/tests/calibrate_backfill.rs
+++ b/tests/calibrate_backfill.rs
@@ -1,0 +1,95 @@
+use std::io::Write;
+
+/// Integration test for `quorum calibrate --backfill-paths --dry-run`.
+#[test]
+fn calibrate_backfill_paths_dry_run() {
+    let dir = tempfile::tempdir().unwrap();
+    let fb_path = dir.path().join("feedback.jsonl");
+    let tr_path = dir.path().join("calibrator_traces.jsonl");
+
+    // Write one feedback entry
+    std::fs::write(
+        &fb_path,
+        "{\"finding_title\":\"A\",\"file_path\":\"f.rs\",\"verdict\":\"tp\"}\n",
+    )
+    .unwrap();
+
+    // Write one trace without file_path
+    std::fs::write(
+        &tr_path,
+        "{\"finding_title\":\"A\",\"finding_category\":\"c\",\"tp_weight\":1.0,\"fp_weight\":0.0}\n",
+    )
+    .unwrap();
+
+    let output = std::process::Command::new(env!("CARGO_BIN_EXE_quorum"))
+        .env("QUORUM_HOME", dir.path())
+        .args(["calibrate", "--backfill-paths", "--dry-run"])
+        .output()
+        .unwrap();
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("total backfilled:"),
+        "should report stats, got: {stderr}"
+    );
+    assert!(
+        stderr.contains("dry run"),
+        "should say dry run, got: {stderr}"
+    );
+
+    // Traces file should be unchanged (dry run)
+    let content = std::fs::read_to_string(&tr_path).unwrap();
+    assert!(
+        !content.contains("f.rs"),
+        "dry run should not modify file, got: {content}"
+    );
+}
+
+/// Integration test for actual backfill (writes file).
+#[test]
+fn calibrate_backfill_paths_writes_file() {
+    let dir = tempfile::tempdir().unwrap();
+    let fb_path = dir.path().join("feedback.jsonl");
+    let tr_path = dir.path().join("calibrator_traces.jsonl");
+
+    std::fs::write(
+        &fb_path,
+        "{\"finding_title\":\"B\",\"file_path\":\"src/lib.rs\",\"verdict\":\"tp\"}\n",
+    )
+    .unwrap();
+
+    std::fs::write(
+        &tr_path,
+        "{\"finding_title\":\"B\",\"finding_category\":\"x\",\"tp_weight\":1.0,\"fp_weight\":0.0}\n",
+    )
+    .unwrap();
+
+    let output = std::process::Command::new(env!("CARGO_BIN_EXE_quorum"))
+        .env("QUORUM_HOME", dir.path())
+        .args(["calibrate", "--backfill-paths"])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success(), "should exit 0");
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("total backfilled:"), "stats: {stderr}");
+    assert!(stderr.contains("Backup:"), "backup msg: {stderr}");
+    assert!(stderr.contains("Wrote"), "wrote msg: {stderr}");
+
+    // Trace file should now contain file_path
+    let content = std::fs::read_to_string(&tr_path).unwrap();
+    assert!(
+        content.contains("src/lib.rs"),
+        "trace should have file_path backfilled, got: {content}"
+    );
+
+    // Backup should exist
+    let bak_path = dir.path().join("calibrator_traces.jsonl.bak");
+    assert!(bak_path.exists(), "backup file should exist");
+    let bak_content = std::fs::read_to_string(&bak_path).unwrap();
+    assert!(
+        !bak_content.contains("src/lib.rs"),
+        "backup should be the original without file_path"
+    );
+}


### PR DESCRIPTION
## Summary

- Add `quorum calibrate --backfill-paths` command that enriches legacy calibrator traces with `file_path` via feedback corpus cross-reference
- Three-tier resolution: exact title match → normalized title → matched_precedent inference
- Atomic write with `.bak` backup; `--dry-run` support
- Fixes test missing exit-status assertion caught by quorum self-review

## Context

After merging #207 (fuzzy title matching) and #209 (trace provenance), the calibrator join rate is 16% (362/2249). Root cause: 97.3% of traces lack `file_path`, making tiers 1-3 of fuzzy matching inert. Estimated backfill recovery: ~1,369 traces (2.7% → 25.5% file_path coverage).

## Changes

| File | Change |
|------|--------|
| `src/calibrate.rs` | `BackfillStats` struct + `backfill_file_paths()` function |
| `src/cli/mod.rs` | `--backfill-paths` flag on `CalibrateOpts` |
| `src/main.rs` | Wire flag into `run_calibrate` with atomic backup |
| `tests/calibrate_backfill.rs` | Integration tests (dry-run + actual write) |

## Test plan

- [x] 8 unit tests covering all tiers, edge cases, stats + mutations
- [x] 2 integration tests (dry-run, actual backfill with backup)
- [x] 1212 bin + 734 lib tests passing, 0 new clippy warnings
- [x] Release build succeeds
- [x] Quorum self-review: 1 in-branch TP fixed, 7 pre-existing triaged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatically backfills missing trace file paths by matching traces with feedback, reporting detailed backfill outcomes.
  * New command-line flag to enable backfilling and a dry-run option to preview results without writing.
  * Safe, atomic updates with automatic backups when writing changes.

* **Tests**
  * Integration tests for dry-run and actual write behaviors, including backup verification and various matching scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->