### PR TITLE
ci: add cargo-audit (RustSec advisory scanning)

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,0 +1,19 @@
+# cargo-audit policy. Consumed by `rustsec/audit-check` in
+# `.github/workflows/audit.yml`. See https://rustsec.org/.
+
+[advisories]
+# Block on `low`, `medium`, `high`, and `critical` vulnerabilities (= the
+# cargo-audit default; documented explicitly so the policy is visible).
+# CodeRabbit suggested `"high"` — rejected because Quorum is security-
+# adjacent and we'd rather take noise on low/medium CVEs than miss them.
+#
+# Informational advisories (unmaintained, unsound, notice) surface as
+# warnings only — they're useful signal but rarely actionable as a hard
+# gate, since the unmaintained-crate problem usually requires an
+# upstream replacement to propagate.
+severity_threshold = "low"
+
+# Each entry below MUST include the advisory ID, an inline comment with
+# justification, an owner, and a date. Empty by default — adding an
+# ignore is a deliberate decision, not a workflow shortcut.
+ignore = []

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -6,12 +6,14 @@ on:
     paths:
       - "**/Cargo.toml"
       - "**/Cargo.lock"
+      - ".cargo/audit.toml"
       - ".github/workflows/audit.yml"
   pull_request:
     branches: [main]
     paths:
       - "**/Cargo.toml"
       - "**/Cargo.lock"
+      - ".cargo/audit.toml"
       - ".github/workflows/audit.yml"
   schedule:
     - cron: "13 6 * * 1"

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -22,14 +22,32 @@ on:
 permissions:
   contents: read
 
+# Two jobs split by event so least-privilege holds: rustsec/audit-check
+# only opens advisory issues on `schedule` runs (it creates check runs on
+# `push`/`pull_request`). Granting `issues: write` only where needed.
+
 jobs:
-  audit:
+  audit-pr:
     name: cargo-audit
+    if: github.event_name == 'push' || github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      issues: write
       checks: write
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: rustsec/audit-check@69366f33c96575abad1ee0dba8212993eecbe998 # v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+  audit-scheduled:
+    name: cargo-audit (scheduled)
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      checks: write
+      issues: write
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - uses: rustsec/audit-check@69366f33c96575abad1ee0dba8212993eecbe998 # v2

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -1,0 +1,35 @@
+name: Audit
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "**/Cargo.toml"
+      - "**/Cargo.lock"
+      - ".github/workflows/audit.yml"
+  pull_request:
+    branches: [main]
+    paths:
+      - "**/Cargo.toml"
+      - "**/Cargo.lock"
+      - ".github/workflows/audit.yml"
+  schedule:
+    - cron: "13 6 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  audit:
+    name: cargo-audit
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+      checks: write
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: rustsec/audit-check@69366f33c96575abad1ee0dba8212993eecbe998 # v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3218,9 +3218,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",


### PR DESCRIPTION
Closes #211.

## Summary

Adds \`audit.yml\` workflow using \`rustsec/audit-check@v2\` (SHA pinned). Catches RustSec advisories filed against currently-pinned versions — Dependabot only catches *update availability*, not advisories on what we already use.

## Triggers

- Push to main and PRs that touch \`Cargo.{toml,lock}\` or this workflow file
- Weekly cron (Mon 06:13 UTC)
- \`workflow_dispatch\` for manual runs

## Permissions

Minimal at workflow scope (\`contents: read\`); elevated only on the audit job (\`issues: write\` to file an advisory issue on push, \`checks: write\` so PR runs surface as a check).

## Test plan

- [ ] Workflow lints clean (actionlint passing locally)
- [ ] First scheduled run completes
- [ ] Any current advisories surface as a check / issue
- [ ] If currently-clean, the workflow stays green

If the first run finds something blocking, triage by either bumping the offending crate (Dependabot will likely have already opened a PR) or adding an entry to a future \`.cargo/audit.toml\` ignore list with justification.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an automated security dependency audit workflow that runs on pushes, pull requests, a weekly schedule, and via manual trigger; it surfaces advisories at a low severity threshold and is configured to operate with least-privilege permissions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->