### PR TITLE
fix(msrv): bump rust-version 1.88 -> 1.93

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,15 +64,11 @@ jobs:
       - run: cargo fmt --all -- --check
 
   msrv:
-    name: msrv (1.88)
+    name: msrv (1.93)
     runs-on: ubuntu-latest
-    # Currently informational: Cargo.toml claims rust-version=1.88 but the
-    # codebase uses round_char_boundary (stabilized in 1.93). See issue tracker
-    # for the fix; flip back to required once rust-version is corrected.
-    continue-on-error: true
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-      - uses: dtolnay/rust-toolchain@98e1b82157cd469e843cb7f524c1313b4ad9492c # 1.88 (snapshot)
+      - uses: dtolnay/rust-toolchain@2ea1b3bdd0261867664fd125505456a7b9c3385c # 1.93 (snapshot)
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           shared-key: msrv-ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,10 +2,10 @@
 name = "quorum"
 version = "0.18.4"
 edition = "2024"
-# `if let` chains used in src/cli_io.rs and src/context/cli.rs stabilized
-# in Rust 1.88. Edition 2024 already requires 1.85+, but document the
-# actual minimum explicitly.
-rust-version = "1.88"
+# `str::floor_char_boundary` (used in src/agent.rs and src/tools.rs to
+# truncate UTF-8 safely) stabilized in Rust 1.93. Older constraints —
+# `if let` chains (1.88) and Edition 2024 (1.85+) — are subsumed by 1.93.
+rust-version = "1.93"
 description = "Multi-source code review: LLM ensemble + local AST analysis + linter orchestration"
 license = "MIT"
 repository = "https://github.com/jsnyder/quorum"


### PR DESCRIPTION
Closes #215.

## Why

The msrv CI job introduced in #210 surfaced 8 instances of \`error[E0658]: use of unstable library feature \`round_char_boundary\`\` on its first run. \`Cargo.toml\` claimed \`rust-version = \"1.88\"\` but \`src/agent.rs\` and \`src/tools.rs\` use \`str::floor_char_boundary\`, which stabilized in **Rust 1.93**.

## Decision

Path A (bump rust-version) over refactoring away from \`floor_char_boundary\`. The helper is the right tool for safely truncating UTF-8 strings to a byte budget, and staying on 1.88 isn't materially valuable since the codebase already uses Rust 2024 edition + tokio + reqwest + fastembed (none of which are tight against 1.88 anyway).

## Changes

- \`Cargo.toml\`: \`rust-version = \"1.93\"\` + comment updated to cite \`floor_char_boundary\`
- \`.github/workflows/ci.yml\`: msrv job pinned to \`dtolnay/rust-toolchain@1.93\` (full SHA), label updated to \`msrv (1.93)\`, \`continue-on-error: true\` removed — this is now a hard gate

## Test plan

- [ ] CI msrv job passes against rust 1.93
- [ ] Other CI jobs still pass (test, clippy, rustfmt, codeql) — clippy + rustfmt remain informational pending #214 / #216

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated minimum supported Rust version from 1.88 to 1.93 across build configuration and CI workflows to align with current toolchain standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->