### PR TITLE
feat: redesign stats dashboard for clarity (v0.19.0)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -401,12 +401,6 @@ checksum = "1e4b40c7323adcfc0a41c4b88143ed58346ff65a288fc144329c5c45e05d70c6"
 
 [[package]]
 name = "bitflags"
-version = "1.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
-
-[[package]]
-name = "bitflags"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
@@ -897,9 +891,9 @@ checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
 
 [[package]]
 name = "digest"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4850db49bf08e663084f7fb5c87d202ef91a3907271aff24a94eb97ff039153c"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
  "block-buffer",
  "const-oid",
@@ -1068,23 +1062,9 @@ checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "fax"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f05de7d48f37cd6730705cbca900770cab77a89f413d23e100ad7fad7795a0ab"
-dependencies = [
- "fax_derive",
-]
-
-[[package]]
-name = "fax_derive"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0aca10fb742cb43f9e7bb8467c91aa9bcb8e3ffbc6a6f7389bb93ffc920577d"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
+checksum = "caf1079563223d5d59d83c85886a56e586cfd5c1a26292e971a0fa266531ac5a"
 
 [[package]]
 name = "fdeflate"
@@ -1354,9 +1334,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1527,9 +1507,9 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hybrid-array"
-version = "0.4.10"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3944cf8cf766b40e2a1a333ee5e9b563f854d5fa49d6a8ca2764e97c6eddb214"
+checksum = "08d46837a0ed51fe95bd3b05de33cd64a1ee88fc797477ca48446872504507c5"
 dependencies = [
  "typenum",
 ]
@@ -1743,9 +1723,9 @@ dependencies = [
 
 [[package]]
 name = "idna_adapter"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
@@ -1803,9 +1783,9 @@ dependencies = [
 
 [[package]]
 name = "imgref"
-version = "1.12.0"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7c5cedc30da3a610cac6b4ba17597bdf7152cf974e8aab3afb3d54455e371c8"
+checksum = "40fac9d56ed6437b198fddba683305e8e2d651aa42647f00f5ae542e7f5c94a2"
 
 [[package]]
 name = "indexmap"
@@ -1838,7 +1818,7 @@ version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd5b3eaf1a28b758ac0faa5a4254e8ab2705605496f1b1f3fbbc3988ad73d199"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags",
  "inotify-sys",
  "libc",
 ]
@@ -1883,16 +1863,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
-name = "iri-string"
-version = "0.7.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25e659a4bb38e810ebc252e53b5814ff908a8c58c2a9ce2fae1bbec24cbf4e20"
-dependencies = [
- "memchr",
- "serde",
-]
-
-[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1925,9 +1895,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.95"
+version = "0.3.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
+checksum = "a1840c94c045fbcf8ba2812c95db44499f7c64910a912551aaaa541decebcacf"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -1947,11 +1917,11 @@ dependencies = [
 
 [[package]]
 name = "kqueue-sys"
-version = "1.0.4"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed9625ffda8729b85e45cf04090035ac368927b8cebc34898e7c120f52e4838b"
+checksum = "a7b65860415f949f23fa882e669f2dbd4a0f0eeb1acdd56790b30494afd7da2f"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags",
  "libc",
 ]
 
@@ -2229,9 +2199,9 @@ checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
 name = "no_std_io2"
-version = "0.9.3"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b51ed7824b6e07d354605f4abb3d9d300350701299da96642ee084f5ce631550"
+checksum = "418abd1b6d34fbf6cae440dc874771b0525a604428704c76e48b29a5e67b8003"
 dependencies = [
  "memchr",
 ]
@@ -2273,7 +2243,7 @@ version = "8.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d3d07927151ff8575b7087f245456e549fea62edf0ec4e565a5ee50c8402bc3"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags",
  "fsevent-sys",
  "inotify",
  "kqueue",
@@ -2291,7 +2261,7 @@ version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42b8cfee0e339a0337359f3c88165702ac6e600dc01c0cc9579a92d62b08477a"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags",
 ]
 
 [[package]]
@@ -2401,11 +2371,11 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "onig"
-version = "6.5.1"
+version = "6.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "336b9c63443aceef14bea841b899035ae3abe89b7c486aaf4c5bd8aafedac3f0"
+checksum = "0cc3cbf698f9438986c11a880c90a6d04b9de27575afd28bbf45b154b6c709e2"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags",
  "libc",
  "once_cell",
  "onig_sys",
@@ -2413,9 +2383,9 @@ dependencies = [
 
 [[package]]
 name = "onig_sys"
-version = "69.9.1"
+version = "69.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7f86c6eef3d6df15f23bcfb6af487cbd2fed4e5581d58d5bf1f5f8b7f6727dc"
+checksum = "1e68317604e77e53b85896388e1a803c1d21b74c899ec9e5e1112db90735edd7"
 dependencies = [
  "cc",
  "pkg-config",
@@ -2423,15 +2393,14 @@ dependencies = [
 
 [[package]]
 name = "openssl"
-version = "0.10.78"
+version = "0.10.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f38c4372413cdaaf3cc79dd92d29d7d9f5ab09b51b10dded508fb90bb70b9222"
+checksum = "bf0b434746ee2832f4f0baf10137e1cabb18cbe6912c69e2e33263c45250f542"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags",
  "cfg-if",
  "foreign-types",
  "libc",
- "once_cell",
  "openssl-macros",
  "openssl-sys",
 ]
@@ -2455,9 +2424,9 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.114"
+version = "0.9.115"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13ce1245cd07fcc4cfdb438f7507b0c7e4f3849a69fd84d52374c66d83741bb6"
+checksum = "158fe5b292746440aa6e7a7e690e55aeb72d41505e2804c23c6973ad0e9c9781"
 dependencies = [
  "cc",
  "libc",
@@ -2563,7 +2532,7 @@ version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags",
  "crc32fast",
  "fdeflate",
  "flate2",
@@ -2660,18 +2629,18 @@ dependencies = [
 
 [[package]]
 name = "profiling"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3eb8486b569e12e2c32ad3e204dbaba5e4b5b216e9367044f25f1dba42341773"
+checksum = "3d595e54a326bc53c1c197b32d295e14b169e3cfeaa8dc82b529f947fba6bcf5"
 dependencies = [
  "profiling-procmacros",
 ]
 
 [[package]]
 name = "profiling-procmacros"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52717f9a02b6965224f95ca2a81e2e0c5c43baacd28ca057577988930b6c3d5b"
+checksum = "4488a4a36b9a4ba6b9334a32a39971f77c1436ec82c38707bce707699cc3bbcb"
 dependencies = [
  "quote",
  "syn",
@@ -2685,7 +2654,7 @@ checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
 dependencies = [
  "bit-set 0.8.0",
  "bit-vec 0.8.0",
- "bitflags 2.11.1",
+ "bitflags",
  "num-traits",
  "rand",
  "rand_chacha",
@@ -2702,7 +2671,7 @@ version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c3a14896dfa883796f1cb410461aef38810ea05f2b2c33c5aded3649095fdad"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags",
  "getopts",
  "memchr",
  "pulldown-cmark-escape",
@@ -2744,7 +2713,7 @@ checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quorum"
-version = "0.18.4"
+version = "0.19.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -2952,7 +2921,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags",
 ]
 
 [[package]]
@@ -3085,7 +3054,7 @@ version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7753b721174eb8ff87a9a0e799e2d7bc3749323e773db92e0984debb00019d6e"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags",
  "fallible-iterator",
  "fallible-streaming-iterator",
  "hashlink",
@@ -3172,7 +3141,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -3181,9 +3150,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.38"
+version = "0.23.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69f9466fb2c14ea04357e91413efb882e2a6d4a406e625449bc0a5d360d53a21"
+checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
  "log",
  "once_cell",
@@ -3196,9 +3165,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.14.0"
+version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
 dependencies = [
  "zeroize",
 ]
@@ -3304,7 +3273,7 @@ version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags",
  "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
@@ -3620,7 +3589,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags",
  "core-foundation 0.9.4",
  "system-configuration-sys",
 ]
@@ -3935,20 +3904,20 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.8"
+version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
+checksum = "a28f0d049ccfaa566e14e9663d304d8577427b368cb4710a20528690287a738b"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags",
  "bytes",
  "futures-util",
  "http",
  "http-body",
- "iri-string",
  "pin-project-lite",
  "tower",
  "tower-layer",
  "tower-service",
+ "url",
 ]
 
 [[package]]
@@ -4393,9 +4362,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.118"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
+checksum = "df52b6d9b87e0c74c9edfa1eb2d9bf85e5d63515474513aa50fa181b3c4f5db1"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -4406,9 +4375,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.68"
+version = "0.4.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f371d383f2fb139252e0bfac3b81b265689bf45b6874af544ffa4c975ac1ebf8"
+checksum = "af934872acec734c2d80e6617bbb5ff4f12b052dd8e6332b0817bce889516084"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4416,9 +4385,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.118"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
+checksum = "78b1041f495fb322e64aca85f5756b2172e35cd459376e67f2a6c9dffcedb103"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -4426,9 +4395,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.118"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
+checksum = "9dcd0ff20416988a18ac686d4d4d0f6aae9ebf08a389ff5d29012b05af2a1b41"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -4439,9 +4408,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.118"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
+checksum = "49757b3c82ebf16c57d69365a142940b384176c24df52a087fb748e2085359ea"
 dependencies = [
  "unicode-ident",
 ]
@@ -4487,7 +4456,7 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags",
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
@@ -4495,9 +4464,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.95"
+version = "0.3.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d"
+checksum = "2eadbac71025cd7b0834f20d1fe8472e8495821b4e9801eb0a60bd1f19827602"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4644,7 +4613,16 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.5",
 ]
 
 [[package]]
@@ -4662,14 +4640,31 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm 0.52.6",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -4679,10 +4674,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -4691,10 +4698,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -4703,10 +4722,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -4715,16 +4746,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
-name = "winnow"
-version = "1.0.1"
+name = "windows_x86_64_msvc"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09dac053f1cd375980747450bfc7250c264eaae0583872e845c0c7cd578872b5"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
+
+[[package]]
+name = "winnow"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
 
 [[package]]
 name = "wiremock"
@@ -4813,7 +4856,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags 2.11.1",
+ "bitflags",
  "indexmap",
  "log",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quorum"
-version = "0.18.4"
+version = "0.19.0"
 edition = "2024"
 # `str::floor_char_boundary` (used in src/agent.rs and src/tools.rs to
 # truncate UTF-8 safely) stabilized in Rust 1.93. Older constraints —

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -167,6 +167,28 @@ Dim, fixed-width, left-aligned:
 
 The label is dim. The value is default color. Two spaces of indent.
 
+### Tables
+
+Use a single dim `─` rule beneath the column header row only. Never above,
+beside, or below data rows. No box characters, no vertical separators —
+horizontal whitespace already conveys column boundaries in monospace.
+
+Numeric columns right-align to the value, not the header. Empty cells
+render as `—` (em-dash) so the eye lands on real signal instead of
+visually identical zero values:
+
+```
+  Channel      Total     TP     FP   Part   Wfix
+  ──────────────────────────────────────────────
+  Human         2052   1062    434    353    203
+  PostFix         45     45      —      —      —
+  External       117    100      4     13      —
+```
+
+For per-row pluralization, prefer "1 entry / N entries" over a fixed
+"entries" suffix — but the rule is informative, not strict, and not
+worth contorting the format string for.
+
 ---
 
 ## 5. Finding Display
@@ -400,6 +422,32 @@ To make trends meaningful:
 - Require minimum 10 feedback entries per window to report
 - Show the trend line, not point estimates ("0.71 -> 0.74 -> 0.77")
 - Don't extrapolate or forecast -- just show what happened
+
+### Trend interpretation
+
+Trends label **scope** (what's rolled in) and **unit** (`7d windows × N`
+or `50 reviews × N`) explicitly so a glance can tell what the line
+measures. The headline trend includes a 95% Wilson confidence interval
+on the most recent window when n ≥ 30 (`74% [69-79]`); below 30 the
+window is replaced with `n<30` because the sample is too small for the
+percent to be informative.
+
+**Channel attribution, not channel-precision**: the dashboard shows
+**counts** per provenance channel (Human / PostFix / External /
+AutoCalibrate), never precision-per-channel. External and AutoCalibrate
+aren't comparable to Human/PostFix on a precision axis — they sample
+from different distributions and carry different signal quality.
+Per-channel precision rollups invite false comparisons.
+
+**Per-finding precision** (`Human > PostFix > drop`) is the headline
+trend once reviews↔feedback `finding_id` linkage rate ≥ 85%. Below that
+threshold the headline falls back to entry-level precision with a
+`entry-level pending finding-id rollout` banner so users know the
+denominator is feedback-rows rather than findings.
+
+**Capture rate** (labeled findings / total findings in 7d) is shown
+inline with the headline so trend footing is visible — a 90% precision
+trend on 5% capture is a different signal than 90% on 80% capture.
 
 ### Data sources
 

--- a/src/analysis.rs
+++ b/src/analysis.rs
@@ -44,6 +44,7 @@ pub fn analyze_complexity(
                     Severity::Low
                 };
                 findings.push(Finding {
+                    id: crate::finding::new_finding_ulid(),
                     title: format!("Function `{}` has cyclomatic complexity {}", name, cc),
                     description: format!(
                         "Cyclomatic complexity of {} exceeds threshold of {}. Consider refactoring.",
@@ -230,6 +231,7 @@ fn scan_insecure_rust(node: &tree_sitter::Node, source: &str, findings: &mut Vec
     // unsafe blocks
     if node.kind() == "unsafe_block" {
         findings.push(Finding {
+            id: crate::finding::new_finding_ulid(),
             title: "Use of `unsafe` block".into(),
             description: "Unsafe code bypasses Rust's safety guarantees. Ensure this is necessary and correct.".into(),
             severity: Severity::Info,
@@ -259,6 +261,7 @@ fn scan_insecure_rust(node: &tree_sitter::Node, source: &str, findings: &mut Vec
                     let field_name = &source[field.byte_range()];
                     if field_name == "unwrap" {
                         findings.push(Finding {
+                            id: crate::finding::new_finding_ulid(),
                             title: "Use of `.unwrap()` may panic at runtime".into(),
                             description: "Consider using `.expect()` with a message or proper error handling.".into(),
                             severity: Severity::Low,
@@ -294,6 +297,7 @@ fn scan_insecure_python(node: &tree_sitter::Node, source: &str, findings: &mut V
             let func_name = &source[func.byte_range()];
             if func_name == "eval" || func_name == "exec" {
                 findings.push(Finding {
+                    id: crate::finding::new_finding_ulid(),
                     title: format!("Use of `{}()` is a code injection risk", func_name),
                     description: format!(
                         "`{}()` executes arbitrary code. Avoid using it with untrusted input.",
@@ -323,6 +327,7 @@ fn scan_insecure_python(node: &tree_sitter::Node, source: &str, findings: &mut V
             let args_text = &source[args.byte_range()];
             if args_text.contains("debug=True") || args_text.contains("debug = True") {
                 findings.push(Finding {
+                    id: crate::finding::new_finding_ulid(),
                     title: "Server running with debug=True".into(),
                     description: "Debug mode exposes detailed error pages and may enable a debugger. Disable in production.".into(),
                     severity: Severity::High,
@@ -344,6 +349,7 @@ fn scan_insecure_python(node: &tree_sitter::Node, source: &str, findings: &mut V
             }
             if args_text.contains("host=\"0.0.0.0\"") || args_text.contains("host='0.0.0.0'") {
                 findings.push(Finding {
+                    id: crate::finding::new_finding_ulid(),
                     title: "Server binding to 0.0.0.0 exposes all network interfaces".into(),
                     description: "Binding to 0.0.0.0 makes the server accessible from any network interface. Use 127.0.0.1 for local-only access.".into(),
                     severity: Severity::Medium,
@@ -378,6 +384,7 @@ fn scan_insecure_python(node: &tree_sitter::Node, source: &str, findings: &mut V
                             && (arg_text.starts_with("f\"") || arg_text.starts_with("f'"))
                         {
                             findings.push(Finding {
+                                id: crate::finding::new_finding_ulid(),
                                 title: "Potential SQL injection via f-string in execute()".into(),
                                 description: "String interpolation in SQL queries allows injection. Use parameterized queries instead.".into(),
                                 severity: Severity::Critical,
@@ -398,6 +405,7 @@ fn scan_insecure_python(node: &tree_sitter::Node, source: &str, findings: &mut V
                             });
                         } else if arg_text.contains(".format(") {
                             findings.push(Finding {
+                                id: crate::finding::new_finding_ulid(),
                                 title: "Potential SQL injection via .format() in execute()".into(),
                                 description: "String formatting in SQL queries allows injection. Use parameterized queries instead.".into(),
                                 severity: Severity::Critical,
@@ -439,6 +447,7 @@ fn scan_insecure_python(node: &tree_sitter::Node, source: &str, findings: &mut V
                         args_text.contains("encoding=") || args_text.contains("encoding =");
                     if !is_binary && !has_encoding {
                         findings.push(Finding {
+                            id: crate::finding::new_finding_ulid(),
                             title: "`open()` without explicit `encoding` parameter".into(),
                             description: "Without `encoding=`, open() uses the system default which varies by platform. Specify `encoding='utf-8'` for portable behavior.".into(),
                             severity: Severity::Low,
@@ -498,6 +507,7 @@ fn scan_insecure_python(node: &tree_sitter::Node, source: &str, findings: &mut V
                     && body.named_child(0).map(|c| c.kind()) == Some("pass_statement");
                 if body_has_only_pass {
                     findings.push(Finding {
+                        id: crate::finding::new_finding_ulid(),
                         title: "Catch-all `except: pass` silently swallows errors".into(),
                         description: "Catching all exceptions with `pass` hides bugs. Log the error or catch a specific exception type.".into(),
                         severity: Severity::Medium,
@@ -571,6 +581,7 @@ fn scan_insecure_python(node: &tree_sitter::Node, source: &str, findings: &mut V
                         && !inner.starts_with("https://")
                     {
                         findings.push(Finding {
+                            id: crate::finding::new_finding_ulid(),
                             title: format!("Hardcoded secret in `{}`", &source[left.byte_range()]),
                             description: "Secrets should be loaded from environment variables or a secrets manager, not hardcoded in source.".into(),
                             severity: Severity::High,
@@ -606,6 +617,7 @@ fn scan_insecure_python(node: &tree_sitter::Node, source: &str, findings: &mut V
                 if let Some(body) = node.child_by_field_name("body") {
                     if has_mutating_call(&body, source, iterable_name) {
                         findings.push(Finding {
+                            id: crate::finding::new_finding_ulid(),
                             title: format!("Mutating `{}` while iterating over it", iterable_name),
                             description: "Modifying a collection while iterating over it leads to skipped elements or RuntimeError. Iterate over a copy instead.".into(),
                             severity: Severity::High,
@@ -658,6 +670,7 @@ fn scan_insecure_python(node: &tree_sitter::Node, source: &str, findings: &mut V
             // Look for return statements that expose the exception
             if has_exception_in_return(node, source, var_name) {
                 findings.push(Finding {
+                    id: crate::finding::new_finding_ulid(),
                     title: "Exception details disclosed in API response".into(),
                     description: format!(
                         "Returning `str({0})` or `repr({0})` in an API response leaks internal details to clients. Log the exception and return a generic error message.",
@@ -692,6 +705,7 @@ fn scan_insecure_python(node: &tree_sitter::Node, source: &str, findings: &mut V
         if func_text.starts_with("async ") {
             if has_result_call(node, source) {
                 findings.push(Finding {
+                    id: crate::finding::new_finding_ulid(),
                     title: "Blocking `.result()` call in async function".into(),
                     description: "Calling `.result()` on a future inside an async function blocks the event loop. Use `await` or run in an executor.".into(),
                     severity: Severity::High,
@@ -724,6 +738,7 @@ fn scan_insecure_python(node: &tree_sitter::Node, source: &str, findings: &mut V
                     .map(|n| &source[n.byte_range()])
                     .unwrap_or("parameter");
                 findings.push(Finding {
+                    id: crate::finding::new_finding_ulid(),
                     title: format!("Mutable default argument `{}`", param_name),
                     description: "Mutable default arguments are shared across calls and cause subtle bugs. Use None and initialize inside the function.".into(),
                     severity: Severity::Medium,
@@ -1094,6 +1109,7 @@ fn scan_insecure_yaml(node: &tree_sitter::Node, source: &str, findings: &mut Vec
                             seen_keys.iter().find(|(k, _)| *k == key_text)
                         {
                             findings.push(Finding {
+                                id: crate::finding::new_finding_ulid(),
                                 title: format!("Duplicate key `{}` in mapping", key_text),
                                 description: format!(
                                     "Key `{}` appears multiple times in the same mapping (first at line {}). The last value silently wins.",
@@ -1130,6 +1146,7 @@ fn scan_insecure_yaml(node: &tree_sitter::Node, source: &str, findings: &mut Vec
             // 3. Missing id
             if !keys.contains(&"id") {
                 findings.push(Finding {
+                    id: crate::finding::new_finding_ulid(),
                     title: "Automation missing `id` -- UI management and debug traces are disabled"
                         .into(),
                     description:
@@ -1156,6 +1173,7 @@ fn scan_insecure_yaml(node: &tree_sitter::Node, source: &str, findings: &mut Vec
             // 4. Missing mode
             if !keys.contains(&"mode") {
                 findings.push(Finding {
+                    id: crate::finding::new_finding_ulid(),
                     title: "Automation has no explicit `mode` (defaults to `single`)".into(),
                     description: "Automation has no explicit `mode` (defaults to `single`)".into(),
                     severity: Severity::Info,
@@ -1185,6 +1203,7 @@ fn scan_insecure_yaml(node: &tree_sitter::Node, source: &str, findings: &mut Vec
             for (singular, plural) in &deprecated {
                 if keys.contains(singular) && !keys.contains(plural) {
                     findings.push(Finding {
+                        id: crate::finding::new_finding_ulid(),
                         title: format!("Deprecated singular `{}:` -- use `{}:` instead", singular, plural),
                         description: format!(
                             "Home Assistant deprecated the singular `{}:` key. Use `{}:` (plural) for forward compatibility.",
@@ -1219,6 +1238,7 @@ fn scan_insecure_yaml(node: &tree_sitter::Node, source: &str, findings: &mut Vec
                                 && yaml_value_is_empty(&child, source)
                             {
                                 findings.push(Finding {
+                                    id: crate::finding::new_finding_ulid(),
                                     title: format!("Empty `{}:` in automation", key_text),
                                     description: format!(
                                         "The `{}:` key has no items. This automation will not function correctly.",
@@ -1263,6 +1283,7 @@ fn scan_insecure_yaml(node: &tree_sitter::Node, source: &str, findings: &mut Vec
                         };
                     if !has_password {
                         findings.push(Finding {
+                            id: crate::finding::new_finding_ulid(),
                             title: "ESPHome OTA section has no password -- firmware updates are unprotected".into(),
                             description: "ESPHome OTA section has no password -- firmware updates are unprotected. Add a password to prevent unauthorized firmware uploads.".into(),
                             severity: Severity::Medium,
@@ -1295,6 +1316,7 @@ fn scan_insecure_yaml(node: &tree_sitter::Node, source: &str, findings: &mut Vec
                         };
                     if !has_encryption {
                         findings.push(Finding {
+                            id: crate::finding::new_finding_ulid(),
                             title: "ESPHome API has no encryption configured".into(),
                             description: "ESPHome API has no encryption configured. Add an encryption key to secure communication.".into(),
                             severity: Severity::Medium,
@@ -1359,6 +1381,7 @@ fn scan_insecure_yaml(node: &tree_sitter::Node, source: &str, findings: &mut Vec
                                     };
                                     if !has_no_new_privs {
                                         findings.push(Finding {
+                                            id: crate::finding::new_finding_ulid(),
                                             title: format!("Docker Compose service `{}` missing `no-new-privileges` security option", svc_name),
                                             description: "Without `security_opt: [no-new-privileges:true]`, containers can escalate privileges via setuid binaries.".into(),
                                             severity: Severity::Medium,
@@ -1382,6 +1405,7 @@ fn scan_insecure_yaml(node: &tree_sitter::Node, source: &str, findings: &mut Vec
                                     // Pattern: Docker Compose service missing read_only
                                     if !svc_keys.contains(&"read_only") {
                                         findings.push(Finding {
+                                            id: crate::finding::new_finding_ulid(),
                                             title: format!("Docker Compose service `{}` has writable root filesystem", svc_name),
                                             description: "Without `read_only: true`, the container root filesystem is writable, which allows malicious payload download.".into(),
                                             severity: Severity::Low,
@@ -1424,6 +1448,7 @@ fn scan_insecure_yaml(node: &tree_sitter::Node, source: &str, findings: &mut Vec
                         let val_text = source[value.byte_range()].trim();
                         if !val_text.is_empty() {
                             findings.push(Finding {
+                                id: crate::finding::new_finding_ulid(),
                                 title: format!(
                                     "Hardcoded secret in `{}`",
                                     source[key.byte_range()].trim()
@@ -1473,6 +1498,7 @@ fn scan_insecure_yaml(node: &tree_sitter::Node, source: &str, findings: &mut Vec
                                                 .trim();
                                             if !item_text.is_empty() && !item_text.contains('.') {
                                                 findings.push(Finding {
+                                                    id: crate::finding::new_finding_ulid(),
                                                     title: "entity_id without domain prefix".into(),
                                                     description: format!(
                                                         "`{}` is missing a domain prefix (e.g. `sensor.{}`)",
@@ -1504,6 +1530,7 @@ fn scan_insecure_yaml(node: &tree_sitter::Node, source: &str, findings: &mut Vec
                     }
                     if !is_list && !val_text.is_empty() && !val_text.contains('.') {
                         findings.push(Finding {
+                            id: crate::finding::new_finding_ulid(),
                             title: "entity_id without domain prefix".into(),
                             description: format!(
                                 "`{}` is missing a domain prefix (e.g. `sensor.{}`)",
@@ -1535,6 +1562,7 @@ fn scan_insecure_yaml(node: &tree_sitter::Node, source: &str, findings: &mut Vec
                     let val_text = source[value.byte_range()].trim();
                     if !val_text.is_empty() && !val_text.contains('.') {
                         findings.push(Finding {
+                            id: crate::finding::new_finding_ulid(),
                             title: "service without domain prefix".into(),
                             description: format!(
                                 "`{}` is missing a domain prefix (e.g. `light.{}`)",
@@ -1566,6 +1594,7 @@ fn scan_insecure_yaml(node: &tree_sitter::Node, source: &str, findings: &mut Vec
                     let val_text = source[value.byte_range()].trim();
                     if val_text.contains("0.0.0.0") {
                         findings.push(Finding {
+                            id: crate::finding::new_finding_ulid(),
                             title: "Server binding to 0.0.0.0 exposes all interfaces".into(),
                             description: "Binding to 0.0.0.0 makes the server accessible from any network interface. Use 127.0.0.1 for local-only access.".into(),
                             severity: Severity::Medium,
@@ -1594,6 +1623,7 @@ fn scan_insecure_yaml(node: &tree_sitter::Node, source: &str, findings: &mut Vec
                 if !val_text.starts_with("!secret") && !val_text.starts_with("!include") {
                     if val_text.contains("://") && yaml_url_has_credentials(val_text) {
                         findings.push(Finding {
+                            id: crate::finding::new_finding_ulid(),
                             title: "URL contains embedded credentials".into(),
                             description: "URLs with embedded user:password credentials are a security risk. Use environment variables or secret references.".into(),
                             severity: Severity::High,
@@ -1633,6 +1663,7 @@ fn scan_insecure_yaml(node: &tree_sitter::Node, source: &str, findings: &mut Vec
                     val_text.contains("unavailable") || val_text.contains("unknown");
                 if !has_availability {
                     findings.push(Finding {
+                        id: crate::finding::new_finding_ulid(),
                         title: "Template uses `states()` without availability check".into(),
                         description: "Templates using states() should check for 'unavailable' and 'unknown' to avoid errors when entities are offline".into(),
                         severity: Severity::Info,
@@ -1689,6 +1720,7 @@ fn scan_insecure_yaml(node: &tree_sitter::Node, source: &str, findings: &mut Vec
             ];
             if dot_domains.iter().any(|d| val_text.contains(d)) {
                 findings.push(Finding {
+                    id: crate::finding::new_finding_ulid(),
                     title: "Deprecated dot-notation state access".into(),
                     description: "Use states('sensor.xxx') instead of states.sensor.xxx.state"
                         .into(),
@@ -1723,6 +1755,7 @@ fn scan_insecure_typescript(node: &tree_sitter::Node, source: &str, findings: &m
             let func_name = &source[func.byte_range()];
             if func_name == "eval" {
                 findings.push(Finding {
+                    id: crate::finding::new_finding_ulid(),
                     title: "Use of `eval()` is a code injection risk".into(),
                     description:
                         "`eval()` executes arbitrary code. Avoid using it with untrusted input."
@@ -1748,6 +1781,7 @@ fn scan_insecure_typescript(node: &tree_sitter::Node, source: &str, findings: &m
             // document.write XSS
             if func_name == "document.write" {
                 findings.push(Finding {
+                    id: crate::finding::new_finding_ulid(),
                     title: "Use of `document.write()` is an XSS risk".into(),
                     description: "`document.write()` injects raw HTML into the page. Use DOM APIs or a framework's safe rendering instead.".into(),
                     severity: Severity::Critical,
@@ -1771,6 +1805,7 @@ fn scan_insecure_typescript(node: &tree_sitter::Node, source: &str, findings: &m
             // console.log / console.debug debug artifacts
             if func_name == "console.log" || func_name == "console.debug" {
                 findings.push(Finding {
+                    id: crate::finding::new_finding_ulid(),
                     title: format!("`{}` debug artifact left in code", func_name),
                     description: "Debug logging should be removed or replaced with a proper logging framework before production.".into(),
                     severity: Severity::Info,
@@ -1823,6 +1858,7 @@ fn scan_insecure_typescript(node: &tree_sitter::Node, source: &str, findings: &m
                             (has_upper || has_digit || has_special) && inner_len > 8;
                         if looks_like_secret && !val_text.contains("process.env") {
                             findings.push(Finding {
+                                id: crate::finding::new_finding_ulid(),
                                 title: format!("Hardcoded secret in `{}`", &source[name_node.byte_range()]),
                                 description: "Secrets should be loaded from environment variables or a secrets manager, not hardcoded in source.".into(),
                                 severity: Severity::High,
@@ -1859,6 +1895,7 @@ fn scan_insecure_typescript(node: &tree_sitter::Node, source: &str, findings: &m
                     "outerHTML"
                 };
                 findings.push(Finding {
+                    id: crate::finding::new_finding_ulid(),
                     title: format!("Direct `{}` assignment is an XSS risk", prop),
                     description: format!("Setting `{}` with untrusted data enables XSS. Use `textContent` or a sanitization library.", prop),
                     severity: Severity::High,
@@ -1886,6 +1923,7 @@ fn scan_insecure_typescript(node: &tree_sitter::Node, source: &str, findings: &m
         let text = &source[node.byte_range()];
         if text.contains(": any") {
             findings.push(Finding {
+                id: crate::finding::new_finding_ulid(),
                 title: "Use of `any` type defeats TypeScript's type safety".into(),
                 description: "Prefer `unknown`, generics, or a specific type instead of `any`."
                     .into(),
@@ -1918,6 +1956,7 @@ fn scan_insecure_typescript(node: &tree_sitter::Node, source: &str, findings: &m
             });
             if !has_statements {
                 findings.push(Finding {
+                    id: crate::finding::new_finding_ulid(),
                     title: "Empty `catch` block silently swallows errors".into(),
                     description:
                         "An empty catch block hides failures. Log the error, handle it, or rethrow."
@@ -1963,6 +2002,7 @@ fn scan_insecure_typescript(node: &tree_sitter::Node, source: &str, findings: &m
                 if func_name.ends_with(api) {
                     if is_in_async_function(node, source) {
                         findings.push(Finding {
+                            id: crate::finding::new_finding_ulid(),
                             title: format!("`{}` blocks the event loop in async function", api),
                             description: format!(
                                 "Calling synchronous `{}` inside an async function blocks the event loop. Use the async equivalent from `fs/promises`.",
@@ -2006,6 +2046,7 @@ fn scan_insecure_typescript(node: &tree_sitter::Node, source: &str, findings: &m
                                 .unwrap_or(false);
                         if is_length_access && right_text.trim() == "0" {
                             findings.push(Finding {
+                                id: crate::finding::new_finding_ulid(),
                                 title: "`.length >= 0` is always true".into(),
                                 description: "Array and string `.length` is always >= 0. This condition is tautological. Did you mean `.length > 0`?".into(),
                                 severity: Severity::Medium,
@@ -2034,6 +2075,7 @@ fn scan_insecure_typescript(node: &tree_sitter::Node, source: &str, findings: &m
     // Non-null assertion operator (!)
     if node.kind() == "non_null_expression" {
         findings.push(Finding {
+            id: crate::finding::new_finding_ulid(),
             title: "Use of non-null assertion operator `!` bypasses type safety".into(),
             description: "The non-null assertion operator tells TypeScript to ignore possible null/undefined. Use proper null checks instead.".into(),
             severity: Severity::Info,
@@ -2064,6 +2106,7 @@ fn scan_insecure_bash(node: &tree_sitter::Node, source: &str, findings: &mut Vec
     if kind == "program" {
         if !source.starts_with("#!") {
             findings.push(Finding {
+                id: crate::finding::new_finding_ulid(),
                 title: "Script has no shebang line".into(),
                 description: "Add a shebang (e.g. #!/usr/bin/env bash) so the script runs with the intended interpreter.".into(),
                 severity: Severity::Low,
@@ -2102,6 +2145,7 @@ fn scan_insecure_bash(node: &tree_sitter::Node, source: &str, findings: &mut Vec
         }
         if !found_set_e {
             findings.push(Finding {
+                id: crate::finding::new_finding_ulid(),
                 title: "Script has no `set -e` -- errors will be silently ignored".into(),
                 description:
                     "Add `set -euo pipefail` near the top of the script to fail on errors.".into(),
@@ -2130,6 +2174,7 @@ fn scan_insecure_bash(node: &tree_sitter::Node, source: &str, findings: &mut Vec
             let name = &source[name_node.byte_range()];
             if name == "eval" {
                 findings.push(Finding {
+                    id: crate::finding::new_finding_ulid(),
                     title: "Use of `eval` is a code injection risk".into(),
                     description: "Avoid `eval` -- use arrays, printf, or parameter expansion instead.".into(),
                     severity: Severity::High,
@@ -2157,6 +2202,7 @@ fn scan_insecure_bash(node: &tree_sitter::Node, source: &str, findings: &mut Vec
                         let text = &source[arg.byte_range()];
                         if text == "777" {
                             findings.push(Finding {
+                                id: crate::finding::new_finding_ulid(),
                                 title: "`chmod 777` grants world-writable permissions".into(),
                                 description: "Use more restrictive permissions (e.g. 755 or 700)."
                                     .into(),
@@ -2198,6 +2244,7 @@ fn scan_insecure_bash(node: &tree_sitter::Node, source: &str, findings: &mut Vec
                             saw_curl = true;
                         } else if saw_curl && (name == "bash" || name == "sh" || name == "zsh") {
                             findings.push(Finding {
+                                id: crate::finding::new_finding_ulid(),
                                 title: "Piping curl/wget to shell executes untrusted remote code"
                                     .into(),
                                 description: "Download to a file first, inspect it, then execute."
@@ -2251,6 +2298,7 @@ fn scan_insecure_bash(node: &tree_sitter::Node, source: &str, findings: &mut Vec
                         // Skip if value contains $ (env var reference)
                         if !val_text.contains('$') {
                             findings.push(Finding {
+                                id: crate::finding::new_finding_ulid(),
                                 title: format!("Hardcoded secret in shell variable `{}`", var_name),
                                 description: "Use environment variables or a secrets manager instead of hardcoded values.".into(),
                                 severity: Severity::High,
@@ -2286,6 +2334,7 @@ fn scan_insecure_dockerfile(node: &tree_sitter::Node, source: &str, findings: &m
             let text = &source[node.byte_range()];
             if !text.contains("http://") && !text.contains("https://") {
                 findings.push(Finding {
+                    id: crate::finding::new_finding_ulid(),
                     title: "Use COPY instead of ADD for local files".into(),
                     description: "ADD has extra functionality (tar extraction, remote URLs) that can be surprising. Use COPY for simple file copies.".into(),
                     severity: Severity::Medium,
@@ -2330,6 +2379,7 @@ fn scan_insecure_dockerfile(node: &tree_sitter::Node, source: &str, findings: &m
                         let value = line[eq_pos + 1..].trim().trim_matches('"');
                         if !value.is_empty() && !value.starts_with('$') {
                             findings.push(Finding {
+                                id: crate::finding::new_finding_ulid(),
                                 title: "Secret hardcoded in Dockerfile ENV/ARG".into(),
                                 description: "Secrets should not be hardcoded in Dockerfiles. Use build secrets (--mount=type=secret) or runtime environment variables instead.".into(),
                                 severity: Severity::High,
@@ -2363,6 +2413,7 @@ fn scan_insecure_dockerfile(node: &tree_sitter::Node, source: &str, findings: &m
             let has_shell = text.contains("bash") || text.contains("/sh") || text.contains("| sh");
             if has_downloader && has_pipe && has_shell {
                 findings.push(Finding {
+                    id: crate::finding::new_finding_ulid(),
                     title: "RUN pipes curl/wget to shell -- executes untrusted remote code".into(),
                     description: "Piping downloaded scripts directly to a shell is dangerous. Download the script first, verify its checksum, then execute.".into(),
                     severity: Severity::Critical,
@@ -2465,6 +2516,7 @@ fn scan_insecure_terraform(node: &tree_sitter::Node, source: &str, findings: &mu
                                 && !inner.starts_with("${")
                             {
                                 findings.push(Finding {
+                                    id: crate::finding::new_finding_ulid(),
                                     title: format!("Hardcoded secret in `{}`", &source[name_node.byte_range()]),
                                     description: "Secrets should be loaded from variables or a secrets manager, not hardcoded in Terraform files.".into(),
                                     severity: Severity::High,
@@ -2506,6 +2558,7 @@ fn scan_insecure_terraform(node: &tree_sitter::Node, source: &str, findings: &mu
                             let inner = val_text.trim_matches('"');
                             if inner == "*" {
                                 findings.push(Finding {
+                                    id: crate::finding::new_finding_ulid(),
                                     title: "Wildcard IAM action grants unrestricted permissions".into(),
                                     description: "Using `Action = \"*\"` grants all permissions. Follow the principle of least privilege.".into(),
                                     severity: Severity::High,
@@ -2580,6 +2633,7 @@ fn scan_insecure_terraform(node: &tree_sitter::Node, source: &str, findings: &mu
 
                 if has_open_cidr && port_is_sensitive && found_port {
                     findings.push(Finding {
+                        id: crate::finding::new_finding_ulid(),
                         title: "Security group open to 0.0.0.0/0 on sensitive port".into(),
                         description: "Allowing ingress from 0.0.0.0/0 on non-HTTP(S) ports exposes the service to the internet. Restrict to specific CIDR ranges.".into(),
                         severity: Severity::High,
@@ -2677,6 +2731,7 @@ fn analyze_terraform_structure(tree: &tree_sitter::Tree, source: &str) -> Vec<Fi
     // S1: Missing required_version
     if (!has_terraform_block || !has_required_version) && has_resource_or_data {
         findings.push(Finding {
+            id: crate::finding::new_finding_ulid(),
             title: "Missing required_version in terraform block".into(),
             description: "Add a `terraform { required_version = \">= X.Y\" }` block to pin the Terraform version and prevent unexpected upgrades.".into(),
             severity: Severity::Medium,
@@ -2766,6 +2821,7 @@ fn check_required_providers(rp_body: tree_sitter::Node, source: &str, findings: 
 
         if has_source && !has_version {
             findings.push(Finding {
+                id: crate::finding::new_finding_ulid(),
                 title: format!(
                     "Provider `{}` in required_providers has no version constraint",
                     provider_name.unwrap_or("unknown")
@@ -2868,6 +2924,7 @@ fn analyze_dockerfile_structure(tree: &tree_sitter::Tree, source: &str) -> Vec<F
                     let uses_latest = image_ref.ends_with(":latest");
                     if !has_tag || uses_latest {
                         findings.push(Finding {
+                            id: crate::finding::new_finding_ulid(),
                             title: "FROM uses `latest` or untagged image -- builds are not reproducible".into(),
                             description: format!("Pin the image to a specific tag or digest: {}", image_ref),
                             severity: Severity::Medium,
@@ -2901,6 +2958,7 @@ fn analyze_dockerfile_structure(tree: &tree_sitter::Tree, source: &str) -> Vec<F
     // D6: No USER instruction
     if !has_user {
         findings.push(Finding {
+            id: crate::finding::new_finding_ulid(),
             title: "No USER instruction -- container runs as root".into(),
             description: "Add a USER instruction to run the container as a non-root user.".into(),
             severity: Severity::Medium,
@@ -2924,6 +2982,7 @@ fn analyze_dockerfile_structure(tree: &tree_sitter::Tree, source: &str) -> Vec<F
     // D8: No HEALTHCHECK
     if !has_healthcheck {
         findings.push(Finding {
+            id: crate::finding::new_finding_ulid(),
             title: "No HEALTHCHECK instruction".into(),
             description: "Add a HEALTHCHECK instruction so the container runtime can detect unhealthy containers.".into(),
             severity: Severity::Low,
@@ -2947,6 +3006,7 @@ fn analyze_dockerfile_structure(tree: &tree_sitter::Tree, source: &str) -> Vec<F
     // D11: Multiple CMD/ENTRYPOINT
     if cmd_count > 1 {
         findings.push(Finding {
+            id: crate::finding::new_finding_ulid(),
             title: "Multiple CMD instructions -- only the last one takes effect".into(),
             description: format!(
                 "Found {} CMD instructions; only the last one will be used.",
@@ -2971,6 +3031,7 @@ fn analyze_dockerfile_structure(tree: &tree_sitter::Tree, source: &str) -> Vec<F
     }
     if entrypoint_count > 1 {
         findings.push(Finding {
+            id: crate::finding::new_finding_ulid(),
             title: "Multiple ENTRYPOINT instructions -- only the last one takes effect".into(),
             description: format!(
                 "Found {} ENTRYPOINT instructions; only the last one will be used.",

--- a/src/analytics.rs
+++ b/src/analytics.rs
@@ -503,7 +503,7 @@ pub fn precision_trend_per_finding(
                 let prev_rank = match &prev.provenance {
                     Provenance::Human => 0,
                     Provenance::PostFix => 1,
-                    _ => 2,
+                    _ => unreachable!("only Human/PostFix enter the map"),
                 };
                 if tier_rank < prev_rank
                     || (tier_rank == prev_rank && e.timestamp < prev.timestamp)
@@ -1030,6 +1030,28 @@ mod tests {
         // Precision: (Partial + TP) / (Partial + TP + FP) = (1+7) / (1+7+1) = 8/9.
         assert_eq!(trend[0].count, 10);
         assert!((trend[0].precision - (8.0 / 9.0)).abs() < 1e-9);
+    }
+
+    #[test]
+    fn per_finding_same_tier_keeps_earliest_timestamp() {
+        use crate::feedback::Provenance;
+        // Two Human entries for F1: earlier is TP, later is FP.
+        // Earliest timestamp wins, so F1 resolves to TP.
+        let mut later = fb_with_id_and_provenance("F1", Verdict::Fp, Provenance::Human);
+        later.timestamp = Utc::now() - chrono::Duration::hours(1);
+        let mut earlier = fb_with_id_and_provenance("F1", Verdict::Tp, Provenance::Human);
+        earlier.timestamp = Utc::now() - chrono::Duration::hours(3);
+        let mut all = vec![later, earlier];
+        for i in 0..9 {
+            all.push(fb_with_id_and_provenance(
+                &format!("P{}", i),
+                Verdict::Tp,
+                Provenance::Human,
+            ));
+        }
+        let trend = precision_trend_per_finding(&all, 7);
+        assert_eq!(trend.len(), 1);
+        assert!((trend[0].precision - 1.0).abs() < 1e-9);
     }
 
     // ─── Stats redesign Task 8: channel attribution table ───

--- a/src/analytics.rs
+++ b/src/analytics.rs
@@ -1,9 +1,57 @@
 /// Per-source TP/FP analytics computed from the feedback store.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use chrono::{DateTime, Utc};
 
 use crate::feedback::{FeedbackEntry, Verdict};
+use crate::review_log::ReviewRecord;
+
+/// Reviews ↔ feedback linkage health.
+///
+/// Counts feedback entries that have a `finding_id` matching some review's
+/// `finding_ids` list. Used by the headline trend to decide whether
+/// per-finding precision math is trustworthy (≥85% linked) or should
+/// fall back to entry-level math with a banner. Also surfaced directly
+/// via `quorum stats --join-health`.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct LinkageStats {
+    pub linked: usize,
+    pub unlinked: usize,
+}
+
+impl LinkageStats {
+    /// Fraction of feedback entries that join back to a known finding.
+    /// Returns 0.0 for an empty corpus rather than NaN.
+    pub fn rate(&self) -> f64 {
+        let total = self.linked + self.unlinked;
+        if total == 0 {
+            0.0
+        } else {
+            self.linked as f64 / total as f64
+        }
+    }
+}
+
+/// Compute reviews ↔ feedback linkage statistics.
+///
+/// O(R + F) where R = total finding_ids across reviews and F = feedback
+/// entries. Builds a HashSet of known finding_ids so duplicate IDs in the
+/// review log don't inflate the linked count.
+pub fn linkage_stats(reviews: &[ReviewRecord], feedback: &[FeedbackEntry]) -> LinkageStats {
+    let known: HashSet<&str> = reviews
+        .iter()
+        .flat_map(|r| r.finding_ids.iter().map(String::as_str))
+        .collect();
+
+    let mut stats = LinkageStats::default();
+    for entry in feedback {
+        match &entry.finding_id {
+            Some(fid) if known.contains(fid.as_str()) => stats.linked += 1,
+            _ => stats.unlinked += 1,
+        }
+    }
+    stats
+}
 
 #[derive(Debug, Clone, Default)]
 pub struct SourceStats {
@@ -510,5 +558,107 @@ mod tests {
         let entries = vec![entry("model", Verdict::Tp)]; // only 1 entry
         let trend = precision_trend(&entries, 7);
         assert!(trend.is_empty()); // not enough data
+    }
+
+    // ─── Stats redesign Phase 0: linkage_stats ───
+    //
+    // Counts feedback entries that have a finding_id matching some review's
+    // finding_ids list. The linkage rate gates whether the headline trend
+    // can compute per-finding precision (≥85%) or must fall back to entry-
+    // level math with a banner.
+
+    fn review_with_finding_ids(ids: &[&str]) -> crate::review_log::ReviewRecord {
+        crate::review_log::ReviewRecord {
+            run_id: crate::review_log::ReviewRecord::new_ulid(),
+            timestamp: Utc::now(),
+            quorum_version: "0.1".into(),
+            repo: None,
+            invoked_from: "tty".into(),
+            model: "test".into(),
+            files_reviewed: 1,
+            lines_added: None,
+            lines_removed: None,
+            findings_by_severity: crate::review_log::SeverityCounts::default(),
+            suppressed_by_rule: HashMap::new(),
+            tokens_in: 0,
+            tokens_out: 0,
+            tokens_cache_read: 0,
+            duration_ms: 0,
+            flags: crate::review_log::Flags::default(),
+            context: crate::review_log::ContextTelemetry::default(),
+            finding_ids: ids.iter().map(|s| s.to_string()).collect(),
+        }
+    }
+
+    fn fb_with_finding_id(id: &str) -> FeedbackEntry {
+        let mut e = entry("model", Verdict::Tp);
+        e.finding_id = Some(id.into());
+        e
+    }
+
+    #[test]
+    fn linkage_with_zero_reviews_and_zero_feedback_returns_zero_rate() {
+        let stats = linkage_stats(&[], &[]);
+        assert_eq!(stats.linked, 0);
+        assert_eq!(stats.unlinked, 0);
+        assert_eq!(stats.rate(), 0.0);
+    }
+
+    #[test]
+    fn linkage_full_when_every_feedback_has_matching_finding_id() {
+        let reviews = vec![review_with_finding_ids(&["A", "B"])];
+        let feedback = vec![fb_with_finding_id("A"), fb_with_finding_id("B")];
+        let stats = linkage_stats(&reviews, &feedback);
+        assert_eq!(stats.linked, 2);
+        assert_eq!(stats.unlinked, 0);
+        assert!((stats.rate() - 1.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn linkage_partial_with_legacy_entries_in_corpus() {
+        let reviews = vec![review_with_finding_ids(&["A", "B"])];
+        let mut legacy = entry("model", Verdict::Tp);
+        legacy.finding_id = None;
+        let feedback = vec![fb_with_finding_id("A"), legacy];
+        let stats = linkage_stats(&reviews, &feedback);
+        assert_eq!(stats.linked, 1);
+        assert_eq!(stats.unlinked, 1);
+        assert!((stats.rate() - 0.5).abs() < 1e-9);
+    }
+
+    #[test]
+    fn linkage_dangling_finding_id_counts_as_unlinked() {
+        // A feedback entry references a finding_id not present in any
+        // review's finding_ids — counts as unlinked, not as match-error.
+        let reviews = vec![review_with_finding_ids(&["A"])];
+        let feedback = vec![fb_with_finding_id("Z-NONEXISTENT")];
+        let stats = linkage_stats(&reviews, &feedback);
+        assert_eq!(stats.linked, 0);
+        assert_eq!(stats.unlinked, 1);
+    }
+
+    #[test]
+    fn linkage_duplicate_finding_id_in_reviews_does_not_double_count() {
+        // Pathological case: the same finding_id appears in two reviews.
+        // The HashSet lookup means we count the feedback entry once.
+        let reviews = vec![
+            review_with_finding_ids(&["A"]),
+            review_with_finding_ids(&["A"]),
+        ];
+        let feedback = vec![fb_with_finding_id("A")];
+        let stats = linkage_stats(&reviews, &feedback);
+        assert_eq!(stats.linked, 1);
+        assert_eq!(stats.unlinked, 0);
+    }
+
+    #[test]
+    fn linkage_two_feedback_for_same_finding_each_count_separately() {
+        // Both entries reference the same finding (e.g. Human + PostFix on
+        // the same finding) — each is a linked entry. Per-finding dedup
+        // happens later in Task 7, not here.
+        let reviews = vec![review_with_finding_ids(&["A"])];
+        let feedback = vec![fb_with_finding_id("A"), fb_with_finding_id("A")];
+        let stats = linkage_stats(&reviews, &feedback);
+        assert_eq!(stats.linked, 2);
     }
 }

--- a/src/analytics.rs
+++ b/src/analytics.rs
@@ -276,6 +276,63 @@ pub fn precision_trend(entries: &[FeedbackEntry], window_days: i64) -> Vec<Preci
     windows
 }
 
+/// Per-finding precision trend with disposition precedence.
+///
+/// Same window-bucketing as `precision_trend`, but feedback entries that
+/// share a `finding_id` collapse to a single row using the precedence
+/// `Human > PostFix > drop`. External and AutoCalibrate are excluded
+/// from the pool entirely (they're a different channel — see Tier
+/// breakdown). Legacy entries (`finding_id == None`) cannot be
+/// deduplicated against and are skipped.
+///
+/// This is the headline trend once linkage rate ≥85%; below that, the
+/// dashboard falls back to entry-level `precision_trend` with a banner.
+pub fn precision_trend_per_finding(
+    entries: &[FeedbackEntry],
+    window_days: i64,
+) -> Vec<PrecisionWindow> {
+    use crate::feedback::Provenance;
+
+    if entries.is_empty() || window_days <= 0 {
+        return vec![];
+    }
+
+    // Filter to Human/PostFix entries with a finding_id, then dedup by
+    // finding_id with Human winning over PostFix. Earliest timestamp wins
+    // among same-tier entries so the resulting row sits in a stable window.
+    let mut keep: HashMap<String, FeedbackEntry> = HashMap::new();
+    for e in entries {
+        let Some(fid) = &e.finding_id else { continue };
+        let tier_rank = match &e.provenance {
+            Provenance::Human => 0,
+            Provenance::PostFix => 1,
+            Provenance::External { .. } | Provenance::AutoCalibrate(_) | Provenance::Unknown => {
+                continue;
+            }
+        };
+        match keep.get(fid) {
+            None => {
+                keep.insert(fid.clone(), e.clone());
+            }
+            Some(prev) => {
+                let prev_rank = match &prev.provenance {
+                    Provenance::Human => 0,
+                    Provenance::PostFix => 1,
+                    _ => 2,
+                };
+                if tier_rank < prev_rank
+                    || (tier_rank == prev_rank && e.timestamp < prev.timestamp)
+                {
+                    keep.insert(fid.clone(), e.clone());
+                }
+            }
+        }
+    }
+
+    let deduped: Vec<FeedbackEntry> = keep.into_values().collect();
+    precision_trend(&deduped, window_days)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -649,6 +706,145 @@ mod tests {
         let stats = linkage_stats(&reviews, &feedback);
         assert_eq!(stats.linked, 1);
         assert_eq!(stats.unlinked, 0);
+    }
+
+    // ─── Stats redesign Task 7: per-finding precision trend ───
+    //
+    // Same window-bucketing as `precision_trend`, but feedback entries that
+    // share a finding_id are deduplicated under a fixed precedence:
+    // Human > PostFix > drop. External and AutoCalibrate are excluded
+    // (different channel; counted separately under Tier breakdown). Legacy
+    // entries (finding_id == None) cannot be deduplicated against and are
+    // skipped entirely so per-finding precision reflects only linkable data.
+
+    fn fb_with_id_and_provenance(
+        id: &str,
+        verdict: Verdict,
+        provenance: crate::feedback::Provenance,
+    ) -> FeedbackEntry {
+        let mut e = entry_with(provenance, verdict);
+        e.finding_id = Some(id.into());
+        e
+    }
+
+    #[test]
+    fn per_finding_dedups_human_plus_postfix_on_same_finding_id() {
+        use crate::feedback::Provenance;
+        // Same finding gets a Human TP and a PostFix TP — Human wins, count
+        // once. (Without dedup, the trend over-counts confirmed findings
+        // because every TP gets a "yes I fixed it" PostFix companion.)
+        let entries = vec![
+            fb_with_id_and_provenance("A", Verdict::Tp, Provenance::Human),
+            fb_with_id_and_provenance("A", Verdict::Tp, Provenance::PostFix),
+            fb_with_id_and_provenance("B", Verdict::Tp, Provenance::Human),
+            fb_with_id_and_provenance("C", Verdict::Tp, Provenance::Human),
+            fb_with_id_and_provenance("D", Verdict::Tp, Provenance::Human),
+            fb_with_id_and_provenance("E", Verdict::Tp, Provenance::Human),
+            fb_with_id_and_provenance("F", Verdict::Tp, Provenance::Human),
+            fb_with_id_and_provenance("G", Verdict::Tp, Provenance::Human),
+            fb_with_id_and_provenance("H", Verdict::Tp, Provenance::Human),
+            fb_with_id_and_provenance("I", Verdict::Tp, Provenance::Human),
+            fb_with_id_and_provenance("J", Verdict::Tp, Provenance::Human),
+        ];
+        let trend = precision_trend_per_finding(&entries, 7);
+        assert_eq!(trend.len(), 1);
+        // 10 distinct findings (A..J), all TP after dedup. Clears the
+        // min_entries=10 gate inherited from precision_trend.
+        assert_eq!(trend[0].count, 10);
+        assert!((trend[0].precision - 1.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn per_finding_human_takes_precedence_over_postfix() {
+        use crate::feedback::Provenance;
+        // Human FP on finding A; PostFix TP on finding A. Human wins —
+        // resulting verdict for A is FP. (PostFix without prior Human is a
+        // weak signal; if Human says FP, that overrides the auto-fix
+        // confirmation.)
+        let mut entries = vec![
+            fb_with_id_and_provenance("A", Verdict::Fp, Provenance::Human),
+            fb_with_id_and_provenance("A", Verdict::Tp, Provenance::PostFix),
+        ];
+        // Pad to clear the min_entries=10 gate.
+        for i in 0..9 {
+            let id = format!("PAD-{i}");
+            entries.push(fb_with_id_and_provenance(&id, Verdict::Tp, Provenance::Human));
+        }
+        let trend = precision_trend_per_finding(&entries, 7);
+        assert_eq!(trend.len(), 1);
+        // 1 FP + 9 TP = 10 distinct findings; 9/10 = 0.9 precision.
+        assert_eq!(trend[0].count, 10);
+        assert!((trend[0].precision - 0.9).abs() < 1e-9);
+    }
+
+    #[test]
+    fn per_finding_excludes_external_and_auto_calibrate() {
+        use crate::feedback::Provenance;
+        // External and AutoCalibrate are different channels — they should
+        // not enter the per-finding precision pool. Only Human and PostFix
+        // count.
+        let mut entries: Vec<FeedbackEntry> = (0..10)
+            .map(|i| {
+                let id = format!("H-{i}");
+                fb_with_id_and_provenance(&id, Verdict::Tp, Provenance::Human)
+            })
+            .collect();
+        entries.push(fb_with_id_and_provenance(
+            "EXT-1",
+            Verdict::Fp,
+            Provenance::External {
+                agent: "pal".into(),
+                model: None,
+                confidence: None,
+            },
+        ));
+        entries.push(fb_with_id_and_provenance(
+            "AC-1",
+            Verdict::Fp,
+            Provenance::AutoCalibrate("gpt-5.4".into()),
+        ));
+        let trend = precision_trend_per_finding(&entries, 7);
+        assert_eq!(trend.len(), 1);
+        assert_eq!(trend[0].count, 10, "External + AutoCalibrate excluded");
+        assert!((trend[0].precision - 1.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn per_finding_skips_legacy_entries_without_finding_id() {
+        use crate::feedback::Provenance;
+        let mut entries: Vec<FeedbackEntry> = (0..10)
+            .map(|i| {
+                let id = format!("ID-{i}");
+                fb_with_id_and_provenance(&id, Verdict::Tp, Provenance::Human)
+            })
+            .collect();
+        // Legacy: no finding_id. Cannot be deduplicated, so excluded.
+        entries.push(entry_with(Provenance::Human, Verdict::Fp));
+        let trend = precision_trend_per_finding(&entries, 7);
+        assert_eq!(trend.len(), 1);
+        assert_eq!(trend[0].count, 10);
+    }
+
+    #[test]
+    fn per_finding_partial_counts_as_relevant_in_precision() {
+        use crate::feedback::Provenance;
+        // Mirror precision_trend semantics: Partial is "relevant" — it
+        // counts in the numerator. Wontfix counts in neither.
+        let mut entries = vec![
+            fb_with_id_and_provenance("A", Verdict::Partial, Provenance::Human),
+            fb_with_id_and_provenance("B", Verdict::Wontfix, Provenance::Human),
+            fb_with_id_and_provenance("C", Verdict::Fp, Provenance::Human),
+        ];
+        for i in 0..7 {
+            let id = format!("TP-{i}");
+            entries.push(fb_with_id_and_provenance(&id, Verdict::Tp, Provenance::Human));
+        }
+        let trend = precision_trend_per_finding(&entries, 7);
+        assert_eq!(trend.len(), 1);
+        // Distinct findings: A (Partial), B (Wontfix), C (FP), TP-0..6 (TP) = 10.
+        // Precision: (Partial + TP) / (Partial + TP + FP) = (1+7) / (1+7+1) = 8/9.
+        assert_eq!(trend[0].count, 10);
+        assert!((trend[0].precision - (8.0 / 9.0)).abs() < 1e-9);
     }
 
     #[test]

--- a/src/analytics.rs
+++ b/src/analytics.rs
@@ -134,6 +134,7 @@ pub struct PrecisionWindow {
     pub week_start: DateTime<Utc>,
     pub precision: f64,
     pub count: usize,
+    pub precision_denom: usize,
 }
 
 /// Tier-level aggregation by `Provenance`. Parallel to (and does not replace)
@@ -276,6 +277,7 @@ pub fn precision_trend(entries: &[FeedbackEntry], window_days: i64) -> Vec<Preci
                 week_start: window_start,
                 precision,
                 count: window_entries.len(),
+                precision_denom: total,
             });
         }
 
@@ -793,6 +795,33 @@ mod tests {
         let entries = vec![entry("model", Verdict::Tp)]; // only 1 entry
         let trend = precision_trend(&entries, 7);
         assert!(trend.is_empty()); // not enough data
+    }
+
+    #[test]
+    fn precision_denom_excludes_wontfix() {
+        let now = Utc::now();
+        let mut entries = Vec::new();
+        for _ in 0..8 {
+            let mut e = entry("model", Verdict::Tp);
+            e.timestamp = now - chrono::Duration::days(3);
+            entries.push(e);
+        }
+        for _ in 0..2 {
+            let mut e = entry("model", Verdict::Fp);
+            e.timestamp = now - chrono::Duration::days(3);
+            entries.push(e);
+        }
+        for _ in 0..5 {
+            let mut e = entry("model", Verdict::Wontfix);
+            e.timestamp = now - chrono::Duration::days(3);
+            entries.push(e);
+        }
+        let trend = precision_trend(&entries, 7);
+        assert!(!trend.is_empty());
+        let w = &trend[0];
+        assert_eq!(w.count, 15, "count includes all entries");
+        assert_eq!(w.precision_denom, 10, "precision_denom excludes wontfix");
+        assert!((w.precision - 0.8).abs() < 1e-9);
     }
 
     // ─── Stats redesign Phase 0: linkage_stats ───

--- a/src/analytics.rs
+++ b/src/analytics.rs
@@ -244,6 +244,8 @@ mod tests {
             timestamp: Utc::now(),
             provenance: crate::feedback::Provenance::Unknown,
             fp_kind: None,
+            finding_id: None,
+            rule_id: None,
         }
     }
 
@@ -258,6 +260,8 @@ mod tests {
             timestamp: Utc::now(),
             provenance,
             fp_kind: None,
+            finding_id: None,
+            rule_id: None,
         }
     }
 

--- a/src/analytics.rs
+++ b/src/analytics.rs
@@ -829,6 +829,7 @@ mod tests {
             flags: crate::review_log::Flags::default(),
             context: crate::review_log::ContextTelemetry::default(),
             finding_ids: ids.iter().map(|s| s.to_string()).collect(),
+            mode: None,
         }
     }
 

--- a/src/analytics.rs
+++ b/src/analytics.rs
@@ -188,6 +188,10 @@ pub fn compute_tier_stats(entries: &[FeedbackEntry]) -> TierSummary {
     summary
 }
 
+#[deprecated(
+    since = "0.19.0",
+    note = "Use `format_channel_attribution` instead. Tier-precision rollups are misleading: External and AutoCalibrate aren't comparable to Human/PostFix on a precision axis."
+)]
 pub fn format_tier_report(summary: &TierSummary) -> String {
     let mut lines = Vec::new();
     lines.push("Feedback by provenance tier:".into());
@@ -274,6 +278,101 @@ pub fn precision_trend(entries: &[FeedbackEntry], window_days: i64) -> Vec<Preci
     }
 
     windows
+}
+
+/// Channel attribution table — replaces format_tier_report.
+///
+/// Reports counts only (no precision column) per provenance channel.
+/// Precision belongs on the headline trend, not the channel rollup —
+/// External and AutoCalibrate aren't comparable to Human/PostFix on a
+/// precision axis (different sampling distributions, different signal
+/// quality).
+///
+/// Layout per DESIGN.md §4.x: thin dim `─` rule under header only;
+/// numeric columns right-aligned; empty cells render as em-dash.
+pub fn format_channel_attribution(summary: &TierSummary) -> String {
+    use std::fmt::Write;
+    let mut out = String::new();
+
+    let rows: [(&str, &SourceStats); 4] = [
+        ("Human", &summary.human),
+        ("PostFix", &summary.post_fix),
+        ("External", &summary.external.total),
+        ("AutoCalib", &summary.auto_calibrate),
+    ];
+
+    // Header.
+    writeln!(
+        out,
+        "  {label:<10}  {total:>6}  {tp:>5}  {fp:>5}  {part:>5}  {wfix:>5}",
+        label = "Channel",
+        total = "Total",
+        tp = "TP",
+        fp = "FP",
+        part = "Part",
+        wfix = "Wfix",
+    )
+    .unwrap();
+    // Single dim rule under header only.
+    writeln!(
+        out,
+        "  {}",
+        "─".repeat(10 + 2 + 6 + 2 + 5 + 2 + 5 + 2 + 5 + 2 + 5)
+    )
+    .unwrap();
+
+    fn cell(n: usize) -> String {
+        if n == 0 {
+            "—".to_string()
+        } else {
+            n.to_string()
+        }
+    }
+
+    for (label, s) in rows {
+        let total = s.total();
+        if total == 0 && label != "Human" {
+            continue; // hide empty channels except Human (always shown)
+        }
+        writeln!(
+            out,
+            "  {label:<10}  {total:>6}  {tp:>5}  {fp:>5}  {part:>5}  {wfix:>5}",
+            label = label,
+            total = if total == 0 { "—".to_string() } else { total.to_string() },
+            tp = cell(s.tp),
+            fp = cell(s.fp),
+            part = cell(s.partial),
+            wfix = cell(s.wontfix),
+        )
+        .unwrap();
+    }
+
+    // Per-agent External rollup.
+    if !summary.external.per_agent.is_empty() {
+        let top: Vec<String> = summary
+            .external
+            .per_agent
+            .iter()
+            .take(3)
+            .map(|(name, s)| format!("{name} ({})", s.total()))
+            .collect();
+        writeln!(out, "    top agents: {}", top.join(", ")).unwrap();
+    }
+
+    if summary.unknown.total() > 0 {
+        let s = &summary.unknown;
+        writeln!(
+            out,
+            "  {label:<10}  {total:>6}  {dim}(legacy rows, no provenance field){reset}",
+            label = "Unknown",
+            total = s.total(),
+            dim = "",
+            reset = "",
+        )
+        .unwrap();
+    }
+
+    out
 }
 
 /// External-agent corpus overlap with quorum's own verdicts.
@@ -931,6 +1030,72 @@ mod tests {
         // Precision: (Partial + TP) / (Partial + TP + FP) = (1+7) / (1+7+1) = 8/9.
         assert_eq!(trend[0].count, 10);
         assert!((trend[0].precision - (8.0 / 9.0)).abs() < 1e-9);
+    }
+
+    // ─── Stats redesign Task 8: channel attribution table ───
+
+    #[test]
+    fn channel_attribution_header_lists_count_columns_only() {
+        // No precision column on the channel rollup; precision lives on
+        // the headline trend instead.
+        let summary = TierSummary::default();
+        let out = format_channel_attribution(&summary);
+        assert!(out.contains("Total"));
+        assert!(out.contains("TP"));
+        assert!(out.contains("FP"));
+        assert!(out.contains("Part"));
+        assert!(out.contains("Wfix"));
+        assert!(!out.contains("prec"), "no precision column expected");
+        assert!(!out.contains('%'), "no percent rendering expected");
+    }
+
+    #[test]
+    fn channel_attribution_renders_em_dash_for_zero_cells() {
+        // Counts of 0 render as `—` so the eye lands on actual signal,
+        // not on rows of zeros.
+        let summary = TierSummary::default(); // all zero
+        let out = format_channel_attribution(&summary);
+        // Human row is always rendered, even when all-zero — its zero
+        // cells should be em-dashes.
+        let human_line = out.lines().find(|l| l.contains("Human")).unwrap();
+        assert!(
+            human_line.contains("—"),
+            "Human row with zeros should use em-dash: {human_line}"
+        );
+    }
+
+    #[test]
+    fn channel_attribution_uses_single_dim_rule_under_header() {
+        let summary = TierSummary::default();
+        let out = format_channel_attribution(&summary);
+        let rule_count = out.matches("──").count();
+        assert!(
+            rule_count >= 1,
+            "expected at least one box-rule run under header, got {rule_count}"
+        );
+        // Sanity: no double rule below data rows
+        let line_count = out.lines().count();
+        assert!(line_count < 12, "too many lines for an empty summary");
+    }
+
+    #[test]
+    fn channel_attribution_hides_empty_postfix_external_autocalib() {
+        // Empty channels (other than Human) are hidden — keeps the table
+        // tight before the user has any non-Human verdicts.
+        let summary = TierSummary::default();
+        let out = format_channel_attribution(&summary);
+        assert!(!out.contains("PostFix"));
+        assert!(!out.contains("External"));
+        assert!(!out.contains("AutoCalib"));
+    }
+
+    #[test]
+    fn channel_attribution_shows_postfix_when_any_postfix_entries_exist() {
+        use crate::feedback::Provenance;
+        let entries = vec![entry_with(Provenance::PostFix, Verdict::Tp)];
+        let summary = compute_tier_stats(&entries);
+        let out = format_channel_attribution(&summary);
+        assert!(out.contains("PostFix"), "PostFix should appear: {out}");
     }
 
     // ─── Stats redesign Task 9: external corpus overlap ───

--- a/src/analytics.rs
+++ b/src/analytics.rs
@@ -276,6 +276,92 @@ pub fn precision_trend(entries: &[FeedbackEntry], window_days: i64) -> Vec<Preci
     windows
 }
 
+/// External-agent corpus overlap with quorum's own verdicts.
+///
+/// `per_agent[i].findings`  — total External entries for that agent in the corpus
+/// `per_agent[i].overlap`   — entries whose finding_id is also in `quorum_verdicts`
+/// `per_agent[i].agree`     — overlap entries where the External verdict matches
+///                            the quorum verdict on the same finding
+///
+/// Surfaced in the External corpus block so users can read agent
+/// contribution without it polluting headline precision.
+#[derive(Debug, Clone, Default)]
+pub struct ExternalOverlap {
+    pub per_agent: Vec<AgentOverlap>,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct AgentOverlap {
+    pub agent: String,
+    pub findings: usize,
+    pub overlap: usize,
+    pub agree: usize,
+}
+
+impl AgentOverlap {
+    /// Fraction of overlap entries where External and quorum agreed.
+    /// Returns 0.0 (not NaN) when there's no overlap to compute on.
+    pub fn agreement_rate(&self) -> f64 {
+        if self.overlap == 0 {
+            0.0
+        } else {
+            self.agree as f64 / self.overlap as f64
+        }
+    }
+}
+
+/// Compute External-agent overlap against a map of quorum verdicts keyed
+/// by finding_id. The quorum-side map is provided externally so callers
+/// can build it however suits them (e.g. the Human path for headline
+/// math, or PostFix-confirmed for stricter ground truth). The function
+/// itself is verdict-source-agnostic.
+pub fn compute_external_overlap(
+    entries: &[FeedbackEntry],
+    quorum_verdicts: &HashMap<String, Verdict>,
+) -> ExternalOverlap {
+    use crate::feedback::Provenance;
+    let mut per_agent: HashMap<String, AgentOverlap> = HashMap::new();
+    for e in entries {
+        let Provenance::External { agent, .. } = &e.provenance else {
+            continue;
+        };
+        let row = per_agent.entry(agent.clone()).or_insert_with(|| AgentOverlap {
+            agent: agent.clone(),
+            ..Default::default()
+        });
+        row.findings += 1;
+        if let Some(fid) = &e.finding_id {
+            if let Some(qv) = quorum_verdicts.get(fid) {
+                row.overlap += 1;
+                if verdict_eq(qv, &e.verdict) {
+                    row.agree += 1;
+                }
+            }
+        }
+    }
+    let mut agents: Vec<AgentOverlap> = per_agent.into_values().collect();
+    agents.sort_by(|a, b| b.findings.cmp(&a.findings).then_with(|| a.agent.cmp(&b.agent)));
+    ExternalOverlap { per_agent: agents }
+}
+
+/// Verdict equivalence for agreement counting. Treats Tp/Partial as
+/// "real" and Fp as "not real" — Wontfix and ContextMisleading are
+/// counted as not-equal to anything since they're not finding-quality
+/// verdicts.
+fn verdict_eq(a: &Verdict, b: &Verdict) -> bool {
+    fn category(v: &Verdict) -> Option<u8> {
+        match v {
+            Verdict::Tp | Verdict::Partial => Some(0),
+            Verdict::Fp => Some(1),
+            Verdict::Wontfix | Verdict::ContextMisleading { .. } => None,
+        }
+    }
+    match (category(a), category(b)) {
+        (Some(x), Some(y)) => x == y,
+        _ => false,
+    }
+}
+
 /// Per-finding precision trend with disposition precedence.
 ///
 /// Same window-bucketing as `precision_trend`, but feedback entries that
@@ -845,6 +931,99 @@ mod tests {
         // Precision: (Partial + TP) / (Partial + TP + FP) = (1+7) / (1+7+1) = 8/9.
         assert_eq!(trend[0].count, 10);
         assert!((trend[0].precision - (8.0 / 9.0)).abs() < 1e-9);
+    }
+
+    // ─── Stats redesign Task 9: external corpus overlap ───
+    //
+    // For each external agent, count how many of its findings overlap
+    // with quorum's own verdicts (linked by finding_id) and what fraction
+    // agree on the disposition. Used by the External corpus block to
+    // surface "this agent flags things quorum also flags X% of the time"
+    // without conflating the External channel into Human precision.
+
+    fn external_fb(id: &str, verdict: Verdict, agent: &str) -> FeedbackEntry {
+        use crate::feedback::Provenance;
+        fb_with_id_and_provenance(
+            id,
+            verdict,
+            Provenance::External {
+                agent: agent.into(),
+                model: None,
+                confidence: None,
+            },
+        )
+    }
+
+    #[test]
+    fn external_overlap_empty_for_no_external_entries() {
+        let entries: Vec<FeedbackEntry> = vec![];
+        let quorum: HashMap<String, Verdict> = HashMap::new();
+        let overlap = compute_external_overlap(&entries, &quorum);
+        assert!(overlap.per_agent.is_empty());
+    }
+
+    #[test]
+    fn external_overlap_counts_findings_per_agent() {
+        let entries = vec![
+            external_fb("A", Verdict::Tp, "pal"),
+            external_fb("B", Verdict::Fp, "pal"),
+            external_fb("C", Verdict::Tp, "third-opinion"),
+        ];
+        let quorum: HashMap<String, Verdict> = HashMap::new();
+        let overlap = compute_external_overlap(&entries, &quorum);
+        assert_eq!(overlap.per_agent.len(), 2);
+        let pal = overlap.per_agent.iter().find(|a| a.agent == "pal").unwrap();
+        assert_eq!(pal.findings, 2);
+    }
+
+    #[test]
+    fn external_overlap_agreement_rate_against_quorum() {
+        // pal flagged A as TP, B as FP. Quorum independently has A=TP and
+        // B=TP. Agreement: A matches (1/2), B disagrees (Quorum says TP,
+        // pal says FP). Overlap considers the 2 findings pal also has on
+        // a quorum-known finding_id; agreement_rate = 1/2.
+        let entries = vec![
+            external_fb("A", Verdict::Tp, "pal"),
+            external_fb("B", Verdict::Fp, "pal"),
+        ];
+        let mut quorum: HashMap<String, Verdict> = HashMap::new();
+        quorum.insert("A".into(), Verdict::Tp);
+        quorum.insert("B".into(), Verdict::Tp);
+        let overlap = compute_external_overlap(&entries, &quorum);
+        let pal = overlap.per_agent.iter().find(|a| a.agent == "pal").unwrap();
+        assert_eq!(pal.overlap, 2);
+        assert_eq!(pal.agree, 1);
+        assert!((pal.agreement_rate() - 0.5).abs() < 1e-9);
+    }
+
+    #[test]
+    fn external_overlap_skips_external_entries_quorum_did_not_flag() {
+        // pal flagged A and Z, but quorum only has A. The Z verdict has no
+        // overlap to compute against — count it in `findings` but exclude
+        // from `overlap` / `agree`.
+        let entries = vec![
+            external_fb("A", Verdict::Tp, "pal"),
+            external_fb("Z", Verdict::Tp, "pal"),
+        ];
+        let mut quorum: HashMap<String, Verdict> = HashMap::new();
+        quorum.insert("A".into(), Verdict::Tp);
+        let overlap = compute_external_overlap(&entries, &quorum);
+        let pal = overlap.per_agent.iter().find(|a| a.agent == "pal").unwrap();
+        assert_eq!(pal.findings, 2);
+        assert_eq!(pal.overlap, 1);
+        assert_eq!(pal.agree, 1);
+        assert!((pal.agreement_rate() - 1.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn external_overlap_agreement_rate_zero_for_no_overlap() {
+        // No quorum overlap at all → agreement_rate is 0.0 (not NaN).
+        let entries = vec![external_fb("Z", Verdict::Tp, "pal")];
+        let quorum: HashMap<String, Verdict> = HashMap::new();
+        let overlap = compute_external_overlap(&entries, &quorum);
+        let pal = overlap.per_agent.iter().find(|a| a.agent == "pal").unwrap();
+        assert_eq!(pal.overlap, 0);
+        assert_eq!(pal.agreement_rate(), 0.0);
     }
 
     #[test]

--- a/src/analytics.rs
+++ b/src/analytics.rs
@@ -38,6 +38,8 @@ impl LinkageStats {
 /// entries. Builds a HashSet of known finding_ids so duplicate IDs in the
 /// review log don't inflate the linked count.
 pub fn linkage_stats(reviews: &[ReviewRecord], feedback: &[FeedbackEntry]) -> LinkageStats {
+    use crate::feedback::Provenance;
+
     let known: HashSet<&str> = reviews
         .iter()
         .flat_map(|r| r.finding_ids.iter().map(String::as_str))
@@ -45,6 +47,9 @@ pub fn linkage_stats(reviews: &[ReviewRecord], feedback: &[FeedbackEntry]) -> Li
 
     let mut stats = LinkageStats::default();
     for entry in feedback {
+        if !matches!(&entry.provenance, Provenance::Human | Provenance::PostFix) {
+            continue;
+        }
         match &entry.finding_id {
             Some(fid) if known.contains(fid.as_str()) => stats.linked += 1,
             _ => stats.unlinked += 1,
@@ -345,18 +350,6 @@ pub fn format_channel_attribution(summary: &TierSummary) -> String {
             wfix = cell(s.wontfix),
         )
         .unwrap();
-    }
-
-    // Per-agent External rollup.
-    if !summary.external.per_agent.is_empty() {
-        let top: Vec<String> = summary
-            .external
-            .per_agent
-            .iter()
-            .take(3)
-            .map(|(name, s)| format!("{name} ({})", s.total()))
-            .collect();
-        writeln!(out, "    top agents: {}", top.join(", ")).unwrap();
     }
 
     if summary.unknown.total() > 0 {
@@ -834,7 +827,7 @@ mod tests {
     }
 
     fn fb_with_finding_id(id: &str) -> FeedbackEntry {
-        let mut e = entry("model", Verdict::Tp);
+        let mut e = entry_with(crate::feedback::Provenance::Human, Verdict::Tp);
         e.finding_id = Some(id.into());
         e
     }
@@ -860,7 +853,7 @@ mod tests {
     #[test]
     fn linkage_partial_with_legacy_entries_in_corpus() {
         let reviews = vec![review_with_finding_ids(&["A", "B"])];
-        let mut legacy = entry("model", Verdict::Tp);
+        let mut legacy = entry_with(crate::feedback::Provenance::Human, Verdict::Tp);
         legacy.finding_id = None;
         let feedback = vec![fb_with_finding_id("A"), legacy];
         let stats = linkage_stats(&reviews, &feedback);
@@ -1223,5 +1216,23 @@ mod tests {
         let feedback = vec![fb_with_finding_id("A"), fb_with_finding_id("A")];
         let stats = linkage_stats(&reviews, &feedback);
         assert_eq!(stats.linked, 2);
+    }
+
+    #[test]
+    fn linkage_excludes_non_human_provenance() {
+        use crate::feedback::Provenance;
+        let reviews = vec![review_with_finding_ids(&["A", "B", "C"])];
+        let feedback = vec![
+            fb_with_id_and_provenance("A", Verdict::Tp, Provenance::Human),
+            fb_with_id_and_provenance("B", Verdict::Tp, Provenance::PostFix),
+            fb_with_id_and_provenance("C", Verdict::Tp, Provenance::External {
+                agent: "pal".into(),
+                model: None,
+                confidence: None,
+            }),
+        ];
+        let stats = linkage_stats(&reviews, &feedback);
+        assert_eq!(stats.linked, 2, "only Human + PostFix should count");
+        assert_eq!(stats.unlinked, 0);
     }
 }

--- a/src/ast_grep.rs
+++ b/src/ast_grep.rs
@@ -275,6 +275,7 @@ pub fn scan_file(source: &str, ext: &str, rules: &[RuleConfig<SupportLang>]) -> 
                 };
 
                 findings.push(Finding {
+                    id: crate::finding::new_finding_ulid(),
                     title: format!("{}: {}", rule.id, message),
                     description: message,
                     severity,

--- a/src/ast_grep.rs
+++ b/src/ast_grep.rs
@@ -917,6 +917,10 @@ rule:
             !findings.is_empty(),
             "should flag setHeader('Access-Control-Allow-Origin', '*')"
         );
+        assert!(
+            findings.iter().all(|f| !f.id.is_empty()),
+            "ast-grep findings must carry a non-empty id for linkage"
+        );
 
         let header_fn = "res.header('Access-Control-Allow-Origin', '*');";
         let findings2 = scan_file(header_fn, "ts", &rules);

--- a/src/calibrator.rs
+++ b/src/calibrator.rs
@@ -1055,6 +1055,8 @@ mod tests {
             timestamp: Utc::now(),
             provenance: crate::feedback::Provenance::Human,
             fp_kind: None,
+            finding_id: None,
+            rule_id: None,
         }
     }
 
@@ -1391,6 +1393,8 @@ mod tests {
             timestamp: now - chrono::Duration::days(40),
             provenance: crate::feedback::Provenance::Human,
             fp_kind: Some(crate::feedback::FpKind::TrustModelAssumption),
+            finding_id: None,
+            rule_id: None,
         };
         let halluc_120d = FeedbackEntry {
             timestamp: now - chrono::Duration::days(120),
@@ -1443,6 +1447,8 @@ mod tests {
             timestamp: now - chrono::Duration::days(120),
             provenance: crate::feedback::Provenance::Human,
             fp_kind: Some(crate::feedback::FpKind::Hallucination),
+            finding_id: None,
+            rule_id: None,
         };
         let w = verdict_weight(&entry, now);
         // 1.0 (Human) * e^-1 ≈ 0.36788 — tight tolerance kills 120→119 mutant.
@@ -1464,6 +1470,8 @@ mod tests {
             fp_kind: Some(crate::feedback::FpKind::CompensatingControl {
                 reference: "PR #99".into(),
             }),
+            finding_id: None,
+            rule_id: None,
         };
         let w = verdict_weight(&entry, now);
         assert!((0.366..=0.370).contains(&w), "expected ≈0.368 (120d), got {}", w);
@@ -1485,6 +1493,8 @@ mod tests {
             timestamp: now - chrono::Duration::days(100),
             provenance: crate::feedback::Provenance::Human,
             fp_kind: None,
+            finding_id: None,
+            rule_id: None,
         };
         let trust_entry = FeedbackEntry {
             fp_kind: Some(crate::feedback::FpKind::TrustModelAssumption),
@@ -1529,6 +1539,8 @@ mod tests {
             // we'd get the 40d trust-model branch — weight ≈ 1.0 * e^(-1) =
             // 0.368. The regression lock asserts we land on the 120d default.
             fp_kind: Some(crate::feedback::FpKind::TrustModelAssumption),
+            finding_id: None,
+            rule_id: None,
         };
         let w = verdict_weight(&entry, now);
         // 1.0 (Human) * e^(-40/120) ≈ 0.7165 — uses 120d default branch.
@@ -1558,6 +1570,8 @@ mod tests {
             fp_kind: Some(crate::feedback::FpKind::OutOfScope {
                 tracked_in: Some(format!("#{}", idx)),
             }),
+            finding_id: None,
+            rule_id: None,
         };
         let feedback = vec![make_oos(1), make_oos(2), make_oos(3)];
         let findings = vec![
@@ -1591,6 +1605,8 @@ mod tests {
             timestamp: chrono::Utc::now() - chrono::Duration::days(idx),
             provenance: crate::feedback::Provenance::Human,
             fp_kind: Some(crate::feedback::FpKind::Hallucination),
+            finding_id: None,
+            rule_id: None,
         };
         let feedback = vec![make_halluc(1), make_halluc(2), make_halluc(3)];
         let findings = vec![
@@ -1633,6 +1649,8 @@ mod tests {
             fp_kind: Some(crate::feedback::FpKind::OutOfScope {
                 tracked_in: Some(format!("#{}", idx)),
             }),
+            finding_id: None,
+            rule_id: None,
         };
         let entries = vec![make_oos(1), make_oos(2), make_oos(3)];
         for e in &entries {
@@ -1928,6 +1946,8 @@ mod tests {
             timestamp: Utc::now(),
             provenance: crate::feedback::Provenance::AutoCalibrate("o3".into()),
             fp_kind: None,
+            finding_id: None,
+            rule_id: None,
         };
         let feedback = vec![auto_fb.clone(), auto_fb];
         let config = CalibratorConfig {
@@ -1951,6 +1971,8 @@ mod tests {
             timestamp: Utc::now(),
             provenance: crate::feedback::Provenance::AutoCalibrate("o3".into()),
             fp_kind: None,
+            finding_id: None,
+            rule_id: None,
         };
         let human_fb = FeedbackEntry {
             provenance: crate::feedback::Provenance::Human,
@@ -1995,6 +2017,8 @@ mod tests {
             timestamp: Utc::now(),
             provenance: crate::feedback::Provenance::Human,
             fp_kind: None,
+            finding_id: None,
+            rule_id: None,
         };
         let auto_fp = FeedbackEntry {
             file_path: "test.py".into(),
@@ -2006,6 +2030,8 @@ mod tests {
             timestamp: Utc::now(),
             provenance: crate::feedback::Provenance::AutoCalibrate("o3".into()),
             fp_kind: None,
+            finding_id: None,
+            rule_id: None,
         };
 
         // Human (1.0) + auto (0.5) = 1.5 >= threshold -> suppress
@@ -2031,6 +2057,8 @@ mod tests {
             timestamp: Utc::now() - chrono::Duration::days(90),
             provenance: crate::feedback::Provenance::Human,
             fp_kind: None,
+            finding_id: None,
+            rule_id: None,
         };
         let recent_fp = FeedbackEntry {
             file_path: "test.rs".into(),
@@ -2042,6 +2070,8 @@ mod tests {
             timestamp: Utc::now(),
             provenance: crate::feedback::Provenance::Human,
             fp_kind: None,
+            finding_id: None,
+            rule_id: None,
         };
 
         let config = CalibratorConfig::default();
@@ -2067,6 +2097,8 @@ mod tests {
             timestamp: Utc::now(),
             provenance: crate::feedback::Provenance::Human,
             fp_kind: None,
+            finding_id: None,
+            rule_id: None,
         };
 
         let config = CalibratorConfig::default();
@@ -2087,6 +2119,8 @@ mod tests {
             timestamp: Utc::now() - chrono::Duration::days(90),
             provenance: crate::feedback::Provenance::Human,
             fp_kind: None,
+            finding_id: None,
+            rule_id: None,
         };
         let weight = verdict_weight(&old_entry, Utc::now());
         assert!(weight >= 0.3,
@@ -2107,6 +2141,8 @@ mod tests {
             timestamp: Utc::now(),
             provenance: crate::feedback::Provenance::PostFix,
             fp_kind: None,
+            finding_id: None,
+            rule_id: None,
         };
 
         let config = CalibratorConfig::default();
@@ -2130,6 +2166,8 @@ mod tests {
             timestamp: Utc::now(),
             provenance: crate::feedback::Provenance::AutoCalibrate("o3".into()),
             fp_kind: None,
+            finding_id: None,
+            rule_id: None,
         };
         let feedback = vec![auto_fb.clone(), auto_fb.clone(), auto_fb.clone(), auto_fb];
         let config = CalibratorConfig::default();
@@ -2152,6 +2190,8 @@ mod tests {
             timestamp: Utc::now(),
             provenance: crate::feedback::Provenance::AutoCalibrate("o3".into()),
             fp_kind: None,
+            finding_id: None,
+            rule_id: None,
         };
         let human_fb = FeedbackEntry {
             provenance: crate::feedback::Provenance::Human,
@@ -2280,6 +2320,8 @@ mod tests {
             timestamp: Utc::now(),
             provenance: crate::feedback::Provenance::PostFix,
             fp_kind: None,
+            finding_id: None,
+            rule_id: None,
         };
 
         let config = CalibratorConfig::default();
@@ -2806,6 +2848,8 @@ mod tests {
             timestamp: Utc::now(),
             provenance: crate::feedback::Provenance::Human,
             fp_kind: None,
+            finding_id: None,
+            rule_id: None,
         }
     }
 
@@ -2912,6 +2956,8 @@ mod tests {
                 confidence: None,
             },
             fp_kind: None,
+            finding_id: None,
+            rule_id: None,
         };
         let w = verdict_weight(&entry, Utc::now());
         assert!((w - 0.7).abs() < 0.01, "expected ~0.7, got {w}");
@@ -2936,6 +2982,8 @@ mod tests {
                 confidence: conf,
             },
             fp_kind: None,
+            finding_id: None,
+            rule_id: None,
         };
         let cases: &[(&str, Option<f32>)] = &[
             ("None", None),
@@ -2968,6 +3016,8 @@ mod tests {
             timestamp: Utc::now(),
             provenance: crate::feedback::Provenance::Unknown,
             fp_kind: None,
+            finding_id: None,
+            rule_id: None,
         };
         let w = verdict_weight(&entry, Utc::now());
         assert!((w - 0.3).abs() < 0.01, "Unknown must stay at 0.3, got {w}");
@@ -2991,6 +3041,8 @@ mod tests {
                 confidence: None,
             },
             fp_kind: None,
+            finding_id: None,
+            rule_id: None,
         }
     }
 
@@ -3094,6 +3146,8 @@ mod tests {
                 confidence: None,
             },
             fp_kind: None,
+            finding_id: None,
+            rule_id: None,
         }
     }
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -350,6 +350,12 @@ pub struct StatsOpts {
     /// precision math is trustworthy or should fall back to entry-level.
     #[arg(long)]
     pub join_health: bool,
+
+    /// Show all dimensional drill-downs (By caller, Rolling N reviews).
+    /// Default omits these to keep the dashboard scannable; By repo is
+    /// always shown.
+    #[arg(long)]
+    pub full: bool,
 }
 
 fn parse_rolling_n(s: &str) -> Result<usize, String> {

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -344,6 +344,12 @@ pub struct StatsOpts {
     /// default dashboard. Restores the pre-highlights output shape.
     #[arg(long)]
     pub minimal: bool,
+
+    /// Diagnostic: report reviews↔feedback finding_id linkage rate and
+    /// short-circuit the normal dashboard. Use to assess whether per-finding
+    /// precision math is trustworthy or should fall back to entry-level.
+    #[arg(long)]
+    pub join_health: bool,
 }
 
 fn parse_rolling_n(s: &str) -> Result<usize, String> {

--- a/src/context/phase6_integration_tests.rs
+++ b/src/context/phase6_integration_tests.rs
@@ -359,6 +359,7 @@ async fn end_to_end_review_with_context_injection_logs_telemetry() {
         flags: Flags::default(),
         mode: None,
         context: tele.clone(),
+        finding_ids: Vec::new(),
     };
     log.record(&record).unwrap();
 

--- a/src/dimensions.rs
+++ b/src/dimensions.rs
@@ -405,6 +405,7 @@ mod tests {
             flags: Flags::default(),
             mode: None,
             context: Default::default(),
+        finding_ids: Vec::new(),
         }
     }
 

--- a/src/feedback.rs
+++ b/src/feedback.rs
@@ -2273,6 +2273,23 @@ mod tests {
         let result: Result<FeedbackEntry, _> = serde_json::from_str(bad_json);
         assert!(result.is_err(), "non-string finding_id must fail to deserialize");
     }
+
+    #[test]
+    fn legacy_row_resave_does_not_introduce_finding_id_or_rule_id_keys() {
+        // The actual disk-bloat regression test: read a legacy row, serialize
+        // it back, and assert no new keys appeared. This guards the
+        // read/modify/write path used by FeedbackStore and the daemon — if
+        // either silently injected `"finding_id":null` on rewrite, the entire
+        // feedback.jsonl would gradually accumulate ~30 KB of null pollution
+        // on full corpus rewrites.
+        let legacy = r#"{"file_path":"x.rs","finding_title":"t","finding_category":"security","verdict":"tp","reason":"r","model":"gpt","timestamp":"2026-01-01T00:00:00Z"}"#;
+        let entry: FeedbackEntry = serde_json::from_str(legacy).expect("legacy load");
+        let resaved = serde_json::to_string(&entry).expect("resave");
+        assert!(!resaved.contains("\"finding_id\""),
+            "resave must not introduce finding_id key: {resaved}");
+        assert!(!resaved.contains("\"rule_id\""),
+            "resave must not introduce rule_id key: {resaved}");
+    }
 }
 
 #[cfg(test)]

--- a/src/feedback.rs
+++ b/src/feedback.rs
@@ -108,6 +108,18 @@ pub struct FeedbackEntry {
     /// ContextMisleading.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub fp_kind: Option<FpKind>,
+
+    /// Stable identifier for the source finding (ULID). Forward-only — None on
+    /// legacy entries (pre stats-redesign rollout). Used for per-finding
+    /// deduplication when computing precision.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub finding_id: Option<String>,
+
+    /// AST rule that produced the finding, if any (e.g. "python/md5-usage").
+    /// Forward-only — None on legacy entries and on findings from non-rule
+    /// sources (LLM, linter, custom AST patterns).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub rule_id: Option<String>,
 }
 
 /// Input for recording a verdict from an external review agent.
@@ -798,6 +810,8 @@ impl FeedbackStore {
                 confidence,
             },
             fp_kind: None,
+            finding_id: None,
+            rule_id: None,
         };
         self.record(&entry)
     }
@@ -823,6 +837,8 @@ impl FeedbackStore {
             timestamp: Utc::now(),
             provenance: Provenance::Human,
             fp_kind: None,
+            finding_id: None,
+            rule_id: None,
         };
         self.record(&entry)
     }
@@ -909,6 +925,8 @@ mod tests {
             timestamp: Utc::now(),
             provenance: Provenance::Human,
             fp_kind,
+            finding_id: None,
+            rule_id: None,
         }
     }
 
@@ -1052,6 +1070,8 @@ mod tests {
             timestamp: Utc::now(),
             provenance: Provenance::Unknown,
             fp_kind: None,
+            finding_id: None,
+            rule_id: None,
         }
     }
 
@@ -1125,6 +1145,8 @@ mod tests {
             timestamp: Utc::now(),
             provenance: Provenance::Human,
             fp_kind: None,
+            finding_id: None,
+            rule_id: None,
         };
         assert_eq!(entry.provenance, Provenance::Human);
     }
@@ -1285,6 +1307,8 @@ mod tests {
                 confidence: Some(0.9),
             },
             fp_kind: None,
+            finding_id: None,
+            rule_id: None,
         };
         store.record(&entry).unwrap();
         let all = store.load_all().unwrap();
@@ -2152,6 +2176,102 @@ mod tests {
         let msg = report.errors[0].message.to_lowercase();
         assert!(msg.contains("tp") || msg.contains("verdict") || msg.contains("unknown variant"),
             "error must reference the bad verdict: {}", report.errors[0].message);
+    }
+
+    // ─── Stats redesign Phase 0: finding_id / rule_id schema additions ───
+    //
+    // FeedbackEntry is persisted JSONL. These tests pin the migration contract:
+    //   - legacy rows (pre-rollout) must still deserialize cleanly,
+    //   - None values must NOT serialize as `"finding_id":null` (disk bloat),
+    //   - the field types stay String, not arbitrary JSON values.
+
+    #[test]
+    fn legacy_jsonl_row_loads_with_none_finding_id_and_rule_id() {
+        // A row written before the schema bump — no finding_id or rule_id keys.
+        let legacy_json = r#"{"file_path":"x.rs","finding_title":"t","finding_category":"security","verdict":"tp","reason":"r","model":"gpt","timestamp":"2026-01-01T00:00:00Z"}"#;
+        let entry: FeedbackEntry = serde_json::from_str(legacy_json)
+            .expect("legacy row must still deserialize");
+        assert_eq!(entry.finding_id, None);
+        assert_eq!(entry.rule_id, None);
+    }
+
+    #[test]
+    fn entry_with_none_finding_id_serializes_without_null_pollution() {
+        // Disk-bloat regression: with ~1,470 historical rows in feedback.jsonl,
+        // injecting `"finding_id":null` on every legacy row would bloat the file
+        // by ~30 KB. skip_serializing_if must omit the key entirely.
+        let entry = FeedbackEntry {
+            file_path: "f.rs".into(),
+            finding_title: "t".into(),
+            finding_category: "c".into(),
+            verdict: Verdict::Tp,
+            reason: "r".into(),
+            model: None,
+            timestamp: Utc::now(),
+            provenance: Provenance::Human,
+            fp_kind: None,
+            finding_id: None,
+            rule_id: None,
+        };
+        let json = serde_json::to_string(&entry).expect("serialize");
+        assert!(!json.contains("\"finding_id\""), "json must not contain finding_id key when None: {json}");
+        assert!(!json.contains("\"rule_id\""), "json must not contain rule_id key when None: {json}");
+    }
+
+    #[test]
+    fn entry_with_some_finding_id_round_trips_losslessly() {
+        let entry = FeedbackEntry {
+            file_path: "f.rs".into(),
+            finding_title: "t".into(),
+            finding_category: "c".into(),
+            verdict: Verdict::Tp,
+            reason: "r".into(),
+            model: None,
+            timestamp: Utc::now(),
+            provenance: Provenance::Human,
+            fp_kind: None,
+            finding_id: Some("01HXYZ1234567890ABCDEFGHJK".into()),
+            rule_id: Some("python/eval-non-literal".into()),
+        };
+        let json = serde_json::to_string(&entry).expect("serialize");
+        let back: FeedbackEntry = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(back.finding_id.as_deref(), Some("01HXYZ1234567890ABCDEFGHJK"));
+        assert_eq!(back.rule_id.as_deref(), Some("python/eval-non-literal"));
+    }
+
+    #[test]
+    fn entry_round_trips_with_only_rule_id_no_finding_id() {
+        // Forward-only AST-rule scoring case: ast-grep rule fires, but the
+        // finding wasn't given a stable identity yet (e.g. legacy review path).
+        let entry = FeedbackEntry {
+            file_path: "f.py".into(),
+            finding_title: "t".into(),
+            finding_category: "security".into(),
+            verdict: Verdict::Tp,
+            reason: "r".into(),
+            model: None,
+            timestamp: Utc::now(),
+            provenance: Provenance::Human,
+            fp_kind: None,
+            finding_id: None,
+            rule_id: Some("python/md5-usage".into()),
+        };
+        let json = serde_json::to_string(&entry).expect("serialize");
+        assert!(!json.contains("\"finding_id\""), "finding_id should be omitted: {json}");
+        assert!(json.contains("\"rule_id\":\"python/md5-usage\""),
+            "rule_id must be present in json: {json}");
+        let back: FeedbackEntry = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(back.finding_id, None);
+        assert_eq!(back.rule_id.as_deref(), Some("python/md5-usage"));
+    }
+
+    #[test]
+    fn entry_rejects_nonstring_finding_id() {
+        // Defensive contract: finding_id is a String, not arbitrary JSON.
+        // Catches accidental refactors to Option<serde_json::Value>.
+        let bad_json = r#"{"file_path":"x.rs","finding_title":"t","finding_category":"c","verdict":"tp","reason":"r","model":null,"timestamp":"2026-01-01T00:00:00Z","finding_id":42}"#;
+        let result: Result<FeedbackEntry, _> = serde_json::from_str(bad_json);
+        assert!(result.is_err(), "non-string finding_id must fail to deserialize");
     }
 }
 

--- a/src/feedback_index.rs
+++ b/src/feedback_index.rs
@@ -471,6 +471,8 @@ mod tests {
             timestamp: Utc::now(),
             provenance: Provenance::Unknown,
             fp_kind: None,
+            finding_id: None,
+            rule_id: None,
         }
     }
 
@@ -742,6 +744,8 @@ mod tests {
             timestamp: ts,
             provenance: Provenance::Human,
             fp_kind: None,
+            finding_id: None,
+            rule_id: None,
         };
         let e_fp = FeedbackEntry { verdict: Verdict::Fp, reason: "false alarm".into(), ..e_tp.clone() };
         store.record(&e_tp).unwrap();

--- a/src/finding.rs
+++ b/src/finding.rs
@@ -1,6 +1,16 @@
 use crate::category::Category;
 use serde::{Deserialize, Serialize};
 
+/// Generate a fresh ULID for a Finding's `id`.
+///
+/// Used both as the FindingBuilder default and as the serde-default for
+/// pre-rollout JSON dumps that lack the `id` field. ULID is monotonic-ish,
+/// 26 chars in Crockford base32 — short enough to display in CLI output,
+/// stable enough to dedup feedback against.
+pub fn new_finding_ulid() -> String {
+    ulid::Ulid::new().to_string()
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum Severity {
@@ -57,6 +67,12 @@ pub enum GroundingStatus {
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Finding {
+    /// Stable per-finding identifier (ULID, 26 chars). Generated at build
+    /// time so it's available for feedback recording, dedup, and reviews.jsonl
+    /// linkage. `#[serde(default)]` mints a fresh ULID for legacy JSON
+    /// dumps that pre-date this field.
+    #[serde(default = "new_finding_ulid")]
+    pub id: String,
     pub title: String,
     pub description: String,
     pub severity: Severity,
@@ -116,6 +132,7 @@ impl FindingBuilder {
     pub fn new() -> Self {
         Self {
             inner: Finding {
+                id: new_finding_ulid(),
                 title: "Test finding".into(),
                 description: "Test description".into(),
                 severity: Severity::Info,
@@ -135,6 +152,14 @@ impl FindingBuilder {
                 grounding_status: None,
             },
         }
+    }
+
+    /// Override the auto-generated ULID. Use only when reconstructing a
+    /// known finding (e.g. JSON re-parse, MCP round-trip); production code
+    /// should let `new()` mint a fresh ULID.
+    pub fn id(mut self, id: &str) -> Self {
+        self.inner.id = id.into();
+        self
     }
 
     pub fn title(mut self, t: &str) -> Self {
@@ -282,6 +307,7 @@ mod tests {
     #[test]
     fn finding_serializes_to_json_with_all_fields() {
         let f = Finding {
+            id: new_finding_ulid(),
             title: "Unvalidated input".into(),
             description: "User input flows to db.execute()".into(),
             severity: Severity::Critical,
@@ -315,6 +341,7 @@ mod tests {
     #[test]
     fn finding_json_roundtrip() {
         let original = Finding {
+            id: new_finding_ulid(),
             title: "Test finding".into(),
             description: "A test".into(),
             severity: Severity::High,
@@ -341,6 +368,7 @@ mod tests {
     #[test]
     fn finding_with_empty_optional_fields_serializes_cleanly() {
         let f = Finding {
+            id: new_finding_ulid(),
             title: "Minimal".into(),
             description: "Desc".into(),
             severity: Severity::Info,
@@ -369,6 +397,7 @@ mod tests {
     #[test]
     fn finding_line_range_valid() {
         let f = Finding {
+            id: new_finding_ulid(),
             title: "T".into(),
             description: "D".into(),
             severity: Severity::Info,
@@ -393,6 +422,7 @@ mod tests {
     #[test]
     fn finding_line_range_single_line_valid() {
         let f = Finding {
+            id: new_finding_ulid(),
             title: "T".into(),
             description: "D".into(),
             severity: Severity::Info,
@@ -417,6 +447,7 @@ mod tests {
     #[test]
     fn finding_line_range_inverted_invalid() {
         let f = Finding {
+            id: new_finding_ulid(),
             title: "T".into(),
             description: "D".into(),
             severity: Severity::Info,
@@ -441,6 +472,7 @@ mod tests {
     #[test]
     fn finding_line_range_zero_start_invalid() {
         let f = Finding {
+            id: new_finding_ulid(),
             title: "T".into(),
             description: "D".into(),
             severity: Severity::Info,
@@ -560,5 +592,42 @@ mod tests {
         let f = FindingBuilder::new().build();
         let json = serde_json::to_string(&f).unwrap();
         assert!(!json.contains("based_on_excerpt"));
+    }
+
+    // ─── Stats redesign Phase 0: Finding.id (per-finding identity) ───
+
+    #[test]
+    fn finding_builder_assigns_unique_ulid_id() {
+        let a = FindingBuilder::new().build();
+        let b = FindingBuilder::new().build();
+        assert_eq!(a.id.len(), 26, "ULID is 26 chars in canonical Crockford encoding");
+        assert_ne!(a.id, b.id, "each FindingBuilder produces a fresh ULID");
+        // ULID monotonicity isn't guaranteed across rapid calls; just check
+        // both are valid Crockford-base32 — alphanumeric, no I/L/O/U.
+        for c in a.id.chars() {
+            assert!(c.is_ascii_alphanumeric(), "ULID char must be alphanumeric: {c}");
+        }
+    }
+
+    #[test]
+    fn finding_id_explicit_overrides_builder_default() {
+        let f = FindingBuilder::new().id("my-explicit-id").build();
+        assert_eq!(f.id, "my-explicit-id");
+    }
+
+    #[test]
+    fn finding_serializes_id_into_json() {
+        let f = FindingBuilder::new().id("01HXYZ").build();
+        let json = serde_json::to_string(&f).unwrap();
+        assert!(json.contains("\"id\":\"01HXYZ\""), "id must appear in JSON: {json}");
+    }
+
+    #[test]
+    fn finding_legacy_json_without_id_deserializes_with_default() {
+        // Pre-rollout JSON dumps (e.g. piped output saved to disk before the
+        // schema bump) must still load. They get a freshly-minted ULID.
+        let legacy = r#"{"title":"t","description":"d","severity":"info","category":"maintainability","source":"local-ast","line_start":1,"line_end":1,"evidence":[],"calibrator_action":null,"similar_precedent":[]}"#;
+        let f: Finding = serde_json::from_str(legacy).expect("legacy load");
+        assert_eq!(f.id.len(), 26, "missing id deserializes to a fresh ULID");
     }
 }

--- a/src/finding.rs
+++ b/src/finding.rs
@@ -11,6 +11,15 @@ pub fn new_finding_ulid() -> String {
     ulid::Ulid::new().to_string()
 }
 
+/// Collect the stable IDs of a slice of findings, in order.
+///
+/// Used at review-write time to populate `ReviewRecord.finding_ids` so
+/// `feedback.jsonl` entries (`FeedbackEntry.finding_id`) can be joined
+/// back to their originating review for per-finding precision math.
+pub fn collect_finding_ids(findings: &[Finding]) -> Vec<String> {
+    findings.iter().map(|f| f.id.clone()).collect()
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum Severity {
@@ -629,5 +638,20 @@ mod tests {
         let legacy = r#"{"title":"t","description":"d","severity":"info","category":"maintainability","source":"local-ast","line_start":1,"line_end":1,"evidence":[],"calibrator_action":null,"similar_precedent":[]}"#;
         let f: Finding = serde_json::from_str(legacy).expect("legacy load");
         assert_eq!(f.id.len(), 26, "missing id deserializes to a fresh ULID");
+    }
+
+    #[test]
+    fn collect_finding_ids_preserves_order() {
+        let a = FindingBuilder::new().id("ID-A").build();
+        let b = FindingBuilder::new().id("ID-B").build();
+        let c = FindingBuilder::new().id("ID-C").build();
+        let ids = collect_finding_ids(&[a, b, c]);
+        assert_eq!(ids, vec!["ID-A", "ID-B", "ID-C"]);
+    }
+
+    #[test]
+    fn collect_finding_ids_empty_input_yields_empty_vec() {
+        let ids = collect_finding_ids(&[]);
+        assert!(ids.is_empty());
     }
 }

--- a/src/finding.rs
+++ b/src/finding.rs
@@ -165,8 +165,12 @@ impl FindingBuilder {
 
     /// Override the auto-generated ULID. Use only when reconstructing a
     /// known finding (e.g. JSON re-parse, MCP round-trip); production code
-    /// should let `new()` mint a fresh ULID.
+    /// should let `new()` mint a fresh ULID. Empty strings are rejected
+    /// because `id` is the join key for `collect_finding_ids` and
+    /// `analytics::linkage_stats` — an empty id would collide with every
+    /// other empty id and silently corrupt linkage.
     pub fn id(mut self, id: &str) -> Self {
+        assert!(!id.is_empty(), "FindingBuilder::id: id must be non-empty");
         self.inner.id = id.into();
         self
     }
@@ -622,6 +626,18 @@ mod tests {
     fn finding_id_explicit_overrides_builder_default() {
         let f = FindingBuilder::new().id("my-explicit-id").build();
         assert_eq!(f.id, "my-explicit-id");
+    }
+
+    #[test]
+    #[should_panic(expected = "non-empty")]
+    fn finding_builder_id_rejects_empty_string() {
+        // Empty IDs would silently corrupt collect_finding_ids /
+        // linkage_stats: every finding with id="" would join to every
+        // feedback row with the same empty id. The default
+        // (`new_finding_ulid`) is non-empty by construction; the explicit
+        // setter must enforce the same invariant for round-trip /
+        // test-fixture callers.
+        let _ = FindingBuilder::new().id("").build();
     }
 
     #[test]

--- a/src/linter.rs
+++ b/src/linter.rs
@@ -890,6 +890,7 @@ mod tests {
         assert!(findings[0].title.contains("F401"));
         assert_eq!(findings[0].line_start, 1);
         assert_eq!(findings[0].source, Source::Linter("ruff".into()));
+        assert!(!findings[0].id.is_empty(), "linter findings must carry a non-empty id for linkage");
     }
 
     #[test]

--- a/src/linter.rs
+++ b/src/linter.rs
@@ -274,6 +274,7 @@ pub fn normalize_ruff_output(json_output: &str) -> anyhow::Result<Vec<Finding>> 
         let severity = ruff_code_to_severity(code);
 
         findings.push(Finding {
+            id: crate::finding::new_finding_ulid(),
             title: format!("{}: {}", code, message),
             description: message.to_string(),
             severity,
@@ -333,6 +334,7 @@ pub fn normalize_clippy_output(json_output: &str) -> anyhow::Result<Vec<Finding>
         };
 
         findings.push(Finding {
+            id: crate::finding::new_finding_ulid(),
             title: format!("{}: {}", code, message),
             description: message.to_string(),
             severity,
@@ -380,6 +382,7 @@ pub fn normalize_eslint_output(json_output: &str) -> anyhow::Result<Vec<Finding>
             };
 
             findings.push(Finding {
+                id: crate::finding::new_finding_ulid(),
                 title: format!("{}: {}", rule_id, message),
                 description: message.to_string(),
                 severity,
@@ -441,6 +444,7 @@ pub fn normalize_yamllint_output(output: &str) -> anyhow::Result<Vec<Finding>> {
         };
 
         findings.push(Finding {
+            id: crate::finding::new_finding_ulid(),
             title: format!("yamllint: {}", message),
             description: message.to_string(),
             severity,
@@ -485,6 +489,7 @@ pub fn normalize_shellcheck_output(json_output: &str) -> anyhow::Result<Vec<Find
             };
 
             findings.push(Finding {
+                id: crate::finding::new_finding_ulid(),
                 title: format!("SC{}: {}", code, message),
                 description: message.to_string(),
                 severity,
@@ -546,6 +551,7 @@ pub fn normalize_hadolint_output(output: &str) -> anyhow::Result<Vec<Finding>> {
         };
 
         findings.push(Finding {
+            id: crate::finding::new_finding_ulid(),
             title: format!("{}: {}", rule, message),
             description: message.to_string(),
             severity,
@@ -591,6 +597,7 @@ pub fn normalize_tflint_output(json_output: &str) -> anyhow::Result<Vec<Finding>
             };
 
             findings.push(Finding {
+                id: crate::finding::new_finding_ulid(),
                 title: format!("{}: {}", rule_name, message),
                 description: message.to_string(),
                 severity,

--- a/src/main.rs
+++ b/src/main.rs
@@ -319,18 +319,39 @@ async fn main() -> anyhow::Result<()> {
 /// Pure function — reads the JSONL files but produces a String rather than
 /// printing, so unit tests can pin the contract on a tempdir fixture.
 fn format_join_health(quorum_home: &std::path::Path) -> String {
+    use std::fmt::Write;
+
     let log = review_log::ReviewLog::new(quorum_home.join("reviews.jsonl"));
-    let reviews = log.load_all().unwrap_or_default();
+    let reviews = match log.load_all() {
+        Ok(r) => r,
+        Err(e) => {
+            // Surface the failure rather than rendering a misleading
+            // "0 reviews" line. The diagnostic exists to assess data
+            // health — silent zeros would defeat the point.
+            let mut out = String::new();
+            writeln!(out, "Linkage health").unwrap();
+            writeln!(out, "  ERROR: failed to read reviews.jsonl: {e}").unwrap();
+            return out;
+        }
+    };
 
     let store = feedback::FeedbackStore::new(quorum_home.join("feedback.jsonl"));
-    let feedback = store.load_all().unwrap_or_default();
+    let feedback = match store.load_all() {
+        Ok(f) => f,
+        Err(e) => {
+            let mut out = String::new();
+            writeln!(out, "Linkage health").unwrap();
+            writeln!(out, "  ERROR: failed to read feedback.jsonl: {e}").unwrap();
+            return out;
+        }
+    };
 
     let stats = analytics::linkage_stats(&reviews, &feedback);
     let total_findings: usize = reviews.iter().map(|r| r.finding_ids.len()).sum();
-    let rate_pct = (stats.rate() * 100.0).round() as u32;
+    let rate = stats.rate();
+    let rate_pct = (rate * 100.0).round() as u32;
 
     let mut out = String::new();
-    use std::fmt::Write;
     writeln!(out, "Linkage health").unwrap();
     writeln!(
         out,
@@ -349,7 +370,7 @@ fn format_join_health(quorum_home: &std::path::Path) -> String {
     .unwrap();
     if stats.linked + stats.unlinked == 0 {
         writeln!(out, "  Linkage rate: — (no feedback entries)").unwrap();
-    } else if rate_pct < 85 {
+    } else if rate < 0.85 {
         writeln!(
             out,
             "  Linkage rate: {}%   ← below 85% threshold; per-finding precision falls back to entry-level",
@@ -2572,6 +2593,55 @@ mod join_health_tests {
         assert!(out.contains("Feedback: 2 entries (1 linked, 1 unlinked legacy)"), "got:\n{out}");
         assert!(out.contains("50%"), "rate must show as 50%: got:\n{out}");
         assert!(out.contains("below 85% threshold"), "fallback banner missing: got:\n{out}");
+    }
+
+    #[test]
+    fn join_health_surfaces_review_log_read_error_instead_of_silent_zeros() {
+        // Regression: load_all().unwrap_or_default() silently swallows IO
+        // errors and renders a healthy-looking "0 reviews" line. Make
+        // reviews.jsonl unreadable (here: a directory at that path) and
+        // assert the diagnostic surfaces the failure rather than lying.
+        let dir = TempDir::new().unwrap();
+        std::fs::create_dir(dir.path().join("reviews.jsonl")).unwrap();
+
+        let out = format_join_health(dir.path());
+        assert!(
+            out.to_lowercase().contains("error"),
+            "must surface read failure; got:\n{out}"
+        );
+        assert!(
+            !out.contains("Reviews: 0 with"),
+            "must not falsely report empty dataset; got:\n{out}"
+        );
+    }
+
+    #[test]
+    fn join_health_rate_below_85_that_rounds_to_85_still_shows_fallback() {
+        // Regression: rate-then-round comparison gives a false pass at the
+        // 85% gate. 169 linked + 31 unlinked = 200 entries → exactly 84.5%
+        // linkage. Rust's f64::round is round-half-away-from-zero, so
+        // (84.5).round() == 85.0. The threshold check must compare the
+        // unrounded rate, not the rendered integer percent.
+        let dir = TempDir::new().unwrap();
+        let ids: Vec<String> = (0..169).map(|i| format!("\"FID-{i}\"")).collect();
+        let id_array = format!("[{}]", ids.join(","));
+        write_jsonl(dir.path(), "reviews.jsonl", &[
+            &format!(r#"{{"run_id":"R1","timestamp":"2026-01-01T00:00:00Z","quorum_version":"0.1","repo":null,"invoked_from":"tty","model":"gpt","files_reviewed":1,"lines_added":null,"lines_removed":null,"findings_by_severity":{{"critical":0,"high":0,"medium":0,"low":0,"info":0}},"tokens_in":0,"tokens_out":0,"duration_ms":0,"finding_ids":{}}}"#, id_array),
+        ]);
+        let mut fb_lines: Vec<String> = (0..169).map(|i| {
+            format!(r#"{{"file_path":"x.rs","finding_title":"t","finding_category":"c","verdict":"tp","reason":"r","model":null,"timestamp":"2026-01-01T00:00:00Z","finding_id":"FID-{}"}}"#, i)
+        }).collect();
+        for _ in 0..31 {
+            fb_lines.push(r#"{"file_path":"y.rs","finding_title":"t","finding_category":"c","verdict":"fp","reason":"r","model":null,"timestamp":"2026-01-01T00:00:00Z"}"#.to_string());
+        }
+        let fb_refs: Vec<&str> = fb_lines.iter().map(|s| s.as_str()).collect();
+        write_jsonl(dir.path(), "feedback.jsonl", &fb_refs);
+
+        let out = format_join_health(dir.path());
+        assert!(
+            out.contains("below 85% threshold"),
+            "84.5% must trigger fallback banner; got:\n{out}"
+        );
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -139,6 +139,15 @@ async fn main() -> anyhow::Result<()> {
             // `$HOME/.quorum`, then to `./.quorum` as a last resort.
             let quorum_home = quorum_dir().unwrap_or_else(|| std::path::PathBuf::from(".quorum"));
 
+            // --join-health diagnostic: short-circuit normal dashboard, just
+            // report reviews↔feedback finding_id linkage rate. Used to assess
+            // whether per-finding precision math (Phase A) is trustworthy or
+            // should fall back to entry-level with a banner.
+            if opts.join_health {
+                let exit_code = run_join_health(&quorum_home);
+                std::process::exit(exit_code);
+            }
+
             // Dimensional views read reviews.jsonl and aggregate via the
             // `dimensions` module. Classic dims: --by-repo/--by-caller/--rolling.
             // Context dims (Task 6.3): --by-source/--by-reviewed-repo/--misleading.
@@ -303,6 +312,71 @@ async fn main() -> anyhow::Result<()> {
         }
     }
     Ok(())
+}
+
+/// Build the rendered `--join-health` diagnostic from a quorum state dir.
+///
+/// Pure function — reads the JSONL files but produces a String rather than
+/// printing, so unit tests can pin the contract on a tempdir fixture.
+fn format_join_health(quorum_home: &std::path::Path) -> String {
+    let log = review_log::ReviewLog::new(quorum_home.join("reviews.jsonl"));
+    let reviews = log.load_all().unwrap_or_default();
+
+    let store = feedback::FeedbackStore::new(quorum_home.join("feedback.jsonl"));
+    let feedback = store.load_all().unwrap_or_default();
+
+    let stats = analytics::linkage_stats(&reviews, &feedback);
+    let total_findings: usize = reviews.iter().map(|r| r.finding_ids.len()).sum();
+    let rate_pct = (stats.rate() * 100.0).round() as u32;
+
+    let mut out = String::new();
+    use std::fmt::Write;
+    writeln!(out, "Linkage health").unwrap();
+    writeln!(
+        out,
+        "  Reviews: {} with {} findings",
+        reviews.len(),
+        total_findings
+    )
+    .unwrap();
+    writeln!(
+        out,
+        "  Feedback: {} entries ({} linked, {} unlinked legacy)",
+        feedback.len(),
+        stats.linked,
+        stats.unlinked
+    )
+    .unwrap();
+    if stats.linked + stats.unlinked == 0 {
+        writeln!(out, "  Linkage rate: — (no feedback entries)").unwrap();
+    } else if rate_pct < 85 {
+        writeln!(
+            out,
+            "  Linkage rate: {}%   ← below 85% threshold; per-finding precision falls back to entry-level",
+            rate_pct
+        )
+        .unwrap();
+    } else {
+        writeln!(
+            out,
+            "  Linkage rate: {}%   ← per-finding precision math active",
+            rate_pct
+        )
+        .unwrap();
+    }
+    out
+}
+
+/// `quorum stats --join-health` — diagnostic that reports the
+/// reviews↔feedback `finding_id` linkage rate. Used to assess whether
+/// per-finding precision math (Phase A headline trend) is trustworthy or
+/// should fall back to entry-level with a banner.
+///
+/// Exit code is always 0 — this is a diagnostic, not a check. A low
+/// linkage rate is a real-world condition during rollout, not a failure.
+fn run_join_health(quorum_home: &std::path::Path) -> i32 {
+    print!("{}", format_join_health(quorum_home));
+    0
 }
 
 /// Translate clap args for `quorum context ...` into a `ContextCmd` and run
@@ -2454,5 +2528,76 @@ mod feedback_tests {
             }
             other => panic!("expected ContextMisleading, got {:?}", other),
         }
+    }
+}
+
+#[cfg(test)]
+mod join_health_tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    /// Write `content` (already JSONL-formatted) to `dir/<name>` for the
+    /// fixture-driven format_join_health tests. Builders rather than
+    /// inline JSON literals so test intent reads top-to-bottom.
+    fn write_jsonl(dir: &std::path::Path, name: &str, lines: &[&str]) {
+        let path = dir.join(name);
+        std::fs::write(&path, lines.join("\n") + "\n").unwrap();
+    }
+
+    #[test]
+    fn join_health_empty_dir_reports_no_feedback() {
+        let dir = TempDir::new().unwrap();
+        let out = format_join_health(dir.path());
+        assert!(out.contains("Linkage health"));
+        assert!(out.contains("Reviews: 0"));
+        assert!(out.contains("Feedback: 0"));
+        assert!(out.contains("(no feedback entries)"));
+    }
+
+    #[test]
+    fn join_health_below_85_percent_emits_fallback_banner() {
+        let dir = TempDir::new().unwrap();
+        // 1 review with 1 finding_id; 2 feedback entries (1 linked, 1 legacy).
+        // Linkage = 50% → below threshold.
+        write_jsonl(dir.path(), "reviews.jsonl", &[
+            r#"{"run_id":"R1","timestamp":"2026-01-01T00:00:00Z","quorum_version":"0.1","repo":null,"invoked_from":"tty","model":"gpt","files_reviewed":1,"lines_added":null,"lines_removed":null,"findings_by_severity":{"critical":0,"high":0,"medium":0,"low":0,"info":0},"tokens_in":0,"tokens_out":0,"duration_ms":0,"finding_ids":["FID-LINKED"]}"#,
+        ]);
+        write_jsonl(dir.path(), "feedback.jsonl", &[
+            r#"{"file_path":"x.rs","finding_title":"t","finding_category":"c","verdict":"tp","reason":"r","model":null,"timestamp":"2026-01-01T00:00:00Z","finding_id":"FID-LINKED"}"#,
+            r#"{"file_path":"y.rs","finding_title":"t","finding_category":"c","verdict":"fp","reason":"r","model":null,"timestamp":"2026-01-01T00:00:00Z"}"#,
+        ]);
+
+        let out = format_join_health(dir.path());
+        assert!(out.contains("Reviews: 1 with 1 findings"), "got:\n{out}");
+        assert!(out.contains("Feedback: 2 entries (1 linked, 1 unlinked legacy)"), "got:\n{out}");
+        assert!(out.contains("50%"), "rate must show as 50%: got:\n{out}");
+        assert!(out.contains("below 85% threshold"), "fallback banner missing: got:\n{out}");
+    }
+
+    #[test]
+    fn join_health_at_or_above_85_percent_omits_fallback_banner() {
+        let dir = TempDir::new().unwrap();
+        // 9 linked + 1 legacy = 90% linkage, above threshold.
+        let mut review_ids = String::from("[");
+        for i in 0..9 {
+            if i > 0 { review_ids.push(','); }
+            review_ids.push_str(&format!("\"FID-{}\"", i));
+        }
+        review_ids.push(']');
+        write_jsonl(dir.path(), "reviews.jsonl", &[
+            &format!(r#"{{"run_id":"R1","timestamp":"2026-01-01T00:00:00Z","quorum_version":"0.1","repo":null,"invoked_from":"tty","model":"gpt","files_reviewed":1,"lines_added":null,"lines_removed":null,"findings_by_severity":{{"critical":0,"high":0,"medium":0,"low":0,"info":0}},"tokens_in":0,"tokens_out":0,"duration_ms":0,"finding_ids":{}}}"#, review_ids),
+        ]);
+
+        let mut fb_lines: Vec<String> = (0..9).map(|i| {
+            format!(r#"{{"file_path":"x.rs","finding_title":"t","finding_category":"c","verdict":"tp","reason":"r","model":null,"timestamp":"2026-01-01T00:00:00Z","finding_id":"FID-{}"}}"#, i)
+        }).collect();
+        fb_lines.push(r#"{"file_path":"y.rs","finding_title":"t","finding_category":"c","verdict":"fp","reason":"r","model":null,"timestamp":"2026-01-01T00:00:00Z"}"#.to_string());
+        let fb_refs: Vec<&str> = fb_lines.iter().map(|s| s.as_str()).collect();
+        write_jsonl(dir.path(), "feedback.jsonl", &fb_refs);
+
+        let out = format_join_health(dir.path());
+        assert!(out.contains("90%"), "rate must show as 90%: got:\n{out}");
+        assert!(!out.contains("below 85% threshold"), "must NOT show fallback banner at 90%: got:\n{out}");
+        assert!(out.contains("per-finding precision math active"), "got:\n{out}");
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -288,7 +288,10 @@ async fn main() -> anyhow::Result<()> {
                         if opts.minimal {
                             print!("{}", stats::format_human_minimal(&report, &style));
                         } else {
-                            print!("{}", stats::format_human(&report, &style));
+                            print!(
+                                "{}",
+                                stats::format_human_with_full(&report, &style, opts.full)
+                            );
                         }
                     }
                 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1712,6 +1712,8 @@ fn run_feedback_inner(
         timestamp: chrono::Utc::now(),
         provenance: feedback::Provenance::Human,
         fp_kind,
+        finding_id: None,
+        rule_id: None,
     };
 
     let store = feedback::FeedbackStore::new(feedback_path.to_path_buf());

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,6 +26,7 @@ pub use quorum::review_mode;
 
 mod agent;
 mod analytics;
+mod stats_math;
 mod cache;
 mod cli;
 mod cli_io;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1483,6 +1483,7 @@ async fn run_review(opts: cli::ReviewOpts) -> i32 {
                 Some(opts.mode.as_str().to_string())
             },
             context: context_telem,
+        finding_ids: Vec::new(),
         };
         if let Err(e) = review_log.record(&record) {
             eprintln!("Warning: failed to write review log: {}", e);

--- a/src/main.rs
+++ b/src/main.rs
@@ -2587,8 +2587,8 @@ mod join_health_tests {
             r#"{"run_id":"R1","timestamp":"2026-01-01T00:00:00Z","quorum_version":"0.1","repo":null,"invoked_from":"tty","model":"gpt","files_reviewed":1,"lines_added":null,"lines_removed":null,"findings_by_severity":{"critical":0,"high":0,"medium":0,"low":0,"info":0},"tokens_in":0,"tokens_out":0,"duration_ms":0,"finding_ids":["FID-LINKED"]}"#,
         ]);
         write_jsonl(dir.path(), "feedback.jsonl", &[
-            r#"{"file_path":"x.rs","finding_title":"t","finding_category":"c","verdict":"tp","reason":"r","model":null,"timestamp":"2026-01-01T00:00:00Z","finding_id":"FID-LINKED"}"#,
-            r#"{"file_path":"y.rs","finding_title":"t","finding_category":"c","verdict":"fp","reason":"r","model":null,"timestamp":"2026-01-01T00:00:00Z"}"#,
+            r#"{"file_path":"x.rs","finding_title":"t","finding_category":"c","verdict":"tp","reason":"r","model":null,"timestamp":"2026-01-01T00:00:00Z","provenance":"human","finding_id":"FID-LINKED"}"#,
+            r#"{"file_path":"y.rs","finding_title":"t","finding_category":"c","verdict":"fp","reason":"r","model":null,"timestamp":"2026-01-01T00:00:00Z","provenance":"human"}"#,
         ]);
 
         let out = format_join_health(dir.path());
@@ -2632,10 +2632,10 @@ mod join_health_tests {
             &format!(r#"{{"run_id":"R1","timestamp":"2026-01-01T00:00:00Z","quorum_version":"0.1","repo":null,"invoked_from":"tty","model":"gpt","files_reviewed":1,"lines_added":null,"lines_removed":null,"findings_by_severity":{{"critical":0,"high":0,"medium":0,"low":0,"info":0}},"tokens_in":0,"tokens_out":0,"duration_ms":0,"finding_ids":{}}}"#, id_array),
         ]);
         let mut fb_lines: Vec<String> = (0..169).map(|i| {
-            format!(r#"{{"file_path":"x.rs","finding_title":"t","finding_category":"c","verdict":"tp","reason":"r","model":null,"timestamp":"2026-01-01T00:00:00Z","finding_id":"FID-{}"}}"#, i)
+            format!(r#"{{"file_path":"x.rs","finding_title":"t","finding_category":"c","verdict":"tp","reason":"r","model":null,"timestamp":"2026-01-01T00:00:00Z","provenance":"human","finding_id":"FID-{}"}}"#, i)
         }).collect();
         for _ in 0..31 {
-            fb_lines.push(r#"{"file_path":"y.rs","finding_title":"t","finding_category":"c","verdict":"fp","reason":"r","model":null,"timestamp":"2026-01-01T00:00:00Z"}"#.to_string());
+            fb_lines.push(r#"{"file_path":"y.rs","finding_title":"t","finding_category":"c","verdict":"fp","reason":"r","model":null,"timestamp":"2026-01-01T00:00:00Z","provenance":"human"}"#.to_string());
         }
         let fb_refs: Vec<&str> = fb_lines.iter().map(|s| s.as_str()).collect();
         write_jsonl(dir.path(), "feedback.jsonl", &fb_refs);
@@ -2662,9 +2662,9 @@ mod join_health_tests {
         ]);
 
         let mut fb_lines: Vec<String> = (0..9).map(|i| {
-            format!(r#"{{"file_path":"x.rs","finding_title":"t","finding_category":"c","verdict":"tp","reason":"r","model":null,"timestamp":"2026-01-01T00:00:00Z","finding_id":"FID-{}"}}"#, i)
+            format!(r#"{{"file_path":"x.rs","finding_title":"t","finding_category":"c","verdict":"tp","reason":"r","model":null,"timestamp":"2026-01-01T00:00:00Z","provenance":"human","finding_id":"FID-{}"}}"#, i)
         }).collect();
-        fb_lines.push(r#"{"file_path":"y.rs","finding_title":"t","finding_category":"c","verdict":"fp","reason":"r","model":null,"timestamp":"2026-01-01T00:00:00Z"}"#.to_string());
+        fb_lines.push(r#"{"file_path":"y.rs","finding_title":"t","finding_category":"c","verdict":"fp","reason":"r","model":null,"timestamp":"2026-01-01T00:00:00Z","provenance":"human"}"#.to_string());
         let fb_refs: Vec<&str> = fb_lines.iter().map(|s| s.as_str()).collect();
         write_jsonl(dir.path(), "feedback.jsonl", &fb_refs);
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1483,7 +1483,7 @@ async fn run_review(opts: cli::ReviewOpts) -> i32 {
                 Some(opts.mode.as_str().to_string())
             },
             context: context_telem,
-        finding_ids: Vec::new(),
+            finding_ids: quorum::finding::collect_finding_ids(&all_findings),
         };
         if let Err(e) = review_log.record(&record) {
             eprintln!("Warning: failed to write review log: {}", e);

--- a/src/mcp/handler.rs
+++ b/src/mcp/handler.rs
@@ -203,6 +203,8 @@ impl QuorumHandler {
             timestamp: chrono::Utc::now(),
             provenance: crate::feedback::Provenance::Human,
             fp_kind,
+            finding_id: None,
+            rule_id: None,
         };
 
         self.feedback_store

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -1235,6 +1235,8 @@ mod tests {
             timestamp: chrono::Utc::now(),
             provenance: Provenance::Human,
             fp_kind,
+            finding_id: None,
+            rule_id: None,
         }
     }
 

--- a/src/review.rs
+++ b/src/review.rs
@@ -132,6 +132,7 @@ impl LlmFinding {
             }
         };
         Finding {
+            id: crate::finding::new_finding_ulid(),
             title: self.title,
             description: self.description,
             severity,

--- a/src/review_log.rs
+++ b/src/review_log.rs
@@ -260,6 +260,14 @@ pub struct ReviewRecord {
     /// written before this field existed.
     #[serde(default)]
     pub context: ContextTelemetry,
+
+    /// Stable per-finding ULIDs emitted by this review (one per finding,
+    /// in stable post-suppression order). Empty for legacy records that
+    /// pre-date this field. Used by stats analytics to join feedback
+    /// entries (`FeedbackEntry.finding_id`) back to their originating
+    /// review for per-finding precision deduplication.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub finding_ids: Vec<String>,
 }
 
 impl ReviewRecord {
@@ -451,6 +459,7 @@ mod tests {
             flags: Flags { deep: false, parallel_n: 4, ensemble: false },
             mode: None,
             context: ContextTelemetry::default(),
+        finding_ids: Vec::new(),
         }
     }
 
@@ -460,6 +469,44 @@ mod tests {
         let json = serde_json::to_string(&rec).unwrap();
         let back: ReviewRecord = serde_json::from_str(&json).unwrap();
         assert_eq!(rec, back);
+    }
+
+    // ─── Stats redesign Phase 0: ReviewRecord.finding_ids ───
+
+    #[test]
+    fn legacy_review_record_deserializes_with_empty_finding_ids() {
+        // Pre-rollout reviews.jsonl rows lack the finding_ids key. They must
+        // load cleanly (default empty Vec) so the linkage diagnostic counts
+        // them as "unlinked legacy" rather than failing the read.
+        let legacy = r#"{"run_id":"01ABC","timestamp":"2026-01-01T00:00:00Z","quorum_version":"0.1","repo":null,"invoked_from":"tty","model":"gpt","files_reviewed":1,"lines_added":null,"lines_removed":null,"findings_by_severity":{"critical":0,"high":0,"medium":0,"low":0,"info":0},"tokens_in":0,"tokens_out":0,"duration_ms":0}"#;
+        let rec: ReviewRecord = serde_json::from_str(legacy).expect("legacy load");
+        assert_eq!(rec.finding_ids, Vec::<String>::new());
+    }
+
+    #[test]
+    fn record_with_finding_ids_round_trips_preserving_order() {
+        // Order matters: linkage_stats joins by ID, but downstream consumers
+        // (rule attribution, time-ordering) may want positional access.
+        let mut rec = sample_record();
+        rec.finding_ids = vec![
+            "01HXYZ0000000000000000000A".into(),
+            "01HXYZ0000000000000000000B".into(),
+            "01HXYZ0000000000000000000C".into(),
+        ];
+        let json = serde_json::to_string(&rec).unwrap();
+        let back: ReviewRecord = serde_json::from_str(&json).unwrap();
+        assert_eq!(rec.finding_ids, back.finding_ids);
+    }
+
+    #[test]
+    fn record_omits_finding_ids_key_when_empty() {
+        // Disk-bloat regression: don't write `"finding_ids":[]` for every
+        // legacy-style record produced by code that doesn't yet populate.
+        let rec = sample_record();
+        assert!(rec.finding_ids.is_empty(), "fixture default must be empty");
+        let json = serde_json::to_string(&rec).unwrap();
+        assert!(!json.contains("finding_ids"),
+            "empty finding_ids must not write the key: {json}");
     }
 
     #[test]

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -655,6 +655,23 @@ pub fn format_compact(report: &StatsReport) -> String {
         parts.push(format!("cost:{}", formatting::format_cost(report.cost_7d)));
     }
 
+    parts.push(format!("linkage:{:.0}%", report.linkage_rate * 100.0));
+    parts.push(format!("capture:{:.0}%", report.capture_rate * 100.0));
+
+    if !report.external_overlap.per_agent.is_empty() {
+        let agent_parts: Vec<String> = report.external_overlap.per_agent.iter()
+            .map(|a| format!("{}:{}/{}", a.agent, a.agree, a.overlap))
+            .collect();
+        parts.push(format!("external:{}", agent_parts.join(",")));
+    }
+
+    if !report.precision_trend_per_finding.is_empty() {
+        let pf: Vec<String> = report.precision_trend_per_finding.iter()
+            .map(|w| formatting::format_pct(w.precision))
+            .collect();
+        parts.push(format!("per-finding:{}", pf.join(">")));
+    }
+
     format!("{}\n", parts.join(" "))
 }
 
@@ -811,6 +828,31 @@ pub fn format_json(report: &StatsReport) -> anyhow::Result<String> {
         "top_repos": report.top_repos,
         "top_callers": report.top_callers,
         "rolling_windows": report.rolling_windows,
+        "linkage_rate": report.linkage_rate,
+        "linkage_linked": report.linkage_linked,
+        "linkage_unlinked": report.linkage_unlinked,
+        "capture_rate": report.capture_rate,
+        "capture_labeled": report.capture_labeled,
+        "capture_total": report.capture_total,
+        "headline_trend_uses_finding_id": report.headline_trend_uses_finding_id,
+        "external_overlap": {
+            "agents": report.external_overlap.per_agent.iter().map(|a| {
+                serde_json::json!({
+                    "agent": a.agent,
+                    "findings": a.findings,
+                    "overlap": a.overlap,
+                    "agree": a.agree,
+                    "agreement_rate": a.agreement_rate(),
+                })
+            }).collect::<Vec<_>>()
+        },
+        "precision_trend_per_finding": report.precision_trend_per_finding.iter().map(|w| {
+            serde_json::json!({
+                "week_start": w.week_start.to_rfc3339(),
+                "precision": w.precision,
+                "count": w.count,
+            })
+        }).collect::<Vec<_>>(),
     });
     Ok(serde_json::to_string_pretty(&json)?)
 }
@@ -1170,6 +1212,11 @@ mod tests {
         assert!(v["top_repos"].is_array());
         assert!(v["top_callers"].is_array());
         assert!(v["rolling_windows"].is_array());
+        assert!(v["linkage_rate"].is_f64());
+        assert!(v["capture_rate"].is_f64());
+        assert!(v["headline_trend_uses_finding_id"].is_boolean());
+        assert!(v["external_overlap"]["agents"].is_array());
+        assert!(v["precision_trend_per_finding"].is_array());
     }
 
     #[test]
@@ -1210,6 +1257,53 @@ mod tests {
         assert!(out.contains("tp:60"));
         assert!(out.contains("fp:20"));
         assert!(out.contains("reviews_7d:5"));
+        assert!(out.contains("linkage:0%"));
+        assert!(out.contains("capture:0%"));
+    }
+
+    #[test]
+    fn format_compact_includes_external_overlap_when_present() {
+        let report = StatsReport {
+            feedback_count: 100,
+            precision: 0.75,
+            tp: 60,
+            fp: 20,
+            partial: 10,
+            wontfix: 10,
+            precision_trend: vec![],
+            reviews_7d: 5,
+            findings_per_review: 3.2,
+            suppression_rate: 0.1,
+            tokens_in_7d: 0,
+            tokens_out_7d: 0,
+            cost_7d: 0.0,
+            tokens_per_finding: 0.0,
+            model: String::new(),
+            top_repos: Vec::new(),
+            top_callers: Vec::new(),
+            rolling_windows: Vec::new(),
+            tier_summary: analytics::TierSummary::default(),
+            linkage_rate: 0.92,
+            linkage_linked: 46,
+            linkage_unlinked: 4,
+            capture_rate: 0.6,
+            capture_labeled: 3,
+            capture_total: 5,
+            headline_trend_uses_finding_id: true,
+            external_overlap: analytics::ExternalOverlap {
+                per_agent: vec![analytics::AgentOverlap {
+                    agent: "pal".into(),
+                    findings: 10,
+                    overlap: 8,
+                    agree: 6,
+                }],
+            },
+            precision_trend_per_finding: Vec::new(),
+        };
+        let out = format_compact(&report);
+        assert!(out.contains("linkage:92%"));
+        assert!(out.contains("capture:60%"));
+        assert!(out.contains("external:pal:6/8"));
     }
 
     #[test]

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -39,6 +39,29 @@ pub struct StatsReport {
     /// Provenance-tier breakdown (Human / PostFix / External / AutoCalib /
     /// Unknown). Computed from the same feedback store as `precision`.
     pub tier_summary: analytics::TierSummary,
+
+    // ─── Stats redesign Phase A: linkage / capture / external overlap ───
+    //
+    /// Fraction of feedback entries whose finding_id matches some review's
+    /// finding_ids. Gates whether per-finding precision math is shown.
+    pub linkage_rate: f64,
+    pub linkage_linked: usize,
+    pub linkage_unlinked: usize,
+    /// Fraction of recent (7d) findings that received any feedback. Used
+    /// inline with the headline trend so trend footing is visible.
+    pub capture_rate: f64,
+    pub capture_labeled: usize,
+    pub capture_total: usize,
+    /// True iff `linkage_rate >= 0.85`. Drives the headline-trend
+    /// rendering between per-finding (`precision_trend_per_finding`) and
+    /// the entry-level fallback with banner.
+    pub headline_trend_uses_finding_id: bool,
+    /// Per-agent overlap with quorum's own (Human-tier) verdicts. Surfaced
+    /// in the External corpus block.
+    pub external_overlap: analytics::ExternalOverlap,
+    /// Per-finding precision trend (None when linkage rate is below the
+    /// per-finding gate so renderers don't have to recompute the cutoff).
+    pub precision_trend_per_finding: Vec<analytics::PrecisionWindow>,
 }
 
 /// Take top-N slices by review volume. Ties resolved by insertion order
@@ -123,6 +146,44 @@ pub fn compute_report(
     let top_callers = take_top(dimensions::group_by_caller(&review_records), HIGHLIGHT_TOP_N);
     let rolling_windows = dimensions::rolling_window(&review_records, ROLLING_N, ROLLING_WINDOWS);
 
+    // Linkage / capture / external overlap (Phase A).
+    let link = analytics::linkage_stats(&review_records, &feedback);
+    let linkage_rate = link.rate();
+    let headline_trend_uses_finding_id = linkage_rate >= 0.85;
+
+    let capture_total = total_findings_7d;
+    // Capture-labeled = feedback entries timestamped in the 7d window.
+    // Coarse but useful — exact would require joining each feedback row
+    // to a review timestamp, which we deliberately don't do here.
+    let capture_labeled = feedback.iter()
+        .filter(|e| e.timestamp >= since_7d)
+        .count();
+    let capture_rate = if capture_total > 0 {
+        (capture_labeled as f64 / capture_total as f64).min(1.0)
+    } else {
+        0.0
+    };
+
+    // Build a quorum verdict map (Human-tier) keyed by finding_id for
+    // External overlap computation.
+    let mut quorum_verdicts: std::collections::HashMap<String, crate::feedback::Verdict> =
+        std::collections::HashMap::new();
+    for e in &feedback {
+        if !matches!(e.provenance, crate::feedback::Provenance::Human) {
+            continue;
+        }
+        if let Some(fid) = &e.finding_id {
+            quorum_verdicts.insert(fid.clone(), e.verdict.clone());
+        }
+    }
+    let external_overlap = analytics::compute_external_overlap(&feedback, &quorum_verdicts);
+
+    let precision_trend_per_finding = if headline_trend_uses_finding_id {
+        analytics::precision_trend_per_finding(&feedback, 7)
+    } else {
+        Vec::new()
+    };
+
     Ok(StatsReport {
         feedback_count,
         precision,
@@ -143,6 +204,15 @@ pub fn compute_report(
         top_callers,
         rolling_windows,
         tier_summary,
+        linkage_rate,
+        linkage_linked: link.linked,
+        linkage_unlinked: link.unlinked,
+        capture_rate,
+        capture_labeled,
+        capture_total,
+        headline_trend_uses_finding_id,
+        external_overlap,
+        precision_trend_per_finding,
     })
 }
 
@@ -656,6 +726,73 @@ mod tests {
         }
     }
 
+    // ─── Stats redesign Task 6: extended StatsReport fields ───
+
+    #[test]
+    fn compute_report_populates_linkage_and_capture_metadata() {
+        // Empty stores still expose the new fields with safe defaults so
+        // callers don't have to None-check or panic on missing data.
+        let dir = TempDir::new().unwrap();
+        let fb = FeedbackStore::new(dir.path().join("fb.jsonl"));
+        let tl = TelemetryStore::new(dir.path().join("tl.jsonl"));
+        let rl = crate::review_log::ReviewLog::new(dir.path().join("reviews.jsonl"));
+        let report = compute_report(&fb, &tl, &rl).unwrap();
+        assert!(report.linkage_rate >= 0.0 && report.linkage_rate <= 1.0);
+        assert_eq!(report.linkage_linked, 0);
+        assert_eq!(report.linkage_unlinked, 0);
+        assert!(report.capture_rate >= 0.0 && report.capture_rate <= 1.0);
+        assert_eq!(report.capture_labeled, 0);
+        assert_eq!(report.capture_total, 0);
+        assert!(!report.headline_trend_uses_finding_id, "no data → false");
+        assert!(report.external_overlap.per_agent.is_empty());
+    }
+
+    #[test]
+    fn headline_trend_uses_finding_id_flips_on_at_85_percent_linkage() {
+        // 17 linked + 3 unlinked = 85% — clears the threshold exactly.
+        let dir = TempDir::new().unwrap();
+        let fb = FeedbackStore::new(dir.path().join("fb.jsonl"));
+        let tl = TelemetryStore::new(dir.path().join("tl.jsonl"));
+
+        let mut record = rec("alpha", "tty", 1);
+        record.finding_ids = (0..17).map(|i| format!("FID-{i}")).collect();
+        let rl = make_review_log(&dir, &[record]);
+
+        for i in 0..17 {
+            fb.record(&crate::feedback::FeedbackEntry {
+                file_path: "x.rs".into(),
+                finding_title: "t".into(),
+                finding_category: "c".into(),
+                verdict: crate::feedback::Verdict::Tp,
+                reason: "r".into(),
+                model: None,
+                timestamp: chrono::Utc::now(),
+                provenance: crate::feedback::Provenance::Human,
+                fp_kind: None,
+                finding_id: Some(format!("FID-{i}")),
+                rule_id: None,
+            }).unwrap();
+        }
+        for _ in 0..3 {
+            fb.record(&crate::feedback::FeedbackEntry {
+                file_path: "y.rs".into(),
+                finding_title: "t".into(),
+                finding_category: "c".into(),
+                verdict: crate::feedback::Verdict::Fp,
+                reason: "r".into(),
+                model: None,
+                timestamp: chrono::Utc::now(),
+                provenance: crate::feedback::Provenance::Human,
+                fp_kind: None,
+                finding_id: None,
+                rule_id: None,
+            }).unwrap();
+        }
+        let report = compute_report(&fb, &tl, &rl).unwrap();
+        assert!((report.linkage_rate - 0.85).abs() < 1e-9);
+        assert!(report.headline_trend_uses_finding_id, "85% must flip the gate");
+    }
+
     #[test]
     fn compute_report_empty_stores() {
         let dir = TempDir::new().unwrap();
@@ -794,6 +931,15 @@ mod tests {
             top_callers: Vec::new(),
             rolling_windows: Vec::new(),
             tier_summary: analytics::TierSummary::default(),
+            linkage_rate: 0.0,
+            linkage_linked: 0,
+            linkage_unlinked: 0,
+            capture_rate: 0.0,
+            capture_labeled: 0,
+            capture_total: 0,
+            headline_trend_uses_finding_id: false,
+            external_overlap: analytics::ExternalOverlap::default(),
+            precision_trend_per_finding: Vec::new(),
         };
         let out = format_compact(&report);
         assert!(out.contains("feedback:100"));
@@ -825,6 +971,15 @@ mod tests {
             top_callers: Vec::new(),
             rolling_windows: Vec::new(),
             tier_summary: analytics::TierSummary::default(),
+            linkage_rate: 0.0,
+            linkage_linked: 0,
+            linkage_unlinked: 0,
+            capture_rate: 0.0,
+            capture_labeled: 0,
+            capture_total: 0,
+            headline_trend_uses_finding_id: false,
+            external_overlap: analytics::ExternalOverlap::default(),
+            precision_trend_per_finding: Vec::new(),
         };
         let out = format_human(&report, &Style::plain());
         assert!(out.contains("Feedback Health"));
@@ -961,6 +1116,15 @@ mod tests {
             top_callers: Vec::new(),
             rolling_windows: Vec::new(),
             tier_summary: analytics::TierSummary::default(),
+            linkage_rate: 0.0,
+            linkage_linked: 0,
+            linkage_unlinked: 0,
+            capture_rate: 0.0,
+            capture_labeled: 0,
+            capture_total: 0,
+            headline_trend_uses_finding_id: false,
+            external_overlap: analytics::ExternalOverlap::default(),
+            precision_trend_per_finding: Vec::new(),
         };
         let json = format_json(&report).unwrap();
         let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -652,6 +652,7 @@ mod tests {
             flags: Flags { deep: false, parallel_n: 1, ensemble: false },
             mode: None,
             context: Default::default(),
+        finding_ids: Vec::new(),
         }
     }
 

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -302,10 +302,11 @@ pub fn format_headline_trend(report: &StatsReport) -> String {
     }
 
     let tail = windows.last().unwrap();
-    let ci = if tail.count >= MIN_TREND_WINDOW_N {
+    let ci = if tail.count >= MIN_TREND_WINDOW_N && tail.precision_denom > 0 {
+        let successes = (tail.precision * tail.precision_denom as f64).round() as usize;
         let (lo, hi) = crate::stats_math::wilson_interval(
-            (tail.precision * tail.count as f64).round() as usize,
-            tail.count,
+            successes,
+            tail.precision_denom,
             0.95,
         );
         format!(
@@ -957,6 +958,7 @@ mod tests {
             week_start: chrono::Utc::now(),
             precision,
             count,
+            precision_denom: count,
         }
     }
 

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -655,8 +655,8 @@ pub fn format_compact(report: &StatsReport) -> String {
         parts.push(format!("cost:{}", formatting::format_cost(report.cost_7d)));
     }
 
-    parts.push(format!("linkage:{:.0}%", report.linkage_rate * 100.0));
-    parts.push(format!("capture:{:.0}%", report.capture_rate * 100.0));
+    parts.push(format!("linkage:{}", formatting::format_pct(report.linkage_rate)));
+    parts.push(format!("capture:{}", formatting::format_pct(report.capture_rate)));
 
     if !report.external_overlap.per_agent.is_empty() {
         let agent_parts: Vec<String> = report.external_overlap.per_agent.iter()

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -222,17 +222,148 @@ pub fn format_human_minimal(report: &StatsReport, style: &Style) -> String {
     format_human_core(report, style)
 }
 
+/// Minimum window count for showing a precision percentage. Below this
+/// the window is rendered as `n<30` to flag low-N noise — matches the
+/// design doc's stability cutoff.
+const MIN_TREND_WINDOW_N: usize = 30;
+
+/// Render the External corpus block — per-agent contribution and
+/// agreement rate against quorum's Human-tier verdicts.
+pub fn format_external_corpus(overlap: &analytics::ExternalOverlap) -> String {
+    use std::fmt::Write;
+    let mut out = String::new();
+    writeln!(out, "\nExternal corpus").unwrap();
+    for agent in &overlap.per_agent {
+        if agent.overlap == 0 {
+            writeln!(
+                out,
+                "  {agent}: {findings} entries (no overlap with quorum verdicts)",
+                agent = agent.agent,
+                findings = agent.findings,
+            )
+            .unwrap();
+        } else {
+            writeln!(
+                out,
+                "  {agent}: {findings} entries, {overlap} overlap, {pct}% agreement",
+                agent = agent.agent,
+                findings = agent.findings,
+                overlap = agent.overlap,
+                pct = (agent.agreement_rate() * 100.0).round() as u32,
+            )
+            .unwrap();
+        }
+    }
+    out
+}
+
+/// Render the headline precision trend with Wilson CI on the most recent
+/// window. Uses `precision_trend_per_finding` when the linkage gate is
+/// open; otherwise falls back to entry-level `precision_trend` with a
+/// "entry-level pending finding-id rollout" banner.
+pub fn format_headline_trend(report: &StatsReport) -> String {
+    use std::fmt::Write;
+    let mut out = String::new();
+
+    let (windows, banner) = if report.headline_trend_uses_finding_id {
+        (&report.precision_trend_per_finding, None)
+    } else {
+        (
+            &report.precision_trend,
+            Some("entry-level pending finding-id rollout"),
+        )
+    };
+
+    if windows.is_empty() {
+        if let Some(b) = banner {
+            writeln!(out, "  Trend: (no data) — {b}").unwrap();
+        } else {
+            writeln!(out, "  Trend: (no data)").unwrap();
+        }
+        return out;
+    }
+
+    // Build "77 → 81 → 78 → 76%" chain — tail window keeps `%` to anchor
+    // the eye on the current value.
+    let mut chain = String::new();
+    for (i, w) in windows.iter().enumerate() {
+        let is_last = i == windows.len() - 1;
+        let cell = if w.count < MIN_TREND_WINDOW_N {
+            "n<30".to_string()
+        } else if is_last {
+            format!("{}%", (w.precision * 100.0).round() as u32)
+        } else {
+            format!("{}", (w.precision * 100.0).round() as u32)
+        };
+        if i > 0 {
+            chain.push_str(" → ");
+        }
+        chain.push_str(&cell);
+    }
+
+    let tail = windows.last().unwrap();
+    let ci = if tail.count >= MIN_TREND_WINDOW_N {
+        let (lo, hi) = crate::stats_math::wilson_interval(
+            (tail.precision * tail.count as f64).round() as usize,
+            tail.count,
+            0.95,
+        );
+        format!(
+            " [{lo}-{hi}]",
+            lo = (lo * 100.0).round() as u32,
+            hi = (hi * 100.0).round() as u32,
+        )
+    } else {
+        String::new()
+    };
+
+    let n_annotation = format!(" n={}", tail.count);
+    let capture = if report.capture_total > 0 {
+        format!(
+            ", capture: {}% ({}/{})",
+            (report.capture_rate * 100.0).round() as u32,
+            report.capture_labeled,
+            report.capture_total,
+        )
+    } else {
+        String::new()
+    };
+
+    if let Some(b) = banner {
+        writeln!(out, "  Trend: {chain}{ci}{n_annotation}{capture} — {b}").unwrap();
+    } else {
+        writeln!(out, "  Trend: {chain}{ci}{n_annotation}{capture}").unwrap();
+    }
+    out
+}
+
 pub fn format_human(report: &StatsReport, style: &Style) -> String {
+    // Default = !full: hide By caller and Rolling, keep By repo. See
+    // format_human_with_full for the full-fat variant.
+    format_human_with_full(report, style, false)
+}
+
+/// Render the dashboard, gating dimensional drill-downs (By caller,
+/// Rolling N) on `full`. By repo stays in default — it's the most
+/// scannable orientation.
+pub fn format_human_with_full(report: &StatsReport, style: &Style, full: bool) -> String {
     let mut out = format_human_core(report, style);
     let unicode = crate::output::unicode_ok_default();
     if !report.top_repos.is_empty() {
         out.push_str(&format_highlight_block("By repo (top)", &report.top_repos, style, unicode));
     }
-    if !report.top_callers.is_empty() {
-        out.push_str(&format_highlight_block("By caller (top)", &report.top_callers, style, unicode));
-    }
-    if !report.rolling_windows.is_empty() {
-        out.push_str(&format_highlight_block("Rolling 50 reviews", &report.rolling_windows, style, unicode));
+    if full {
+        if !report.top_callers.is_empty() {
+            out.push_str(&format_highlight_block("By caller (top)", &report.top_callers, style, unicode));
+        }
+        if !report.rolling_windows.is_empty() {
+            out.push_str(&format_highlight_block(
+                "Rolling windows (50 reviews each)",
+                &report.rolling_windows,
+                style,
+                unicode,
+            ));
+        }
     }
     out
 }
@@ -294,28 +425,23 @@ fn format_human_core(report: &StatsReport, style: &Style) -> String {
         report.tp, report.fp, report.partial, report.wontfix,
     ));
 
-    // Tier breakdown is only interesting once at least one non-Human entry
-    // exists — otherwise it's redundant with the TP/FP line above.
-    let ts = &report.tier_summary;
-    let has_tier_data = ts.post_fix.total() > 0
-        || ts.external.total.total() > 0
-        || ts.auto_calibrate.total() > 0
-        || ts.unknown.total() > 0;
-    if has_tier_data {
-        out.push('\n');
-        out.push_str(&analytics::format_tier_report(ts));
-        out.push('\n');
-    }
+    // Channel attribution table — counts only, no precision column.
+    // Always rendered (even all-zero Human) so the dashboard shape is
+    // stable; format_channel_attribution hides empty non-Human channels.
+    out.push('\n');
+    out.push_str(&analytics::format_channel_attribution(&report.tier_summary));
 
-    if !report.precision_trend.is_empty() {
-        let trend_str: Vec<String> = report.precision_trend.iter()
-            .map(|w| formatting::format_pct(w.precision))
-            .collect();
-        out.push_str(&format!("  Trend: {}\n", trend_str.join(">")));
+    // Headline trend with Wilson CI on the most recent window, plus
+    // capture-rate inline so trend footing is visible.
+    out.push_str(&format_headline_trend(report));
+
+    // External corpus block — per-agent overlap + agreement rate.
+    if !report.external_overlap.per_agent.is_empty() {
+        out.push_str(&format_external_corpus(&report.external_overlap));
     }
 
     out.push_str(&format!(
-        "\n{bold}Activity (7d){reset}\n",
+        "\n{bold}Activity (last 7 days){reset}\n",
         bold = style.bold, reset = style.reset
     ));
     out.push_str(&format!(
@@ -326,7 +452,7 @@ fn format_human_core(report: &StatsReport, style: &Style) -> String {
 
     if report.tokens_in_7d > 0 || report.tokens_out_7d > 0 {
         out.push_str(&format!(
-            "\n{bold}Spend (7d){reset}\n",
+            "\n{bold}Spend (last 7 days){reset}\n",
             bold = style.bold, reset = style.reset
         ));
         out.push_str(&format!(
@@ -726,6 +852,143 @@ mod tests {
         }
     }
 
+    // ─── Stats redesign Task 11: section label normalization ───
+
+    #[test]
+    fn format_human_uses_normalized_section_labels() {
+        // The redesign explicitly states "(7d)" reads as jargon — replace
+        // with "(last 7 days)". Same for "Rolling 50 reviews" which is
+        // ambiguous about whether 50 is the window size or the count.
+        let dir = TempDir::new().unwrap();
+        let fb = FeedbackStore::new(dir.path().join("fb.jsonl"));
+        let tl = TelemetryStore::new(dir.path().join("tl.jsonl"));
+        let records: Vec<_> = (0..6).map(|_| rec("alpha", "claude_code", 2)).collect();
+        let rl = make_review_log(&dir, &records);
+        let report = compute_report(&fb, &tl, &rl).unwrap();
+        let out = format_human(&report, &Style::plain());
+        assert!(
+            !out.contains("(7d)"),
+            "old jargon label '(7d)' should be replaced: {out}"
+        );
+        assert!(
+            out.contains("last 7 days"),
+            "expected 'last 7 days' label: {out}"
+        );
+    }
+
+    // ─── Stats redesign Task 12: --full flag ───
+
+    #[test]
+    fn format_human_default_omits_by_caller_and_rolling() {
+        // The default dashboard hides the dimensional drill-downs (caller,
+        // rolling) — they live behind --full.
+        let dir = TempDir::new().unwrap();
+        let fb = FeedbackStore::new(dir.path().join("fb.jsonl"));
+        let tl = TelemetryStore::new(dir.path().join("tl.jsonl"));
+        let records: Vec<_> = (0..120).map(|_| rec("alpha", "claude_code", 2)).collect();
+        let rl = make_review_log(&dir, &records);
+        let report = compute_report(&fb, &tl, &rl).unwrap();
+        let out = format_human_with_full(&report, &Style::plain(), false);
+        assert!(out.contains("By repo"), "By repo stays in default: {out}");
+        assert!(!out.contains("By caller"), "By caller hides without --full: {out}");
+        assert!(!out.contains("Rolling"), "Rolling hides without --full: {out}");
+    }
+
+    #[test]
+    fn format_human_full_shows_all_dimensional_views() {
+        let dir = TempDir::new().unwrap();
+        let fb = FeedbackStore::new(dir.path().join("fb.jsonl"));
+        let tl = TelemetryStore::new(dir.path().join("tl.jsonl"));
+        let records: Vec<_> = (0..120).map(|_| rec("alpha", "claude_code", 2)).collect();
+        let rl = make_review_log(&dir, &records);
+        let report = compute_report(&fb, &tl, &rl).unwrap();
+        let out = format_human_with_full(&report, &Style::plain(), true);
+        assert!(out.contains("By repo"));
+        assert!(out.contains("By caller"));
+        assert!(out.contains("Rolling"));
+    }
+
+    // ─── Stats redesign Task 10: headline trend rendering ───
+
+    fn pw(precision: f64, count: usize) -> analytics::PrecisionWindow {
+        analytics::PrecisionWindow {
+            week_start: chrono::Utc::now(),
+            precision,
+            count,
+        }
+    }
+
+    fn make_report_for_trend(
+        trend_per_finding: Vec<analytics::PrecisionWindow>,
+        capture_labeled: usize,
+        capture_total: usize,
+        uses_finding_id: bool,
+    ) -> StatsReport {
+        StatsReport {
+            feedback_count: 0,
+            precision: 0.0,
+            tp: 0, fp: 0, partial: 0, wontfix: 0,
+            precision_trend: vec![],
+            reviews_7d: 0,
+            findings_per_review: 0.0,
+            suppression_rate: 0.0,
+            tokens_in_7d: 0, tokens_out_7d: 0,
+            cost_7d: 0.0, tokens_per_finding: 0.0,
+            model: String::new(),
+            top_repos: Vec::new(),
+            top_callers: Vec::new(),
+            rolling_windows: Vec::new(),
+            tier_summary: analytics::TierSummary::default(),
+            linkage_rate: 0.0,
+            linkage_linked: 0,
+            linkage_unlinked: 0,
+            capture_rate: if capture_total > 0 { capture_labeled as f64 / capture_total as f64 } else { 0.0 },
+            capture_labeled,
+            capture_total,
+            headline_trend_uses_finding_id: uses_finding_id,
+            external_overlap: analytics::ExternalOverlap::default(),
+            precision_trend_per_finding: trend_per_finding,
+        }
+    }
+
+    #[test]
+    fn headline_trend_renders_arrow_chain_with_ci_on_current_window() {
+        // 4-window trend, last window n=145 ≥ 30 → Wilson CI shown.
+        let report = make_report_for_trend(
+            vec![pw(0.77, 30), pw(0.81, 32), pw(0.78, 90), pw(0.76, 145)],
+            212, 1159, true,
+        );
+        let out = format_headline_trend(&report);
+        assert!(out.contains("77 → 81"), "trend chain missing: {out}");
+        assert!(out.contains("76%"), "current window pct missing: {out}");
+        assert!(out.contains("["), "expected CI bracket: {out}");
+        assert!(out.contains("n=145"), "expected sample-size annotation: {out}");
+        assert!(out.contains("capture"), "capture-rate inline missing: {out}");
+    }
+
+    #[test]
+    fn headline_trend_replaces_low_n_window_with_n_too_low() {
+        let report = make_report_for_trend(
+            vec![pw(0.77, 8), pw(0.81, 32), pw(0.78, 90), pw(0.76, 145)],
+            10, 100, true,
+        );
+        let out = format_headline_trend(&report);
+        assert!(
+            out.contains("n<30") || out.contains("n=8"),
+            "low-n window must be marked: {out}"
+        );
+    }
+
+    #[test]
+    fn headline_trend_shows_legacy_banner_when_finding_id_unused() {
+        let report = make_report_for_trend(vec![], 0, 0, false);
+        let out = format_headline_trend(&report);
+        assert!(
+            out.contains("entry-level") && out.contains("finding-id"),
+            "legacy banner should indicate the fallback: {out}"
+        );
+    }
+
     // ─── Stats redesign Task 6: extended StatsReport fields ───
 
     #[test]
@@ -854,7 +1117,9 @@ mod tests {
     }
 
     #[test]
-    fn format_human_default_includes_highlights_when_data_present() {
+    fn format_human_default_includes_by_repo_when_data_present() {
+        // After Task 12, default omits By caller / Rolling — only By repo
+        // is shown by default.
         let dir = TempDir::new().unwrap();
         let fb = FeedbackStore::new(dir.path().join("fb.jsonl"));
         let tl = TelemetryStore::new(dir.path().join("tl.jsonl"));
@@ -863,9 +1128,7 @@ mod tests {
         let report = compute_report(&fb, &tl, &rl).unwrap();
         let out = format_human(&report, &Style::plain());
         assert!(out.contains("By repo"), "missing repo section: {}", out);
-        assert!(out.contains("By caller"), "missing caller section: {}", out);
         assert!(out.contains("alpha"));
-        assert!(out.contains("claude_code"));
     }
 
     #[test]
@@ -983,8 +1246,8 @@ mod tests {
         };
         let out = format_human(&report, &Style::plain());
         assert!(out.contains("Feedback Health"));
-        assert!(out.contains("Activity (7d)"));
-        assert!(out.contains("Spend (7d)"));
+        assert!(out.contains("Activity (last 7 days)"));
+        assert!(out.contains("Spend (last 7 days)"));
         assert!(out.contains("2.0k"));  // feedback count
         assert!(out.contains("74%"));   // precision
     }

--- a/src/stats_math.rs
+++ b/src/stats_math.rs
@@ -20,19 +20,21 @@
 /// Reference: Wilson (1927), "Probable Inference, the Law of Succession,
 /// and Statistical Inference."
 pub fn wilson_interval(successes: usize, total: usize, confidence: f64) -> (f64, f64) {
-    if total == 0 {
-        return (0.0, 1.0);
-    }
     // assert! (not debug_assert!) so that release builds also reject
     // impossible inputs. Silent clamping to p=1 would mask upstream data
     // corruption — off-by-one in aggregation, malformed feedback rows,
     // hand-edited JSONL — and produce plausible-looking intervals.
+    // Must be checked BEFORE the total==0 early return so (successes=k>0,
+    // total=0) doesn't slip through as "no data".
     assert!(
         successes <= total,
         "wilson_interval: successes ({}) must not exceed total ({})",
         successes,
         total
     );
+    if total == 0 {
+        return (0.0, 1.0);
+    }
     let n = total as f64;
     let p = (successes as f64 / n).clamp(0.0, 1.0);
     let z = z_score(confidence);
@@ -96,6 +98,16 @@ mod tests {
         let (lo, hi) = wilson_interval(0, 5, 0.95);
         assert_eq!(lo, 0.0, "lower bound clamps to 0");
         assert!(hi > 0.0 && hi < 1.0, "upper bound informative: {}", hi);
+    }
+
+    #[test]
+    #[should_panic(expected = "successes")]
+    fn wilson_interval_panics_when_total_is_zero_but_successes_is_positive() {
+        // The "no data" early-return for total==0 must not also short-
+        // circuit the successes<=total contract: (successes=7, total=0)
+        // is impossible input, not "no data". Without the guard ahead of
+        // the early return it slips through and silently returns (0,1).
+        let _ = wilson_interval(7, 0, 0.95);
     }
 
     #[test]

--- a/src/stats_math.rs
+++ b/src/stats_math.rs
@@ -23,7 +23,11 @@ pub fn wilson_interval(successes: usize, total: usize, confidence: f64) -> (f64,
     if total == 0 {
         return (0.0, 1.0);
     }
-    debug_assert!(
+    // assert! (not debug_assert!) so that release builds also reject
+    // impossible inputs. Silent clamping to p=1 would mask upstream data
+    // corruption — off-by-one in aggregation, malformed feedback rows,
+    // hand-edited JSONL — and produce plausible-looking intervals.
+    assert!(
         successes <= total,
         "wilson_interval: successes ({}) must not exceed total ({})",
         successes,
@@ -92,6 +96,18 @@ mod tests {
         let (lo, hi) = wilson_interval(0, 5, 0.95);
         assert_eq!(lo, 0.0, "lower bound clamps to 0");
         assert!(hi > 0.0 && hi < 1.0, "upper bound informative: {}", hi);
+    }
+
+    #[test]
+    #[should_panic(expected = "successes")]
+    fn wilson_interval_panics_when_successes_exceeds_total() {
+        // Documents the contract: successes must not exceed total.
+        // Production guard is `assert!` (not `debug_assert!`) so the
+        // failure is visible in release builds too — silently clamping
+        // to p=1 would mask upstream data corruption (off-by-one in
+        // aggregation, malformed feedback rows, etc.) and produce
+        // plausible-looking intervals on broken inputs.
+        let _ = wilson_interval(7, 5, 0.95);
     }
 
     #[test]

--- a/src/stats_math.rs
+++ b/src/stats_math.rs
@@ -1,0 +1,105 @@
+//! Pure math helpers for the stats dashboard.
+//!
+//! Kept narrowly scoped: Wilson confidence intervals for proportions, used
+//! by the headline precision trend to surface uncertainty bands. No I/O,
+//! no allocations beyond return values, no logging. If a future change
+//! needs more, prefer adding a new helper here over expanding an existing one.
+
+/// Wilson score interval for a binomial proportion.
+///
+/// Returns `(lower, upper)` bounds at the given confidence level, both in
+/// `[0.0, 1.0]`. Wilson is preferred over the normal-approximation (Wald)
+/// interval for small `n` and proportions near 0 or 1, where Wald can
+/// produce bounds outside the unit interval or zero-width "intervals" at
+/// the extremes.
+///
+/// `total == 0` returns `(0.0, 1.0)` — an uninformative band, which is
+/// the right answer for "we have no data" rather than panicking or
+/// returning NaN.
+///
+/// Reference: Wilson (1927), "Probable Inference, the Law of Succession,
+/// and Statistical Inference."
+pub fn wilson_interval(successes: usize, total: usize, confidence: f64) -> (f64, f64) {
+    if total == 0 {
+        return (0.0, 1.0);
+    }
+    debug_assert!(
+        successes <= total,
+        "wilson_interval: successes ({}) must not exceed total ({})",
+        successes,
+        total
+    );
+    let n = total as f64;
+    let p = (successes as f64 / n).clamp(0.0, 1.0);
+    let z = z_score(confidence);
+    let z2 = z * z;
+    let denom = 1.0 + z2 / n;
+    let center = (p + z2 / (2.0 * n)) / denom;
+    let half_width = (z * (p * (1.0 - p) / n + z2 / (4.0 * n * n)).sqrt()) / denom;
+    let lo = (center - half_width).max(0.0);
+    let hi = (center + half_width).min(1.0);
+    (lo, hi)
+}
+
+/// Two-sided z-score for a given confidence level.
+///
+/// Hard-coded for the values we actually use — avoids pulling in a stats
+/// crate for one function. Unrecognized confidence levels fall back to
+/// 95% (the dashboard's documented default).
+fn z_score(confidence: f64) -> f64 {
+    match (confidence * 100.0).round() as u32 {
+        99 => 2.576,
+        95 => 1.96,
+        90 => 1.645,
+        _ => 1.96,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn wilson_interval_with_zero_n_returns_unit_band() {
+        // No data: report the entire unit interval. Don't panic, don't NaN.
+        assert_eq!(wilson_interval(0, 0, 0.95), (0.0, 1.0));
+    }
+
+    #[test]
+    fn wilson_interval_n_60_p_0_5_matches_published_reference() {
+        // Numerical pin against a known textbook value: Wilson at n=60,
+        // p=0.5, z=1.96 yields approximately (0.376, 0.624). Catches
+        // sign errors and wrong z constants without re-deriving the
+        // formula in test names.
+        let (lo, hi) = wilson_interval(30, 60, 0.95);
+        assert!((lo - 0.376).abs() < 0.005, "lower {} not near 0.376", lo);
+        assert!((hi - 0.624).abs() < 0.005, "upper {} not near 0.624", hi);
+    }
+
+    #[test]
+    fn wilson_interval_confidence_unknown_falls_back_to_95() {
+        // Locks the documented fallback in z_score: any unrecognized
+        // confidence (e.g. 0.42) uses the 95% z constant.
+        let unknown = wilson_interval(30, 60, 0.42);
+        let ninetyfive = wilson_interval(30, 60, 0.95);
+        assert_eq!(unknown, ninetyfive);
+    }
+
+    #[test]
+    fn wilson_interval_p_zero_at_small_n_lower_bound_is_zero() {
+        // Edge case: 0 successes out of 5. Wald would produce a degenerate
+        // (0, 0) "interval"; Wilson must give a proper upper bound > 0.
+        let (lo, hi) = wilson_interval(0, 5, 0.95);
+        assert_eq!(lo, 0.0, "lower bound clamps to 0");
+        assert!(hi > 0.0 && hi < 1.0, "upper bound informative: {}", hi);
+    }
+
+    #[test]
+    fn wilson_interval_p_one_at_small_n_upper_bound_is_one() {
+        // Mirror of the above: 5/5 successes. Lower should be < 1, upper
+        // clamps to 1.
+        let (lo, hi) = wilson_interval(5, 5, 0.95);
+        assert_eq!(hi, 1.0, "upper bound clamps to 1");
+        assert!(lo > 0.0 && lo < 1.0, "lower bound informative: {}", lo);
+    }
+}

--- a/tests/calibrator_pre_refactor_snapshot.rs
+++ b/tests/calibrator_pre_refactor_snapshot.rs
@@ -65,6 +65,8 @@ fn human_fb(title: &str, category: &str, verdict: Verdict) -> FeedbackEntry {
         timestamp: Utc::now() - ChronoDuration::hours(1),
         provenance: Provenance::Human,
         fp_kind: None,
+        finding_id: None,
+        rule_id: None,
     }
 }
 

--- a/tests/finding_schema_test.rs
+++ b/tests/finding_schema_test.rs
@@ -4,6 +4,7 @@ use quorum::finding::{Finding, FindingBuilder, GroundingStatus, Severity, Source
 #[test]
 fn finding_with_new_fields_roundtrips() {
     let finding = Finding {
+        id: quorum::finding::new_finding_ulid(),
         title: "SQL injection".into(),
         description: "Unsanitized input".into(),
         severity: Severity::High,
@@ -54,6 +55,7 @@ fn old_json_without_new_fields_deserializes() {
 #[test]
 fn new_fields_omitted_from_json_when_none() {
     let finding = Finding {
+        id: quorum::finding::new_finding_ulid(),
         title: "Test".into(),
         description: "Test".into(),
         severity: Severity::Info,
@@ -82,6 +84,7 @@ fn new_fields_omitted_from_json_when_none() {
 #[test]
 fn category_serializes_as_kebab_case_in_finding() {
     let finding = Finding {
+        id: quorum::finding::new_finding_ulid(),
         title: "Test".into(),
         description: "Test".into(),
         severity: Severity::Info,

--- a/tests/lib_integration_smoke.rs
+++ b/tests/lib_integration_smoke.rs
@@ -20,6 +20,7 @@ fn lib_exports_are_reachable_from_integration_tests() {
 
     // Finding must be constructible.
     let finding = Finding {
+        id: quorum::finding::new_finding_ulid(),
         title: "smoke".into(),
         description: String::new(),
         severity: Severity::Low,


### PR DESCRIPTION
## Summary

- **Replace tier-precision table with channel attribution**: counts-only breakdown (Human/PostFix/External/AutoCal/Unknown) — per-channel precision was a category error since External and AutoCal sample from different distributions
- **Per-finding precision trend**: deduplicates by `finding_id` with Human > PostFix > drop precedence; gated behind 85% linkage rate, falls back to entry-level with banner
- **Headline trend**: arrow chain with Wilson 95% CI on tail window (n>=30), capture rate inline, `n<30` marker when sample too small
- **External corpus block**: per-agent contribution counts + agreement rate against Human verdicts
- **`--full` flag**: gates verbose dimensions (By caller, Rolling windows) behind opt-in; By repo stays in default
- **JSON + compact output**: all new metrics surfaced in both programmatic output modes
- **DESIGN.md**: table formatting rules (single dim rule, em-dash for zeros) + trend interpretation guidance

Implements plan: `docs/plans/2026-05-05-stats-redesign.md`

## Quorum self-review verdicts

| Finding | Verdict | Action |
|---------|---------|--------|
| wilson_interval assert ordering | tp (post_fix) | Fixed — assert before early return |
| format_join_health silent error swallow | tp (post_fix) | Fixed — surfaces read errors |
| format_join_health rounding threshold | tp (post_fix) | Fixed — uses unrounded f64 |
| FindingBuilder empty-id invariant | tp (post_fix) | Fixed — assert added |
| LLM prompt injection risk | fp (out-of-scope) | Pre-existing, filed #230 |
| 4 additional pre-existing findings | fp (out-of-scope) | Filed #231-#234 |

## Test plan

- [x] 1258 bin tests passing (1746 total including lib)
- [x] 0 clippy errors
- [x] Release build succeeds
- [x] Smoke test against real data (812 reviews, 2532 feedback entries) renders cleanly in all 3 modes
- [x] 5 pre-existing `parallel_review` integration failures confirmed on main (env leak, not this branch)
- [x] Independent code review pass — 2 MAJOR findings (JSON/compact missing fields) fixed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Findings now get unique IDs for reliable tracking and linking.
  * Linkage analytics and dashboard metrics added: linkage rate, capture rate, external-overlap, and per‑finding precision trends.
  * New CLI flags to view run health and request full/detailed stats.
  * Feedback and review records can now reference finding and rule IDs for better traceability.

* **Documentation**
  * Table layout rules and dashboard trend interpretation guidance added.

* **Chores**
  * Version bumped to 0.19.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->