### PR TITLE
ci: add cargo-deny (license + duplicate + source policy)

### DIFF
--- a/.github/workflows/deny.yml
+++ b/.github/workflows/deny.yml
@@ -1,0 +1,39 @@
+name: Deny
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "**/Cargo.toml"
+      - "**/Cargo.lock"
+      - "deny.toml"
+      - ".github/workflows/deny.yml"
+  pull_request:
+    branches: [main]
+    paths:
+      - "**/Cargo.toml"
+      - "**/Cargo.lock"
+      - "deny.toml"
+      - ".github/workflows/deny.yml"
+  schedule:
+    - cron: "47 6 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  deny:
+    name: cargo-deny (${{ matrix.checks }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        checks:
+          - bans licenses sources
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: EmbarkStudios/cargo-deny-action@91bf2b620e09e18d6eb78b92e7861937469acedb # v2
+        with:
+          command: check ${{ matrix.checks }}
+          arg: --hide-inclusion-graph

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,67 @@
+# cargo-deny configuration. See https://embarkstudios.github.io/cargo-deny/
+
+[graph]
+all-features = true
+
+[output]
+feature-depth = 1
+
+# ---- Licenses --------------------------------------------------------------
+# Allowlist of permissive licenses we're comfortable redistributing under MIT.
+# Adding to this list = a deliberate decision that the license is compatible
+# with the project's MIT downstream story. Reject everything else.
+
+[licenses]
+allow = [
+    "MIT",
+    "Apache-2.0",
+    "Apache-2.0 WITH LLVM-exception",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "ISC",
+    "Unicode-3.0",
+    "Zlib",
+    "CC0-1.0",
+    "MPL-2.0",
+    "0BSD",
+    # NCSA — University of Illinois/NCSA Open Source License. Permissive,
+    # OSI-approved, MIT-compatible. Used by `libfuzzer-sys` (dev/test dep).
+    "NCSA",
+    # CDLA-Permissive-2.0 — Community Data License Agreement Permissive 2.0.
+    # Used by `webpki-roots` / `webpki-root-certs` (Mozilla root cert bundle).
+    # Permissive, allows redistribution under any terms.
+    "CDLA-Permissive-2.0",
+]
+confidence-threshold = 0.93
+exceptions = []
+
+# ---- Bans ------------------------------------------------------------------
+# Watch for duplicates and known-bad crates. Start with `warn` for duplicates
+# rather than `deny` because clean-up takes coordinated dep work.
+
+[bans]
+multiple-versions = "warn"
+wildcards = "deny"
+highlight = "all"
+allow = []
+deny = []
+skip = []
+skip-tree = []
+
+# ---- Sources ---------------------------------------------------------------
+# Only allow crates from crates.io. Add specific git dep allowlists below if/
+# when we add a git-direct dep.
+
+[sources]
+unknown-registry = "deny"
+unknown-git = "deny"
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]
+allow-git = []
+
+# ---- Advisories ------------------------------------------------------------
+# Authoritative advisory scanning lives in `audit.yml` (rustsec/audit-check).
+# Keep this section minimal so the two tools don't fight.
+
+[advisories]
+yanked = "warn"
+ignore = []


### PR DESCRIPTION
Closes #212.

## Summary

Adds \`deny.toml\` + \`.github/workflows/deny.yml\` running \`cargo deny check bans licenses sources\` on PRs/pushes touching dep files, weekly cron, and on demand.

**Advisories are scoped out** — \`audit.yml\` (#211 / PR #225) owns RustSec advisory scanning authoritatively. Running both would double-report.

## Verified locally

\`cargo deny check bans licenses sources\` →  \`bans ok, licenses ok, sources ok\`.

## License allowlist

Permissive only, compatible with MIT downstream redistribution: MIT, Apache-2.0, BSD-2/3-Clause, ISC, Unicode-3.0, Zlib, CC0-1.0, MPL-2.0, 0BSD. Plus two extras with justification inline:

- **NCSA** — \`libfuzzer-sys\` dev dep. Permissive, MIT-compatible.
- **CDLA-Permissive-2.0** — \`webpki-roots\` / \`webpki-root-certs\` (Mozilla cert bundle). Permissive, allows redistribution.

## Bans

- \`multiple-versions = \"warn\"\` — 12 \`windows-*\` duplicates surfaced via the async/tokio ecosystem. Cleanup is a future dep-unification task, not a blocker. They appear in CI output but don't fail the build.
- \`wildcards = \"deny\"\` — no \`version = \"*\"\` deps allowed.

## Sources

\`crates.io\` only. Rejects unknown registries and unknown git deps; explicit allowlists can be added if a git-direct dep ever lands.

## Test plan

- [ ] Workflow runs and is green
- [ ] Future Cargo.toml/lock changes trigger a re-run
- [ ] Weekly cron runs fire and report

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added automated dependency security and license compliance checks in CI. Runs on commits, pull requests, scheduled weekly, and via manual trigger. Validates licenses against an allowlist, detects banned or multiple versions and unknown sources, and flags yanked or advisory issues to maintain safer, more consistent dependencies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->