### PR TITLE
style: apply rustfmt across codebase

### DIFF
--- a/examples/compare_calibration.rs
+++ b/examples/compare_calibration.rs
@@ -17,23 +17,37 @@ fn load_entries(path: &std::path::Path) -> anyhow::Result<Vec<Entry>> {
     let txt = std::fs::read_to_string(path)?;
     let mut out = Vec::new();
     for line in txt.lines() {
-        if line.trim().is_empty() { continue; }
+        if line.trim().is_empty() {
+            continue;
+        }
         if let Ok(e) = serde_json::from_str::<Entry>(line) {
-            if !e.finding_title.is_empty() { out.push(e); }
+            if !e.finding_title.is_empty() {
+                out.push(e);
+            }
         }
     }
     Ok(out)
 }
 
 fn cosine(a: &[f32], b: &[f32]) -> f32 {
-    let mut d = 0.0; let mut na = 0.0; let mut nb = 0.0;
-    for i in 0..a.len() { d += a[i]*b[i]; na += a[i]*a[i]; nb += b[i]*b[i]; }
+    let mut d = 0.0;
+    let mut na = 0.0;
+    let mut nb = 0.0;
+    for i in 0..a.len() {
+        d += a[i] * b[i];
+        na += a[i] * a[i];
+        nb += b[i] * b[i];
+    }
     d / ((na.sqrt() * nb.sqrt()).max(1e-9))
 }
 
 /// Return ranked entry indices, highest similarity first.
 fn embed_rank(qv: &[f32], corpus_vecs: &[Vec<f32>], top_n: usize) -> Vec<(usize, f32)> {
-    let mut scored: Vec<(usize, f32)> = corpus_vecs.iter().enumerate().map(|(i, v)| (i, cosine(qv, v))).collect();
+    let mut scored: Vec<(usize, f32)> = corpus_vecs
+        .iter()
+        .enumerate()
+        .map(|(i, v)| (i, cosine(qv, v)))
+        .collect();
     scored.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
     scored.truncate(top_n);
     scored
@@ -52,16 +66,23 @@ fn rrf(bm25_ranked: &[usize], embed_ranked: &[usize], top_k: usize) -> Vec<(usiz
     let mut fused: Vec<(usize, f32)> = scores.into_iter().collect();
     fused.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
     let max = fused.first().map(|(_, s)| *s).unwrap_or(1e-6).max(1e-6);
-    fused.into_iter().take(top_k).map(|(i, s)| (i, (s / max).clamp(0.0, 1.0))).collect()
+    fused
+        .into_iter()
+        .take(top_k)
+        .map(|(i, s)| (i, (s / max).clamp(0.0, 1.0)))
+        .collect()
 }
 
 /// Simulate the calibrator's TP/FP weight accumulation for a given set of
 /// precedent indices and verdicts. Returns (tp_weight, fp_weight).
 fn calibrate(indices: &[usize], entries: &[Entry], similarities: &[f32]) -> (f64, f64) {
-    let mut tp = 0.0; let mut fp = 0.0;
+    let mut tp = 0.0;
+    let mut fp = 0.0;
     for (k, idx) in indices.iter().enumerate() {
         let sim = similarities.get(k).copied().unwrap_or(1.0) as f64;
-        if sim < 0.80 { continue; }
+        if sim < 0.80 {
+            continue;
+        }
         let e = &entries[*idx];
         match e.verdict.as_deref() {
             Some("tp") | Some("partial") => tp += 1.0 * sim,
@@ -97,42 +118,93 @@ fn main() -> anyhow::Result<()> {
 
     // Fixed query set: 40 realistic recent findings
     let queries: Vec<(&str, &str)> = vec![
-        ("Function `check_vendor_urls` has cyclomatic complexity 11", "complexity"),
-        ("Function `gameLoop` has cyclomatic complexity 19", "complexity"),
+        (
+            "Function `check_vendor_urls` has cyclomatic complexity 11",
+            "complexity",
+        ),
+        (
+            "Function `gameLoop` has cyclomatic complexity 19",
+            "complexity",
+        ),
         ("Function `pipe` has cyclomatic complexity 30", "complexity"),
-        ("Function `createFood` has cyclomatic complexity 13", "complexity"),
-        ("Function `checkCollisions` has cyclomatic complexity 10", "complexity"),
-        ("Catch-all `except: pass` silently swallows errors", "error-handling"),
+        (
+            "Function `createFood` has cyclomatic complexity 13",
+            "complexity",
+        ),
+        (
+            "Function `checkCollisions` has cyclomatic complexity 10",
+            "complexity",
+        ),
+        (
+            "Catch-all `except: pass` silently swallows errors",
+            "error-handling",
+        ),
         ("console.log debug artifact left in code", "style"),
         ("SQL injection risk in query builder", "security"),
-        ("`open()` without explicit `encoding` parameter", "reliability"),
+        (
+            "`open()` without explicit `encoding` parameter",
+            "reliability",
+        ),
         ("Unused import increases noise", "style"),
         ("Image load failure causes endless polling loop", "logic"),
-        ("Canvas lookup and 2D context used without null checks", "reliability"),
-        ("Missing error handling on subprocess call", "error-handling"),
-        ("Schema conversion assumes properties always exist", "robustness"),
-        ("Broad exception catch hides network failures", "error-handling"),
+        (
+            "Canvas lookup and 2D context used without null checks",
+            "reliability",
+        ),
+        (
+            "Missing error handling on subprocess call",
+            "error-handling",
+        ),
+        (
+            "Schema conversion assumes properties always exist",
+            "robustness",
+        ),
+        (
+            "Broad exception catch hides network failures",
+            "error-handling",
+        ),
         ("Hardcoded URL in configuration", "config"),
         ("State is never reset between requests", "state-management"),
-        ("Mutable default argument retains state across calls", "python"),
-        ("Race condition on shared counter without lock", "concurrency"),
+        (
+            "Mutable default argument retains state across calls",
+            "python",
+        ),
+        (
+            "Race condition on shared counter without lock",
+            "concurrency",
+        ),
         ("Unvalidated redirect destination", "security"),
         ("Bare except masks KeyboardInterrupt", "error-handling"),
         ("Deprecated use of datetime.utcnow()", "deprecation"),
         ("Input path validation accepts directories", "robustness"),
         ("Blocking input() in async code freezes event loop", "async"),
         ("Only first tool call from response is executed", "logic"),
-        ("Restarting game creates additional concurrent loops", "state-management"),
+        (
+            "Restarting game creates additional concurrent loops",
+            "state-management",
+        ),
         ("Floor game-over unreachable due to clamping", "logic"),
         ("Exception details disclosed in API response", "security"),
-        ("Search result titles injected into Markdown without escaping", "security"),
-        ("Naive/aware datetime mixing in timezone calculation", "correctness"),
+        (
+            "Search result titles injected into Markdown without escaping",
+            "security",
+        ),
+        (
+            "Naive/aware datetime mixing in timezone calculation",
+            "correctness",
+        ),
         ("YAML duplicate keys cause silent override", "correctness"),
-        ("Docker FROM :latest causes non-reproducible builds", "infrastructure"),
+        (
+            "Docker FROM :latest causes non-reproducible builds",
+            "infrastructure",
+        ),
         ("Wildcard IAM permission in terraform config", "security"),
         ("Missing HEALTHCHECK in Dockerfile", "reliability"),
         ("Bash curl | bash without verification", "security"),
-        ("Terraform security group opens port 22 to 0.0.0.0/0", "security"),
+        (
+            "Terraform security group opens port 22 to 0.0.0.0/0",
+            "security",
+        ),
         ("Non-threadsafe singleton pattern", "concurrency"),
         ("Mutation during iteration in Python dict", "correctness"),
         ("Jinja template list accumulation in loop", "template"),
@@ -155,10 +227,15 @@ fn main() -> anyhow::Result<()> {
     let mut action_agreement = 0;
     let mut only_e: std::collections::HashMap<&'static str, usize> = Default::default();
     let mut only_r: std::collections::HashMap<&'static str, usize> = Default::default();
-    let mut both_act: std::collections::HashMap<(&'static str, &'static str), usize> = Default::default();
+    let mut both_act: std::collections::HashMap<(&'static str, &'static str), usize> =
+        Default::default();
 
     for (qt, _qc) in &queries {
-        let qv = embedder.embed(vec![qt.to_string()], None)?.into_iter().next().unwrap();
+        let qv = embedder
+            .embed(vec![qt.to_string()], None)?
+            .into_iter()
+            .next()
+            .unwrap();
         let e_ranked = embed_rank(&qv, &corpus_vecs, pool);
         let b_results = bm25.search(qt, pool);
         let b_ranked: Vec<usize> = b_results.iter().map(|r| r.document.id as usize).collect();
@@ -193,7 +270,11 @@ fn main() -> anyhow::Result<()> {
 
     println!("\n================================================");
     println!("Query set: {}", queries.len());
-    println!("Action agreement between EMBED and RRF: {}/{}", action_agreement, queries.len());
+    println!(
+        "Action agreement between EMBED and RRF: {}/{}",
+        action_agreement,
+        queries.len()
+    );
     println!("\nConfusion matrix (EMBED_action → RRF_action : count):");
     let mut sorted: Vec<_> = both_act.iter().collect();
     sorted.sort_by_key(|(k, _)| (k.0, k.1));

--- a/examples/compare_retrieval.rs
+++ b/examples/compare_retrieval.rs
@@ -19,9 +19,13 @@ fn load_entries(path: &std::path::Path) -> anyhow::Result<Vec<Entry>> {
     let txt = std::fs::read_to_string(path)?;
     let mut out = Vec::new();
     for line in txt.lines() {
-        if line.trim().is_empty() { continue; }
+        if line.trim().is_empty() {
+            continue;
+        }
         if let Ok(e) = serde_json::from_str::<Entry>(line) {
-            if !e.finding_title.is_empty() { out.push(e); }
+            if !e.finding_title.is_empty() {
+                out.push(e);
+            }
         }
     }
     Ok(out)
@@ -29,7 +33,10 @@ fn load_entries(path: &std::path::Path) -> anyhow::Result<Vec<Entry>> {
 
 fn word_set(s: &str) -> HashSet<String> {
     s.split_whitespace()
-        .map(|w| w.trim_matches(|c: char| !c.is_alphanumeric()).to_lowercase())
+        .map(|w| {
+            w.trim_matches(|c: char| !c.is_alphanumeric())
+                .to_lowercase()
+        })
         .filter(|w| !w.is_empty())
         .collect()
 }
@@ -52,13 +59,26 @@ fn cosine(a: &[f32], b: &[f32]) -> f32 {
     let mut dot = 0.0f32;
     let mut na = 0.0f32;
     let mut nb = 0.0f32;
-    for i in 0..a.len() { dot += a[i]*b[i]; na += a[i]*a[i]; nb += b[i]*b[i]; }
+    for i in 0..a.len() {
+        dot += a[i] * b[i];
+        na += a[i] * a[i];
+        nb += b[i] * b[i];
+    }
     let denom = (na.sqrt() * nb.sqrt()).max(1e-9);
     dot / denom
 }
 
-fn embed_top_k(query_vec: &[f32], corpus_vecs: &[Vec<f32>], corpus_titles: &[String], k: usize) -> Vec<String> {
-    let mut scored: Vec<(f32, &String)> = corpus_vecs.iter().enumerate().map(|(i, v)| (cosine(query_vec, v), &corpus_titles[i])).collect();
+fn embed_top_k(
+    query_vec: &[f32],
+    corpus_vecs: &[Vec<f32>],
+    corpus_titles: &[String],
+    k: usize,
+) -> Vec<String> {
+    let mut scored: Vec<(f32, &String)> = corpus_vecs
+        .iter()
+        .enumerate()
+        .map(|(i, v)| (cosine(query_vec, v), &corpus_titles[i]))
+        .collect();
     scored.sort_by(|a, b| b.0.partial_cmp(&a.0).unwrap_or(std::cmp::Ordering::Equal));
     scored.into_iter().take(k).map(|(_, s)| s.clone()).collect()
 }
@@ -121,7 +141,8 @@ fn main() -> anyhow::Result<()> {
 
     // --- Build indices ---
     let t0 = Instant::now();
-    let bm25_engine = SearchEngineBuilder::<u32>::with_corpus(Language::English, titles.clone()).build();
+    let bm25_engine =
+        SearchEngineBuilder::<u32>::with_corpus(Language::English, titles.clone()).build();
     let bm25_build_ms = t0.elapsed().as_millis();
 
     let t0 = Instant::now();
@@ -139,10 +160,16 @@ fn main() -> anyhow::Result<()> {
     let mut tot_b = 0u128;
     let mut tot_e = 0u128;
     let mut tot_r = 0u128;
-    let mut jb = 0.0f64; let mut je = 0.0f64; let mut be_ = 0.0f64;
-    let mut re_ = 0.0f64; let mut rb = 0.0f64;
-    let mut jb_t1 = 0; let mut je_t1 = 0; let mut be_t1 = 0;
-    let mut re_t1 = 0; let mut rb_t1 = 0;
+    let mut jb = 0.0f64;
+    let mut je = 0.0f64;
+    let mut be_ = 0.0f64;
+    let mut re_ = 0.0f64;
+    let mut rb = 0.0f64;
+    let mut jb_t1 = 0;
+    let mut je_t1 = 0;
+    let mut be_t1 = 0;
+    let mut re_t1 = 0;
+    let mut rb_t1 = 0;
 
     for q in &queries {
         let t0 = Instant::now();
@@ -155,14 +182,19 @@ fn main() -> anyhow::Result<()> {
         let b_top: Vec<String> = b_res.iter().map(|r| r.document.contents.clone()).collect();
 
         let t0 = Instant::now();
-        let q_vec = embedder.embed(vec![q.to_string()], None)?.into_iter().next().unwrap();
+        let q_vec = embedder
+            .embed(vec![q.to_string()], None)?
+            .into_iter()
+            .next()
+            .unwrap();
         let e_top = embed_top_k(&q_vec, &corpus_vecs, &titles, k);
         tot_e += t0.elapsed().as_micros();
 
         // RRF fusion of BM25 + embedding top-20 pools
         let t0 = Instant::now();
         let b_pool = bm25_engine.search(q, 20);
-        let b_pool_titles: Vec<String> = b_pool.iter().map(|r| r.document.contents.clone()).collect();
+        let b_pool_titles: Vec<String> =
+            b_pool.iter().map(|r| r.document.contents.clone()).collect();
         let e_pool = embed_top_k(&q_vec, &corpus_vecs, &titles, 20);
         let r_top = rrf_fuse(&b_pool_titles, &e_pool, k);
         tot_r += t0.elapsed().as_micros();
@@ -172,11 +204,21 @@ fn main() -> anyhow::Result<()> {
         be_ += set_overlap(&b_top, &e_top);
         re_ += set_overlap(&r_top, &e_top);
         rb += set_overlap(&r_top, &b_top);
-        if !j_top.is_empty() && !b_top.is_empty() && j_top[0] == b_top[0] { jb_t1 += 1; }
-        if !j_top.is_empty() && !e_top.is_empty() && j_top[0] == e_top[0] { je_t1 += 1; }
-        if !b_top.is_empty() && !e_top.is_empty() && b_top[0] == e_top[0] { be_t1 += 1; }
-        if !r_top.is_empty() && !e_top.is_empty() && r_top[0] == e_top[0] { re_t1 += 1; }
-        if !r_top.is_empty() && !b_top.is_empty() && r_top[0] == b_top[0] { rb_t1 += 1; }
+        if !j_top.is_empty() && !b_top.is_empty() && j_top[0] == b_top[0] {
+            jb_t1 += 1;
+        }
+        if !j_top.is_empty() && !e_top.is_empty() && j_top[0] == e_top[0] {
+            je_t1 += 1;
+        }
+        if !b_top.is_empty() && !e_top.is_empty() && b_top[0] == e_top[0] {
+            be_t1 += 1;
+        }
+        if !r_top.is_empty() && !e_top.is_empty() && r_top[0] == e_top[0] {
+            re_t1 += 1;
+        }
+        if !r_top.is_empty() && !b_top.is_empty() && r_top[0] == b_top[0] {
+            rb_t1 += 1;
+        }
 
         println!("\nQ: {}", q);
         println!("  J: {}", j_top.first().map(|s| s.as_str()).unwrap_or(""));
@@ -186,12 +228,21 @@ fn main() -> anyhow::Result<()> {
     }
 
     println!("\n=================================================");
-    println!("Build:  BM25={}ms  embedder_init={}ms  embed_corpus={}ms", bm25_build_ms, embedder_init_ms, embed_build_ms);
+    println!(
+        "Build:  BM25={}ms  embedder_init={}ms  embed_corpus={}ms",
+        bm25_build_ms, embedder_init_ms, embed_build_ms
+    );
     println!("\nAvg query latency ({} queries):", queries.len());
     println!("  Jaccard   : {} µs", tot_j / n as u128);
     println!("  BM25      : {} µs", tot_b / n as u128);
-    println!("  Embedding : {} µs  (includes per-query encode)", tot_e / n as u128);
-    println!("  RRF (B+E) : {} µs  (both retrievals + fuse)", tot_r / n as u128);
+    println!(
+        "  Embedding : {} µs  (includes per-query encode)",
+        tot_e / n as u128
+    );
+    println!(
+        "  RRF (B+E) : {} µs  (both retrievals + fuse)",
+        tot_r / n as u128
+    );
 
     println!("\nTop-5 set overlap (higher = more agreement):");
     println!("  Jaccard ↔ BM25      : {:.2}", jb / n);

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -1,7 +1,6 @@
 /// Bounded agent loop for deep code review.
 /// Gives the LLM tools to investigate the codebase before producing findings.
 /// Bounded by max iterations, max tool calls, and max bytes read.
-
 use crate::finding::Finding;
 use crate::pipeline::LlmReviewer;
 use crate::tools::ToolRegistry;
@@ -83,10 +82,20 @@ pub fn agent_review(
 
     // Get project file listing for context (bounded by config)
     let file_listing = tools
-        .execute("list_files", &serde_json::json!({}), config.max_bytes_read / 2)
+        .execute(
+            "list_files",
+            &serde_json::json!({}),
+            config.max_bytes_read / 2,
+        )
         .unwrap_or_else(|_| "Unable to list files.".into());
 
-    let prompt = render_review_prompt(&safe_path_or_default(file_path), &file_listing, code, &tool_descriptions, config);
+    let prompt = render_review_prompt(
+        &safe_path_or_default(file_path),
+        &file_listing,
+        code,
+        &tool_descriptions,
+        config,
+    );
 
     let sys_prompt = crate::llm_client::OpenAiClient::system_prompt();
     let resp = reviewer.review(&prompt, model, sys_prompt)?;
@@ -305,14 +314,20 @@ fn force_final_turn(
     }
 }
 
-fn append_assistant_tool_calls(messages: &mut Vec<serde_json::Value>, calls: &[crate::llm_client::ToolCall]) {
-    let tc_json: Vec<serde_json::Value> = calls.iter().map(|tc| {
-        serde_json::json!({
-            "id": tc.id,
-            "type": "function",
-            "function": {"name": tc.name, "arguments": tc.arguments}
+fn append_assistant_tool_calls(
+    messages: &mut Vec<serde_json::Value>,
+    calls: &[crate::llm_client::ToolCall],
+) {
+    let tc_json: Vec<serde_json::Value> = calls
+        .iter()
+        .map(|tc| {
+            serde_json::json!({
+                "id": tc.id,
+                "type": "function",
+                "function": {"name": tc.name, "arguments": tc.arguments}
+            })
         })
-    }).collect();
+        .collect();
     messages.push(serde_json::json!({
         "role": "assistant",
         "content": null,
@@ -340,7 +355,10 @@ pub fn agent_loop(
         )}),
     ];
 
-    let mut state = AgentState { total_bytes_read: 0, total_tool_calls: 0 };
+    let mut state = AgentState {
+        total_bytes_read: 0,
+        total_tool_calls: 0,
+    };
 
     for _iteration in 0..config.max_iterations {
         let result = reviewer.chat_turn(&messages, &tool_defs, model)?;
@@ -374,10 +392,8 @@ pub fn agent_loop(
                         // values aren't escaped by sanitize_inline_metadata, and
                         // tool_call_id already distinguishes which call produced
                         // this output for the LLM.
-                        let wrapped = format!(
-                            "<tool_output>{}</tool_output>",
-                            escape_for_xml_wrap(result),
-                        );
+                        let wrapped =
+                            format!("<tool_output>{}</tool_output>", escape_for_xml_wrap(result),);
                         messages.push(serde_json::json!({
                             "role": "tool",
                             "tool_call_id": tc.id,
@@ -388,7 +404,9 @@ pub fn agent_loop(
 
                 if state.limit_reached(config) {
                     return force_final_turn(
-                        reviewer, &mut messages, model,
+                        reviewer,
+                        &mut messages,
+                        model,
                         "Limit reached. Produce your findings JSON array now based on what you have seen so far.",
                     );
                 }
@@ -398,7 +416,9 @@ pub fn agent_loop(
 
     eprintln!("Agent: iteration limit ({}) reached", config.max_iterations);
     force_final_turn(
-        reviewer, &mut messages, model,
+        reviewer,
+        &mut messages,
+        model,
         "You've reached the investigation limit. Produce your findings JSON array now.",
     )
 }
@@ -477,8 +497,8 @@ mod tests {
     use super::*;
     use tempfile::TempDir;
 
-    use crate::test_support::fakes::{FakeReviewer, FakeAgentReviewer};
     use crate::llm_client::{LlmTurnResult, ToolCall};
+    use crate::test_support::fakes::{FakeAgentReviewer, FakeReviewer};
     use std::collections::VecDeque;
     use std::sync::Mutex;
 
@@ -529,7 +549,10 @@ mod tests {
             max_tool_calls: 5,
             ..AgentConfig::default()
         };
-        let mut state = AgentState { total_bytes_read: 0, total_tool_calls: 0 };
+        let mut state = AgentState {
+            total_bytes_read: 0,
+            total_tool_calls: 0,
+        };
         let tc = ToolCall {
             id: "1".into(),
             name: "read_file".into(),
@@ -639,7 +662,8 @@ mod tests {
             .next()
             .expect("wrapper must close");
         assert!(
-            body.contains("&lt;/code_under_review&gt;") || body.contains("&#60;/code_under_review&#62;"),
+            body.contains("&lt;/code_under_review&gt;")
+                || body.contains("&#60;/code_under_review&#62;"),
             "inner </code_under_review> must be HTML-escaped inside the wrapper; body was:\n{body}"
         );
 
@@ -676,7 +700,8 @@ mod tests {
             max_bytes_read: 100,
             ..AgentConfig::default()
         };
-        let prompt = render_review_prompt_with_budget_for_test("src/main.rs", &oversized, "x = 1", &config);
+        let prompt =
+            render_review_prompt_with_budget_for_test("src/main.rs", &oversized, "x = 1", &config);
 
         let body = prompt
             .split(LISTING_OPEN_TAG)
@@ -840,8 +865,16 @@ mod tests {
         let payload = "a".repeat(200);
         std::fs::write(dir.path().join("big.txt"), &payload).unwrap();
         let tools = ToolRegistry::new(dir.path());
-        let config = AgentConfig { max_iterations: 1, max_tool_calls: 1, max_bytes_read: 100, ..AgentConfig::default() };
-        let mut state = AgentState { total_bytes_read: 0, total_tool_calls: 0 };
+        let config = AgentConfig {
+            max_iterations: 1,
+            max_tool_calls: 1,
+            max_bytes_read: 100,
+            ..AgentConfig::default()
+        };
+        let mut state = AgentState {
+            total_bytes_read: 0,
+            total_tool_calls: 0,
+        };
         let tc = ToolCall {
             id: "t".into(),
             name: "read_file".into(),
@@ -879,7 +912,15 @@ mod tests {
             ),
         ]);
 
-        let result = agent_loop("eval(input())", "test.py", &reviewer, "gpt-5.4", &tools, &config).unwrap();
+        let result = agent_loop(
+            "eval(input())",
+            "test.py",
+            &reviewer,
+            "gpt-5.4",
+            &tools,
+            &config,
+        )
+        .unwrap();
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].title, "Dangerous eval");
     }
@@ -887,7 +928,11 @@ mod tests {
     #[test]
     fn agent_loop_single_tool_round() {
         let dir = TempDir::new().unwrap();
-        std::fs::write(dir.path().join("auth.py"), "SECRET = 'hunter2'\ndef login(): pass\n").unwrap();
+        std::fs::write(
+            dir.path().join("auth.py"),
+            "SECRET = 'hunter2'\ndef login(): pass\n",
+        )
+        .unwrap();
         let tools = ToolRegistry::new(dir.path());
         let config = AgentConfig::default();
 
@@ -904,8 +949,13 @@ mod tests {
 
         let result = agent_loop(
             "SECRET = 'hunter2'\ndef login(): pass\n",
-            "auth.py", &reviewer, "gpt-5.4", &tools, &config,
-        ).unwrap();
+            "auth.py",
+            &reviewer,
+            "gpt-5.4",
+            &tools,
+            &config,
+        )
+        .unwrap();
         assert_eq!(result.len(), 1);
         assert!(result[0].title.contains("secret") || result[0].title.contains("Secret"));
     }
@@ -922,19 +972,27 @@ mod tests {
             captured_messages: Mutex<Vec<Vec<serde_json::Value>>>,
         }
         impl AgentReviewer for CapturingReviewer {
-            fn chat_turn(&self, messages: &[serde_json::Value], _tools: &serde_json::Value, _model: &str)
-                -> anyhow::Result<LlmTurnResult>
-            {
-                self.captured_messages.lock().unwrap().push(messages.to_vec());
+            fn chat_turn(
+                &self,
+                messages: &[serde_json::Value],
+                _tools: &serde_json::Value,
+                _model: &str,
+            ) -> anyhow::Result<LlmTurnResult> {
+                self.captured_messages
+                    .lock()
+                    .unwrap()
+                    .push(messages.to_vec());
                 let mut q = self.turns.lock().unwrap();
-                Ok(q.pop_front().unwrap_or(LlmTurnResult::FinalContent("[]".into())))
+                Ok(q.pop_front()
+                    .unwrap_or(LlmTurnResult::FinalContent("[]".into())))
             }
         }
 
         let reviewer = CapturingReviewer {
             turns: Mutex::new(VecDeque::from([
                 LlmTurnResult::ToolCalls(vec![ToolCall {
-                    id: "call_1".into(), name: "read_file".into(),
+                    id: "call_1".into(),
+                    name: "read_file".into(),
                     arguments: r#"{"path": "test.py"}"#.into(),
                 }]),
                 LlmTurnResult::FinalContent("[]".into()),
@@ -949,9 +1007,15 @@ mod tests {
 
         // Second turn should have: system, user, assistant(tool_calls), tool(result)
         let turn2 = &captures[1];
-        assert!(turn2.len() >= 4, "Turn 2 should have system + user + assistant + tool messages");
+        assert!(
+            turn2.len() >= 4,
+            "Turn 2 should have system + user + assistant + tool messages"
+        );
 
-        let tool_msg = turn2.iter().find(|m| m["role"] == "tool").expect("Should have tool role message");
+        let tool_msg = turn2
+            .iter()
+            .find(|m| m["role"] == "tool")
+            .expect("Should have tool role message");
         assert_eq!(tool_msg["tool_call_id"], "call_1");
         assert!(tool_msg["content"].as_str().unwrap().contains("x = 1"));
     }
@@ -1006,9 +1070,17 @@ mod tests {
         // Capture what the reviewer sees
         struct CapturingReviewer(std::sync::Mutex<String>);
         impl crate::pipeline::LlmReviewer for CapturingReviewer {
-            fn review(&self, prompt: &str, _model: &str, _system_prompt: &str) -> anyhow::Result<crate::llm_client::LlmResponse> {
+            fn review(
+                &self,
+                prompt: &str,
+                _model: &str,
+                _system_prompt: &str,
+            ) -> anyhow::Result<crate::llm_client::LlmResponse> {
                 *self.0.lock().unwrap() = prompt.to_string();
-                Ok(crate::llm_client::LlmResponse { content: "[]".into(), usage: None })
+                Ok(crate::llm_client::LlmResponse {
+                    content: "[]".into(),
+                    usage: None,
+                })
             }
         }
 
@@ -1018,8 +1090,14 @@ mod tests {
         agent_review("x = 1", "main.py", &reviewer, "m", &tools, &config).unwrap();
 
         let captured = reviewer.0.lock().unwrap().clone();
-        assert!(captured.contains("main.py"), "Prompt should contain file listing");
-        assert!(captured.contains("deep code review"), "Prompt should mention deep review");
+        assert!(
+            captured.contains("main.py"),
+            "Prompt should contain file listing"
+        );
+        assert!(
+            captured.contains("deep code review"),
+            "Prompt should mention deep review"
+        );
     }
 
     #[test]
@@ -1027,11 +1105,17 @@ mod tests {
         let dir = TempDir::new().unwrap();
         std::fs::write(dir.path().join("test.py"), "x = 1").unwrap();
         let tools = ToolRegistry::new(dir.path());
-        let config = AgentConfig { max_iterations: 1, max_tool_calls: 10, max_bytes_read: 50_000, ..AgentConfig::default() };
+        let config = AgentConfig {
+            max_iterations: 1,
+            max_tool_calls: 10,
+            max_bytes_read: 50_000,
+            ..AgentConfig::default()
+        };
 
         let reviewer = FakeAgentReviewer::new(vec![
             LlmTurnResult::ToolCalls(vec![ToolCall {
-                id: "c1".into(), name: "read_file".into(),
+                id: "c1".into(),
+                name: "read_file".into(),
                 arguments: r#"{"path":"test.py"}"#.into(),
             }]),
             // This turn is the forced "produce findings" turn after limit
@@ -1047,14 +1131,31 @@ mod tests {
         let dir = TempDir::new().unwrap();
         std::fs::write(dir.path().join("a.py"), "x").unwrap();
         let tools = ToolRegistry::new(dir.path());
-        let config = AgentConfig { max_iterations: 5, max_tool_calls: 2, max_bytes_read: 50_000, ..AgentConfig::default() };
+        let config = AgentConfig {
+            max_iterations: 5,
+            max_tool_calls: 2,
+            max_bytes_read: 50_000,
+            ..AgentConfig::default()
+        };
 
         let reviewer = FakeAgentReviewer::new(vec![
             // 3 tool calls in one turn — exceeds limit of 2
             LlmTurnResult::ToolCalls(vec![
-                ToolCall { id: "c1".into(), name: "read_file".into(), arguments: r#"{"path":"a.py"}"#.into() },
-                ToolCall { id: "c2".into(), name: "read_file".into(), arguments: r#"{"path":"a.py"}"#.into() },
-                ToolCall { id: "c3".into(), name: "read_file".into(), arguments: r#"{"path":"a.py"}"#.into() },
+                ToolCall {
+                    id: "c1".into(),
+                    name: "read_file".into(),
+                    arguments: r#"{"path":"a.py"}"#.into(),
+                },
+                ToolCall {
+                    id: "c2".into(),
+                    name: "read_file".into(),
+                    arguments: r#"{"path":"a.py"}"#.into(),
+                },
+                ToolCall {
+                    id: "c3".into(),
+                    name: "read_file".into(),
+                    arguments: r#"{"path":"a.py"}"#.into(),
+                },
             ]),
             LlmTurnResult::FinalContent("[]".into()),
         ]);
@@ -1072,7 +1173,8 @@ mod tests {
 
         let reviewer = FakeAgentReviewer::new(vec![
             LlmTurnResult::ToolCalls(vec![ToolCall {
-                id: "c1".into(), name: "read_file".into(),
+                id: "c1".into(),
+                name: "read_file".into(),
                 arguments: "not valid json{{{".into(),
             }]),
             LlmTurnResult::FinalContent("[]".into()),
@@ -1090,7 +1192,8 @@ mod tests {
 
         let reviewer = FakeAgentReviewer::new(vec![
             LlmTurnResult::ToolCalls(vec![ToolCall {
-                id: "c1".into(), name: "read_file".into(),
+                id: "c1".into(),
+                name: "read_file".into(),
                 arguments: r#"{"path":"nonexistent.py"}"#.into(),
             }]),
             LlmTurnResult::FinalContent("[]".into()),
@@ -1108,7 +1211,12 @@ mod tests {
         // max_bytes_read=8 => /2=4 => slices at byte 4 (mid-UTF-8 of é)
         std::fs::write(dir.path().join("café.py"), "x = 1").unwrap();
         let tools = ToolRegistry::new(dir.path());
-        let config = AgentConfig { max_iterations: 3, max_tool_calls: 10, max_bytes_read: 8, ..AgentConfig::default() };
+        let config = AgentConfig {
+            max_iterations: 3,
+            max_tool_calls: 10,
+            max_bytes_read: 8,
+            ..AgentConfig::default()
+        };
         let reviewer = FakeReviewer::always("[]");
         // Should not panic on truncation at mid-multibyte boundary
         let result = agent_review("x = 1", "test.py", &reviewer, "m", &tools, &config);
@@ -1121,21 +1229,30 @@ mod tests {
         std::fs::write(dir.path().join("t.py"), "x").unwrap();
         let tools = ToolRegistry::new(dir.path());
         // Config with max_iterations=1 to force the final turn path
-        let config = AgentConfig { max_iterations: 1, max_tool_calls: 10, max_bytes_read: 50_000, ..AgentConfig::default() };
+        let config = AgentConfig {
+            max_iterations: 1,
+            max_tool_calls: 10,
+            max_bytes_read: 50_000,
+            ..AgentConfig::default()
+        };
 
         struct FailingAgentReviewer {
             call_count: Mutex<usize>,
         }
         impl AgentReviewer for FailingAgentReviewer {
-            fn chat_turn(&self, _messages: &[serde_json::Value], _tools: &serde_json::Value, _model: &str)
-                -> anyhow::Result<LlmTurnResult>
-            {
+            fn chat_turn(
+                &self,
+                _messages: &[serde_json::Value],
+                _tools: &serde_json::Value,
+                _model: &str,
+            ) -> anyhow::Result<LlmTurnResult> {
                 let mut count = self.call_count.lock().unwrap();
                 *count += 1;
                 if *count == 1 {
                     // First call: request a tool call to consume the iteration
                     Ok(LlmTurnResult::ToolCalls(vec![ToolCall {
-                        id: "c1".into(), name: "read_file".into(),
+                        id: "c1".into(),
+                        name: "read_file".into(),
                         arguments: r#"{"path":"t.py"}"#.into(),
                     }]))
                 } else {
@@ -1145,10 +1262,15 @@ mod tests {
             }
         }
 
-        let reviewer = FailingAgentReviewer { call_count: Mutex::new(0) };
+        let reviewer = FailingAgentReviewer {
+            call_count: Mutex::new(0),
+        };
         let result = agent_loop("x", "t.py", &reviewer, "m", &tools, &config);
         // Should propagate the error, not silently return empty
-        assert!(result.is_err(), "API error should propagate, not be swallowed");
+        assert!(
+            result.is_err(),
+            "API error should propagate, not be swallowed"
+        );
     }
 
     #[test]
@@ -1189,17 +1311,26 @@ mod tests {
         let code = "fn main() {}";
         let budget = 5;
         let result = wrap_code_with_budget(code, budget);
-        assert!(result.is_empty(), "should return empty when budget can't fit tags");
+        assert!(
+            result.is_empty(),
+            "should return empty when budget can't fit tags"
+        );
     }
 
     #[test]
     fn execute_tool_call_multi_call_budget_accounting() {
-        let config = AgentConfig { max_bytes_read: 100, ..AgentConfig::default() };
+        let config = AgentConfig {
+            max_bytes_read: 100,
+            ..AgentConfig::default()
+        };
         let dir = tempfile::tempdir().unwrap();
         std::fs::write(dir.path().join("a.txt"), "a".repeat(60)).unwrap();
         std::fs::write(dir.path().join("b.txt"), "b".repeat(60)).unwrap();
         let tools = crate::tools::ToolRegistry::new(dir.path());
-        let mut state = AgentState { total_bytes_read: 0, total_tool_calls: 0 };
+        let mut state = AgentState {
+            total_bytes_read: 0,
+            total_tool_calls: 0,
+        };
         let tc1 = crate::llm_client::ToolCall {
             id: "1".into(),
             name: "read_file".into(),
@@ -1213,7 +1344,10 @@ mod tests {
         let r1 = state.execute_tool_call(&tc1, &tools, &config);
         assert!(r1.is_some(), "first call should succeed");
         let r2 = state.execute_tool_call(&tc2, &tools, &config);
-        assert!(r2.is_some(), "second call should succeed (may be truncated)");
+        assert!(
+            r2.is_some(),
+            "second call should succeed (may be truncated)"
+        );
         assert!(
             state.total_bytes_read <= config.max_bytes_read,
             "total_bytes_read {} exceeds max {}",
@@ -1234,7 +1368,10 @@ mod tests {
             max_bytes_read: 100,
             ..AgentConfig::default()
         };
-        let mut state = AgentState { total_bytes_read: 0, total_tool_calls: 0 };
+        let mut state = AgentState {
+            total_bytes_read: 0,
+            total_tool_calls: 0,
+        };
 
         let tc = crate::llm_client::ToolCall {
             id: "call_1".into(),
@@ -1275,7 +1412,10 @@ mod tests {
                 _tools: &serde_json::Value,
                 _model: &str,
             ) -> anyhow::Result<LlmTurnResult> {
-                self.captured_messages.lock().unwrap().push(messages.to_vec());
+                self.captured_messages
+                    .lock()
+                    .unwrap()
+                    .push(messages.to_vec());
                 Ok(self
                     .turns
                     .lock()
@@ -1308,7 +1448,9 @@ mod tests {
             .iter()
             .find(|m| m.get("role").and_then(|v| v.as_str()) == Some("tool"))
             .expect("tool role message exists in second turn");
-        let content = tool_msg["content"].as_str().expect("tool content is string");
+        let content = tool_msg["content"]
+            .as_str()
+            .expect("tool content is string");
 
         // Three independent assertions — but they're all aspects of ONE behavior:
         // "the tool output is sandbox-wrapped, not raw". Per testing antipatterns
@@ -1345,15 +1487,26 @@ mod tests {
         let target_trunc_room = prefix.len() + 4 + 2; // 25, mid-2nd 🦀
         let body_budget = target_trunc_room + trunc_note_len;
         let share_budget = body_budget + wrapper_overhead;
-        assert!(listing.len() > body_budget, "listing must exceed body_budget to trigger truncation");
+        assert!(
+            listing.len() > body_budget,
+            "listing must exceed body_budget to trigger truncation"
+        );
 
         let res = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
             wrap_listing_with_budget(&listing, share_budget)
         }));
-        assert!(res.is_ok(), "wrap_listing_with_budget panicked at multi-byte boundary");
+        assert!(
+            res.is_ok(),
+            "wrap_listing_with_budget panicked at multi-byte boundary"
+        );
         let out = res.unwrap();
         // Real behavior assertion: rendered ≤ share_budget AND tags wrap intact.
-        assert!(out.len() <= share_budget, "rendered={} > budget={}", out.len(), share_budget);
+        assert!(
+            out.len() <= share_budget,
+            "rendered={} > budget={}",
+            out.len(),
+            share_budget
+        );
         assert!(out.starts_with("<file_listing>"));
         assert!(out.ends_with("</file_listing>"));
     }

--- a/src/analytics.rs
+++ b/src/analytics.rs
@@ -1,7 +1,6 @@
-/// Per-source TP/FP analytics computed from the feedback store.
-
-use std::collections::{HashMap, HashSet};
 use chrono::{DateTime, Utc};
+/// Per-source TP/FP analytics computed from the feedback store.
+use std::collections::{HashMap, HashSet};
 
 use crate::feedback::{FeedbackEntry, Verdict};
 use crate::review_log::ReviewRecord;
@@ -115,7 +114,12 @@ pub fn format_stats_report(stats: &HashMap<String, SourceStats>) -> String {
     for (source, s) in &sources {
         lines.push(format!(
             "{:<18} {:>3}  {:>3}  {:>7}  {:>7}  {:>5}  {:>6.0}%",
-            source, s.tp, s.fp, s.partial, s.wontfix, s.total(),
+            source,
+            s.tp,
+            s.fp,
+            s.partial,
+            s.wontfix,
+            s.total(),
             s.precision() * 100.0
         ));
     }
@@ -124,7 +128,10 @@ pub fn format_stats_report(stats: &HashMap<String, SourceStats>) -> String {
     let total_fp: usize = sources.iter().map(|(_, s)| s.fp).sum();
     let total: usize = sources.iter().map(|(_, s)| s.total()).sum();
     lines.push("-".repeat(65));
-    lines.push(format!("Total: {} entries ({} TP, {} FP)", total, total_tp, total_fp));
+    lines.push(format!(
+        "Total: {} entries ({} TP, {} FP)",
+        total, total_tp, total_fp
+    ));
 
     lines.join("\n")
 }
@@ -185,11 +192,7 @@ pub fn compute_tier_stats(entries: &[FeedbackEntry]) -> TierSummary {
     }
 
     let mut agents: Vec<(String, SourceStats)> = per_agent.into_iter().collect();
-    agents.sort_by(|a, b| {
-        b.1.total()
-            .cmp(&a.1.total())
-            .then_with(|| a.0.cmp(&b.0))
-    });
+    agents.sort_by(|a, b| b.1.total().cmp(&a.1.total()).then_with(|| a.0.cmp(&b.0)));
     summary.external.per_agent = agents;
     summary
 }
@@ -252,7 +255,8 @@ pub fn precision_trend(entries: &[FeedbackEntry], window_days: i64) -> Vec<Preci
     let mut window_start = first_ts;
     while window_start <= last_ts {
         let window_end = window_start + chrono::Duration::days(window_days);
-        let window_entries: Vec<_> = sorted.iter()
+        let window_entries: Vec<_> = sorted
+            .iter()
             .filter(|e| e.timestamp >= window_start && e.timestamp < window_end)
             .collect();
 
@@ -272,7 +276,11 @@ pub fn precision_trend(entries: &[FeedbackEntry], window_days: i64) -> Vec<Preci
             }
             let relevant = tp + partial;
             let total = relevant + fp;
-            let precision = if total > 0 { relevant as f64 / total as f64 } else { 0.0 };
+            let precision = if total > 0 {
+                relevant as f64 / total as f64
+            } else {
+                0.0
+            };
             windows.push(PrecisionWindow {
                 week_start: window_start,
                 precision,
@@ -345,7 +353,11 @@ pub fn format_channel_attribution(summary: &TierSummary) -> String {
             out,
             "  {label:<10}  {total:>6}  {tp:>5}  {fp:>5}  {part:>5}  {wfix:>5}",
             label = label,
-            total = if total == 0 { "—".to_string() } else { total.to_string() },
+            total = if total == 0 {
+                "—".to_string()
+            } else {
+                total.to_string()
+            },
             tp = cell(s.tp),
             fp = cell(s.fp),
             part = cell(s.partial),
@@ -419,10 +431,12 @@ pub fn compute_external_overlap(
         let Provenance::External { agent, .. } = &e.provenance else {
             continue;
         };
-        let row = per_agent.entry(agent.clone()).or_insert_with(|| AgentOverlap {
-            agent: agent.clone(),
-            ..Default::default()
-        });
+        let row = per_agent
+            .entry(agent.clone())
+            .or_insert_with(|| AgentOverlap {
+                agent: agent.clone(),
+                ..Default::default()
+            });
         row.findings += 1;
         if let Some(fid) = &e.finding_id {
             if let Some(qv) = quorum_verdicts.get(fid) {
@@ -434,7 +448,11 @@ pub fn compute_external_overlap(
         }
     }
     let mut agents: Vec<AgentOverlap> = per_agent.into_values().collect();
-    agents.sort_by(|a, b| b.findings.cmp(&a.findings).then_with(|| a.agent.cmp(&b.agent)));
+    agents.sort_by(|a, b| {
+        b.findings
+            .cmp(&a.findings)
+            .then_with(|| a.agent.cmp(&b.agent))
+    });
     ExternalOverlap { per_agent: agents }
 }
 
@@ -500,8 +518,7 @@ pub fn precision_trend_per_finding(
                     Provenance::PostFix => 1,
                     _ => unreachable!("only Human/PostFix enter the map"),
                 };
-                if tier_rank < prev_rank
-                    || (tier_rank == prev_rank && e.timestamp < prev.timestamp)
+                if tier_rank < prev_rank || (tier_rank == prev_rank && e.timestamp < prev.timestamp)
                 {
                     keep.insert(fid.clone(), e.clone());
                 }
@@ -558,11 +575,19 @@ mod tests {
             entry_with(Provenance::Human, Verdict::Fp),
             entry_with(Provenance::PostFix, Verdict::Tp),
             entry_with(
-                Provenance::External { agent: "pal".into(), model: None, confidence: None },
+                Provenance::External {
+                    agent: "pal".into(),
+                    model: None,
+                    confidence: None,
+                },
                 Verdict::Tp,
             ),
             entry_with(
-                Provenance::External { agent: "pal".into(), model: None, confidence: None },
+                Provenance::External {
+                    agent: "pal".into(),
+                    model: None,
+                    confidence: None,
+                },
                 Verdict::Fp,
             ),
             entry_with(
@@ -593,11 +618,19 @@ mod tests {
         use crate::feedback::Provenance;
         let fb = vec![
             entry_with(
-                Provenance::External { agent: "pal".into(), model: None, confidence: None },
+                Provenance::External {
+                    agent: "pal".into(),
+                    model: None,
+                    confidence: None,
+                },
                 Verdict::Tp,
             ),
             entry_with(
-                Provenance::External { agent: "pal".into(), model: None, confidence: None },
+                Provenance::External {
+                    agent: "pal".into(),
+                    model: None,
+                    confidence: None,
+                },
                 Verdict::Tp,
             ),
             entry_with(
@@ -619,8 +652,8 @@ mod tests {
 
         // Format contract: sub-line lists agents with counts.
         let report = format_tier_report(&summary);
-        let re = regex::Regex::new(r"top agents:\s+pal\s*\(\d+\).*third-opinion\s*\(\d+\)")
-            .unwrap();
+        let re =
+            regex::Regex::new(r"top agents:\s+pal\s*\(\d+\).*third-opinion\s*\(\d+\)").unwrap();
         assert!(
             re.is_match(&report),
             "sub-line format must list agents with counts: {report}"
@@ -976,7 +1009,11 @@ mod tests {
         // Pad to clear the min_entries=10 gate.
         for i in 0..9 {
             let id = format!("PAD-{i}");
-            entries.push(fb_with_id_and_provenance(&id, Verdict::Tp, Provenance::Human));
+            entries.push(fb_with_id_and_provenance(
+                &id,
+                Verdict::Tp,
+                Provenance::Human,
+            ));
         }
         let trend = precision_trend_per_finding(&entries, 7);
         assert_eq!(trend.len(), 1);
@@ -1045,7 +1082,11 @@ mod tests {
         ];
         for i in 0..7 {
             let id = format!("TP-{i}");
-            entries.push(fb_with_id_and_provenance(&id, Verdict::Tp, Provenance::Human));
+            entries.push(fb_with_id_and_provenance(
+                &id,
+                Verdict::Tp,
+                Provenance::Human,
+            ));
         }
         let trend = precision_trend_per_finding(&entries, 7);
         assert_eq!(trend.len(), 1);
@@ -1254,11 +1295,15 @@ mod tests {
         let feedback = vec![
             fb_with_id_and_provenance("A", Verdict::Tp, Provenance::Human),
             fb_with_id_and_provenance("B", Verdict::Tp, Provenance::PostFix),
-            fb_with_id_and_provenance("C", Verdict::Tp, Provenance::External {
-                agent: "pal".into(),
-                model: None,
-                confidence: None,
-            }),
+            fb_with_id_and_provenance(
+                "C",
+                Verdict::Tp,
+                Provenance::External {
+                    agent: "pal".into(),
+                    model: None,
+                    confidence: None,
+                },
+            ),
         ];
         let stats = linkage_stats(&reviews, &feedback);
         assert_eq!(stats.linked, 2, "only Human + PostFix should count");

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -1,6 +1,5 @@
 /// AST parse cache: avoid re-parsing unchanged files.
 /// Keyed by SHA-256 hash of file content.
-
 use std::num::NonZeroUsize;
 use std::sync::Mutex;
 
@@ -25,9 +24,7 @@ pub struct ParseCache {
 impl ParseCache {
     pub fn new(capacity: usize) -> Self {
         Self {
-            inner: Mutex::new(LruCache::new(
-                NonZeroUsize::new(capacity.max(1)).unwrap(),
-            )),
+            inner: Mutex::new(LruCache::new(NonZeroUsize::new(capacity.max(1)).unwrap())),
             hits: Mutex::new(0),
             misses: Mutex::new(0),
             capacity,
@@ -40,11 +37,7 @@ impl ParseCache {
         hex::encode(hasher.finalize())
     }
 
-    pub fn get_or_parse(
-        &self,
-        content: &str,
-        lang: Language,
-    ) -> anyhow::Result<tree_sitter::Tree> {
+    pub fn get_or_parse(&self, content: &str, lang: Language) -> anyhow::Result<tree_sitter::Tree> {
         let hash = Self::content_hash(content);
         let mut cache = self.inner.lock().unwrap();
 
@@ -59,7 +52,13 @@ impl ParseCache {
 
         let tree = crate::parser::parse(content, lang)?;
         let mut cache = self.inner.lock().unwrap();
-        cache.put(hash, CachedParse { tree: tree.clone(), lang });
+        cache.put(
+            hash,
+            CachedParse {
+                tree: tree.clone(),
+                lang,
+            },
+        );
         Ok(tree)
     }
 
@@ -178,7 +177,9 @@ mod tests {
     fn cache_different_languages() {
         let cache = ParseCache::new(10);
         cache.get_or_parse("x = 1", Language::Python).unwrap();
-        cache.get_or_parse("let x = 1;", Language::TypeScript).unwrap();
+        cache
+            .get_or_parse("let x = 1;", Language::TypeScript)
+            .unwrap();
         assert_eq!(cache.stats().size, 2);
     }
 }

--- a/src/calibrate.rs
+++ b/src/calibrate.rs
@@ -290,7 +290,10 @@ pub fn join_feedback_and_traces_with_options(
 
                 // Tier 3: file -> normalized traces for fuzzy
                 if !norm.is_empty() {
-                    file_traces.entry(fp).or_default().push((norm, (tp_w, fp_w)));
+                    file_traces
+                        .entry(fp)
+                        .or_default()
+                        .push((norm, (tp_w, fp_w)));
                 }
             }
         }
@@ -562,7 +565,10 @@ pub fn backfill_file_paths(
     let mut stats = BackfillStats::default();
 
     for trace in traces.iter_mut() {
-        let existing = trace.get("file_path").and_then(|v| v.as_str()).unwrap_or("");
+        let existing = trace
+            .get("file_path")
+            .and_then(|v| v.as_str())
+            .unwrap_or("");
         if !existing.is_empty() {
             stats.already_present += 1;
             continue;
@@ -677,7 +683,11 @@ mod tests {
         let (samples, _stats) = join_feedback_and_traces(&feedback, &traces);
         assert_eq!(samples.len(), 2);
         assert!(samples.iter().any(|(s, l)| *l && (*s - 0.893).abs() < 0.01));
-        assert!(samples.iter().any(|(s, l)| !*l && (*s - 0.053).abs() < 0.01));
+        assert!(
+            samples
+                .iter()
+                .any(|(s, l)| !*l && (*s - 0.053).abs() < 0.01)
+        );
     }
 
     #[test]
@@ -769,7 +779,10 @@ mod tests {
             make_trace("Bug", 0.1, 1.8, None), // duplicate title-only
         ];
         let (samples, _stats) = join_feedback_and_traces(&feedback, &traces);
-        assert!(samples.is_empty(), "ambiguous title-only keys should be skipped");
+        assert!(
+            samples.is_empty(),
+            "ambiguous title-only keys should be skipped"
+        );
     }
 
     #[test]
@@ -779,12 +792,15 @@ mod tests {
         let feedback = vec![make_feedback("Bug", "tp", "src/a.rs")];
         let traces = vec![
             make_trace("Bug", 2.5, 0.3, Some("src/a.rs")), // primary match
-            make_trace("Bug", 0.1, 1.8, None),              // title-only fallback
+            make_trace("Bug", 0.1, 1.8, None),             // title-only fallback
         ];
         let (samples, _stats) = join_feedback_and_traces(&feedback, &traces);
         assert_eq!(samples.len(), 1);
         let (score, _) = samples[0];
-        assert!((score - 0.893).abs() < 0.01, "should use primary key match, got {score}");
+        assert!(
+            (score - 0.893).abs() < 0.01,
+            "should use primary key match, got {score}"
+        );
     }
 
     #[test]
@@ -794,7 +810,7 @@ mod tests {
         let feedback = vec![make_feedback("Bug", "tp", "src/b.rs")]; // no file-scoped match
         let traces = vec![
             make_trace("Bug", 2.5, 0.3, Some("src/a.rs")), // file-scoped for different file
-            make_trace("Bug", 0.1, 1.8, None),              // title-only
+            make_trace("Bug", 0.1, 1.8, None),             // title-only
         ];
         let (samples, _stats) = join_feedback_and_traces(&feedback, &traces);
         assert!(
@@ -831,13 +847,23 @@ mod tests {
 
     #[test]
     fn normalized_exact_matches_backtick_difference() {
-        let feedback = vec![make_feedback("uses a fixed .tmp filename", "tp", "src/a.rs")];
+        let feedback = vec![make_feedback(
+            "uses a fixed .tmp filename",
+            "tp",
+            "src/a.rs",
+        )];
         let traces = vec![make_trace(
             "uses a fixed `.tmp` filename",
-            2.0, 0.3, Some("src/a.rs"),
+            2.0,
+            0.3,
+            Some("src/a.rs"),
         )];
         let (samples, stats) = join_feedback_and_traces(&feedback, &traces);
-        assert_eq!(samples.len(), 1, "normalized exact should match backtick variants");
+        assert_eq!(
+            samples.len(),
+            1,
+            "normalized exact should match backtick variants"
+        );
         assert_eq!(stats.exact_normalized, 1);
     }
 
@@ -846,10 +872,16 @@ mod tests {
         let feedback = vec![make_feedback("Empty .expect() message", "fp", "src/b.rs")];
         let traces = vec![make_trace(
             "expect-empty-message: Empty `.expect()` message",
-            0.2, 1.5, Some("src/b.rs"),
+            0.2,
+            1.5,
+            Some("src/b.rs"),
         )];
         let (samples, stats) = join_feedback_and_traces(&feedback, &traces);
-        assert_eq!(samples.len(), 1, "normalized exact should match rule-prefix variants");
+        assert_eq!(
+            samples.len(),
+            1,
+            "normalized exact should match rule-prefix variants"
+        );
         assert_eq!(stats.exact_normalized, 1);
     }
 
@@ -864,10 +896,16 @@ mod tests {
 
     #[test]
     fn normalized_exact_different_file_no_match() {
-        let feedback = vec![make_feedback("uses a fixed .tmp filename", "tp", "src/a.rs")];
+        let feedback = vec![make_feedback(
+            "uses a fixed .tmp filename",
+            "tp",
+            "src/a.rs",
+        )];
         let traces = vec![make_trace(
             "uses a fixed `.tmp` filename",
-            2.0, 0.3, Some("src/b.rs"),
+            2.0,
+            0.3,
+            Some("src/b.rs"),
         )];
         let (samples, stats) = join_feedback_and_traces(&feedback, &traces);
         assert!(samples.is_empty(), "different file should not match");
@@ -880,14 +918,21 @@ mod tests {
     fn fuzzy_same_file_matches_extended_title() {
         let feedback = vec![make_feedback(
             "Reset can race with visit processing",
-            "tp", "src/visit.rs",
+            "tp",
+            "src/visit.rs",
         )];
         let traces = vec![make_trace(
             "Reset can race with visit processing and lose the cleaned state",
-            2.0, 0.5, Some("src/visit.rs"),
+            2.0,
+            0.5,
+            Some("src/visit.rs"),
         )];
         let (samples, stats) = join_feedback_and_traces(&feedback, &traces);
-        assert_eq!(samples.len(), 1, "fuzzy same-file should match extended title");
+        assert_eq!(
+            samples.len(),
+            1,
+            "fuzzy same-file should match extended title"
+        );
         assert_eq!(stats.fuzzy_same_file, 1);
     }
 
@@ -896,7 +941,9 @@ mod tests {
         let feedback = vec![make_feedback("API key leak", "tp", "src/a.rs")];
         let traces = vec![make_trace(
             "Database connection pool exhaustion under load",
-            2.0, 0.5, Some("src/a.rs"),
+            2.0,
+            0.5,
+            Some("src/a.rs"),
         )];
         let (samples, _stats) = join_feedback_and_traces(&feedback, &traces);
         assert!(samples.is_empty(), "below-threshold fuzzy should not match");
@@ -904,28 +951,45 @@ mod tests {
 
     #[test]
     fn fuzzy_same_file_rejects_ambiguous() {
-        let feedback = vec![make_feedback(
-            "error handling is missing",
-            "tp", "src/a.rs",
-        )];
+        let feedback = vec![make_feedback("error handling is missing", "tp", "src/a.rs")];
         let traces = vec![
-            make_trace("error handling is missing for IO", 2.0, 0.5, Some("src/a.rs")),
-            make_trace("error handling is missing for parse", 1.0, 0.8, Some("src/a.rs")),
+            make_trace(
+                "error handling is missing for IO",
+                2.0,
+                0.5,
+                Some("src/a.rs"),
+            ),
+            make_trace(
+                "error handling is missing for parse",
+                1.0,
+                0.8,
+                Some("src/a.rs"),
+            ),
         ];
         let (samples, stats) = join_feedback_and_traces(&feedback, &traces);
-        assert!(samples.is_empty(), "ambiguous fuzzy matches should be skipped");
+        assert!(
+            samples.is_empty(),
+            "ambiguous fuzzy matches should be skipped"
+        );
         assert!(stats.ambiguous_skipped >= 1);
     }
 
     #[test]
     fn fuzzy_same_file_accepts_clear_winner() {
-        let feedback = vec![make_feedback(
-            "error handling is missing",
-            "tp", "src/a.rs",
-        )];
+        let feedback = vec![make_feedback("error handling is missing", "tp", "src/a.rs")];
         let traces = vec![
-            make_trace("error handling is missing for IO operations", 2.0, 0.5, Some("src/a.rs")),
-            make_trace("something completely different xyz abc", 1.0, 0.8, Some("src/a.rs")),
+            make_trace(
+                "error handling is missing for IO operations",
+                2.0,
+                0.5,
+                Some("src/a.rs"),
+            ),
+            make_trace(
+                "something completely different xyz abc",
+                1.0,
+                0.8,
+                Some("src/a.rs"),
+            ),
         ];
         let (samples, stats) = join_feedback_and_traces(&feedback, &traces);
         assert_eq!(samples.len(), 1, "clear winner should match");
@@ -936,11 +1000,14 @@ mod tests {
     fn fuzzy_same_file_different_file_no_match() {
         let feedback = vec![make_feedback(
             "Reset can race with visit processing",
-            "tp", "src/a.rs",
+            "tp",
+            "src/a.rs",
         )];
         let traces = vec![make_trace(
             "Reset can race with visit processing and lose state",
-            2.0, 0.5, Some("src/b.rs"),
+            2.0,
+            0.5,
+            Some("src/b.rs"),
         )];
         let (samples, _stats) = join_feedback_and_traces(&feedback, &traces);
         assert!(samples.is_empty(), "fuzzy is file-scoped");
@@ -952,7 +1019,9 @@ mod tests {
         let feedback = vec![make_feedback("alpha beta gamma", "tp", "src/a.rs")];
         let traces = vec![make_trace(
             "alpha beta gamma delta epsilon zeta",
-            2.0, 0.5, Some("src/a.rs"),
+            2.0,
+            0.5,
+            Some("src/a.rs"),
         )];
         let (samples, stats) = join_feedback_and_traces(&feedback, &traces);
         assert_eq!(samples.len(), 1, ">= 0.5 is inclusive");
@@ -965,7 +1034,9 @@ mod tests {
         let feedback = vec![make_feedback("alpha beta", "tp", "src/a.rs")];
         let traces = vec![make_trace(
             "alpha beta gamma delta epsilon",
-            2.0, 0.5, Some("src/a.rs"),
+            2.0,
+            0.5,
+            Some("src/a.rs"),
         )];
         let (samples, _stats) = join_feedback_and_traces(&feedback, &traces);
         assert!(samples.is_empty(), "0.4 < 0.5 should be rejected");
@@ -1020,13 +1091,12 @@ mod tests {
     #[test]
     fn fuzzy_single_trace_in_file_no_margin_needed() {
         // Only one trace in file, Jaccard >= 0.5
-        let feedback = vec![make_feedback(
-            "error handling is missing",
-            "tp", "src/a.rs",
-        )];
+        let feedback = vec![make_feedback("error handling is missing", "tp", "src/a.rs")];
         let traces = vec![make_trace(
             "error handling is missing for IO operations",
-            2.0, 0.5, Some("src/a.rs"),
+            2.0,
+            0.5,
+            Some("src/a.rs"),
         )];
         let (samples, stats) = join_feedback_and_traces(&feedback, &traces);
         assert_eq!(samples.len(), 1, "single trace, margin trivially satisfied");
@@ -1040,7 +1110,11 @@ mod tests {
         let feedback = vec![make_feedback("fixed .tmp filename", "tp", "src/a.rs")];
         let traces = vec![make_trace("fixed `.tmp` filename", 1.5, 0.5, None)];
         let (samples, stats) = join_feedback_and_traces(&feedback, &traces);
-        assert_eq!(samples.len(), 1, "normalized title-only fallback should match");
+        assert_eq!(
+            samples.len(),
+            1,
+            "normalized title-only fallback should match"
+        );
         assert_eq!(stats.normalized_title_only, 1);
     }
 
@@ -1052,18 +1126,22 @@ mod tests {
             make_trace("fixed `.tmp` filename", 0.1, 1.8, None),
         ];
         let (samples, _stats) = join_feedback_and_traces(&feedback, &traces);
-        assert!(samples.is_empty(),
-            "normalized title-only fallback blocked when file-scoped traces exist");
+        assert!(
+            samples.is_empty(),
+            "normalized title-only fallback blocked when file-scoped traces exist"
+        );
     }
 
     #[test]
     fn title_only_not_attempted_after_fuzzy_match() {
-        let feedback = vec![make_feedback(
-            "error handling is missing",
-            "tp", "src/a.rs",
-        )];
+        let feedback = vec![make_feedback("error handling is missing", "tp", "src/a.rs")];
         let traces = vec![
-            make_trace("error handling is missing for IO operations", 2.0, 0.5, Some("src/a.rs")),
+            make_trace(
+                "error handling is missing for IO operations",
+                2.0,
+                0.5,
+                Some("src/a.rs"),
+            ),
             make_trace("error handling is missing", 1.0, 0.8, None),
         ];
         let (samples, stats) = join_feedback_and_traces(&feedback, &traces);
@@ -1086,7 +1164,12 @@ mod tests {
         let traces = vec![
             make_trace("SQL injection", 2.0, 0.3, Some("src/db.rs")),
             make_trace("fixed `.tmp` filename", 0.2, 1.5, Some("src/a.rs")),
-            make_trace("reset can race with processing and lose state", 1.5, 0.5, Some("src/v.rs")),
+            make_trace(
+                "reset can race with processing and lose state",
+                1.5,
+                0.5,
+                Some("src/v.rs"),
+            ),
             make_trace("missing error context", 0.8, 1.0, None),
         ];
         let (samples, stats) = join_feedback_and_traces(&feedback, &traces);
@@ -1111,13 +1194,19 @@ mod tests {
             make_trace("fixed `.tmp` filename", 0.2, 1.5, Some("src/a.rs")),
         ];
         let (samples, stats) = join_feedback_and_traces(&feedback, &traces);
-        let total_classified = stats.exact_raw + stats.exact_normalized
-            + stats.fuzzy_same_file + stats.raw_title_only
+        let total_classified = stats.exact_raw
+            + stats.exact_normalized
+            + stats.fuzzy_same_file
+            + stats.raw_title_only
             + stats.normalized_title_only
-            + stats.ambiguous_skipped + stats.below_threshold
+            + stats.ambiguous_skipped
+            + stats.below_threshold
             + stats.unmatched;
         // 3 eligible (tp, fp, tp) — wontfix filtered before classification
-        assert_eq!(total_classified, 3, "every eligible entry must be classified");
+        assert_eq!(
+            total_classified, 3,
+            "every eligible entry must be classified"
+        );
         assert_eq!(samples.len(), 2);
     }
 
@@ -1285,10 +1374,16 @@ mod tests {
     fn disable_fuzzy_skips_normalized_exact() {
         // Without fuzzy disabled, normalized exact (tier 2) matches backtick variants.
         // With fuzzy disabled, only raw exact (tier 1) is used -- no match.
-        let feedback = vec![make_feedback("uses a fixed .tmp filename", "tp", "src/a.rs")];
+        let feedback = vec![make_feedback(
+            "uses a fixed .tmp filename",
+            "tp",
+            "src/a.rs",
+        )];
         let traces = vec![make_trace(
             "uses a fixed `.tmp` filename",
-            2.0, 0.3, Some("src/a.rs"),
+            2.0,
+            0.3,
+            Some("src/a.rs"),
         )];
 
         // Fuzzy enabled: should match via tier 2
@@ -1297,10 +1392,12 @@ mod tests {
         assert_eq!(stats.exact_normalized, 1);
 
         // Fuzzy disabled: no match
-        let (samples, stats) = join_feedback_and_traces_with_options(
-            &feedback, &traces, &JoinFilter::default(), true,
+        let (samples, stats) =
+            join_feedback_and_traces_with_options(&feedback, &traces, &JoinFilter::default(), true);
+        assert!(
+            samples.is_empty(),
+            "fuzzy disabled should skip normalized exact"
         );
-        assert!(samples.is_empty(), "fuzzy disabled should skip normalized exact");
         assert_eq!(stats.exact_normalized, 0);
         assert_eq!(stats.unmatched, 1);
     }
@@ -1309,11 +1406,14 @@ mod tests {
     fn disable_fuzzy_skips_fuzzy_same_file() {
         let feedback = vec![make_feedback(
             "Reset can race with visit processing",
-            "tp", "src/visit.rs",
+            "tp",
+            "src/visit.rs",
         )];
         let traces = vec![make_trace(
             "Reset can race with visit processing and lose the cleaned state",
-            2.0, 0.5, Some("src/visit.rs"),
+            2.0,
+            0.5,
+            Some("src/visit.rs"),
         )];
 
         // Fuzzy enabled: should match via tier 3
@@ -1322,10 +1422,12 @@ mod tests {
         assert_eq!(stats.fuzzy_same_file, 1);
 
         // Fuzzy disabled: no match
-        let (samples, stats) = join_feedback_and_traces_with_options(
-            &feedback, &traces, &JoinFilter::default(), true,
+        let (samples, stats) =
+            join_feedback_and_traces_with_options(&feedback, &traces, &JoinFilter::default(), true);
+        assert!(
+            samples.is_empty(),
+            "fuzzy disabled should skip fuzzy same-file"
         );
-        assert!(samples.is_empty(), "fuzzy disabled should skip fuzzy same-file");
         assert_eq!(stats.fuzzy_same_file, 0);
     }
 
@@ -1340,10 +1442,12 @@ mod tests {
         assert_eq!(stats.normalized_title_only, 1);
 
         // Fuzzy disabled: no match (raw title-only doesn't match either since titles differ)
-        let (samples, stats) = join_feedback_and_traces_with_options(
-            &feedback, &traces, &JoinFilter::default(), true,
+        let (samples, stats) =
+            join_feedback_and_traces_with_options(&feedback, &traces, &JoinFilter::default(), true);
+        assert!(
+            samples.is_empty(),
+            "fuzzy disabled should skip normalized title-only"
         );
-        assert!(samples.is_empty(), "fuzzy disabled should skip normalized title-only");
         assert_eq!(stats.normalized_title_only, 0);
     }
 
@@ -1356,11 +1460,10 @@ mod tests {
         ];
         let traces = vec![
             make_trace("SQL injection", 2.5, 0.3, Some("src/db.rs")), // tier 1
-            make_trace("Unused var", 0.1, 1.8, None),                  // raw title-only
+            make_trace("Unused var", 0.1, 1.8, None),                 // raw title-only
         ];
-        let (samples, stats) = join_feedback_and_traces_with_options(
-            &feedback, &traces, &JoinFilter::default(), true,
-        );
+        let (samples, stats) =
+            join_feedback_and_traces_with_options(&feedback, &traces, &JoinFilter::default(), true);
         assert_eq!(samples.len(), 2);
         assert_eq!(stats.exact_raw, 1);
         assert_eq!(stats.raw_title_only, 1);
@@ -1374,9 +1477,16 @@ mod tests {
         let feedback = vec![make_feedback("Bug", "tp", "src/a.rs")];
         let traces = vec![make_trace("Bug", 2.0, 0.3, Some("src/a.rs"))]; // no provenance
         let (samples, _stats) = join_feedback_and_traces_with_options(
-            &feedback, &traces, &JoinFilter::default(), false,
+            &feedback,
+            &traces,
+            &JoinFilter::default(),
+            false,
         );
-        assert_eq!(samples.len(), 1, "default filter should retain legacy traces");
+        assert_eq!(
+            samples.len(),
+            1,
+            "default filter should retain legacy traces"
+        );
     }
 
     #[test]
@@ -1388,10 +1498,12 @@ mod tests {
             quorum_version: Some("0.18.4".to_string()),
             ..Default::default()
         };
-        let (samples, _stats) = join_feedback_and_traces_with_options(
-            &feedback, &traces, &filter, false,
+        let (samples, _stats) =
+            join_feedback_and_traces_with_options(&feedback, &traces, &filter, false);
+        assert!(
+            samples.is_empty(),
+            "positive filter should exclude legacy traces"
         );
-        assert!(samples.is_empty(), "positive filter should exclude legacy traces");
     }
 
     #[test]
@@ -1401,22 +1513,33 @@ mod tests {
             make_feedback("Bug B", "fp", "src/b.rs"),
         ];
         let traces = vec![
-            make_trace_with_provenance("Bug A", 2.0, 0.3, Some("src/a.rs"), Some(serde_json::json!({
-                "quorum_version": "0.18.4",
-                "repo": "quorum"
-            }))),
-            make_trace_with_provenance("Bug B", 0.1, 1.8, Some("src/b.rs"), Some(serde_json::json!({
-                "quorum_version": "0.18.3",
-                "repo": "quorum"
-            }))),
+            make_trace_with_provenance(
+                "Bug A",
+                2.0,
+                0.3,
+                Some("src/a.rs"),
+                Some(serde_json::json!({
+                    "quorum_version": "0.18.4",
+                    "repo": "quorum"
+                })),
+            ),
+            make_trace_with_provenance(
+                "Bug B",
+                0.1,
+                1.8,
+                Some("src/b.rs"),
+                Some(serde_json::json!({
+                    "quorum_version": "0.18.3",
+                    "repo": "quorum"
+                })),
+            ),
         ];
         let filter = JoinFilter {
             quorum_version: Some("0.18.4".to_string()),
             ..Default::default()
         };
-        let (samples, stats) = join_feedback_and_traces_with_options(
-            &feedback, &traces, &filter, false,
-        );
+        let (samples, stats) =
+            join_feedback_and_traces_with_options(&feedback, &traces, &filter, false);
         assert_eq!(samples.len(), 1, "only version 0.18.4 trace should match");
         assert_eq!(stats.exact_raw, 1);
         // The matched sample should be the TP (Bug A)
@@ -1430,25 +1553,39 @@ mod tests {
             make_feedback("Bug B", "fp", "src/b.rs"),
         ];
         let traces = vec![
-            make_trace_with_provenance("Bug A", 2.0, 0.3, Some("src/a.rs"), Some(serde_json::json!({
-                "quorum_version": "0.18.4",
-                "dirty": false
-            }))),
-            make_trace_with_provenance("Bug B", 0.1, 1.8, Some("src/b.rs"), Some(serde_json::json!({
-                "quorum_version": "0.18.4",
-                "dirty": true
-            }))),
+            make_trace_with_provenance(
+                "Bug A",
+                2.0,
+                0.3,
+                Some("src/a.rs"),
+                Some(serde_json::json!({
+                    "quorum_version": "0.18.4",
+                    "dirty": false
+                })),
+            ),
+            make_trace_with_provenance(
+                "Bug B",
+                0.1,
+                1.8,
+                Some("src/b.rs"),
+                Some(serde_json::json!({
+                    "quorum_version": "0.18.4",
+                    "dirty": true
+                })),
+            ),
         ];
         let filter = JoinFilter {
             clean_only: true,
             ..Default::default()
         };
-        let (samples, stats) = join_feedback_and_traces_with_options(
-            &feedback, &traces, &filter, false,
-        );
+        let (samples, stats) =
+            join_feedback_and_traces_with_options(&feedback, &traces, &filter, false);
         assert_eq!(samples.len(), 1, "dirty trace should be excluded");
         assert_eq!(stats.exact_raw, 1);
-        assert!(samples[0].1, "matched sample should be positive (Bug A, clean)");
+        assert!(
+            samples[0].1,
+            "matched sample should be positive (Bug A, clean)"
+        );
     }
 
     #[test]
@@ -1458,20 +1595,31 @@ mod tests {
             make_feedback("Bug B", "fp", "src/b.rs"),
         ];
         let traces = vec![
-            make_trace_with_provenance("Bug A", 2.0, 0.3, Some("src/a.rs"), Some(serde_json::json!({
-                "repo": "quorum"
-            }))),
-            make_trace_with_provenance("Bug B", 0.1, 1.8, Some("src/b.rs"), Some(serde_json::json!({
-                "repo": "other-project"
-            }))),
+            make_trace_with_provenance(
+                "Bug A",
+                2.0,
+                0.3,
+                Some("src/a.rs"),
+                Some(serde_json::json!({
+                    "repo": "quorum"
+                })),
+            ),
+            make_trace_with_provenance(
+                "Bug B",
+                0.1,
+                1.8,
+                Some("src/b.rs"),
+                Some(serde_json::json!({
+                    "repo": "other-project"
+                })),
+            ),
         ];
         let filter = JoinFilter {
             repo: Some("quorum".to_string()),
             ..Default::default()
         };
-        let (samples, _stats) = join_feedback_and_traces_with_options(
-            &feedback, &traces, &filter, false,
-        );
+        let (samples, _stats) =
+            join_feedback_and_traces_with_options(&feedback, &traces, &filter, false);
         assert_eq!(samples.len(), 1, "only quorum-repo trace should match");
         assert!(samples[0].1, "matched sample should be positive (Bug A)");
     }
@@ -1479,36 +1627,42 @@ mod tests {
     #[test]
     fn join_filter_by_commit_sha() {
         let feedback = vec![make_feedback("Bug", "tp", "src/a.rs")];
-        let traces = vec![
-            make_trace_with_provenance("Bug", 2.0, 0.3, Some("src/a.rs"), Some(serde_json::json!({
+        let traces = vec![make_trace_with_provenance(
+            "Bug",
+            2.0,
+            0.3,
+            Some("src/a.rs"),
+            Some(serde_json::json!({
                 "commit_sha": "abc123"
-            }))),
-        ];
+            })),
+        )];
         let filter = JoinFilter {
             commit_sha: Some("def456".to_string()),
             ..Default::default()
         };
-        let (samples, _stats) = join_feedback_and_traces_with_options(
-            &feedback, &traces, &filter, false,
-        );
+        let (samples, _stats) =
+            join_feedback_and_traces_with_options(&feedback, &traces, &filter, false);
         assert!(samples.is_empty(), "wrong commit_sha should exclude trace");
     }
 
     #[test]
     fn join_filter_by_run_id() {
         let feedback = vec![make_feedback("Bug", "tp", "src/a.rs")];
-        let traces = vec![
-            make_trace_with_provenance("Bug", 2.0, 0.3, Some("src/a.rs"), Some(serde_json::json!({
+        let traces = vec![make_trace_with_provenance(
+            "Bug",
+            2.0,
+            0.3,
+            Some("src/a.rs"),
+            Some(serde_json::json!({
                 "run_id": "run-42"
-            }))),
-        ];
+            })),
+        )];
         let filter = JoinFilter {
             run_id: Some("run-42".to_string()),
             ..Default::default()
         };
-        let (samples, stats) = join_feedback_and_traces_with_options(
-            &feedback, &traces, &filter, false,
-        );
+        let (samples, stats) =
+            join_feedback_and_traces_with_options(&feedback, &traces, &filter, false);
         assert_eq!(samples.len(), 1, "matching run_id should pass");
         assert_eq!(stats.exact_raw, 1);
     }
@@ -1521,28 +1675,49 @@ mod tests {
             make_feedback("Bug C", "tp", "src/c.rs"),
         ];
         let traces = vec![
-            make_trace_with_provenance("Bug A", 2.0, 0.3, Some("src/a.rs"), Some(serde_json::json!({
-                "quorum_version": "0.18.4",
-                "dirty": false
-            }))),
-            make_trace_with_provenance("Bug B", 0.1, 1.8, Some("src/b.rs"), Some(serde_json::json!({
-                "quorum_version": "0.18.4",
-                "dirty": true
-            }))),
-            make_trace_with_provenance("Bug C", 1.0, 0.5, Some("src/c.rs"), Some(serde_json::json!({
-                "quorum_version": "0.18.3",
-                "dirty": false
-            }))),
+            make_trace_with_provenance(
+                "Bug A",
+                2.0,
+                0.3,
+                Some("src/a.rs"),
+                Some(serde_json::json!({
+                    "quorum_version": "0.18.4",
+                    "dirty": false
+                })),
+            ),
+            make_trace_with_provenance(
+                "Bug B",
+                0.1,
+                1.8,
+                Some("src/b.rs"),
+                Some(serde_json::json!({
+                    "quorum_version": "0.18.4",
+                    "dirty": true
+                })),
+            ),
+            make_trace_with_provenance(
+                "Bug C",
+                1.0,
+                0.5,
+                Some("src/c.rs"),
+                Some(serde_json::json!({
+                    "quorum_version": "0.18.3",
+                    "dirty": false
+                })),
+            ),
         ];
         let filter = JoinFilter {
             quorum_version: Some("0.18.4".to_string()),
             clean_only: true,
             ..Default::default()
         };
-        let (samples, _stats) = join_feedback_and_traces_with_options(
-            &feedback, &traces, &filter, false,
+        let (samples, _stats) =
+            join_feedback_and_traces_with_options(&feedback, &traces, &filter, false);
+        assert_eq!(
+            samples.len(),
+            1,
+            "only Bug A passes both version + clean filter"
         );
-        assert_eq!(samples.len(), 1, "only Bug A passes both version + clean filter");
         assert!(samples[0].1, "matched sample should be positive (Bug A)");
     }
 
@@ -1553,22 +1728,37 @@ mod tests {
             make_feedback("Bug B", "fp", "src/b.rs"),
         ];
         let traces = vec![
-            make_trace_with_provenance("Bug A", 2.0, 0.3, Some("src/a.rs"), Some(serde_json::json!({
-                "quorum_version": "0.18.4",
-                "dirty": false
-            }))),
-            make_trace_with_provenance("Bug B", 0.1, 1.8, Some("src/b.rs"), Some(serde_json::json!({
-                "quorum_version": "0.18.4"
-            }))),
+            make_trace_with_provenance(
+                "Bug A",
+                2.0,
+                0.3,
+                Some("src/a.rs"),
+                Some(serde_json::json!({
+                    "quorum_version": "0.18.4",
+                    "dirty": false
+                })),
+            ),
+            make_trace_with_provenance(
+                "Bug B",
+                0.1,
+                1.8,
+                Some("src/b.rs"),
+                Some(serde_json::json!({
+                    "quorum_version": "0.18.4"
+                })),
+            ),
         ];
         let filter = JoinFilter {
             clean_only: true,
             ..Default::default()
         };
-        let (samples, _stats) = join_feedback_and_traces_with_options(
-            &feedback, &traces, &filter, false,
+        let (samples, _stats) =
+            join_feedback_and_traces_with_options(&feedback, &traces, &filter, false);
+        assert_eq!(
+            samples.len(),
+            1,
+            "trace with unknown dirty should be excluded by clean_only"
         );
-        assert_eq!(samples.len(), 1, "trace with unknown dirty should be excluded by clean_only");
     }
 
     #[test]
@@ -1585,14 +1775,12 @@ mod tests {
                 "verdict": "fp"
             }),
         ];
-        let mut traces = vec![
-            serde_json::json!({
-                "finding_title": "SQL injection risk",
-                "finding_category": "security",
-                "tp_weight": 2.0,
-                "fp_weight": 0.5
-            }),
-        ];
+        let mut traces = vec![serde_json::json!({
+            "finding_title": "SQL injection risk",
+            "finding_category": "security",
+            "tp_weight": 2.0,
+            "fp_weight": 0.5
+        })];
         let stats = backfill_file_paths(&mut traces, &feedback);
         assert_eq!(traces[0]["file_path"].as_str(), Some("src/db.rs"));
         assert_eq!(stats.feedback_exact, 1);
@@ -1601,22 +1789,18 @@ mod tests {
 
     #[test]
     fn backfill_skips_traces_with_existing_file_path() {
-        let feedback = vec![
-            serde_json::json!({
-                "finding_title": "SQL injection",
-                "file_path": "src/db.rs",
-                "verdict": "tp"
-            }),
-        ];
-        let mut traces = vec![
-            serde_json::json!({
-                "finding_title": "SQL injection",
-                "finding_category": "security",
-                "tp_weight": 1.0,
-                "fp_weight": 0.0,
-                "file_path": "src/other.rs"
-            }),
-        ];
+        let feedback = vec![serde_json::json!({
+            "finding_title": "SQL injection",
+            "file_path": "src/db.rs",
+            "verdict": "tp"
+        })];
+        let mut traces = vec![serde_json::json!({
+            "finding_title": "SQL injection",
+            "finding_category": "security",
+            "tp_weight": 1.0,
+            "fp_weight": 0.0,
+            "file_path": "src/other.rs"
+        })];
         let stats = backfill_file_paths(&mut traces, &feedback);
         assert_eq!(traces[0]["file_path"].as_str(), Some("src/other.rs"));
         assert_eq!(stats.already_present, 1);
@@ -1637,14 +1821,12 @@ mod tests {
                 "verdict": "fp"
             }),
         ];
-        let mut traces = vec![
-            serde_json::json!({
-                "finding_title": "Use of unwrap()",
-                "finding_category": "correctness",
-                "tp_weight": 1.0,
-                "fp_weight": 0.0
-            }),
-        ];
+        let mut traces = vec![serde_json::json!({
+            "finding_title": "Use of unwrap()",
+            "finding_category": "correctness",
+            "tp_weight": 1.0,
+            "fp_weight": 0.0
+        })];
         let stats = backfill_file_paths(&mut traces, &feedback);
         // Should NOT have file_path set
         let fp = traces[0].get("file_path");
@@ -1671,18 +1853,16 @@ mod tests {
                 "verdict": "fp"
             }),
         ];
-        let mut traces = vec![
-            serde_json::json!({
-                "finding_title": "Use of unwrap()",
-                "finding_category": "correctness",
-                "tp_weight": 1.0,
-                "fp_weight": 0.0,
-                "matched_precedents": [
-                    {"finding_title": "unwrap risk", "file_path": "src/a.rs", "verdict": "tp"},
-                    {"finding_title": "unwrap again", "file_path": "src/a.rs", "verdict": "tp"}
-                ]
-            }),
-        ];
+        let mut traces = vec![serde_json::json!({
+            "finding_title": "Use of unwrap()",
+            "finding_category": "correctness",
+            "tp_weight": 1.0,
+            "fp_weight": 0.0,
+            "matched_precedents": [
+                {"finding_title": "unwrap risk", "file_path": "src/a.rs", "verdict": "tp"},
+                {"finding_title": "unwrap again", "file_path": "src/a.rs", "verdict": "tp"}
+            ]
+        })];
         let stats = backfill_file_paths(&mut traces, &feedback);
         assert_eq!(traces[0]["file_path"].as_str(), Some("src/a.rs"));
         assert_eq!(stats.precedent_inferred, 1);
@@ -1699,19 +1879,15 @@ mod tests {
 
     #[test]
     fn backfill_skips_trace_with_missing_title() {
-        let feedback = vec![
-            serde_json::json!({
-                "finding_title": "A",
-                "file_path": "f.rs",
-                "verdict": "tp"
-            }),
-        ];
-        let mut traces = vec![
-            serde_json::json!({
-                "tp_weight": 1.0,
-                "fp_weight": 0.0
-            }),
-        ];
+        let feedback = vec![serde_json::json!({
+            "finding_title": "A",
+            "file_path": "f.rs",
+            "verdict": "tp"
+        })];
+        let mut traces = vec![serde_json::json!({
+            "tp_weight": 1.0,
+            "fp_weight": 0.0
+        })];
         let stats = backfill_file_paths(&mut traces, &feedback);
         assert_eq!(stats.no_match, 1);
         assert_eq!(stats.total_backfilled, 0);
@@ -1720,21 +1896,17 @@ mod tests {
     #[test]
     fn backfill_falls_through_to_normalized_title() {
         // Feedback has rule-prefixed title, trace has bare title
-        let feedback = vec![
-            serde_json::json!({
-                "finding_title": "bare-except-pass: Using bare except: pass",
-                "file_path": "src/handler.py",
-                "verdict": "tp"
-            }),
-        ];
-        let mut traces = vec![
-            serde_json::json!({
-                "finding_title": "Using bare except: pass",
-                "finding_category": "correctness",
-                "tp_weight": 1.0,
-                "fp_weight": 0.0
-            }),
-        ];
+        let feedback = vec![serde_json::json!({
+            "finding_title": "bare-except-pass: Using bare except: pass",
+            "file_path": "src/handler.py",
+            "verdict": "tp"
+        })];
+        let mut traces = vec![serde_json::json!({
+            "finding_title": "Using bare except: pass",
+            "finding_category": "correctness",
+            "tp_weight": 1.0,
+            "fp_weight": 0.0
+        })];
         let stats = backfill_file_paths(&mut traces, &feedback);
         assert_eq!(traces[0]["file_path"].as_str(), Some("src/handler.py"));
         assert_eq!(stats.feedback_normalized, 1);

--- a/src/calibrator.rs
+++ b/src/calibrator.rs
@@ -90,7 +90,10 @@ fn calibrator_disabled(config: &CalibratorConfig) -> bool {
 /// Build a `CalibratorTraceEntry` for a finding with no matching precedents
 /// (empty feedback corpus, empty index, or all entries filtered out). All
 /// weight fields are zero and the reason is `NoMatch`.
-fn make_no_match_trace(finding: &Finding, file_path: &str) -> crate::calibrator_trace::CalibratorTraceEntry {
+fn make_no_match_trace(
+    finding: &Finding,
+    file_path: &str,
+) -> crate::calibrator_trace::CalibratorTraceEntry {
     crate::calibrator_trace::CalibratorTraceEntry {
         finding_title: finding.title.clone(),
         finding_category: finding.category.to_string(),
@@ -103,10 +106,12 @@ fn make_no_match_trace(finding: &Finding, file_path: &str) -> crate::calibrator_
         action: None,
         input_severity: finding.severity.clone(),
         output_severity: finding.severity.clone(),
-        severity_change_reason: Some(
-            crate::calibrator_trace::SeverityChangeReason::NoMatch,
-        ),
-        file_path: if file_path.is_empty() { None } else { Some(file_path.to_string()) },
+        severity_change_reason: Some(crate::calibrator_trace::SeverityChangeReason::NoMatch),
+        file_path: if file_path.is_empty() {
+            None
+        } else {
+            Some(file_path.to_string())
+        },
         provenance: None,
     }
 }
@@ -141,7 +146,11 @@ fn make_trace_entry(
         input_severity,
         output_severity: finding.severity.clone(),
         severity_change_reason,
-        file_path: if file_path.is_empty() { None } else { Some(file_path.to_string()) },
+        file_path: if file_path.is_empty() {
+            None
+        } else {
+            Some(file_path.to_string())
+        },
         provenance: None,
     }
 }
@@ -207,11 +216,16 @@ fn calibrate_core_decision(
                 Some(crate::calibrator_trace::SeverityChangeReason::Disputed),
                 file_path,
             );
-            return CoreDecision { suppressed, boosted, trace };
+            return CoreDecision {
+                suppressed,
+                boosted,
+                trace,
+            };
         }
     } else {
         // Legacy fallback: magic numbers.
-        if full_suppress_weight >= 1.5 && fp_weight > 0.0 && full_suppress_weight > tp_weight * 2.0 {
+        if full_suppress_weight >= 1.5 && fp_weight > 0.0 && full_suppress_weight > tp_weight * 2.0
+        {
             finding.calibrator_action = Some(CalibratorAction::Disputed);
             suppressed = true;
             let trace = make_trace_entry(
@@ -227,7 +241,11 @@ fn calibrate_core_decision(
                 Some(crate::calibrator_trace::SeverityChangeReason::Disputed),
                 file_path,
             );
-            return CoreDecision { suppressed, boosted, trace };
+            return CoreDecision {
+                suppressed,
+                boosted,
+                trace,
+            };
         }
     }
 
@@ -268,18 +286,14 @@ fn calibrate_core_decision(
             boosted = true;
             reason = Some(crate::calibrator_trace::SeverityChangeReason::Boosted);
         } else {
-            reason = Some(
-                crate::calibrator_trace::SeverityChangeReason::BoostBlockedByGate,
-            );
+            reason = Some(crate::calibrator_trace::SeverityChangeReason::BoostBlockedByGate);
         }
         finding.calibrator_action = Some(CalibratorAction::Confirmed);
     } else if tp_weight > fp_weight * 1.5 {
         // Confirm only when TP meaningfully outweighs FP.
         finding.calibrator_action = Some(CalibratorAction::Confirmed);
         if reason.is_none() {
-            reason = Some(
-                crate::calibrator_trace::SeverityChangeReason::BoostWeightTooLow,
-            );
+            reason = Some(crate::calibrator_trace::SeverityChangeReason::BoostWeightTooLow);
         }
     }
     // Mixed signal (TP ~ FP): leave calibrator_action as None.
@@ -302,7 +316,11 @@ fn calibrate_core_decision(
         file_path,
     );
 
-    CoreDecision { suppressed, boosted, trace }
+    CoreDecision {
+        suppressed,
+        boosted,
+        trace,
+    }
 }
 
 // Issue #97: cap on the global External-provenance contribution to any single
@@ -381,7 +399,10 @@ fn verdict_weight(entry: &FeedbackEntry, now: chrono::DateTime<chrono::Utc>) -> 
         (Verdict::Fp, Some(FpKind::PatternOvergeneralization { .. })) => 120.0,
         (Verdict::Fp, Some(FpKind::OutOfScope { .. })) => 120.0,
         (Verdict::Fp, None) => 120.0,
-        (Verdict::Tp | Verdict::Partial | Verdict::Wontfix | Verdict::ContextMisleading { .. }, _) => 120.0,
+        (
+            Verdict::Tp | Verdict::Partial | Verdict::Wontfix | Verdict::ContextMisleading { .. },
+            _,
+        ) => 120.0,
     };
 
     // Future-dated entries (clock skew, mis-set system clocks, manual edits)
@@ -411,7 +432,12 @@ pub fn calibrate(
     // prefer the config field to avoid env mutation races (CR review on
     // PR #189, citing docs/TEST_STRATEGY.md).
     if calibrator_disabled(config) {
-        return CalibrationResult { findings, suppressed: 0, boosted: 0, traces: vec![] };
+        return CalibrationResult {
+            findings,
+            suppressed: 0,
+            boosted: 0,
+            traces: vec![],
+        };
     }
 
     // Capture `now` once so every verdict_weight invocation in this calibration
@@ -442,11 +468,14 @@ pub fn calibrate(
     if filtered.is_empty() {
         // Track B: emit NoMatch traces so the eval harness sees per-finding
         // calibration outcomes even when the corpus is empty / fully filtered.
-        let traces = findings.iter().map(|f| {
-            let mut t = make_no_match_trace(f, file_path);
-            t.provenance = config.trace_provenance.clone();
-            t
-        }).collect();
+        let traces = findings
+            .iter()
+            .map(|f| {
+                let mut t = make_no_match_trace(f, file_path);
+                t.provenance = config.trace_provenance.clone();
+                t
+            })
+            .collect();
         return CalibrationResult {
             findings,
             suppressed: 0,
@@ -619,17 +648,30 @@ pub fn calibrate_with_index(
     //
     // See `calibrator_disabled` for config-vs-env precedence.
     if calibrator_disabled(config) {
-        return CalibrationResult { findings, suppressed: 0, boosted: 0, traces: vec![] };
+        return CalibrationResult {
+            findings,
+            suppressed: 0,
+            boosted: 0,
+            traces: vec![],
+        };
     }
     if index.is_empty() {
         // Track B: emit NoMatch traces so the eval harness sees per-finding
         // calibration outcomes even when the index is empty.
-        let traces = findings.iter().map(|f| {
-            let mut t = make_no_match_trace(f, file_path);
-            t.provenance = config.trace_provenance.clone();
-            t
-        }).collect();
-        return CalibrationResult { findings, suppressed: 0, boosted: 0, traces };
+        let traces = findings
+            .iter()
+            .map(|f| {
+                let mut t = make_no_match_trace(f, file_path);
+                t.provenance = config.trace_provenance.clone();
+                t
+            })
+            .collect();
+        return CalibrationResult {
+            findings,
+            suppressed: 0,
+            boosted: 0,
+            traces,
+        };
     }
 
     // Capture `now` once so every verdict_weight invocation in this calibration
@@ -666,11 +708,18 @@ pub fn calibrate_with_index(
         // comparable cyclomatic number. Without this, a CC=5 FP precedent at
         // embedding similarity 0.9 will wrongly suppress a real CC=11 finding.
         let finding_title_for_metric = finding.title.clone();
-        let similar: Vec<&crate::feedback_index::SimilarEntry> = similar_entries.iter()
+        let similar: Vec<&crate::feedback_index::SimilarEntry> = similar_entries
+            .iter()
             .filter(|s| s.similarity >= config.embedding_similarity_threshold as f32)
             .filter(|s| {
-                if config.use_auto_feedback { true }
-                else { !matches!(s.entry.provenance, crate::feedback::Provenance::AutoCalibrate(_)) }
+                if config.use_auto_feedback {
+                    true
+                } else {
+                    !matches!(
+                        s.entry.provenance,
+                        crate::feedback::Provenance::AutoCalibrate(_)
+                    )
+                }
             })
             // OutOfScope FP exclusion (#123 Layer 1) — these represent "real
             // defect, tracked elsewhere", NOT suppression signal. Excluding
@@ -679,10 +728,15 @@ pub fn calibrate_with_index(
             .filter(|s| {
                 !matches!(
                     (&s.entry.verdict, &s.entry.fp_kind),
-                    (Verdict::Fp, Some(crate::feedback::FpKind::OutOfScope { .. }))
+                    (
+                        Verdict::Fp,
+                        Some(crate::feedback::FpKind::OutOfScope { .. })
+                    )
                 )
             })
-            .filter(|s| precedent_metric_compatible(&finding_title_for_metric, &s.entry.finding_title))
+            .filter(|s| {
+                precedent_metric_compatible(&finding_title_for_metric, &s.entry.finding_title)
+            })
             .collect();
 
         if similar.is_empty() {
@@ -699,19 +753,32 @@ pub fn calibrate_with_index(
             similar
                 .iter()
                 .filter(|s| matches!(s.entry.verdict, Verdict::Tp | Verdict::Partial))
-                .map(|s| (&s.entry.provenance, verdict_weight(&s.entry, now) * s.similarity as f64)),
+                .map(|s| {
+                    (
+                        &s.entry.provenance,
+                        verdict_weight(&s.entry, now) * s.similarity as f64,
+                    )
+                }),
         );
         let fp_weight = accumulate_capped(
             similar
                 .iter()
                 .filter(|s| s.entry.verdict == Verdict::Fp)
-                .map(|s| (&s.entry.provenance, verdict_weight(&s.entry, now) * s.similarity as f64)),
+                .map(|s| {
+                    (
+                        &s.entry.provenance,
+                        verdict_weight(&s.entry, now) * s.similarity as f64,
+                    )
+                }),
         );
 
         // Wontfix weight — retained only for trace diagnostics. Wontfix no longer
         // contributes to soft or full suppression (see inertness rationale below).
         let mut wontfix_weight: f64 = 0.0;
-        for s in similar.iter().filter(|s| s.entry.verdict == Verdict::Wontfix) {
+        for s in similar
+            .iter()
+            .filter(|s| s.entry.verdict == Verdict::Wontfix)
+        {
             let w = verdict_weight(&s.entry, now) * s.similarity as f64;
             wontfix_weight += w;
         }
@@ -740,11 +807,15 @@ pub fn calibrate_with_index(
             finding.similar_precedent.push(format!(
                 "{}: {} ({}) [sim={:.2}]",
                 match s.entry.verdict {
-                    Verdict::Tp => "TP", Verdict::Fp => "FP",
-                    Verdict::Partial => "Partial", Verdict::Wontfix => "Wontfix",
+                    Verdict::Tp => "TP",
+                    Verdict::Fp => "FP",
+                    Verdict::Partial => "Partial",
+                    Verdict::Wontfix => "Wontfix",
                     Verdict::ContextMisleading { .. } => "ContextMisleading",
                 },
-                s.entry.finding_title, s.entry.reason, s.similarity
+                s.entry.finding_title,
+                s.entry.reason,
+                s.similarity
             ));
         }
 
@@ -772,7 +843,12 @@ pub fn calibrate_with_index(
         output.push(finding);
     }
 
-    CalibrationResult { findings: output, suppressed, boosted, traces }
+    CalibrationResult {
+        findings: output,
+        suppressed,
+        boosted,
+        traces,
+    }
 }
 
 fn boost_severity(severity: &Severity) -> Severity {
@@ -825,8 +901,8 @@ fn rubric_supports_severity_bump(target: &Severity, finding: &Finding) -> bool {
         while i + nlen <= bytes.len() {
             if &bytes[i..i + nlen] == needle.as_bytes() {
                 let left_ok = i == 0 || !(bytes[i - 1] as char).is_alphanumeric();
-                let right_ok = i + nlen == bytes.len()
-                    || !(bytes[i + nlen] as char).is_alphanumeric();
+                let right_ok =
+                    i + nlen == bytes.len() || !(bytes[i + nlen] as char).is_alphanumeric();
                 if left_ok && right_ok {
                     return true;
                 }
@@ -865,7 +941,9 @@ fn rubric_supports_severity_bump(target: &Severity, finding: &Finding) -> bool {
                 "durable data loss",
                 "permanent data loss",
             ];
-            CRITICAL_KEYWORDS.iter().any(|k| contains_word(&haystack, k))
+            CRITICAL_KEYWORDS
+                .iter()
+                .any(|k| contains_word(&haystack, k))
         }
         Severity::High => {
             // Allowlist of categories that may freely promote medium → high.
@@ -910,7 +988,9 @@ fn rubric_supports_severity_bump(target: &Severity, finding: &Finding) -> bool {
                     "buffer overflow",
                     "unsafe",
                 ];
-                HIGH_EVIDENCE_KEYWORDS.iter().any(|k| contains_word(&haystack, k))
+                HIGH_EVIDENCE_KEYWORDS
+                    .iter()
+                    .any(|k| contains_word(&haystack, k))
             }
         }
         // Medium and below: no gate
@@ -945,7 +1025,10 @@ fn word_jaccard(a: &str, b: &str) -> f64 {
     // Lowering here keeps the set tokens equivalent without affecting display.
     fn tokens(s: &str) -> std::collections::HashSet<String> {
         s.split_whitespace()
-            .map(|w| w.trim_matches(|c: char| !c.is_alphanumeric()).to_lowercase())
+            .map(|w| {
+                w.trim_matches(|c: char| !c.is_alphanumeric())
+                    .to_lowercase()
+            })
             .filter(|w| !w.is_empty())
             .collect()
     }
@@ -953,7 +1036,11 @@ fn word_jaccard(a: &str, b: &str) -> f64 {
     let words_b = tokens(b);
     let intersection = words_a.intersection(&words_b).count() as f64;
     let union = words_a.union(&words_b).count() as f64;
-    if union == 0.0 { 0.0 } else { intersection / union }
+    if union == 0.0 {
+        0.0
+    } else {
+        intersection / union
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -1016,7 +1103,10 @@ impl Calibrator {
     /// Record one ContextMisleading confirmation for `chunk_id`. Primarily for
     /// tests; the production path rebuilds state via [`Self::from_feedback`].
     pub fn record_misleading(&mut self, chunk_id: &str, _finding_title: &str) {
-        *self.misleading_counts.entry(chunk_id.to_string()).or_insert(0) += 1;
+        *self
+            .misleading_counts
+            .entry(chunk_id.to_string())
+            .or_insert(0) += 1;
     }
 
     /// Return the effective injection threshold for `chunk_id`.
@@ -1126,8 +1216,16 @@ mod tests {
         for (title, cat, desc) in [
             ("Unused variable", "quality", "Cosmetic only."),
             ("Missing docs", "documentation", "Add module docs."),
-            ("Magic constant 100 reused", "best-practices", "Pull into constant."),
-            ("Logging missing", "observability", "Add structured logging."),
+            (
+                "Magic constant 100 reused",
+                "best-practices",
+                "Pull into constant.",
+            ),
+            (
+                "Logging missing",
+                "observability",
+                "Add structured logging.",
+            ),
             ("Some thing", "unknown", "Unclassified."),
         ] {
             let f = finding_at(title, cat, Severity::Medium, desc);
@@ -1152,12 +1250,7 @@ mod tests {
             "compound category with allowlisted head must permit HIGH"
         );
         // Unknown head is blocked.
-        let f2 = finding_at(
-            "Y is wrong",
-            "lint/quality",
-            Severity::Medium,
-            "An issue.",
-        );
+        let f2 = finding_at("Y is wrong", "lint/quality", Severity::Medium, "An issue.");
         assert!(
             !rubric_supports_severity_bump(&Severity::High, &f2),
             "compound category with non-allowlisted head must require evidence"
@@ -1414,13 +1507,16 @@ mod tests {
         assert!(
             (0.95..=1.05).contains(&ratio),
             "TrustModelAssumption@40d should ≈ Hallucination@120d; ratio={}, trust={}, halluc_120d={}",
-            ratio, trust_w, halluc_120d_w,
+            ratio,
+            trust_w,
+            halluc_120d_w,
         );
         // Anchor: prove the 40d branch fired — same age, different decay.
         assert!(
             trust_w < halluc_40d_w,
             "TrustModel@40d ({}) must decay faster than Hallucination@40d ({})",
-            trust_w, halluc_40d_w,
+            trust_w,
+            halluc_40d_w,
         );
         // Absolute-value lock for the 40d τ constant (kills 40.0→39.0 mutant).
         // 1.0 (Human) * e^(-40/40) = e^-1 ≈ 0.36788.
@@ -1474,7 +1570,11 @@ mod tests {
             rule_id: None,
         };
         let w = verdict_weight(&entry, now);
-        assert!((0.366..=0.370).contains(&w), "expected ≈0.368 (120d), got {}", w);
+        assert!(
+            (0.366..=0.370).contains(&w),
+            "expected ≈0.368 (120d), got {}",
+            w
+        );
     }
 
     #[test]
@@ -1505,7 +1605,8 @@ mod tests {
         assert!(
             none_w > trust_w,
             "None must route to 120d default; none={} should exceed trust@40d={}",
-            none_w, trust_w,
+            none_w,
+            trust_w,
         );
         // Spot check absolute value: 1.0 * e^(-100/120) ≈ 0.4346.
         assert!(
@@ -1582,7 +1683,8 @@ mod tests {
         ];
         let result = calibrate(findings, &feedback, &CalibratorConfig::default(), "");
         assert_eq!(
-            result.findings.len(), 1,
+            result.findings.len(),
+            1,
             "OutOfScope FPs must NOT suppress (they're 'real, tracked elsewhere', not 'wrong')"
         );
         assert_eq!(result.suppressed, 0);
@@ -1620,7 +1722,8 @@ mod tests {
         // If this fails, the OutOfScope test above is meaningless — it could
         // be passing because suppression itself is broken.
         assert_eq!(
-            result.findings.len(), 0,
+            result.findings.len(),
+            0,
             "control: 3 Hallucination FPs MUST suppress; if this fails, suppression itself is broken"
         );
         assert_eq!(result.suppressed, 1);
@@ -1657,10 +1760,12 @@ mod tests {
             store.record(e).unwrap();
         }
 
-        let make_finding = || FindingBuilder::new()
-            .title("SQL injection")
-            .category("security".into())
-            .build();
+        let make_finding = || {
+            FindingBuilder::new()
+                .title("SQL injection")
+                .category("security".into())
+                .build()
+        };
         let config = CalibratorConfig::default();
 
         // Path A: calibrate() — in-memory feedback slice.
@@ -1672,10 +1777,12 @@ mod tests {
         let result_b = calibrate_with_index(vec![make_finding()], &mut index, &config, "");
 
         assert_eq!(
-            result_a.findings.len(), result_b.findings.len(),
+            result_a.findings.len(),
+            result_b.findings.len(),
             "calibrate() and calibrate_with_index() must agree on OutOfScope exclusion; \
              A.findings={}, B.findings={}",
-            result_a.findings.len(), result_b.findings.len(),
+            result_a.findings.len(),
+            result_b.findings.len(),
         );
         assert_eq!(
             result_a.suppressed, result_b.suppressed,
@@ -1683,8 +1790,16 @@ mod tests {
             result_a.suppressed, result_b.suppressed,
         );
         // Both paths must let the finding survive (OutOfScope is non-suppressive).
-        assert_eq!(result_a.findings.len(), 1, "path A: OutOfScope must not suppress");
-        assert_eq!(result_b.findings.len(), 1, "path B: OutOfScope must not suppress");
+        assert_eq!(
+            result_a.findings.len(),
+            1,
+            "path A: OutOfScope must not suppress"
+        );
+        assert_eq!(
+            result_b.findings.len(),
+            1,
+            "path B: OutOfScope must not suppress"
+        );
     }
 
     // -- No feedback: passthrough --
@@ -1692,8 +1807,10 @@ mod tests {
     #[test]
     fn calibrator_config_has_separate_thresholds() {
         let config = CalibratorConfig::default();
-        assert!(config.embedding_similarity_threshold > config.similarity_threshold,
-            "Embedding threshold should be higher than Jaccard threshold");
+        assert!(
+            config.embedding_similarity_threshold > config.similarity_threshold,
+            "Embedding threshold should be higher than Jaccard threshold"
+        );
     }
 
     #[test]
@@ -1703,9 +1820,11 @@ mod tests {
         // A threshold of 0.80 was empirically too strict — real precedents kept missing their
         // matches, leading to the March→April precision regression.
         let config = CalibratorConfig::default();
-        assert!(config.embedding_similarity_threshold <= 0.75,
+        assert!(
+            config.embedding_similarity_threshold <= 0.75,
             "embedding threshold {} excludes legitimate paraphrases — should be <= 0.75",
-            config.embedding_similarity_threshold);
+            config.embedding_similarity_threshold
+        );
     }
 
     #[test]
@@ -1735,7 +1854,11 @@ mod tests {
             fb("SQL injection", "security", Verdict::Fp),
         ];
         let result = calibrate(findings, &feedback, &CalibratorConfig::default(), "");
-        assert_eq!(result.findings.len(), 0, "Finding should be suppressed by 2 FP precedents");
+        assert_eq!(
+            result.findings.len(),
+            0,
+            "Finding should be suppressed by 2 FP precedents"
+        );
         assert_eq!(result.suppressed, 1);
     }
 
@@ -1791,7 +1914,10 @@ mod tests {
         ];
         let result = calibrate(findings, &feedback, &CalibratorConfig::default(), "");
         assert_eq!(result.findings.len(), 1);
-        assert!(result.findings[0].severity > Severity::Medium, "Should be boosted above Medium");
+        assert!(
+            result.findings[0].severity > Severity::Medium,
+            "Should be boosted above Medium"
+        );
         assert_eq!(result.boosted, 1);
     }
 
@@ -1843,10 +1969,17 @@ mod tests {
             ..CalibratorConfig::default()
         };
         let result = calibrate(findings, &feedback, &config, "");
-        assert_eq!(result.findings[0].severity, Severity::Medium, "must not boost when disabled");
+        assert_eq!(
+            result.findings[0].severity,
+            Severity::Medium,
+            "must not boost when disabled"
+        );
         assert_eq!(result.boosted, 0);
         assert_eq!(result.suppressed, 0);
-        assert!(result.traces.is_empty(), "no traces should be emitted when disabled");
+        assert!(
+            result.traces.is_empty(),
+            "no traces should be emitted when disabled"
+        );
     }
 
     // -- Mixed precedent --
@@ -1880,8 +2013,11 @@ mod tests {
         let a = "SQL Injection via f-string formatting";
         let b = "sql injection via f-string formatting";
         let score = word_jaccard(a, b);
-        assert!((score - 1.0).abs() < 1e-9,
-            "case-only difference should score 1.0, got {}", score);
+        assert!(
+            (score - 1.0).abs() < 1e-9,
+            "case-only difference should score 1.0, got {}",
+            score
+        );
     }
 
     #[test]
@@ -1912,7 +2048,11 @@ mod tests {
             .build();
         let entry = fb("SQL injection in query builder", "security", Verdict::Tp);
         let sim = finding_feedback_similarity(&finding, &entry);
-        assert!(sim > 0.4 && sim < 0.9, "Partial match should be moderate: {}", sim);
+        assert!(
+            sim > 0.4 && sim < 0.9,
+            "Partial match should be moderate: {}",
+            sim
+        );
     }
 
     // -- Precedent annotation --
@@ -1925,17 +2065,22 @@ mod tests {
                 .category("security".into())
                 .build(),
         ];
-        let feedback = vec![
-            fb("SQL injection", "security", Verdict::Tp),
-        ];
+        let feedback = vec![fb("SQL injection", "security", Verdict::Tp)];
         let result = calibrate(findings, &feedback, &CalibratorConfig::default(), "");
-        assert!(!result.findings[0].similar_precedent.is_empty(),
-            "Finding should have precedent annotation");
+        assert!(
+            !result.findings[0].similar_precedent.is_empty(),
+            "Finding should have precedent annotation"
+        );
     }
 
     #[test]
     fn calibrator_excludes_auto_feedback_when_configured() {
-        let findings = vec![FindingBuilder::new().title("Bug").category("test".into()).build()];
+        let findings = vec![
+            FindingBuilder::new()
+                .title("Bug")
+                .category("test".into())
+                .build(),
+        ];
         let auto_fb = FeedbackEntry {
             file_path: "test.rs".into(),
             finding_title: "Bug".into(),
@@ -1955,12 +2100,20 @@ mod tests {
             ..Default::default()
         };
         let result = calibrate(findings, &feedback, &config, "");
-        assert_eq!(result.suppressed, 0, "Auto feedback excluded, should not suppress");
+        assert_eq!(
+            result.suppressed, 0,
+            "Auto feedback excluded, should not suppress"
+        );
     }
 
     #[test]
     fn calibrator_includes_auto_feedback_by_default() {
-        let findings = vec![FindingBuilder::new().title("Bug").category("test".into()).build()];
+        let findings = vec![
+            FindingBuilder::new()
+                .title("Bug")
+                .category("test".into())
+                .build(),
+        ];
         let auto_fb = FeedbackEntry {
             file_path: "test.rs".into(),
             finding_title: "Bug".into(),
@@ -1983,7 +2136,10 @@ mod tests {
         let feedback = vec![auto_fb.clone(), auto_fb, human_fb];
         let config = CalibratorConfig::default(); // use_auto_feedback defaults to true
         let result = calibrate(findings, &feedback, &config, "");
-        assert_eq!(result.suppressed, 1, "Auto+human feedback should suppress (auto capped at 1.0 + human 1.0 = 2.0)");
+        assert_eq!(
+            result.suppressed, 1,
+            "Auto+human feedback should suppress (auto capped at 1.0 + human 1.0 = 2.0)"
+        );
     }
 
     #[test]
@@ -1994,18 +2150,24 @@ mod tests {
                 .category("safety".into())
                 .build(),
         ];
-        let feedback = vec![
-            fb("Null pointer", "safety", Verdict::Tp),
-        ];
+        let feedback = vec![fb("Null pointer", "safety", Verdict::Tp)];
         let result = calibrate(findings, &feedback, &CalibratorConfig::default(), "");
-        assert_eq!(result.findings[0].calibrator_action, Some(CalibratorAction::Confirmed));
+        assert_eq!(
+            result.findings[0].calibrator_action,
+            Some(CalibratorAction::Confirmed)
+        );
     }
 
     // -- Weighted scoring tests --
 
     #[test]
     fn weighted_calibrator_human_feedback_counts_more() {
-        let findings = vec![FindingBuilder::new().title("SQL injection").category("security".into()).build()];
+        let findings = vec![
+            FindingBuilder::new()
+                .title("SQL injection")
+                .category("security".into())
+                .build(),
+        ];
 
         let human_fp = FeedbackEntry {
             file_path: "test.py".into(),
@@ -2036,17 +2198,35 @@ mod tests {
 
         // Human (1.0) + auto (0.5) = 1.5 >= threshold -> suppress
         let config = CalibratorConfig::default();
-        let result1 = calibrate(findings.clone(), &vec![human_fp.clone(), auto_fp.clone()], &config, "");
+        let result1 = calibrate(
+            findings.clone(),
+            &vec![human_fp.clone(), auto_fp.clone()],
+            &config,
+            "",
+        );
         assert_eq!(result1.suppressed, 1, "Human+auto FP should suppress");
 
         // 2 auto only: 0.5 + 0.5 = 1.0 < 1.5 threshold -> NOT suppress
-        let result2 = calibrate(findings.clone(), &vec![auto_fp.clone(), auto_fp], &config, "");
-        assert_eq!(result2.suppressed, 0, "2 auto FPs alone should not suppress (insufficient weight)");
+        let result2 = calibrate(
+            findings.clone(),
+            &vec![auto_fp.clone(), auto_fp],
+            &config,
+            "",
+        );
+        assert_eq!(
+            result2.suppressed, 0,
+            "2 auto FPs alone should not suppress (insufficient weight)"
+        );
     }
 
     #[test]
     fn weighted_calibrator_recency_matters() {
-        let findings = vec![FindingBuilder::new().title("Bug").category("test".into()).build()];
+        let findings = vec![
+            FindingBuilder::new()
+                .title("Bug")
+                .category("test".into())
+                .build(),
+        ];
         let old_fp = FeedbackEntry {
             file_path: "test.rs".into(),
             finding_title: "Bug".into(),
@@ -2076,7 +2256,12 @@ mod tests {
 
         let config = CalibratorConfig::default();
         // 2 recent human FPs: 1.0 + 1.0 = 2.0 >= 1.5 -> suppress
-        let result1 = calibrate(findings.clone(), &vec![recent_fp.clone(), recent_fp], &config, "");
+        let result1 = calibrate(
+            findings.clone(),
+            &vec![recent_fp.clone(), recent_fp],
+            &config,
+            "",
+        );
         assert_eq!(result1.suppressed, 1);
 
         // 2 old FPs: exp(-90/60) ~= 0.22 each, total ~0.44 < 1.5 -> NOT suppress
@@ -2086,7 +2271,12 @@ mod tests {
 
     #[test]
     fn weighted_calibrator_produces_confidence() {
-        let findings = vec![FindingBuilder::new().title("SQL injection").category("security".into()).build()];
+        let findings = vec![
+            FindingBuilder::new()
+                .title("SQL injection")
+                .category("security".into())
+                .build(),
+        ];
         let tp = FeedbackEntry {
             file_path: "test.py".into(),
             finding_title: "SQL injection".into(),
@@ -2104,7 +2294,10 @@ mod tests {
         let config = CalibratorConfig::default();
         let result = calibrate(findings, &vec![tp], &config, "");
         assert_eq!(result.findings.len(), 1);
-        assert_eq!(result.findings[0].calibrator_action, Some(CalibratorAction::Confirmed));
+        assert_eq!(
+            result.findings[0].calibrator_action,
+            Some(CalibratorAction::Confirmed)
+        );
     }
 
     #[test]
@@ -2123,14 +2316,22 @@ mod tests {
             rule_id: None,
         };
         let weight = verdict_weight(&old_entry, Utc::now());
-        assert!(weight >= 0.3,
-            "90-day-old human feedback should retain >= 30% weight, got {:.3}", weight);
+        assert!(
+            weight >= 0.3,
+            "90-day-old human feedback should retain >= 30% weight, got {:.3}",
+            weight
+        );
     }
 
     #[test]
     fn postfix_provenance_has_highest_weight() {
         // A single PostFix TP (weight 1.5) should be enough to confirm
-        let findings = vec![FindingBuilder::new().title("SQL injection").category("security".into()).build()];
+        let findings = vec![
+            FindingBuilder::new()
+                .title("SQL injection")
+                .category("security".into())
+                .build(),
+        ];
         let postfix_tp = FeedbackEntry {
             file_path: "test.py".into(),
             finding_title: "SQL injection".into(),
@@ -2147,7 +2348,10 @@ mod tests {
 
         let config = CalibratorConfig::default();
         let result = calibrate(findings, &vec![postfix_tp], &config, "");
-        assert_eq!(result.findings[0].calibrator_action, Some(CalibratorAction::Confirmed));
+        assert_eq!(
+            result.findings[0].calibrator_action,
+            Some(CalibratorAction::Confirmed)
+        );
     }
 
     #[test]
@@ -2155,7 +2359,12 @@ mod tests {
         // 4 auto FPs: uncapped = 4 * 0.5 = 2.0 (would suppress)
         // capped = min(2.0, 1.0) = 1.0 (should NOT fully suppress — needs human corroboration)
         // Note: soft suppression downgrades severity to INFO but finding remains in output
-        let findings = vec![FindingBuilder::new().title("Bug").category("test".into()).build()];
+        let findings = vec![
+            FindingBuilder::new()
+                .title("Bug")
+                .category("test".into())
+                .build(),
+        ];
         let auto_fb = FeedbackEntry {
             file_path: "test.rs".into(),
             finding_title: "Bug".into(),
@@ -2172,14 +2381,21 @@ mod tests {
         let feedback = vec![auto_fb.clone(), auto_fb.clone(), auto_fb.clone(), auto_fb];
         let config = CalibratorConfig::default();
         let result = calibrate(findings, &feedback, &config, "");
-        assert_eq!(result.suppressed, 0,
-            "4 auto FPs should not suppress (capped at 1.0 weight, needs human corroboration)");
+        assert_eq!(
+            result.suppressed, 0,
+            "4 auto FPs should not suppress (capped at 1.0 weight, needs human corroboration)"
+        );
     }
 
     #[test]
     fn auto_plus_human_still_suppresses() {
         // 2 auto FPs (capped at 1.0) + 1 human FP (1.0) = 2.0 >= 1.5 -> suppress
-        let findings = vec![FindingBuilder::new().title("Bug").category("test".into()).build()];
+        let findings = vec![
+            FindingBuilder::new()
+                .title("Bug")
+                .category("test".into())
+                .build(),
+        ];
         let auto_fb = FeedbackEntry {
             file_path: "test.rs".into(),
             finding_title: "Bug".into(),
@@ -2201,8 +2417,10 @@ mod tests {
         let feedback = vec![auto_fb.clone(), auto_fb, human_fb];
         let config = CalibratorConfig::default();
         let result = calibrate(findings, &feedback, &config, "");
-        assert_eq!(result.suppressed, 1,
-            "Auto (capped 1.0) + human (1.0) = 2.0 should suppress");
+        assert_eq!(
+            result.suppressed, 1,
+            "Auto (capped 1.0) + human (1.0) = 2.0 should suppress"
+        );
     }
 
     #[test]
@@ -2214,15 +2432,30 @@ mod tests {
             .category("quality".into())
             .build();
         let feedback = vec![
-            fb("Template uses states() without availability check", "quality", Verdict::Fp),
-            fb("Template uses states() without availability check", "quality", Verdict::Fp),
-            fb("Template uses states() without availability check", "quality", Verdict::Fp),
+            fb(
+                "Template uses states() without availability check",
+                "quality",
+                Verdict::Fp,
+            ),
+            fb(
+                "Template uses states() without availability check",
+                "quality",
+                Verdict::Fp,
+            ),
+            fb(
+                "Template uses states() without availability check",
+                "quality",
+                Verdict::Fp,
+            ),
         ];
         // Make all entries auto-calibrate provenance
-        let auto_feedback: Vec<FeedbackEntry> = feedback.into_iter().map(|mut e| {
-            e.provenance = crate::feedback::Provenance::AutoCalibrate("gpt-5.4".into());
-            e
-        }).collect();
+        let auto_feedback: Vec<FeedbackEntry> = feedback
+            .into_iter()
+            .map(|mut e| {
+                e.provenance = crate::feedback::Provenance::AutoCalibrate("gpt-5.4".into());
+                e
+            })
+            .collect();
 
         let config = CalibratorConfig::default();
         let result = calibrate(vec![finding], &auto_feedback, &config, "");
@@ -2232,7 +2465,10 @@ mod tests {
         assert_eq!(result.findings.len(), 1);
         // But should be downgraded to INFO
         assert_eq!(result.findings[0].severity, Severity::Info);
-        assert_eq!(result.findings[0].calibrator_action, Some(CalibratorAction::Disputed));
+        assert_eq!(
+            result.findings[0].calibrator_action,
+            Some(CalibratorAction::Disputed)
+        );
     }
 
     #[test]
@@ -2244,8 +2480,16 @@ mod tests {
             .category("quality".into())
             .build();
         let mut feedback = vec![
-            fb("Template uses states() without availability check", "quality", Verdict::Fp),
-            fb("Template uses states() without availability check", "quality", Verdict::Fp),
+            fb(
+                "Template uses states() without availability check",
+                "quality",
+                Verdict::Fp,
+            ),
+            fb(
+                "Template uses states() without availability check",
+                "quality",
+                Verdict::Fp,
+            ),
         ];
         // One auto, one human — human provides the extra weight to cross 1.5
         feedback[0].provenance = crate::feedback::Provenance::AutoCalibrate("gpt-5.4".into());
@@ -2293,11 +2537,13 @@ mod tests {
             .severity(Severity::High)
             .category("quality".into())
             .build();
-        let auto_feedback: Vec<FeedbackEntry> = (0..5).map(|_| {
-            let mut e = fb("Deprecated trigger syntax", "quality", Verdict::Fp);
-            e.provenance = crate::feedback::Provenance::AutoCalibrate("gpt-5.4".into());
-            e
-        }).collect();
+        let auto_feedback: Vec<FeedbackEntry> = (0..5)
+            .map(|_| {
+                let mut e = fb("Deprecated trigger syntax", "quality", Verdict::Fp);
+                e.provenance = crate::feedback::Provenance::AutoCalibrate("gpt-5.4".into());
+                e
+            })
+            .collect();
 
         let config = CalibratorConfig::default();
         let result = calibrate(vec![finding], &auto_feedback, &config, "");
@@ -2309,7 +2555,12 @@ mod tests {
     #[test]
     fn postfix_fp_suppresses_with_single_entry() {
         // A single PostFix FP (weight 1.5) meets the 1.5 threshold alone
-        let findings = vec![FindingBuilder::new().title("Unused import").category("style".into()).build()];
+        let findings = vec![
+            FindingBuilder::new()
+                .title("Unused import")
+                .category("style".into())
+                .build(),
+        ];
         let postfix_fp = FeedbackEntry {
             file_path: "test.py".into(),
             finding_title: "Unused import".into(),
@@ -2326,7 +2577,10 @@ mod tests {
 
         let config = CalibratorConfig::default();
         let result = calibrate(findings, &vec![postfix_fp], &config, "");
-        assert_eq!(result.suppressed, 1, "Single PostFix FP should suppress (weight 1.5 >= threshold)");
+        assert_eq!(
+            result.suppressed, 1,
+            "Single PostFix FP should suppress (weight 1.5 >= threshold)"
+        );
     }
 
     #[test]
@@ -2349,8 +2603,11 @@ mod tests {
 
         assert_eq!(result.suppressed, 0, "wontfix should NOT fully suppress");
         assert_eq!(result.findings.len(), 1);
-        assert_eq!(result.findings[0].severity, Severity::Medium,
-            "wontfix should not change severity — it's inert like Partial");
+        assert_eq!(
+            result.findings[0].severity,
+            Severity::Medium,
+            "wontfix should not change severity — it's inert like Partial"
+        );
     }
 
     #[test]
@@ -2405,13 +2662,20 @@ mod tests {
 
         let feedback = vec![
             fb("Missing explicit mode", "quality", Verdict::Fp),
-            fb("Missing explicit mode defaults", "quality", Verdict::Wontfix),
+            fb(
+                "Missing explicit mode defaults",
+                "quality",
+                Verdict::Wontfix,
+            ),
             fb("No explicit mode set", "quality", Verdict::Wontfix),
         ];
 
         let config = CalibratorConfig::default();
         let result = calibrate(vec![finding], &feedback, &config, "");
-        assert_eq!(result.suppressed, 0, "1 FP + wontfix should NOT reach full suppress threshold");
+        assert_eq!(
+            result.suppressed, 0,
+            "1 FP + wontfix should NOT reach full suppress threshold"
+        );
         assert_eq!(result.findings.len(), 1);
     }
 
@@ -2437,8 +2701,11 @@ mod tests {
         let result = calibrate(vec![finding], &feedback, &config, "");
         assert_eq!(result.suppressed, 0);
         assert_eq!(result.findings.len(), 1);
-        assert_eq!(result.findings[0].severity, Severity::Medium,
-            "wontfix is inert — must not downgrade severity");
+        assert_eq!(
+            result.findings[0].severity,
+            Severity::Medium,
+            "wontfix is inert — must not downgrade severity"
+        );
     }
 
     #[test]
@@ -2497,9 +2764,7 @@ mod tests {
             .category("concurrency".into())
             .build();
 
-        let feedback = vec![
-            fb("Unused import", "style", Verdict::Fp),
-        ];
+        let feedback = vec![fb("Unused import", "style", Verdict::Fp)];
 
         let config = CalibratorConfig::default();
         let result = calibrate(vec![finding], &feedback, &config, "");
@@ -2632,11 +2897,13 @@ mod tests {
         let dir = tempfile::TempDir::new().unwrap();
         let store = crate::feedback::FeedbackStore::new(dir.path().join("fb.jsonl"));
         // Slightly different title -> similarity ~0.83, fp_weight ~0.83.
-        store.record(&fb(
-            "Function `helper` has cyclomatic complexity 12",
-            "complexity",
-            Verdict::Fp,
-        )).unwrap();
+        store
+            .record(&fb(
+                "Function `helper` has cyclomatic complexity 12",
+                "complexity",
+                Verdict::Fp,
+            ))
+            .unwrap();
         let mut index = crate::feedback_index::FeedbackIndex::build(&store).unwrap();
         let finding = FindingBuilder::new()
             .title("Function `createFood` has cyclomatic complexity 13")
@@ -2665,9 +2932,21 @@ mod tests {
         let dir = tempfile::TempDir::new().unwrap();
         let store = crate::feedback::FeedbackStore::new(dir.path().join("fb.jsonl"));
         for e in [
-            fb("Function `simple` has cyclomatic complexity 5", "complexity", Verdict::Fp),
-            fb("Function `tiny` has cyclomatic complexity 6", "complexity", Verdict::Fp),
-            fb("Function `tiny2` has cyclomatic complexity 4", "complexity", Verdict::Fp),
+            fb(
+                "Function `simple` has cyclomatic complexity 5",
+                "complexity",
+                Verdict::Fp,
+            ),
+            fb(
+                "Function `tiny` has cyclomatic complexity 6",
+                "complexity",
+                Verdict::Fp,
+            ),
+            fb(
+                "Function `tiny2` has cyclomatic complexity 4",
+                "complexity",
+                Verdict::Fp,
+            ),
         ] {
             store.record(&e).unwrap();
         }
@@ -2707,19 +2986,23 @@ mod tests {
         // fully suppress IF they match.
         let mut fp1 = fb("Missing input validation", "security", Verdict::Fp);
         fp1.reason = "API endpoint parameters not validated before DB write — \
-                      handled by pydantic models downstream".into();
+                      handled by pydantic models downstream"
+            .into();
         let mut fp2 = fb("Missing input validation", "security", Verdict::Fp);
         fp2.reason = "request body type checks missing — already covered by \
-                      FastAPI response_model".into();
+                      FastAPI response_model"
+            .into();
         store.record(&fp1).unwrap();
         store.record(&fp2).unwrap();
 
         // New finding: JWT signature validation — completely different concern.
         let jwt_finding = FindingBuilder::new()
             .title("Missing input validation")
-            .description("decode_token() does not verify the JWT signature \
+            .description(
+                "decode_token() does not verify the JWT signature \
                           algorithm claim, allowing HS256 tokens signed with \
-                          untrusted keys to bypass jwt.verify checks")
+                          untrusted keys to bypass jwt.verify checks",
+            )
             .category("security".into())
             .severity(Severity::High)
             .evidence("jwt.verify(token, secret, { algorithms: ['HS256'] })")
@@ -2732,22 +3015,35 @@ mod tests {
         // Diagnostic trace output (visible with --nocapture).
         let trace = &result.traces[0];
         eprintln!("\n=== enrichment probe ===");
-        eprintln!("TP weight: {:.3}  FP weight: {:.3}  full_suppress: {:.3}",
-            trace.tp_weight, trace.fp_weight, trace.full_suppress_weight);
+        eprintln!(
+            "TP weight: {:.3}  FP weight: {:.3}  full_suppress: {:.3}",
+            trace.tp_weight, trace.fp_weight, trace.full_suppress_weight
+        );
         for p in &trace.matched_precedents {
-            eprintln!("  precedent: sim={:.3} weight={:.3} verdict={:?} reason={}",
-                p.similarity, p.weight, p.verdict, p.finding_title);
+            eprintln!(
+                "  precedent: sim={:.3} weight={:.3} verdict={:?} reason={}",
+                p.similarity, p.weight, p.verdict, p.finding_title
+            );
         }
         eprintln!("action: {:?}", trace.action);
-        eprintln!("output severity: {:?} (input High)\n", result.findings.get(0).map(|f| f.severity.clone()));
+        eprintln!(
+            "output severity: {:?} (input High)\n",
+            result.findings.get(0).map(|f| f.severity.clone())
+        );
 
         // Core assertion: JWT finding must not be suppressed (output or disputed).
-        assert_eq!(result.suppressed, 0,
+        assert_eq!(
+            result.suppressed, 0,
             "JWT finding must NOT be suppressed by generic input-validation FPs. \
-             full_suppress_weight={:.3}", trace.full_suppress_weight);
+             full_suppress_weight={:.3}",
+            trace.full_suppress_weight
+        );
         // And severity should stay High (not downgraded to Info).
-        assert_eq!(result.findings[0].severity, Severity::High,
-            "severity must stay High; was downgraded, indicating FP precedent match");
+        assert_eq!(
+            result.findings[0].severity,
+            Severity::High,
+            "severity must stay High; was downgraded, indicating FP precedent match"
+        );
     }
 
     #[test]
@@ -2760,17 +3056,19 @@ mod tests {
             .category("security".into())
             .severity(Severity::High)
             .build();
-        let feedback = vec![
-            fb("Missing input validation", "security", Verdict::Fp),
-        ];
+        let feedback = vec![fb("Missing input validation", "security", Verdict::Fp)];
         let config = CalibratorConfig::default();
         let result = calibrate(vec![finding], &feedback, &config, "");
         let trace = &result.traces[0];
-        let prec = trace.matched_precedents.first()
+        let prec = trace
+            .matched_precedents
+            .first()
             .expect("should have a matched precedent");
-        assert!(prec.similarity < 1.0,
+        assert!(
+            prec.similarity < 1.0,
             "legacy trace similarity should reflect actual Jaccard, got {}",
-            prec.similarity);
+            prec.similarity
+        );
     }
 
     #[test]
@@ -2785,7 +3083,13 @@ mod tests {
         // Jaccard-only index avoids fastembed flakiness: with deliberately
         // non-overlapping titles, similarity stays well below 1.0 so the
         // multiplier matters.
-        store.record(&fb("Missing input validation on endpoint", "security", Verdict::Tp)).unwrap();
+        store
+            .record(&fb(
+                "Missing input validation on endpoint",
+                "security",
+                Verdict::Tp,
+            ))
+            .unwrap();
         let mut index = crate::feedback_index::FeedbackIndex::build_jaccard_only(&store).unwrap();
 
         let finding = FindingBuilder::new()
@@ -2798,15 +3102,23 @@ mod tests {
         config.embedding_similarity_threshold = 0.3;
         let result = calibrate_with_index(vec![finding], &mut index, &config, "");
         let trace = &result.traces[0];
-        let prec = trace.matched_precedents.first()
+        let prec = trace
+            .matched_precedents
+            .first()
             .expect("precedent should be present when index has a matching entry");
-        assert!(prec.similarity < 1.0,
-            "test fixture should yield a sub-1.0 similarity, got {}", prec.similarity);
+        assert!(
+            prec.similarity < 1.0,
+            "test fixture should yield a sub-1.0 similarity, got {}",
+            prec.similarity
+        );
         let expected = prec.similarity * verdict_weight(&store.load_all().unwrap()[0], Utc::now());
-        assert!((prec.weight - expected).abs() < 1e-6,
+        assert!(
+            (prec.weight - expected).abs() < 1e-6,
             "trace weight {} must equal verdict_weight * similarity ({}); \
              decisions use the product, trace must match",
-            prec.weight, expected);
+            prec.weight,
+            expected
+        );
     }
 
     #[test]
@@ -2814,9 +3126,21 @@ mod tests {
         // Legacy calibrate() path (no embedding index) must also drop
         // metric-incompatible precedents. CC=11 finding vs CC=5/6/4 FPs.
         let feedback = vec![
-            fb("Function `simple` has cyclomatic complexity 5", "complexity", Verdict::Fp),
-            fb("Function `tiny` has cyclomatic complexity 6", "complexity", Verdict::Fp),
-            fb("Function `tiny2` has cyclomatic complexity 4", "complexity", Verdict::Fp),
+            fb(
+                "Function `simple` has cyclomatic complexity 5",
+                "complexity",
+                Verdict::Fp,
+            ),
+            fb(
+                "Function `tiny` has cyclomatic complexity 6",
+                "complexity",
+                Verdict::Fp,
+            ),
+            fb(
+                "Function `tiny2` has cyclomatic complexity 4",
+                "complexity",
+                Verdict::Fp,
+            ),
         ];
         let finding = FindingBuilder::new()
             .title("Function `bigfn` has cyclomatic complexity 11")
@@ -2829,8 +3153,11 @@ mod tests {
             trace.fp_weight, 0.0,
             "legacy calibrate must reject CC=5/6/4 precedents for CC=11 finding"
         );
-        assert_eq!(result.findings[0].severity, crate::finding::Severity::Medium,
-            "metric-incompatible FPs must not downgrade severity");
+        assert_eq!(
+            result.findings[0].severity,
+            crate::finding::Severity::Medium,
+            "metric-incompatible FPs must not downgrade severity"
+        );
     }
 
     // -- Per-chunk injection threshold escalation (Task 8.3) --
@@ -2891,7 +3218,10 @@ mod tests {
         ];
         let cal = Calibrator::from_feedback(0.65, &feedback);
         let t = cal.injection_threshold_for("chunk-a");
-        assert!(t > 0.65 && t.is_finite(), "expected raised but finite, got {t}");
+        assert!(
+            t > 0.65 && t.is_finite(),
+            "expected raised but finite, got {t}"
+        );
 
         // One more confirmation in the store should seal it.
         let mut feedback = feedback;
@@ -2918,8 +3248,8 @@ mod tests {
         // finding_title must not consult the misleading-escalation path.
         let feedback = vec![
             fb("chunk-a was flagged", "context", Verdict::Tp),
-            fb("chunk-a again",       "context", Verdict::Fp),
-            fb("chunk-a ignored",     "context", Verdict::Wontfix),
+            fb("chunk-a again", "context", Verdict::Fp),
+            fb("chunk-a ignored", "context", Verdict::Wontfix),
         ];
         let cal = Calibrator::from_feedback(0.65, &feedback);
         assert!((cal.injection_threshold_for("chunk-a") - 0.65).abs() < 1e-6);
@@ -3113,7 +3443,10 @@ mod tests {
                 (1, _) => Outcome::Full,
                 (0, Some(Severity::Info)) => Outcome::Soft,
                 (0, Some(_)) => Outcome::Kept,
-                _ => panic!("unexpected result for n={n}: suppressed={} findings={:?}", result.suppressed, result.findings),
+                _ => panic!(
+                    "unexpected result for n={n}: suppressed={} findings={:?}",
+                    result.suppressed, result.findings
+                ),
             };
             assert_eq!(
                 outcome, *expected,
@@ -3354,9 +3687,21 @@ mod tests {
                 .build(),
         ];
         let feedback = vec![
-            fb("Race condition in shared HashMap", "concurrency", Verdict::Tp),
-            fb("Race condition in shared HashMap", "concurrency", Verdict::Tp),
-            fb("Race condition in shared HashMap", "concurrency", Verdict::Tp),
+            fb(
+                "Race condition in shared HashMap",
+                "concurrency",
+                Verdict::Tp,
+            ),
+            fb(
+                "Race condition in shared HashMap",
+                "concurrency",
+                Verdict::Tp,
+            ),
+            fb(
+                "Race condition in shared HashMap",
+                "concurrency",
+                Verdict::Tp,
+            ),
         ];
         let result = calibrate(findings, &feedback, &CalibratorConfig::default(), "");
         assert_eq!(result.findings[0].severity, Severity::High);
@@ -3379,12 +3724,28 @@ mod tests {
                 .build(),
         ];
         let feedback = vec![
-            fb("Function `foo` has cyclomatic complexity 30", "complexity", Verdict::Tp),
-            fb("Function `foo` has cyclomatic complexity 30", "complexity", Verdict::Tp),
-            fb("Function `foo` has cyclomatic complexity 30", "complexity", Verdict::Tp),
+            fb(
+                "Function `foo` has cyclomatic complexity 30",
+                "complexity",
+                Verdict::Tp,
+            ),
+            fb(
+                "Function `foo` has cyclomatic complexity 30",
+                "complexity",
+                Verdict::Tp,
+            ),
+            fb(
+                "Function `foo` has cyclomatic complexity 30",
+                "complexity",
+                Verdict::Tp,
+            ),
         ];
         let result = calibrate(findings, &feedback, &CalibratorConfig::default(), "");
-        assert_eq!(result.findings[0].severity, Severity::Medium, "gate blocked the bump");
+        assert_eq!(
+            result.findings[0].severity,
+            Severity::Medium,
+            "gate blocked the bump"
+        );
         assert_eq!(
             result.traces[0].severity_change_reason,
             Some(crate::calibrator_trace::SeverityChangeReason::BoostBlockedByGate)
@@ -3423,7 +3784,9 @@ mod tests {
         let dir = tempfile::TempDir::new().unwrap();
         let store = crate::feedback::FeedbackStore::new(dir.path().join("fb.jsonl"));
         // Index built from a corpus that won't match the test finding.
-        store.record(&fb("Totally unrelated foo", "other", Verdict::Tp)).unwrap();
+        store
+            .record(&fb("Totally unrelated foo", "other", Verdict::Tp))
+            .unwrap();
         let mut index = crate::feedback_index::FeedbackIndex::build_jaccard_only(&store).unwrap();
 
         let findings = vec![
@@ -3515,10 +3878,10 @@ mod tests {
         let decision = calibrate_core_decision(
             &mut finding,
             &config,
-            0.01,  // tp_weight
-            1.0,   // fp_weight
-            0.0,   // wontfix_weight
-            1.0,   // soft_fp_weight
+            0.01, // tp_weight
+            1.0,  // fp_weight
+            0.0,  // wontfix_weight
+            1.0,  // soft_fp_weight
             vec![],
             Severity::High,
             "",
@@ -3545,10 +3908,10 @@ mod tests {
         let decision = calibrate_core_decision(
             &mut finding,
             &config,
-            1.2,  // tp_weight
-            0.1,  // fp_weight
-            0.0,  // wontfix_weight
-            0.1,  // soft_fp_weight
+            1.2, // tp_weight
+            0.1, // fp_weight
+            0.0, // wontfix_weight
+            0.1, // soft_fp_weight
             vec![],
             Severity::Medium,
             "",
@@ -3571,10 +3934,10 @@ mod tests {
         let decision = calibrate_core_decision(
             &mut finding,
             &config,
-            0.01,  // tp_weight
-            1.0,   // fp_weight
-            0.0,   // wontfix_weight
-            1.0,   // soft_fp_weight
+            0.01, // tp_weight
+            1.0,  // fp_weight
+            0.0,  // wontfix_weight
+            1.0,  // soft_fp_weight
             vec![],
             Severity::High,
             "",
@@ -3599,10 +3962,10 @@ mod tests {
         let decision = calibrate_core_decision(
             &mut finding,
             &config,
-            0.01,  // tp_weight
-            1.0,   // fp_weight
-            0.0,   // wontfix_weight
-            1.0,   // soft_fp_weight
+            0.01, // tp_weight
+            1.0,  // fp_weight
+            0.0,  // wontfix_weight
+            1.0,  // soft_fp_weight
             vec![],
             Severity::High,
             "",
@@ -3629,8 +3992,8 @@ mod tests {
         let decision = calibrate_core_decision(
             &mut finding,
             &config,
-            0.5,  // tp_weight
-            0.5,  // fp_weight
+            0.5, // tp_weight
+            0.5, // fp_weight
             0.0,
             0.5,
             vec![],
@@ -3653,8 +4016,8 @@ mod tests {
         let decision2 = calibrate_core_decision(
             &mut finding2,
             &config2,
-            0.5,  // tp_weight
-            0.5,  // fp_weight
+            0.5, // tp_weight
+            0.5, // fp_weight
             0.0,
             0.5,
             vec![],
@@ -3683,8 +4046,8 @@ mod tests {
         let decision = calibrate_core_decision(
             &mut finding,
             &config,
-            0.0,  // tp_weight
-            0.0,  // fp_weight
+            0.0, // tp_weight
+            0.0, // fp_weight
             0.0,
             0.0,
             vec![],

--- a/src/calibrator_trace.rs
+++ b/src/calibrator_trace.rs
@@ -1,8 +1,8 @@
 //! Calibrator decision tracing: structured records of per-finding calibration decisions.
 
-use serde::{Deserialize, Serialize};
-use crate::finding::{CalibratorAction, Severity};
 use crate::feedback::Verdict;
+use crate::finding::{CalibratorAction, Severity};
+use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PrecedentTrace {
@@ -149,7 +149,10 @@ mod tests {
             (NoMatch, "\"no_match\""),
         ] {
             let s = serde_json::to_string(&variant).unwrap();
-            assert_eq!(s, expected, "variant {variant:?} must serialize to {expected}");
+            assert_eq!(
+                s, expected,
+                "variant {variant:?} must serialize to {expected}"
+            );
         }
     }
 
@@ -173,8 +176,10 @@ mod tests {
             provenance: None,
         };
         let json = serde_json::to_string(&trace).unwrap();
-        assert!(!json.contains("severity_change_reason"),
-            "None reason must be omitted from JSON to keep traces backward-compatible");
+        assert!(
+            !json.contains("severity_change_reason"),
+            "None reason must be omitted from JSON to keep traces backward-compatible"
+        );
     }
 
     #[test]
@@ -220,7 +225,10 @@ mod tests {
     fn old_trace_entry_without_file_path_deserializes() {
         let json = r#"{"finding_title":"test","finding_category":"security","tp_weight":1.0,"fp_weight":0.5,"wontfix_weight":0.0,"full_suppress_weight":0.5,"soft_fp_weight":0.5,"matched_precedents":[],"action":null,"input_severity":"medium","output_severity":"medium"}"#;
         let trace: CalibratorTraceEntry = serde_json::from_str(json).unwrap();
-        assert_eq!(trace.file_path, None, "old entries should parse with None file_path");
+        assert_eq!(
+            trace.file_path, None,
+            "old entries should parse with None file_path"
+        );
     }
 
     #[test]
@@ -251,19 +259,27 @@ mod tests {
         let trace = CalibratorTraceEntry {
             finding_title: "test".into(),
             finding_category: "security".into(),
-            tp_weight: 0.0, fp_weight: 0.0, wontfix_weight: 0.0,
-            full_suppress_weight: 0.0, soft_fp_weight: 0.0,
-            matched_precedents: vec![], action: None,
-            input_severity: Severity::Low, output_severity: Severity::Low,
-            severity_change_reason: None, file_path: None,
+            tp_weight: 0.0,
+            fp_weight: 0.0,
+            wontfix_weight: 0.0,
+            full_suppress_weight: 0.0,
+            soft_fp_weight: 0.0,
+            matched_precedents: vec![],
+            action: None,
+            input_severity: Severity::Low,
+            output_severity: Severity::Low,
+            severity_change_reason: None,
+            file_path: None,
             provenance: Some(TraceProvenance {
                 quorum_version: Some("0.19.0".into()),
                 ..Default::default()
             }),
         };
         let json = serde_json::to_string(&trace).unwrap();
-        assert!(json.contains(r#""provenance":{"quorum_version":"0.19.0"}"#),
-            "provenance must be a nested object, got: {json}");
+        assert!(
+            json.contains(r#""provenance":{"quorum_version":"0.19.0"}"#),
+            "provenance must be a nested object, got: {json}"
+        );
     }
 
     #[test]
@@ -285,15 +301,23 @@ mod tests {
         let trace = CalibratorTraceEntry {
             finding_title: "x".into(),
             finding_category: "y".into(),
-            tp_weight: 0.0, fp_weight: 0.0, wontfix_weight: 0.0,
-            full_suppress_weight: 0.0, soft_fp_weight: 0.0,
-            matched_precedents: vec![], action: None,
-            input_severity: Severity::Low, output_severity: Severity::Low,
-            severity_change_reason: None, file_path: None,
+            tp_weight: 0.0,
+            fp_weight: 0.0,
+            wontfix_weight: 0.0,
+            full_suppress_weight: 0.0,
+            soft_fp_weight: 0.0,
+            matched_precedents: vec![],
+            action: None,
+            input_severity: Severity::Low,
+            output_severity: Severity::Low,
+            severity_change_reason: None,
+            file_path: None,
             provenance: None,
         };
         let json = serde_json::to_string(&trace).unwrap();
-        assert!(!json.contains("provenance"),
-            "None provenance must be omitted from JSON");
+        assert!(
+            !json.contains("provenance"),
+            "None provenance must be omitted from JSON"
+        );
     }
 }

--- a/src/category.rs
+++ b/src/category.rs
@@ -74,7 +74,13 @@ impl PartialEq<&str> for Category {
 
 impl From<String> for Category {
     fn from(s: String) -> Self {
-        match s.to_lowercase().trim().replace(' ', "-").replace('_', "-").as_str() {
+        match s
+            .to_lowercase()
+            .trim()
+            .replace(' ', "-")
+            .replace('_', "-")
+            .as_str()
+        {
             "security" | "safety" => Category::Security,
             "correctness" | "functional-bug" | "bug" => Category::Correctness,
             "logic" | "logic-error" => Category::Logic,

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -104,10 +104,7 @@ pub fn validate_source_name(s: &str) -> Result<String, String> {
         return Err("--name must not be empty".into());
     }
     if s.len() > 64 {
-        return Err(format!(
-            "--name length must be 1..=64 (got {})",
-            s.len()
-        ));
+        return Err(format!("--name length must be 1..=64 (got {})", s.len()));
     }
     if s.starts_with('.') {
         return Err("--name must not start with '.'".into());
@@ -117,8 +114,7 @@ pub fn validate_source_name(s: &str) -> Result<String, String> {
         .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-')
     {
         return Err(
-            "--name may only contain [a-zA-Z0-9_-] (no path separators, spaces, or unicode)"
-                .into(),
+            "--name may only contain [a-zA-Z0-9_-] (no path separators, spaces, or unicode)".into(),
         );
     }
     Ok(s.to_string())
@@ -643,9 +639,7 @@ pub fn parse_confidence(s: &str) -> Result<f32, String> {
         return Err(format!("--confidence must be finite, got {v}"));
     }
     if !(0.0..=1.0).contains(&v) {
-        return Err(format!(
-            "--confidence must be in [0.0, 1.0], got {v}"
-        ));
+        return Err(format!("--confidence must be in [0.0, 1.0], got {v}"));
     }
     Ok(v)
 }
@@ -710,8 +704,14 @@ mod tests {
     fn parse_verdict_valid() {
         assert_eq!(parse_verdict("tp").unwrap(), crate::feedback::Verdict::Tp);
         assert_eq!(parse_verdict("fp").unwrap(), crate::feedback::Verdict::Fp);
-        assert_eq!(parse_verdict("partial").unwrap(), crate::feedback::Verdict::Partial);
-        assert_eq!(parse_verdict("wontfix").unwrap(), crate::feedback::Verdict::Wontfix);
+        assert_eq!(
+            parse_verdict("partial").unwrap(),
+            crate::feedback::Verdict::Partial
+        );
+        assert_eq!(
+            parse_verdict("wontfix").unwrap(),
+            crate::feedback::Verdict::Wontfix
+        );
     }
 
     // -----------------------------------------------------------------
@@ -728,9 +728,18 @@ mod tests {
     #[test]
     fn cli_fp_kind_trust_model_parses() {
         let opts = parse_args(&[
-            "--file", "f.rs", "--finding", "x", "--verdict", "fp",
-            "--fp-kind", "trust-model", "--reason", "r",
-        ]).expect("parse");
+            "--file",
+            "f.rs",
+            "--finding",
+            "x",
+            "--verdict",
+            "fp",
+            "--fp-kind",
+            "trust-model",
+            "--reason",
+            "r",
+        ])
+        .expect("parse");
         let kind = opts.into_fp_kind().expect("into_fp_kind");
         assert_eq!(kind, Some(crate::feedback::FpKind::TrustModelAssumption));
     }
@@ -743,11 +752,23 @@ mod tests {
         // parse_args() — that's the signal to update the test, not to silently
         // rely on a different error path.
         let opts = parse_args(&[
-            "--file", "f.rs", "--finding", "x", "--verdict", "fp",
-            "--fp-kind", "compensating-control", "--reason", "r",
-        ]).expect("clap parses; cross-field validation lives in into_fp_kind");
+            "--file",
+            "f.rs",
+            "--finding",
+            "x",
+            "--verdict",
+            "fp",
+            "--fp-kind",
+            "compensating-control",
+            "--reason",
+            "r",
+        ])
+        .expect("clap parses; cross-field validation lives in into_fp_kind");
         let result = opts.into_fp_kind();
-        assert!(result.is_err(), "compensating-control without --fp-reference must error");
+        assert!(
+            result.is_err(),
+            "compensating-control without --fp-reference must error"
+        );
         let err = result.unwrap_err().to_string();
         assert!(
             err.contains("--fp-reference"),
@@ -759,11 +780,20 @@ mod tests {
     #[test]
     fn cli_fp_kind_compensating_control_with_reference_parses() {
         let opts = parse_args(&[
-            "--file", "f.rs", "--finding", "x", "--verdict", "fp",
-            "--fp-kind", "compensating-control",
-            "--fp-reference", "PR #99 line 42",
-            "--reason", "r",
-        ]).expect("parse");
+            "--file",
+            "f.rs",
+            "--finding",
+            "x",
+            "--verdict",
+            "fp",
+            "--fp-kind",
+            "compensating-control",
+            "--fp-reference",
+            "PR #99 line 42",
+            "--reason",
+            "r",
+        ])
+        .expect("parse");
         let kind = opts.into_fp_kind().expect("into_fp_kind").unwrap();
         match kind {
             crate::feedback::FpKind::CompensatingControl { reference } => {
@@ -776,8 +806,16 @@ mod tests {
     #[test]
     fn cli_fp_kind_invalid_value_rejected_by_clap() {
         let result = parse_args(&[
-            "--file", "f.rs", "--finding", "x", "--verdict", "fp",
-            "--fp-kind", "bogus-kind", "--reason", "r",
+            "--file",
+            "f.rs",
+            "--finding",
+            "x",
+            "--verdict",
+            "fp",
+            "--fp-kind",
+            "bogus-kind",
+            "--reason",
+            "r",
         ]);
         assert!(result.is_err(), "clap must reject unknown --fp-kind value");
     }
@@ -789,9 +827,18 @@ mod tests {
         // site is responsible for emitting a tracing::warn. Test the dropped-
         // kind contract here.
         let opts = parse_args(&[
-            "--file", "f.rs", "--finding", "x", "--verdict", "tp",
-            "--fp-kind", "trust-model", "--reason", "r",
-        ]).expect("parse");
+            "--file",
+            "f.rs",
+            "--finding",
+            "x",
+            "--verdict",
+            "tp",
+            "--fp-kind",
+            "trust-model",
+            "--reason",
+            "r",
+        ])
+        .expect("parse");
         let kind = opts.into_fp_kind().expect("must not fail on tp+kind");
         assert_eq!(kind, None, "fp_kind must be dropped when verdict != fp");
     }
@@ -799,15 +846,27 @@ mod tests {
     #[test]
     fn cli_fp_kind_pattern_overgeneralization_with_discriminator() {
         let opts = parse_args(&[
-            "--file", "f.rs", "--finding", "x", "--verdict", "fp",
-            "--fp-kind", "pattern-overgeneralization",
-            "--fp-discriminator", "When in #[derive], ignore",
-            "--reason", "r",
-        ]).expect("parse");
+            "--file",
+            "f.rs",
+            "--finding",
+            "x",
+            "--verdict",
+            "fp",
+            "--fp-kind",
+            "pattern-overgeneralization",
+            "--fp-discriminator",
+            "When in #[derive], ignore",
+            "--reason",
+            "r",
+        ])
+        .expect("parse");
         let kind = opts.into_fp_kind().expect("into_fp_kind").unwrap();
         match kind {
             crate::feedback::FpKind::PatternOvergeneralization { discriminator_hint } => {
-                assert_eq!(discriminator_hint.as_deref(), Some("When in #[derive], ignore"));
+                assert_eq!(
+                    discriminator_hint.as_deref(),
+                    Some("When in #[derive], ignore")
+                );
             }
             other => panic!("expected PatternOvergeneralization, got {:?}", other),
         }
@@ -816,9 +875,18 @@ mod tests {
     #[test]
     fn cli_fp_kind_out_of_scope_optional_tracked_in() {
         let opts = parse_args(&[
-            "--file", "f.rs", "--finding", "x", "--verdict", "fp",
-            "--fp-kind", "out-of-scope", "--reason", "r",
-        ]).expect("parse");
+            "--file",
+            "f.rs",
+            "--finding",
+            "x",
+            "--verdict",
+            "fp",
+            "--fp-kind",
+            "out-of-scope",
+            "--reason",
+            "r",
+        ])
+        .expect("parse");
         let kind = opts.into_fp_kind().expect("into_fp_kind").unwrap();
         assert!(matches!(
             kind,
@@ -829,11 +897,20 @@ mod tests {
     #[test]
     fn cli_fp_kind_out_of_scope_with_tracked_in() {
         let opts = parse_args(&[
-            "--file", "f.rs", "--finding", "x", "--verdict", "fp",
-            "--fp-kind", "out-of-scope",
-            "--fp-tracked-in", "#456",
-            "--reason", "r",
-        ]).expect("parse");
+            "--file",
+            "f.rs",
+            "--finding",
+            "x",
+            "--verdict",
+            "fp",
+            "--fp-kind",
+            "out-of-scope",
+            "--fp-tracked-in",
+            "#456",
+            "--reason",
+            "r",
+        ])
+        .expect("parse");
         let kind = opts.into_fp_kind().expect("into_fp_kind").unwrap();
         match kind {
             crate::feedback::FpKind::OutOfScope { tracked_in } => {
@@ -846,9 +923,16 @@ mod tests {
     #[test]
     fn cli_fp_kind_omitted_means_none() {
         let opts = parse_args(&[
-            "--file", "f.rs", "--finding", "x", "--verdict", "fp",
-            "--reason", "r",
-        ]).expect("parse");
+            "--file",
+            "f.rs",
+            "--finding",
+            "x",
+            "--verdict",
+            "fp",
+            "--reason",
+            "r",
+        ])
+        .expect("parse");
         let kind = opts.into_fp_kind().expect("into_fp_kind");
         assert_eq!(kind, None, "no --fp-kind flag = no kind");
     }
@@ -954,11 +1038,16 @@ mod tests {
         use clap::Parser;
         for v in ["tp", "fp", "partial", "wontfix", "context_misleading"] {
             let res = Args::try_parse_from([
-                "quorum", "feedback",
-                "--file", "x.rs",
-                "--finding", "t",
-                "--verdict", v,
-                "--reason", "r",
+                "quorum",
+                "feedback",
+                "--file",
+                "x.rs",
+                "--finding",
+                "t",
+                "--verdict",
+                v,
+                "--reason",
+                "r",
             ]);
             assert!(res.is_ok(), "verdict {} should parse", v);
         }
@@ -968,12 +1057,18 @@ mod tests {
     fn feedback_parses_blamed_chunks_flag() {
         use clap::Parser;
         let args = Args::parse_from([
-            "quorum", "feedback",
-            "--file", "src/x.rs",
-            "--finding", "t",
-            "--verdict", "context_misleading",
-            "--reason", "r",
-            "--blamed-chunks", "chunk-abc,chunk-def",
+            "quorum",
+            "feedback",
+            "--file",
+            "src/x.rs",
+            "--finding",
+            "t",
+            "--verdict",
+            "context_misleading",
+            "--reason",
+            "r",
+            "--blamed-chunks",
+            "chunk-abc,chunk-def",
         ]);
         match args.command {
             Command::Feedback(opts) => {
@@ -988,11 +1083,16 @@ mod tests {
         // Plan is explicit: missing --blamed-chunks must NOT error at parse time.
         use clap::Parser;
         let res = Args::try_parse_from([
-            "quorum", "feedback",
-            "--file", "src/x.rs",
-            "--finding", "t",
-            "--verdict", "context_misleading",
-            "--reason", "r",
+            "quorum",
+            "feedback",
+            "--file",
+            "src/x.rs",
+            "--finding",
+            "t",
+            "--verdict",
+            "context_misleading",
+            "--reason",
+            "r",
         ]);
         assert!(res.is_ok(), "--blamed-chunks must remain optional");
         match res.unwrap().command {
@@ -1033,8 +1133,10 @@ mod tests {
         let v = parse_verdict("context_misleading").unwrap();
         match v {
             crate::feedback::Verdict::ContextMisleading { blamed_chunk_ids } => {
-                assert!(blamed_chunk_ids.is_empty(),
-                    "parse_verdict alone never fills chunks; caller merges --blamed-chunks");
+                assert!(
+                    blamed_chunk_ids.is_empty(),
+                    "parse_verdict alone never fills chunks; caller merges --blamed-chunks"
+                );
             }
             other => panic!("expected ContextMisleading, got {:?}", other),
         }
@@ -1107,7 +1209,9 @@ mod tests {
     fn review_with_no_files_yields_missing_required_argument() {
         use clap::Parser;
         let res = Args::try_parse_from(["quorum", "review"]);
-        let err = res.err().expect("review with zero files must fail to parse");
+        let err = res
+            .err()
+            .expect("review with zero files must fail to parse");
         assert_eq!(
             err.kind(),
             clap::error::ErrorKind::MissingRequiredArgument,
@@ -1149,10 +1253,10 @@ mod tests {
     #[test]
     fn regression_guard_79_index_rejects_source_and_all() {
         use clap::Parser;
-        let res = Args::try_parse_from([
-            "quorum", "context", "index", "--source", "foo", "--all",
-        ]);
-        let err = res.err().expect("index with both --source and --all must fail");
+        let res = Args::try_parse_from(["quorum", "context", "index", "--source", "foo", "--all"]);
+        let err = res
+            .err()
+            .expect("index with both --source and --all must fail");
         assert_eq!(
             err.kind(),
             clap::error::ErrorKind::ArgumentConflict,
@@ -1164,10 +1268,11 @@ mod tests {
     #[test]
     fn regression_guard_79_refresh_rejects_source_and_all() {
         use clap::Parser;
-        let res = Args::try_parse_from([
-            "quorum", "context", "refresh", "--source", "foo", "--all",
-        ]);
-        let err = res.err().expect("refresh with both --source and --all must fail");
+        let res =
+            Args::try_parse_from(["quorum", "context", "refresh", "--source", "foo", "--all"]);
+        let err = res
+            .err()
+            .expect("refresh with both --source and --all must fail");
         assert_eq!(err.kind(), clap::error::ErrorKind::ArgumentConflict);
     }
 
@@ -1230,10 +1335,7 @@ mod tests {
     fn context_add_name_rejects_dotdot() {
         use clap::Parser;
         let r = Args::try_parse_from([
-            "quorum", "context", "add",
-            "--name", "../etc",
-            "--kind", "rust",
-            "--path", "/tmp/x",
+            "quorum", "context", "add", "--name", "../etc", "--kind", "rust", "--path", "/tmp/x",
         ]);
         assert!(r.is_err(), "../etc must be rejected at parse time");
     }
@@ -1242,10 +1344,15 @@ mod tests {
     fn context_add_name_rejects_absolute() {
         use clap::Parser;
         let r = Args::try_parse_from([
-            "quorum", "context", "add",
-            "--name", "/etc/passwd",
-            "--kind", "rust",
-            "--path", "/tmp/x",
+            "quorum",
+            "context",
+            "add",
+            "--name",
+            "/etc/passwd",
+            "--kind",
+            "rust",
+            "--path",
+            "/tmp/x",
         ]);
         assert!(r.is_err());
     }
@@ -1254,10 +1361,7 @@ mod tests {
     fn context_add_name_rejects_slash() {
         use clap::Parser;
         let r = Args::try_parse_from([
-            "quorum", "context", "add",
-            "--name", "a/b",
-            "--kind", "rust",
-            "--path", "/tmp/x",
+            "quorum", "context", "add", "--name", "a/b", "--kind", "rust", "--path", "/tmp/x",
         ]);
         assert!(r.is_err());
     }
@@ -1266,10 +1370,7 @@ mod tests {
     fn context_add_name_rejects_backslash() {
         use clap::Parser;
         let r = Args::try_parse_from([
-            "quorum", "context", "add",
-            "--name", r"a\b",
-            "--kind", "rust",
-            "--path", "/tmp/x",
+            "quorum", "context", "add", "--name", r"a\b", "--kind", "rust", "--path", "/tmp/x",
         ]);
         assert!(r.is_err());
     }
@@ -1278,10 +1379,7 @@ mod tests {
     fn context_add_name_rejects_leading_dot() {
         use clap::Parser;
         let r = Args::try_parse_from([
-            "quorum", "context", "add",
-            "--name", ".hidden",
-            "--kind", "rust",
-            "--path", "/tmp/x",
+            "quorum", "context", "add", "--name", ".hidden", "--kind", "rust", "--path", "/tmp/x",
         ]);
         assert!(r.is_err());
     }
@@ -1291,10 +1389,7 @@ mod tests {
         use clap::Parser;
         let long = "a".repeat(65);
         let r = Args::try_parse_from([
-            "quorum", "context", "add",
-            "--name", &long,
-            "--kind", "rust",
-            "--path", "/tmp/x",
+            "quorum", "context", "add", "--name", &long, "--kind", "rust", "--path", "/tmp/x",
         ]);
         assert!(r.is_err());
     }
@@ -1303,10 +1398,7 @@ mod tests {
     fn context_add_name_rejects_empty() {
         use clap::Parser;
         let r = Args::try_parse_from([
-            "quorum", "context", "add",
-            "--name", "",
-            "--kind", "rust",
-            "--path", "/tmp/x",
+            "quorum", "context", "add", "--name", "", "--kind", "rust", "--path", "/tmp/x",
         ]);
         assert!(r.is_err());
     }
@@ -1315,12 +1407,21 @@ mod tests {
     fn context_add_name_accepts_simple() {
         use clap::Parser;
         let r = Args::try_parse_from([
-            "quorum", "context", "add",
-            "--name", "my-source_1",
-            "--kind", "rust",
-            "--path", "/tmp/x",
+            "quorum",
+            "context",
+            "add",
+            "--name",
+            "my-source_1",
+            "--kind",
+            "rust",
+            "--path",
+            "/tmp/x",
         ]);
-        assert!(r.is_ok(), "simple alnum/dash/underscore must parse: {:?}", r.err().map(|e| e.to_string()));
+        assert!(
+            r.is_ok(),
+            "simple alnum/dash/underscore must parse: {:?}",
+            r.err().map(|e| e.to_string())
+        );
     }
 
     #[test]
@@ -1328,10 +1429,7 @@ mod tests {
         use clap::Parser;
         let max_len = "a".repeat(64);
         let r = Args::try_parse_from([
-            "quorum", "context", "add",
-            "--name", &max_len,
-            "--kind", "rust",
-            "--path", "/tmp/x",
+            "quorum", "context", "add", "--name", &max_len, "--kind", "rust", "--path", "/tmp/x",
         ]);
         assert!(r.is_ok(), "64-char name (max allowed) must parse");
     }
@@ -1346,54 +1444,45 @@ mod tests {
     #[test]
     fn context_query_k_rejects_zero() {
         use clap::Parser;
-        let r = Args::try_parse_from([
-            "quorum", "context", "query", "hello", "--k", "0",
-        ]);
-        assert!(r.is_err(), "--k 0 must be rejected (would produce empty results)");
+        let r = Args::try_parse_from(["quorum", "context", "query", "hello", "--k", "0"]);
+        assert!(
+            r.is_err(),
+            "--k 0 must be rejected (would produce empty results)"
+        );
     }
 
     #[test]
     fn context_query_k_rejects_above_cap() {
         use clap::Parser;
-        let r = Args::try_parse_from([
-            "quorum", "context", "query", "hello", "--k", "101",
-        ]);
+        let r = Args::try_parse_from(["quorum", "context", "query", "hello", "--k", "101"]);
         assert!(r.is_err(), "--k 101 must be rejected (above 100 cap)");
     }
 
     #[test]
     fn context_query_k_rejects_negative() {
         use clap::Parser;
-        let r = Args::try_parse_from([
-            "quorum", "context", "query", "hello", "--k", "-1",
-        ]);
+        let r = Args::try_parse_from(["quorum", "context", "query", "hello", "--k", "-1"]);
         assert!(r.is_err(), "--k -1 must be rejected (not a usize)");
     }
 
     #[test]
     fn context_query_k_accepts_in_range() {
         use clap::Parser;
-        let r = Args::try_parse_from([
-            "quorum", "context", "query", "hello", "--k", "50",
-        ]);
+        let r = Args::try_parse_from(["quorum", "context", "query", "hello", "--k", "50"]);
         assert!(r.is_ok(), "--k 50 must parse");
     }
 
     #[test]
     fn context_query_k_accepts_one() {
         use clap::Parser;
-        let r = Args::try_parse_from([
-            "quorum", "context", "query", "hello", "--k", "1",
-        ]);
+        let r = Args::try_parse_from(["quorum", "context", "query", "hello", "--k", "1"]);
         assert!(r.is_ok(), "--k 1 must parse (lower bound)");
     }
 
     #[test]
     fn context_query_k_accepts_hundred() {
         use clap::Parser;
-        let r = Args::try_parse_from([
-            "quorum", "context", "query", "hello", "--k", "100",
-        ]);
+        let r = Args::try_parse_from(["quorum", "context", "query", "hello", "--k", "100"]);
         assert!(r.is_ok(), "--k 100 must parse (upper bound)");
     }
 
@@ -1417,9 +1506,12 @@ mod tests {
     fn calibrate_custom_precision_parses() {
         use clap::Parser;
         let args = Args::parse_from([
-            "quorum", "calibrate",
-            "--suppress-precision", "0.90",
-            "--boost-precision", "0.80",
+            "quorum",
+            "calibrate",
+            "--suppress-precision",
+            "0.90",
+            "--boost-precision",
+            "0.80",
         ]);
         match args.command {
             Command::Calibrate(opts) => {

--- a/src/cli_io.rs
+++ b/src/cli_io.rs
@@ -26,11 +26,7 @@ use crate::context::cli::CmdOutput;
 ///
 /// Errors writing to `err` (the diagnostic channel) are themselves swallowed
 /// — there is no useful recovery if both stdout and stderr are broken.
-pub fn write_cmd_output<W: Write, E: Write>(
-    out: &mut W,
-    err: &mut E,
-    cmd: &CmdOutput,
-) -> i32 {
+pub fn write_cmd_output<W: Write, E: Write>(out: &mut W, err: &mut E, cmd: &CmdOutput) -> i32 {
     // Capture the exit code from the first stdout error (if any) but do NOT
     // return early — warnings still need to reach stderr regardless of the
     // stdout state. The pre-extraction inline code in `run_context` had this

--- a/src/config.rs
+++ b/src/config.rs
@@ -39,8 +39,8 @@ impl Config {
 
         let api_key = Self::get_trimmed(source, "QUORUM_API_KEY");
 
-        let model = Self::get_trimmed(source, "QUORUM_MODEL")
-            .unwrap_or_else(|| Self::DEFAULT_MODEL.into());
+        let model =
+            Self::get_trimmed(source, "QUORUM_MODEL").unwrap_or_else(|| Self::DEFAULT_MODEL.into());
 
         Ok(Config {
             base_url,

--- a/src/context/bootstrap.rs
+++ b/src/context/bootstrap.rs
@@ -152,27 +152,29 @@ pub fn build_production_injector(
 
     let retriever: Arc<RetrieverFn> = {
         let embedder = std::sync::Arc::clone(&embedder);
-        Arc::new(move |q: &RetrievalQuery| -> anyhow::Result<Vec<ScoredChunk>> {
-            // Every invocation is a fresh process-safe open; the vec0 hook
-            // must be registered before `Connection::open*` or the vector
-            // leg of retrieval errors with `no such module: vec0`.
-            ensure_vec_loaded();
-            let conn = Connection::open_with_flags(
-                &db_path_owned,
-                rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY,
-            )?;
-            let clock = SystemClock;
-            let retriever = Retriever::new(&conn, embedder.as_ref(), &clock);
-            // Constrain to the specific source we picked so multi-source
-            // layouts don't accidentally leak hits from other indexes.
-            let mut q = q.clone();
-            q.filters = Filters {
-                sources: vec![src_for_filter.clone()],
-                kinds: q.filters.kinds,
-                exclude_source_paths: q.filters.exclude_source_paths,
-            };
-            retriever.query(q)
-        })
+        Arc::new(
+            move |q: &RetrievalQuery| -> anyhow::Result<Vec<ScoredChunk>> {
+                // Every invocation is a fresh process-safe open; the vec0 hook
+                // must be registered before `Connection::open*` or the vector
+                // leg of retrieval errors with `no such module: vec0`.
+                ensure_vec_loaded();
+                let conn = Connection::open_with_flags(
+                    &db_path_owned,
+                    rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY,
+                )?;
+                let clock = SystemClock;
+                let retriever = Retriever::new(&conn, embedder.as_ref(), &clock);
+                // Constrain to the specific source we picked so multi-source
+                // layouts don't accidentally leak hits from other indexes.
+                let mut q = q.clone();
+                q.filters = Filters {
+                    sources: vec![src_for_filter.clone()],
+                    kinds: q.filters.kinds,
+                    exclude_source_paths: q.filters.exclude_source_paths,
+                };
+                retriever.query(q)
+            },
+        )
     };
 
     let calibrator = Calibrator::from_feedback(cfg.context.inject_min_score, feedback);
@@ -235,7 +237,7 @@ path = "/tmp/demo"
         // Build a real minimal index so the bootstrap finds `index.db` and
         // can open it. We don't care whether the retriever returns hits for
         // an empty query — only that the injector is wired and dispatchable.
-        use crate::context::extract::dispatch::{extract_source, ExtractConfig};
+        use crate::context::extract::dispatch::{ExtractConfig, extract_source};
         use crate::context::index::builder::IndexBuilder;
         use crate::context::index::traits::FixedClock;
         use crate::context::store::ChunkStore;

--- a/src/context/cli.rs
+++ b/src/context/cli.rs
@@ -17,12 +17,12 @@
 
 use std::path::{Path, PathBuf};
 
-use anyhow::{anyhow, Result};
+use anyhow::{Result, anyhow};
 use rusqlite::Connection;
 
 use crate::context::config::{SourceEntry, SourceKind, SourceLocation, SourcesConfig};
-use crate::context::extract::dispatch::{extract_source, ExtractConfig};
-use crate::context::index::builder::{ensure_vec_loaded, IndexBuilder};
+use crate::context::extract::dispatch::{ExtractConfig, extract_source};
+use crate::context::index::builder::{IndexBuilder, ensure_vec_loaded};
 use crate::context::index::state::IndexState;
 #[cfg(feature = "embeddings")]
 use crate::context::index::traits::FastEmbedEmbedder;
@@ -592,10 +592,7 @@ fn run_init<D: ContextDeps>(deps: &D) -> Result<CmdOutput> {
                 ));
             }
             Ok(CmdOutput {
-                stdout: format!(
-                    "context already initialized at {}",
-                    sources_path.display()
-                ),
+                stdout: format!("context already initialized at {}", sources_path.display()),
                 created_paths: Vec::new(),
                 removed_paths: Vec::new(),
                 warnings: vec![format!(
@@ -622,8 +619,7 @@ fn run_add<D: ContextDeps>(args: &AddArgs, deps: &D) -> Result<CmdOutput> {
     // gate before we touch the on-disk file or join `<home>/sources/<name>`
     // anywhere downstream.
     let name = args.name.trim();
-    crate::cli::validate_source_name(name)
-        .map_err(|e| anyhow!("source name invalid: {e}"))?;
+    crate::cli::validate_source_name(name).map_err(|e| anyhow!("source name invalid: {e}"))?;
     let kind = SourceKind::parse_cli(&args.kind).ok_or_else(|| {
         anyhow!(
             "unknown kind '{}' (expected one of: rust, typescript, javascript, python, go, terraform, service, docs)",
@@ -693,8 +689,7 @@ fn run_add<D: ContextDeps>(args: &AddArgs, deps: &D) -> Result<CmdOutput> {
     };
 
     let sources_path = deps.home_dir().join("sources.toml");
-    SourcesConfig::append_source(&sources_path, &entry)
-        .map_err(|e| anyhow!("{e}"))?;
+    SourcesConfig::append_source(&sources_path, &entry).map_err(|e| anyhow!("{e}"))?;
 
     Ok(CmdOutput {
         stdout: format!("added source '{}'", entry.name),
@@ -710,8 +705,7 @@ fn run_add<D: ContextDeps>(args: &AddArgs, deps: &D) -> Result<CmdOutput> {
 fn run_list<D: ContextDeps>(args: &ListArgs, deps: &D) -> Result<CmdOutput> {
     let sources_path = deps.home_dir().join("sources.toml");
     if !sources_path.exists() {
-        let msg =
-            "no sources registered; run `quorum context init` first".to_string();
+        let msg = "no sources registered; run `quorum context init` first".to_string();
         return Ok(CmdOutput {
             stdout: msg.clone(),
             created_paths: Vec::new(),
@@ -806,7 +800,10 @@ fn render_list_compact(sources: &[SourceEntry]) -> String {
     // callers can rely on stable, user-visible ordering.
     let mut out = String::new();
     for e in sources {
-        let weight = e.weight.map(|w| w.to_string()).unwrap_or_else(|| "-".into());
+        let weight = e
+            .weight
+            .map(|w| w.to_string())
+            .unwrap_or_else(|| "-".into());
         out.push_str(&format!(
             "{}\t{}\t{}\t{}\t{}\n",
             e.name,
@@ -1085,7 +1082,10 @@ fn run_refresh<D: ContextDeps>(args: &RefreshArgs, deps: &D) -> Result<CmdOutput
 
     if failures == entries.len() && matches!(args.selector, SourceSelector::Single(_)) {
         return Err(anyhow!(
-            lines.last().cloned().unwrap_or_else(|| "refresh failed".into())
+            lines
+                .last()
+                .cloned()
+                .unwrap_or_else(|| "refresh failed".into())
         ));
     }
 
@@ -1172,11 +1172,8 @@ fn run_query<D: ContextDeps>(args: &QueryArgs, deps: &D) -> Result<CmdOutput> {
     // straight to `query` has never run it.
     ensure_vec_loaded();
 
-    let conn = Connection::open_with_flags(
-        &db_path,
-        rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY,
-    )
-    .map_err(|e| anyhow!("open {}: {e}", db_path.display()))?;
+    let conn = Connection::open_with_flags(&db_path, rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY)
+        .map_err(|e| anyhow!("open {}: {e}", db_path.display()))?;
 
     let k = args.k.unwrap_or(5).max(1);
     let filters = if args.source.is_some() {
@@ -1239,10 +1236,7 @@ fn resolve_query_target<D: ContextDeps>(
     ))
 }
 
-fn render_query_table(
-    hits: &[crate::context::retrieve::ScoredChunk],
-    explain: bool,
-) -> String {
+fn render_query_table(hits: &[crate::context::retrieve::ScoredChunk], explain: bool) -> String {
     if hits.is_empty() {
         return "no hits".to_string();
     }
@@ -1271,10 +1265,7 @@ fn render_query_table(
     out
 }
 
-fn render_query_compact(
-    hits: &[crate::context::retrieve::ScoredChunk],
-    explain: bool,
-) -> String {
+fn render_query_compact(hits: &[crate::context::retrieve::ScoredChunk], explain: bool) -> String {
     if hits.is_empty() {
         return "no hits".to_string();
     }
@@ -1384,13 +1375,11 @@ fn on_disk_source_dirs(home: &Path) -> Result<Vec<(String, PathBuf)>> {
         return Ok(Vec::new());
     }
     let mut out = Vec::new();
-    let entries = std::fs::read_dir(&root)
-        .map_err(|e| anyhow!("read_dir({}): {e}", root.display()))?;
+    let entries =
+        std::fs::read_dir(&root).map_err(|e| anyhow!("read_dir({}): {e}", root.display()))?;
     for ent in entries {
         let ent = ent.map_err(|e| anyhow!("read_dir entry: {e}"))?;
-        let ft = ent
-            .file_type()
-            .map_err(|e| anyhow!("file_type: {e}"))?;
+        let ft = ent.file_type().map_err(|e| anyhow!("file_type: {e}"))?;
         if !ft.is_dir() {
             continue;
         }
@@ -1433,7 +1422,8 @@ fn run_prune<D: ContextDeps>(args: &PruneArgs, deps: &D) -> Result<CmdOutput> {
         // No config => every sources/<x>/ dir is orphan. Proceed without
         // erroring: prune is inherently idempotent and this is a valid
         // "clean up an abandoned install" case.
-        SourcesConfig::from_str("").unwrap_or_else(|_| SourcesConfig::from_str("[context]\n").expect("empty config"))
+        SourcesConfig::from_str("")
+            .unwrap_or_else(|_| SourcesConfig::from_str("[context]\n").expect("empty config"))
     };
     let (registered, unsafe_names) = registered_safe_names(&cfg);
     let root = sources_root(deps.home_dir());
@@ -1518,7 +1508,10 @@ fn check_sources_toml<D: ContextDeps>(deps: &D) -> (CheckResult, Option<SourcesC
                 name: "sources_toml_exists_and_parses",
                 scope: None,
                 status: CheckStatus::Fail { fixable: false },
-                detail: format!("{} does not exist; run `quorum context init`", path.display()),
+                detail: format!(
+                    "{} does not exist; run `quorum context init`",
+                    path.display()
+                ),
             },
             None,
         );
@@ -1614,10 +1607,7 @@ fn db_chunk_count(db: &Path) -> Result<i64> {
     // the future and we don't want a subtle "works in tests, fails in
     // production" split between the fresh-process and post-index cases.
     ensure_vec_loaded();
-    let conn = Connection::open_with_flags(
-        db,
-        rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY,
-    )?;
+    let conn = Connection::open_with_flags(db, rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY)?;
     let n: i64 = conn.query_row("SELECT count(*) FROM chunks", [], |r| r.get(0))?;
     Ok(n)
 }
@@ -1757,10 +1747,7 @@ fn check_state_json<D: ContextDeps>(deps: &D, name: &str) -> CheckResult {
     }
 }
 
-fn check_orphan_dirs<D: ContextDeps>(
-    deps: &D,
-    cfg: Option<&SourcesConfig>,
-) -> Result<CheckResult> {
+fn check_orphan_dirs<D: ContextDeps>(deps: &D, cfg: Option<&SourcesConfig>) -> Result<CheckResult> {
     let registered: std::collections::HashSet<String> = cfg
         .map(|c| c.sources.iter().map(|s| s.name.clone()).collect())
         .unwrap_or_default();
@@ -1961,9 +1948,7 @@ fn repair_one_source<D: ContextDeps>(
 
         // Write fresh state.json.
         let head_sha = match source_repo_root(entry) {
-            Some(root) if root.exists() => {
-                deps.git().head_sha(root).unwrap_or(None)
-            }
+            Some(root) if root.exists() => deps.git().head_sha(root).unwrap_or(None),
             _ => None,
         };
         let state = IndexState::new(deps.embedder().model_hash())
@@ -1983,11 +1968,7 @@ fn repair_one_source<D: ContextDeps>(
     Ok(())
 }
 
-fn render_doctor_json(
-    checks: &[CheckResult],
-    ok: bool,
-    repair_lines: &[String],
-) -> Result<String> {
+fn render_doctor_json(checks: &[CheckResult], ok: bool, repair_lines: &[String]) -> Result<String> {
     let items: Vec<serde_json::Value> = checks
         .iter()
         .map(|c| {

--- a/src/context/cli_tests.rs
+++ b/src/context/cli_tests.rs
@@ -1,9 +1,9 @@
 //! Unit tests for `src/context/cli.rs`.
 
 use super::cli::{
-    run_context_cmd, AddArgs, AddLocation, CheckStatus, ContextCmd, ContextDeps, DoctorArgs,
-    DoctorFormat, IndexArgs, ListArgs, ListFormat, PruneArgs, QueryArgs, QueryFormat,
-    RefreshArgs, SourceSelector, TestDeps,
+    AddArgs, AddLocation, CheckStatus, ContextCmd, ContextDeps, DoctorArgs, DoctorFormat,
+    IndexArgs, ListArgs, ListFormat, PruneArgs, QueryArgs, QueryFormat, RefreshArgs,
+    SourceSelector, TestDeps, run_context_cmd,
 };
 use super::config::{SourceLocation, SourcesConfig};
 use std::path::PathBuf;
@@ -30,11 +30,7 @@ fn run_context_cmd_init_creates_sources_toml() {
     let output = run_context_cmd(&ContextCmd::Init, &deps).expect("init succeeds");
 
     let expected = deps.home_dir().join("sources.toml");
-    assert!(
-        expected.exists(),
-        "init must create {}",
-        expected.display()
-    );
+    assert!(expected.exists(), "init must create {}", expected.display());
     assert_eq!(output.created_paths, vec![expected.clone()]);
     assert!(output.warnings.is_empty(), "first init emits no warnings");
     assert!(
@@ -71,10 +67,7 @@ fn run_context_cmd_init_is_idempotent_and_preserves_existing_config() {
         output.created_paths
     );
     assert!(
-        output
-            .warnings
-            .iter()
-            .any(|w| w.contains("already exists")),
+        output.warnings.iter().any(|w| w.contains("already exists")),
         "warning should mention the existing file: {:?}",
         output.warnings
     );
@@ -152,8 +145,8 @@ fn run_context_cmd_init_errors_when_sources_path_is_a_directory() {
     let deps = TestDeps::new();
     std::fs::create_dir_all(deps.home_dir().join("sources.toml"))
         .expect("mkdir sources.toml as a dir");
-    let err = run_context_cmd(&ContextCmd::Init, &deps)
-        .expect_err("init over a non-file path must fail");
+    let err =
+        run_context_cmd(&ContextCmd::Init, &deps).expect_err("init over a non-file path must fail");
     let msg = format!("{err}");
     assert!(
         msg.contains("not a regular file"),
@@ -170,7 +163,10 @@ fn run_context_cmd_init_writes_directly_under_home_dir() {
     let deps = TestDeps::new();
     let output = run_context_cmd(&ContextCmd::Init, &deps).unwrap();
     let expected = deps.home_dir().join("sources.toml");
-    assert!(expected.exists(), "sources.toml must land at <home>/sources.toml");
+    assert!(
+        expected.exists(),
+        "sources.toml must land at <home>/sources.toml"
+    );
     assert_eq!(output.created_paths, vec![expected]);
     let doubled = deps.home_dir().join(".quorum").join("sources.toml");
     assert!(
@@ -225,17 +221,17 @@ fn add_appends_path_source_to_sources_toml() {
         out.stdout
     );
 
-    let cfg = SourcesConfig::load(&deps.home_dir().join("sources.toml"))
-        .expect("re-load after add");
+    let cfg =
+        SourcesConfig::load(&deps.home_dir().join("sources.toml")).expect("re-load after add");
     assert_eq!(cfg.sources.len(), 1);
     let e = &cfg.sources[0];
     assert_eq!(e.name, "core");
     assert_eq!(e.weight, Some(3));
-    assert_eq!(e.ignore, vec!["target/**".to_string(), "**/*.snap".to_string()]);
     assert_eq!(
-        e.location,
-        SourceLocation::Path(PathBuf::from("/tmp/core"))
+        e.ignore,
+        vec!["target/**".to_string(), "**/*.snap".to_string()]
     );
+    assert_eq!(e.location, SourceLocation::Path(PathBuf::from("/tmp/core")));
 }
 
 #[test]
@@ -251,7 +247,12 @@ fn add_appends_git_source_with_optional_rev() {
     );
     run_context_cmd(&ContextCmd::Add(args), &deps).expect("add git w/ rev");
 
-    let args_no_rev = git_add_args("ha", "python", "https://github.com/home-assistant/core", None);
+    let args_no_rev = git_add_args(
+        "ha",
+        "python",
+        "https://github.com/home-assistant/core",
+        None,
+    );
     run_context_cmd(&ContextCmd::Add(args_no_rev), &deps).expect("add git no rev");
 
     let cfg = SourcesConfig::load(&deps.home_dir().join("sources.toml")).expect("load");
@@ -303,18 +304,12 @@ fn add_rejects_empty_name_or_empty_path_or_empty_url() {
     let deps = TestDeps::new();
     run_context_cmd(&ContextCmd::Init, &deps).expect("init");
 
-    let e1 = run_context_cmd(
-        &ContextCmd::Add(path_add_args("", "rust", "/tmp/x")),
-        &deps,
-    )
-    .expect_err("empty name");
+    let e1 = run_context_cmd(&ContextCmd::Add(path_add_args("", "rust", "/tmp/x")), &deps)
+        .expect_err("empty name");
     assert!(format!("{e1}").to_lowercase().contains("name"));
 
-    let e2 = run_context_cmd(
-        &ContextCmd::Add(path_add_args("x", "rust", "   ")),
-        &deps,
-    )
-    .expect_err("empty path");
+    let e2 = run_context_cmd(&ContextCmd::Add(path_add_args("x", "rust", "   ")), &deps)
+        .expect_err("empty path");
     assert!(format!("{e2}").to_lowercase().contains("path"));
 
     let e3 = run_context_cmd(
@@ -322,7 +317,10 @@ fn add_rejects_empty_name_or_empty_path_or_empty_url() {
         &deps,
     )
     .expect_err("empty url");
-    assert!(format!("{e3}").to_lowercase().contains("url") || format!("{e3}").to_lowercase().contains("git"));
+    assert!(
+        format!("{e3}").to_lowercase().contains("url")
+            || format!("{e3}").to_lowercase().contains("git")
+    );
 
     // None of the failed adds should have mutated the file.
     let cfg = SourcesConfig::load(&deps.home_dir().join("sources.toml")).expect("load");
@@ -391,8 +389,9 @@ fn list_on_uninitialized_repo_returns_friendly_message_not_error() {
     let out = run_context_cmd(&ContextCmd::List(ListArgs::default()), &deps)
         .expect("list on uninit is NOT an error");
     assert!(
-        out.warnings.iter().any(|w| w.contains("no sources")
-            || w.contains("context init")),
+        out.warnings
+            .iter()
+            .any(|w| w.contains("no sources") || w.contains("context init")),
         "should warn and suggest init: {:?}",
         out.warnings
     );
@@ -438,7 +437,8 @@ fn list_renders_table_of_registered_sources() {
     assert!(s.contains("dev"), "{s}");
     // The weight "2" and ignore count "1" for core must actually appear.
     assert!(
-        s.lines().any(|l| l.contains("core") && l.contains('2') && l.contains('1')),
+        s.lines()
+            .any(|l| l.contains("core") && l.contains('2') && l.contains('1')),
         "row for 'core' must surface weight=2 and ignore count=1: {s}"
     );
     // ha has no weight and no ignore globs — expect a "0" ignore count on its row.
@@ -446,7 +446,10 @@ fn list_renders_table_of_registered_sources() {
         s.lines().any(|l| l.contains("ha") && l.contains('0')),
         "row for 'ha' must surface ignore count=0: {s}"
     );
-    assert!(s.contains("NAME") || s.contains("name"), "header expected: {s}");
+    assert!(
+        s.contains("NAME") || s.contains("name"),
+        "header expected: {s}"
+    );
 }
 
 #[test]
@@ -505,7 +508,10 @@ fn add_rejects_control_characters_in_user_strings() {
         AddArgs {
             name: "ok".to_string(),
             kind: "rust".to_string(),
-            location: AddLocation::Git { url: "https://bad\n.com".into(), rev: None },
+            location: AddLocation::Git {
+                url: "https://bad\n.com".into(),
+                rev: None,
+            },
             weight: None,
             ignore: Vec::new(),
         },
@@ -559,10 +565,7 @@ fn add_rejects_path_traversal_name_at_handler() {
     )
     .expect_err("../etc must be rejected by handler even if clap is bypassed");
     let msg = format!("{err}").to_lowercase();
-    assert!(
-        msg.contains("name"),
-        "error must mention --name: {msg}"
-    );
+    assert!(msg.contains("name"), "error must mention --name: {msg}");
 }
 
 #[test]
@@ -717,9 +720,17 @@ fn index_single_source_creates_jsonl_and_db_under_home() {
     let jsonl = src_dir.join("chunks.jsonl");
     let db = src_dir.join("index.db");
     let state = src_dir.join("state.json");
-    assert!(jsonl.exists(), "chunks.jsonl must be created at {}", jsonl.display());
+    assert!(
+        jsonl.exists(),
+        "chunks.jsonl must be created at {}",
+        jsonl.display()
+    );
     assert!(db.exists(), "index.db must be created at {}", db.display());
-    assert!(state.exists(), "state.json must be created at {}", state.display());
+    assert!(
+        state.exists(),
+        "state.json must be created at {}",
+        state.display()
+    );
 
     assert!(out.created_paths.contains(&jsonl));
     assert!(out.created_paths.contains(&db));
@@ -729,7 +740,11 @@ fn index_single_source_creates_jsonl_and_db_under_home() {
         "stdout must announce per-source success: {:?}",
         out.stdout
     );
-    assert!(out.warnings.is_empty(), "no warnings on happy path: {:?}", out.warnings);
+    assert!(
+        out.warnings.is_empty(),
+        "no warnings on happy path: {:?}",
+        out.warnings
+    );
 }
 
 #[test]
@@ -738,7 +753,11 @@ fn index_all_continues_past_single_source_failure() {
     run_context_cmd(&ContextCmd::Init, &deps).expect("init");
     // Good source.
     run_context_cmd(
-        &ContextCmd::Add(path_add_args("good", "rust", &fixture_path_str("mini-rust"))),
+        &ContextCmd::Add(path_add_args(
+            "good",
+            "rust",
+            &fixture_path_str("mini-rust"),
+        )),
         &deps,
     )
     .expect("add good");
@@ -765,7 +784,10 @@ fn index_all_continues_past_single_source_failure() {
         .join("sources")
         .join("good")
         .join("index.db");
-    assert!(good_db.exists(), "good source must be indexed despite bad one failing");
+    assert!(
+        good_db.exists(),
+        "good source must be indexed despite bad one failing"
+    );
     // Summary must mention both.
     assert!(out.stdout.contains("indexed 'good'"), "{:?}", out.stdout);
     assert!(
@@ -1059,8 +1081,7 @@ fn prune_removes_orphan_source_dirs_listed_in_output() {
     let keeper_dir = make_source_dir(&deps, "keeper");
     let orphan_dir = make_source_dir(&deps, "orphan");
 
-    let out = run_context_cmd(&ContextCmd::Prune(PruneArgs::default()), &deps)
-        .expect("prune ok");
+    let out = run_context_cmd(&ContextCmd::Prune(PruneArgs::default()), &deps).expect("prune ok");
 
     assert!(
         !orphan_dir.exists(),
@@ -1105,10 +1126,12 @@ fn prune_preserves_registered_source_dirs() {
     let a = make_source_dir(&deps, "alpha");
     let b = make_source_dir(&deps, "beta");
 
-    let out = run_context_cmd(&ContextCmd::Prune(PruneArgs::default()), &deps)
-        .expect("prune ok");
+    let out = run_context_cmd(&ContextCmd::Prune(PruneArgs::default()), &deps).expect("prune ok");
 
-    assert!(a.exists() && b.exists(), "both registered dirs must survive");
+    assert!(
+        a.exists() && b.exists(),
+        "both registered dirs must survive"
+    );
     assert!(
         out.removed_paths.is_empty(),
         "no orphans => removed_paths empty: {:?}",
@@ -1211,11 +1234,15 @@ fn doctor_all_green_on_healthy_state() {
     let out = run_context_cmd(&ContextCmd::Doctor(args), &deps).expect("doctor ok");
 
     let v = parse_doctor_json(&out.stdout);
-    let checks = v.get("checks").and_then(|x| x.as_array()).expect("checks[]");
+    let checks = v
+        .get("checks")
+        .and_then(|x| x.as_array())
+        .expect("checks[]");
     for c in checks {
         let status = c.get("status").and_then(|x| x.as_str()).unwrap_or("");
         assert_eq!(
-            status, "pass",
+            status,
+            "pass",
             "check {} must be pass on healthy state: {c}",
             c.get("name").and_then(|x| x.as_str()).unwrap_or("?")
         );
@@ -1232,7 +1259,11 @@ fn doctor_reports_missing_source_dir_as_fixable_failure() {
     let deps = TestDeps::new();
     run_context_cmd(&ContextCmd::Init, &deps).expect("init");
     run_context_cmd(
-        &ContextCmd::Add(path_add_args("mini", "rust", &fixture_path_str("mini-rust"))),
+        &ContextCmd::Add(path_add_args(
+            "mini",
+            "rust",
+            &fixture_path_str("mini-rust"),
+        )),
         &deps,
     )
     .expect("add");
@@ -1257,7 +1288,11 @@ fn doctor_reports_missing_source_dir_as_fixable_failure() {
 fn doctor_reports_missing_index_db_as_fixable_failure() {
     let deps = TestDeps::new();
     seed_and_index(&deps, "mini", "mini-rust");
-    let db = deps.home_dir().join("sources").join("mini").join("index.db");
+    let db = deps
+        .home_dir()
+        .join("sources")
+        .join("mini")
+        .join("index.db");
     std::fs::remove_file(&db).expect("remove index.db");
 
     let args = DoctorArgs {
@@ -1281,7 +1316,11 @@ fn doctor_reports_mismatched_model_hash() {
     seed_and_index(&deps, "mini", "mini-rust");
     // Rewrite state.json with a bogus model hash to simulate an embedder
     // upgrade between index runs.
-    let state_path = deps.home_dir().join("sources").join("mini").join("state.json");
+    let state_path = deps
+        .home_dir()
+        .join("sources")
+        .join("mini")
+        .join("state.json");
     let bad = serde_json::json!({
         "schema_version": 1,
         "embedder_model_hash": "definitely-not-the-current-hash",
@@ -1342,15 +1381,15 @@ fn doctor_json_schema_is_stable() {
     let v = parse_doctor_json(&out.stdout);
     // Top-level: ok: bool, checks: array.
     assert!(v.get("ok").and_then(|x| x.as_bool()).is_some(), "ok: bool");
-    let checks = v.get("checks").and_then(|x| x.as_array()).expect("checks[]");
+    let checks = v
+        .get("checks")
+        .and_then(|x| x.as_array())
+        .expect("checks[]");
     assert!(!checks.is_empty(), "must emit at least one check");
     // Each check: name, status, fixable, detail, scope (None or "<source>").
     for c in checks {
         for key in ["name", "status", "fixable", "detail"] {
-            assert!(
-                c.get(key).is_some(),
-                "check must have '{key}': {c}"
-            );
+            assert!(c.get(key).is_some(), "check must have '{key}': {c}");
         }
         let status = c.get("status").and_then(|x| x.as_str()).unwrap();
         assert!(
@@ -1383,7 +1422,11 @@ fn doctor_json_schema_is_stable() {
 fn doctor_repair_rebuilds_missing_index_db() {
     let deps = TestDeps::new();
     seed_and_index(&deps, "mini", "mini-rust");
-    let db = deps.home_dir().join("sources").join("mini").join("index.db");
+    let db = deps
+        .home_dir()
+        .join("sources")
+        .join("mini")
+        .join("index.db");
     std::fs::remove_file(&db).expect("remove db");
     assert!(!db.exists());
 
@@ -1412,10 +1455,7 @@ fn doctor_repair_rebuilds_missing_index_db() {
     let checks = v.get("checks").and_then(|x| x.as_array()).unwrap();
     for c in checks {
         let status = c.get("status").and_then(|x| x.as_str()).unwrap_or("");
-        assert_ne!(
-            status, "fail",
-            "no residual failures after repair: {c}"
-        );
+        assert_ne!(status, "fail", "no residual failures after repair: {c}");
     }
 }
 
@@ -1425,7 +1465,11 @@ fn doctor_repair_is_best_effort_continues_past_one_source_failure() {
     run_context_cmd(&ContextCmd::Init, &deps).expect("init");
     // Good source: fully indexed.
     run_context_cmd(
-        &ContextCmd::Add(path_add_args("good", "rust", &fixture_path_str("mini-rust"))),
+        &ContextCmd::Add(path_add_args(
+            "good",
+            "rust",
+            &fixture_path_str("mini-rust"),
+        )),
         &deps,
     )
     .expect("add good");
@@ -1437,7 +1481,11 @@ fn doctor_repair_is_best_effort_continues_past_one_source_failure() {
     )
     .expect("index good");
     // Delete good's db to force a fixable failure.
-    let good_db = deps.home_dir().join("sources").join("good").join("index.db");
+    let good_db = deps
+        .home_dir()
+        .join("sources")
+        .join("good")
+        .join("index.db");
     std::fs::remove_file(&good_db).expect("remove good db");
 
     // Bad source: registered but sources/bad/ never created and jsonl absent
@@ -1519,12 +1567,12 @@ fn run_doctor_doctor_failed_false_with_warn_only() {
     // a real regression in orphan-warning behavior.
     let v = parse_doctor_json(&out.stdout);
     let checks = v.get("checks").and_then(|x| x.as_array()).unwrap();
-    let any_fail_in_json = checks.iter().any(|c| {
-        c.get("status").and_then(|x| x.as_str()) == Some("fail")
-    });
-    let any_warn_in_json = checks.iter().any(|c| {
-        c.get("status").and_then(|x| x.as_str()) == Some("warn")
-    });
+    let any_fail_in_json = checks
+        .iter()
+        .any(|c| c.get("status").and_then(|x| x.as_str()) == Some("fail"));
+    let any_warn_in_json = checks
+        .iter()
+        .any(|c| c.get("status").and_then(|x| x.as_str()) == Some("warn"));
     assert!(
         !any_fail_in_json,
         "fixture must produce warn-only state; got fail rows in: {}",
@@ -1543,4 +1591,3 @@ fn run_doctor_doctor_failed_false_with_warn_only() {
         out.doctor_failed
     );
 }
-

--- a/src/context/config.rs
+++ b/src/context/config.rs
@@ -479,7 +479,9 @@ fn build_context(raw: RawContext) -> Result<ContextConfig, ConfigError> {
         rerank_recency_floor: raw
             .rerank_recency_floor
             .unwrap_or(defaults.rerank_recency_floor),
-        max_source_size_mb: raw.max_source_size_mb.unwrap_or(defaults.max_source_size_mb),
+        max_source_size_mb: raw
+            .max_source_size_mb
+            .unwrap_or(defaults.max_source_size_mb),
         ignore: raw.ignore,
     };
 

--- a/src/context/config_tests.rs
+++ b/src/context/config_tests.rs
@@ -24,7 +24,10 @@ inject_min_score = 0.65
     assert_eq!(config.sources[0].name, "internal-auth");
     assert_eq!(config.sources[0].kind, SourceKind::Rust);
     assert_eq!(config.sources[0].weight, Some(10));
-    assert!(matches!(config.sources[0].location, SourceLocation::Git { .. }));
+    assert!(matches!(
+        config.sources[0].location,
+        SourceLocation::Git { .. }
+    ));
     match &config.sources[0].location {
         SourceLocation::Git { url, rev } => {
             assert_eq!(url, "git@github.com:myorg/auth.git");
@@ -34,7 +37,10 @@ inject_min_score = 0.65
     }
     assert_eq!(config.sources[1].name, "tf-net");
     assert_eq!(config.sources[1].kind, SourceKind::Terraform);
-    assert!(matches!(config.sources[1].location, SourceLocation::Path(_)));
+    assert!(matches!(
+        config.sources[1].location,
+        SourceLocation::Path(_)
+    ));
     assert_eq!(config.context.inject_budget_tokens, 1500);
 }
 
@@ -187,7 +193,10 @@ kind = "rust"
 inject_budget_tokens = 0
 "#;
     let err = SourcesConfig::from_str(toml).unwrap_err();
-    assert!(err.to_string().contains("inject_budget_tokens"), "got: {err}");
+    assert!(
+        err.to_string().contains("inject_budget_tokens"),
+        "got: {err}"
+    );
 }
 
 #[test]
@@ -248,7 +257,10 @@ inject_min_socre = 0.5   # typo
 "#;
     let err = SourcesConfig::from_str(toml).unwrap_err();
     let s = err.to_string().to_lowercase();
-    assert!(s.contains("unknown") || s.contains("inject_min_socre"), "got: {err}");
+    assert!(
+        s.contains("unknown") || s.contains("inject_min_socre"),
+        "got: {err}"
+    );
 }
 
 #[test]
@@ -278,7 +290,10 @@ foo = "bar"
 "#;
     let err = SourcesConfig::from_str(toml).unwrap_err();
     let s = err.to_string().to_lowercase();
-    assert!(s.contains("unknown") || s.contains("unknown_block"), "got: {err}");
+    assert!(
+        s.contains("unknown") || s.contains("unknown_block"),
+        "got: {err}"
+    );
 }
 
 #[test]

--- a/src/context/extract/astgrep_hcl.rs
+++ b/src/context/extract/astgrep_hcl.rs
@@ -17,7 +17,7 @@
 //! content is the `description` attribute value if present (variable/output),
 //! else a whitespace-collapsed, length-capped rendering of the block body.
 
-use ast_grep_config::{from_yaml_string, GlobalRules, RuleConfig};
+use ast_grep_config::{GlobalRules, RuleConfig, from_yaml_string};
 use ast_grep_language::{LanguageExt, SupportLang};
 use chrono::{DateTime, Utc};
 
@@ -125,8 +125,7 @@ pub fn extract_hcl(
     let mut seen: std::collections::HashSet<(String, usize)> = std::collections::HashSet::new();
     raw.retain(|s| seen.insert((s.qualified_name.clone(), s.byte_start)));
 
-    let mut name_counts: std::collections::HashMap<String, u32> =
-        std::collections::HashMap::new();
+    let mut name_counts: std::collections::HashMap<String, u32> = std::collections::HashMap::new();
     for s in &raw {
         *name_counts.entry(s.qualified_name.clone()).or_insert(0) += 1;
     }
@@ -147,7 +146,10 @@ pub fn extract_hcl(
                 .collect();
 
             let id = if name_counts.get(&s.qualified_name).copied().unwrap_or(1) > 1 {
-                format!("{source}:{source_path}:{}@{}", s.qualified_name, s.byte_start)
+                format!(
+                    "{source}:{source_path}:{}@{}",
+                    s.qualified_name, s.byte_start
+                )
             } else {
                 format!("{source}:{source_path}:{}", s.qualified_name)
             };
@@ -272,9 +274,7 @@ fn find_description<D: ast_grep_core::Doc>(
     block: &ast_grep_core::Node<'_, D>,
     src: &str,
 ) -> Option<String> {
-    let body = block
-        .children()
-        .find(|c| c.kind().as_ref() == "body")?;
+    let body = block.children().find(|c| c.kind().as_ref() == "body")?;
 
     for attr in body.children() {
         if attr.kind().as_ref() != "attribute" {

--- a/src/context/extract/astgrep_hcl_tests.rs
+++ b/src/context/extract/astgrep_hcl_tests.rs
@@ -63,7 +63,10 @@ resource \"aws_vpc\" \"this\" {
         .iter()
         .find(|c| c.qualified_name.as_deref() == Some("aws_vpc.this"))
         .expect("expected aws_vpc.this chunk");
-    assert_eq!(r.signature.as_deref(), Some("resource \"aws_vpc\" \"this\""));
+    assert_eq!(
+        r.signature.as_deref(),
+        Some("resource \"aws_vpc\" \"this\"")
+    );
 }
 
 #[test]
@@ -149,8 +152,8 @@ resource \"aws_vpc\" \"this\" {
 
 #[test]
 fn extracts_multiple_blocks_from_fixture() {
-    let base =
-        std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/context/repos/mini-terraform/networking");
+    let base = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/fixtures/context/repos/mini-terraform/networking");
 
     let main = std::fs::read_to_string(base.join("main.tf")).unwrap();
     let outs = std::fs::read_to_string(base.join("outputs.tf")).unwrap();
@@ -400,4 +403,3 @@ variable \"region\" {
         v.content
     );
 }
-

--- a/src/context/extract/astgrep_py.rs
+++ b/src/context/extract/astgrep_py.rs
@@ -17,7 +17,7 @@
 //! - Conditional module-level defs (inside `if TYPE_CHECKING:` etc.) are
 //!   extracted if they sit at module top level in the parse tree.
 
-use ast_grep_config::{from_yaml_string, GlobalRules, RuleConfig};
+use ast_grep_config::{GlobalRules, RuleConfig, from_yaml_string};
 use ast_grep_language::{LanguageExt, SupportLang};
 use chrono::{DateTime, Utc};
 use std::collections::HashSet;
@@ -29,8 +29,7 @@ const RULE_YAMLS: &[&str] = &[
     include_str!("../../../rules/python/extraction/classes.yml"),
 ];
 
-const DUNDER_ALL_RULE_YAML: &str =
-    include_str!("../../../rules/python/extraction/dunder-all.yml");
+const DUNDER_ALL_RULE_YAML: &str = include_str!("../../../rules/python/extraction/dunder-all.yml");
 
 fn load_extraction_rules() -> anyhow::Result<Vec<RuleConfig<SupportLang>>> {
     let globals = GlobalRules::default();
@@ -122,8 +121,7 @@ pub fn extract_python(
     let mut seen: HashSet<(String, usize)> = HashSet::new();
     raw.retain(|s| seen.insert((s.name.clone(), s.byte_start)));
 
-    let mut name_counts: std::collections::HashMap<String, u32> =
-        std::collections::HashMap::new();
+    let mut name_counts: std::collections::HashMap<String, u32> = std::collections::HashMap::new();
     for s in &raw {
         *name_counts.entry(s.name.clone()).or_insert(0) += 1;
     }
@@ -424,9 +422,7 @@ fn item_signature(item_text: &str) -> String {
             }
         }
         tidied.push(b as char);
-        if matches!(b, b'(' | b'[' | b'{')
-            && bytes.get(i + 1) == Some(&b' ')
-        {
+        if matches!(b, b'(' | b'[' | b'{') && bytes.get(i + 1) == Some(&b' ') {
             i += 2;
             continue;
         }
@@ -454,9 +450,7 @@ fn extract_docstring<D: ast_grep_core::Doc>(
     node: &ast_grep_core::Node<'_, D>,
 ) -> Option<String> {
     // Locate the body `block` child.
-    let block = node
-        .children()
-        .find(|c| c.kind().as_ref() == "block")?;
+    let block = node.children().find(|c| c.kind().as_ref() == "block")?;
 
     // Inspect the FIRST statement-like child of the body. tree-sitter-python
     // may place trivia (comments) as siblings, so skip those but stop at the
@@ -506,10 +500,7 @@ fn dedent_docstring(raw: &str) -> String {
     let mut i = 0;
     while i < bytes.len() {
         let c = bytes[i];
-        if matches!(
-            c,
-            b'r' | b'R' | b'b' | b'B' | b'u' | b'U' | b'f' | b'F'
-        ) {
+        if matches!(c, b'r' | b'R' | b'b' | b'B' | b'u' | b'U' | b'f' | b'F') {
             i += 1;
         } else {
             break;

--- a/src/context/extract/astgrep_py_tests.rs
+++ b/src/context/extract/astgrep_py_tests.rs
@@ -19,11 +19,7 @@ def verify_token(token: str) -> bool:
         .unwrap();
     assert_eq!(vt.kind, super::super::types::ChunkKind::Symbol);
     assert!(vt.content.contains("Validate the JWT"));
-    assert!(vt
-        .signature
-        .as_ref()
-        .unwrap()
-        .contains("def verify_token"));
+    assert!(vt.signature.as_ref().unwrap().contains("def verify_token"));
     assert!(vt.metadata.is_exported);
     assert_eq!(vt.metadata.language.as_deref(), Some("python"));
     assert_eq!(vt.provenance.extractor, "ast-grep-python");
@@ -41,11 +37,12 @@ class AuthError(Exception):
         .find(|c| c.qualified_name.as_deref() == Some("AuthError"))
         .unwrap();
     assert!(ae.content.contains("Raised when"));
-    assert!(ae
-        .signature
-        .as_ref()
-        .unwrap()
-        .contains("class AuthError(Exception)"));
+    assert!(
+        ae.signature
+            .as_ref()
+            .unwrap()
+            .contains("class AuthError(Exception)")
+    );
 }
 
 #[test]
@@ -149,7 +146,10 @@ def foo(
         sig.contains("foo(x: int, y: int) -> int"),
         "signature should collapse to single line, got: {sig}"
     );
-    assert!(!sig.contains('\n'), "signature must not contain newlines: {sig}");
+    assert!(
+        !sig.contains('\n'),
+        "signature must not contain newlines: {sig}"
+    );
 }
 
 #[test]
@@ -284,7 +284,11 @@ def foo():
         foo.content
     );
     // Content should just be the signature in this case.
-    assert!(foo.content.contains("def foo()"), "content = {:?}", foo.content);
+    assert!(
+        foo.content.contains("def foo()"),
+        "content = {:?}",
+        foo.content
+    );
 }
 
 #[test]
@@ -321,4 +325,3 @@ fn signature_survives_colon_in_triple_quoted_default() {
         "triple-quoted default was truncated: {sig}"
     );
 }
-

--- a/src/context/extract/astgrep_rust.rs
+++ b/src/context/extract/astgrep_rust.rs
@@ -11,7 +11,7 @@
 //! - Methods inside `impl` blocks, `use` statements, macros, consts, and type
 //!   aliases are not extracted.
 
-use ast_grep_config::{from_yaml_string, GlobalRules, RuleConfig};
+use ast_grep_config::{GlobalRules, RuleConfig, from_yaml_string};
 use ast_grep_language::{LanguageExt, SupportLang};
 use chrono::{DateTime, Utc};
 
@@ -109,8 +109,7 @@ pub fn extract_rust(
 
     // Count name occurrences so we can disambiguate chunk ids when the same name
     // appears more than once in a file.
-    let mut name_counts: std::collections::HashMap<String, u32> =
-        std::collections::HashMap::new();
+    let mut name_counts: std::collections::HashMap<String, u32> = std::collections::HashMap::new();
     for s in &raw {
         *name_counts.entry(s.name.clone()).or_insert(0) += 1;
     }

--- a/src/context/extract/astgrep_rust_tests.rs
+++ b/src/context/extract/astgrep_rust_tests.rs
@@ -20,12 +20,18 @@ pub fn verify_token(token: &str, opts: VerifyOpts) -> Result<Claims, AuthError> 
         .find(|c| c.qualified_name.as_deref() == Some("verify_token"))
         .unwrap();
     assert_eq!(vt.kind, super::super::types::ChunkKind::Symbol);
-    assert!(vt.signature.as_ref().unwrap().contains("pub fn verify_token"));
-    assert!(vt
-        .signature
-        .as_ref()
-        .unwrap()
-        .contains("Result<Claims, AuthError>"));
+    assert!(
+        vt.signature
+            .as_ref()
+            .unwrap()
+            .contains("pub fn verify_token")
+    );
+    assert!(
+        vt.signature
+            .as_ref()
+            .unwrap()
+            .contains("Result<Claims, AuthError>")
+    );
     assert!(vt.content.contains("Validates a JWT"));
     assert!(vt.content.contains("Errors if expired"));
     assert!(vt.metadata.is_exported);
@@ -44,9 +50,11 @@ fn signature_without_doc_comment_falls_back_to_signature_as_content() {
 #[test]
 fn skips_private_fn() {
     let src = "fn private() {}";
-    assert!(extract_rust(src, "x.rs", "s", "c", when())
-        .unwrap()
-        .is_empty());
+    assert!(
+        extract_rust(src, "x.rs", "s", "c", when())
+            .unwrap()
+            .is_empty()
+    );
 }
 
 #[test]
@@ -161,8 +169,18 @@ mod b { pub fn foo() {} }
     assert!(foos[0].id.contains("@"));
     assert!(foos[1].id.contains("@"));
     // Each `foo` lists the OTHER `foo` as a neighbor.
-    assert!(foos[0].metadata.neighboring_symbols.contains(&"foo".to_string()));
-    assert!(foos[1].metadata.neighboring_symbols.contains(&"foo".to_string()));
+    assert!(
+        foos[0]
+            .metadata
+            .neighboring_symbols
+            .contains(&"foo".to_string())
+    );
+    assert!(
+        foos[1]
+            .metadata
+            .neighboring_symbols
+            .contains(&"foo".to_string())
+    );
 }
 
 #[test]

--- a/src/context/extract/astgrep_ts.rs
+++ b/src/context/extract/astgrep_ts.rs
@@ -12,7 +12,7 @@
 //! - `export const`/`export let`/`export var` bindings are NOT extracted.
 //! - Non-exported items are NOT extracted.
 
-use ast_grep_config::{from_yaml_string, GlobalRules, RuleConfig};
+use ast_grep_config::{GlobalRules, RuleConfig, from_yaml_string};
 use ast_grep_language::{LanguageExt, SupportLang};
 use chrono::{DateTime, Utc};
 
@@ -109,8 +109,7 @@ pub fn extract_typescript(
     let mut seen: std::collections::HashSet<(String, usize)> = std::collections::HashSet::new();
     raw.retain(|s| seen.insert((s.name.clone(), s.byte_start)));
 
-    let mut name_counts: std::collections::HashMap<String, u32> =
-        std::collections::HashMap::new();
+    let mut name_counts: std::collections::HashMap<String, u32> = std::collections::HashMap::new();
     for s in &raw {
         *name_counts.entry(s.name.clone()).or_insert(0) += 1;
     }

--- a/src/context/extract/astgrep_ts_tests.rs
+++ b/src/context/extract/astgrep_ts_tests.rs
@@ -22,16 +22,18 @@ export function verifyToken(token: string, opts: VerifyOpts): Claims | AuthError
         .find(|c| c.qualified_name.as_deref() == Some("verifyToken"))
         .unwrap();
     assert_eq!(vt.kind, super::super::types::ChunkKind::Symbol);
-    assert!(vt
-        .signature
-        .as_ref()
-        .unwrap()
-        .contains("export function verifyToken"));
-    assert!(vt
-        .signature
-        .as_ref()
-        .unwrap()
-        .contains("Claims | AuthError"));
+    assert!(
+        vt.signature
+            .as_ref()
+            .unwrap()
+            .contains("export function verifyToken")
+    );
+    assert!(
+        vt.signature
+            .as_ref()
+            .unwrap()
+            .contains("Claims | AuthError")
+    );
     assert!(vt.content.contains("Validates a JWT"));
     assert!(vt.content.contains("signing key"));
     assert!(vt.metadata.is_exported);
@@ -48,11 +50,13 @@ fn extracts_exported_interface() {
         .find(|c| c.qualified_name.as_deref() == Some("VerifyOpts"))
         .expect("VerifyOpts not extracted");
     assert_eq!(iface.kind, super::super::types::ChunkKind::Symbol);
-    assert!(iface
-        .signature
-        .as_ref()
-        .unwrap()
-        .contains("export interface VerifyOpts"));
+    assert!(
+        iface
+            .signature
+            .as_ref()
+            .unwrap()
+            .contains("export interface VerifyOpts")
+    );
 }
 
 #[test]
@@ -228,15 +232,23 @@ export class Widget {
         .expect("Widget class not extracted");
     let sig = w.signature.as_ref().unwrap();
     assert!(sig.contains("export class Widget"), "got: {sig}");
-    assert!(!sig.contains('{'), "class body must be stripped, got: {sig}");
-    assert!(!sig.contains("render"), "class body must be stripped, got: {sig}");
-    assert!(!sig.contains("private id"), "class body must be stripped, got: {sig}");
+    assert!(
+        !sig.contains('{'),
+        "class body must be stripped, got: {sig}"
+    );
+    assert!(
+        !sig.contains("render"),
+        "class body must be stripped, got: {sig}"
+    );
+    assert!(
+        !sig.contains("private id"),
+        "class body must be stripped, got: {sig}"
+    );
 }
 
 #[test]
 fn mini_ts_auth_fixture_extracts_verify_token() {
-    let src =
-        std::fs::read_to_string("tests/fixtures/context/repos/mini-ts/src/auth.ts").unwrap();
+    let src = std::fs::read_to_string("tests/fixtures/context/repos/mini-ts/src/auth.ts").unwrap();
     let chunks = extract_typescript(&src, "src/auth.ts", "mini-ts", "abc", when()).unwrap();
     let names: Vec<_> = chunks
         .iter()

--- a/src/context/extract/dispatch.rs
+++ b/src/context/extract/dispatch.rs
@@ -15,7 +15,7 @@ use super::astgrep_hcl::extract_hcl;
 use super::astgrep_py::extract_python;
 use super::astgrep_rust::extract_rust;
 use super::astgrep_ts::extract_typescript;
-use super::markdown::{split_markdown, DocSubtype};
+use super::markdown::{DocSubtype, split_markdown};
 use crate::context::config::{SourceEntry, SourceLocation};
 use crate::context::types::Chunk;
 
@@ -255,34 +255,18 @@ pub fn extract_source(
             };
 
             let result: anyhow::Result<Vec<Chunk>> = match dispatched {
-                FileKind::Rust => extract_rust(
-                    &src_text,
-                    &rel,
-                    &source.name,
-                    UNVERSIONED_SHA,
-                    indexed_at,
-                ),
-                FileKind::Typescript => extract_typescript(
-                    &src_text,
-                    &rel,
-                    &source.name,
-                    UNVERSIONED_SHA,
-                    indexed_at,
-                ),
-                FileKind::Python => extract_python(
-                    &src_text,
-                    &rel,
-                    &source.name,
-                    UNVERSIONED_SHA,
-                    indexed_at,
-                ),
-                FileKind::Hcl => extract_hcl(
-                    &src_text,
-                    &rel,
-                    &source.name,
-                    UNVERSIONED_SHA,
-                    indexed_at,
-                ),
+                FileKind::Rust => {
+                    extract_rust(&src_text, &rel, &source.name, UNVERSIONED_SHA, indexed_at)
+                }
+                FileKind::Typescript => {
+                    extract_typescript(&src_text, &rel, &source.name, UNVERSIONED_SHA, indexed_at)
+                }
+                FileKind::Python => {
+                    extract_python(&src_text, &rel, &source.name, UNVERSIONED_SHA, indexed_at)
+                }
+                FileKind::Hcl => {
+                    extract_hcl(&src_text, &rel, &source.name, UNVERSIONED_SHA, indexed_at)
+                }
                 FileKind::Markdown => {
                     let subtype = classify_markdown(&rel);
                     Ok(split_markdown(

--- a/src/context/extract/dispatch_tests.rs
+++ b/src/context/extract/dispatch_tests.rs
@@ -3,7 +3,7 @@ use std::path::PathBuf;
 
 use tempfile::TempDir;
 
-use super::dispatch::{extract_source, ExtractConfig, FixedClock};
+use super::dispatch::{ExtractConfig, FixedClock, extract_source};
 use crate::context::config::{SourceEntry, SourceKind, SourceLocation};
 use crate::context::types::ChunkKind;
 

--- a/src/context/extract/markdown.rs
+++ b/src/context/extract/markdown.rs
@@ -183,7 +183,10 @@ fn collect_h2_starts(md: &str) -> Vec<H2Start> {
 
     for (event, range) in parser {
         match event {
-            Event::Start(Tag::Heading { level: HeadingLevel::H2, .. }) => {
+            Event::Start(Tag::Heading {
+                level: HeadingLevel::H2,
+                ..
+            }) => {
                 current = Some((range.start, String::new()));
             }
             Event::End(end_tag) if current.is_some() => {

--- a/src/context/extract/markdown_tests.rs
+++ b/src/context/extract/markdown_tests.rs
@@ -19,7 +19,14 @@ fn main() { foo(); }
 ## Design
 some prose
 "#;
-    let chunks = split_markdown(md, "README.md", "test-src", DocSubtype::Readme, "abc", when());
+    let chunks = split_markdown(
+        md,
+        "README.md",
+        "test-src",
+        DocSubtype::Readme,
+        "abc",
+        when(),
+    );
     // Now: preamble ("# Project\nintro"), Usage, Design
     assert_eq!(chunks.len(), 3);
     assert_eq!(chunks[0].id, "test-src:README.md:__preamble__");
@@ -125,7 +132,14 @@ fn metadata_reflects_source_and_commit() {
     // Use H2-only doc so chunks[0] is the section (not a preamble).
     let md = "## A\nfoo\n";
     let when = DateTime::<Utc>::from_timestamp(1700000000, 0).unwrap();
-    let chunks = split_markdown(md, "docs/readme.md", "my-src", DocSubtype::Readme, "abc123", when);
+    let chunks = split_markdown(
+        md,
+        "docs/readme.md",
+        "my-src",
+        DocSubtype::Readme,
+        "abc123",
+        when,
+    );
     assert_eq!(chunks.len(), 1);
     assert_eq!(chunks[0].source, "my-src");
     assert_eq!(chunks[0].metadata.source_path, "docs/readme.md");
@@ -149,13 +163,23 @@ fn section_with_only_whitespace_is_skipped() {
 fn chunk_kind_is_doc() {
     let md = "## A\nfoo\n";
     let chunks = split_markdown(md, "d.md", "s", DocSubtype::Doc, "c", when());
-    assert!(matches!(chunks[0].kind, super::super::types::ChunkKind::Doc));
+    assert!(matches!(
+        chunks[0].kind,
+        super::super::types::ChunkKind::Doc
+    ));
 }
 
 #[test]
 fn mini_rust_readme_fixture_splits() {
     let md = std::fs::read_to_string("tests/fixtures/context/repos/mini-rust/README.md").unwrap();
-    let chunks = split_markdown(&md, "README.md", "mini-rust", DocSubtype::Readme, "abc", when());
+    let chunks = split_markdown(
+        &md,
+        "README.md",
+        "mini-rust",
+        DocSubtype::Readme,
+        "abc",
+        when(),
+    );
     // Fixture has >=2 H2 headings per Task 1.1 spec
     assert!(
         chunks.len() >= 2,

--- a/src/context/index/builder.rs
+++ b/src/context/index/builder.rs
@@ -215,17 +215,15 @@ impl<'a, C: Clock, E: Embedder> IndexBuilder<'a, C, E> {
                 "INSERT INTO chunks_fts (id, content, qualified_name, signature)
                  VALUES (?1, ?2, ?3, ?4)",
             )?;
-            let mut ins_vec = tx.prepare(
-                "INSERT INTO chunks_vec(id, embedding) VALUES (?1, ?2)",
-            )?;
+            let mut ins_vec =
+                tx.prepare("INSERT INTO chunks_vec(id, embedding) VALUES (?1, ?2)")?;
 
             for (chunk, vec) in &embedded {
                 let kind_str = serde_json::to_value(&chunk.kind)
                     .ok()
                     .and_then(|v| v.as_str().map(str::to_string))
                     .unwrap_or_default();
-                let neighbors_json =
-                    serde_json::to_string(&chunk.metadata.neighboring_symbols)?;
+                let neighbors_json = serde_json::to_string(&chunk.metadata.neighboring_symbols)?;
                 let indexed_at = chunk.metadata.indexed_at.to_rfc3339();
 
                 ins_chunk.execute(params![
@@ -270,9 +268,8 @@ impl<'a, C: Clock, E: Embedder> IndexBuilder<'a, C, E> {
     fn open_with_vec(db_path: &Path) -> rusqlite::Result<Connection> {
         if let Some(parent) = db_path.parent() {
             if !parent.as_os_str().is_empty() {
-                std::fs::create_dir_all(parent).map_err(|e| {
-                    rusqlite::Error::ToSqlConversionFailure(Box::new(e))
-                })?;
+                std::fs::create_dir_all(parent)
+                    .map_err(|e| rusqlite::Error::ToSqlConversionFailure(Box::new(e)))?;
             }
         }
         ensure_vec_loaded();

--- a/src/context/index/builder_tests.rs
+++ b/src/context/index/builder_tests.rs
@@ -8,14 +8,12 @@ use crate::context::types::{Chunk, ChunkKind, ChunkMeta, LineRange, Provenance};
 
 fn table_names(db: &std::path::Path) -> Vec<String> {
     let conn = Connection::open(db).unwrap();
-    conn.prepare(
-        "SELECT name FROM sqlite_master WHERE type IN ('table') ORDER BY name",
-    )
-    .unwrap()
-    .query_map([], |r| r.get::<_, String>(0))
-    .unwrap()
-    .collect::<Result<_, _>>()
-    .unwrap()
+    conn.prepare("SELECT name FROM sqlite_master WHERE type IN ('table') ORDER BY name")
+        .unwrap()
+        .query_map([], |r| r.get::<_, String>(0))
+        .unwrap()
+        .collect::<Result<_, _>>()
+        .unwrap()
 }
 
 #[test]
@@ -102,9 +100,7 @@ fn tokenizer_preserves_underscores_in_identifiers() {
     assert_eq!(matches_verify, vec!["b".to_string()]);
 
     let matches_full: Vec<String> = conn
-        .prepare(
-            "SELECT id FROM chunks_fts WHERE chunks_fts MATCH 'verify_token' ORDER BY id",
-        )
+        .prepare("SELECT id FROM chunks_fts WHERE chunks_fts MATCH 'verify_token' ORDER BY id")
         .unwrap()
         .query_map([], |r| r.get::<_, String>(0))
         .unwrap()
@@ -361,11 +357,9 @@ fn rebuild_replaces_prior_source_chunks_atomically() {
     );
     for gone in ["a", "b", "c"] {
         let present: i64 = conn
-            .query_row(
-                "SELECT count(*) FROM chunks WHERE id = ?1",
-                [gone],
-                |r| r.get(0),
-            )
+            .query_row("SELECT count(*) FROM chunks WHERE id = ?1", [gone], |r| {
+                r.get(0)
+            })
             .unwrap();
         assert_eq!(present, 0, "chunk {gone} should have been removed");
     }
@@ -404,8 +398,14 @@ fn rebuild_preserves_other_sources() {
     builder.rebuild_from_jsonl("A", &jsonl_a2).unwrap();
 
     let conn = builder.conn();
-    assert_eq!(count(conn, "SELECT count(*) FROM chunks WHERE source = 'A'"), 1);
-    assert_eq!(count(conn, "SELECT count(*) FROM chunks WHERE source = 'B'"), 3);
+    assert_eq!(
+        count(conn, "SELECT count(*) FROM chunks WHERE source = 'A'"),
+        1
+    );
+    assert_eq!(
+        count(conn, "SELECT count(*) FROM chunks WHERE source = 'B'"),
+        3
+    );
     assert_eq!(count(conn, "SELECT count(*) FROM chunks_vec"), 4);
     assert_eq!(count(conn, "SELECT count(*) FROM chunks_fts"), 4);
 }

--- a/src/context/index/state.rs
+++ b/src/context/index/state.rs
@@ -101,10 +101,7 @@ impl IndexState {
             path: tmp.clone(),
             source,
         })?;
-        std::fs::rename(&tmp, path).map_err(|source| StateError::Io {
-            path: tmp,
-            source,
-        })?;
+        std::fs::rename(&tmp, path).map_err(|source| StateError::Io { path: tmp, source })?;
         Ok(())
     }
 
@@ -117,10 +114,12 @@ impl IndexState {
                     expected: CURRENT_SCHEMA_VERSION,
                 }
             }
-            Some(s) if s.embedder_model_hash != expected_model_hash => StateCheck::ReembedRequired {
-                on_disk: s.embedder_model_hash.clone(),
-                expected: expected_model_hash.to_string(),
-            },
+            Some(s) if s.embedder_model_hash != expected_model_hash => {
+                StateCheck::ReembedRequired {
+                    on_disk: s.embedder_model_hash.clone(),
+                    expected: expected_model_hash.to_string(),
+                }
+            }
             Some(_) => StateCheck::Ok,
         }
     }
@@ -187,11 +186,7 @@ mod tests {
         let leftovers: Vec<_> = std::fs::read_dir(dir.path())
             .unwrap()
             .filter_map(|e| e.ok())
-            .filter(|e| {
-                e.file_name()
-                    .to_string_lossy()
-                    .starts_with("state.json.")
-            })
+            .filter(|e| e.file_name().to_string_lossy().starts_with("state.json."))
             .collect();
         assert!(
             leftovers.is_empty(),

--- a/src/context/index/state_tests.rs
+++ b/src/context/index/state_tests.rs
@@ -2,7 +2,7 @@ use std::path::PathBuf;
 
 use tempfile::tempdir;
 
-use super::state::{IndexState, StateCheck, StateError, CURRENT_SCHEMA_VERSION};
+use super::state::{CURRENT_SCHEMA_VERSION, IndexState, StateCheck, StateError};
 
 fn sample(hash: &str) -> IndexState {
     IndexState::new(hash.to_string())

--- a/src/context/inject/injector.rs
+++ b/src/context/inject/injector.rs
@@ -15,10 +15,10 @@ use crate::context::inject::plan::plan_injection;
 use crate::context::inject::render::render_context_block;
 use crate::context::inject::stale::NoStaleness;
 use crate::context::retrieve::{
-    resolve_precedence, Filters, PrecedenceLog, RetrievalQuery, ScoredChunk, SourceWeights,
+    Filters, PrecedenceLog, RetrievalQuery, ScoredChunk, SourceWeights, resolve_precedence,
 };
 use crate::context::types::ChunkKind;
-use crate::review_log::{hash_rendered_block, ContextTelemetry};
+use crate::review_log::{ContextTelemetry, hash_rendered_block};
 
 /// Request shape that the review pipeline passes to the injector.
 ///
@@ -255,7 +255,11 @@ impl ContextInjectionSource for ContextInjector {
                     // nuke every remaining chunk via a `>=` that can
                     // never be true — fail loud in debug builds and
                     // drop defensively in release.
-                    debug_assert!(!thr.is_nan(), "calibrator returned NaN threshold for {}", h.chunk.id);
+                    debug_assert!(
+                        !thr.is_nan(),
+                        "calibrator returned NaN threshold for {}",
+                        h.chunk.id
+                    );
                     !thr.is_nan() && h.score >= thr
                 })
                 .collect();
@@ -302,11 +306,7 @@ impl ContextInjectionSource for ContextInjector {
         tele.injected_chunk_count = plan.injected.len() as u32;
         tele.injected_by_leg = crate::review_log::LegCounts::from_chunks(&plan.injected);
         tele.injected_tokens = plan.token_count as u32;
-        tele.injected_chunk_ids = plan
-            .injected
-            .iter()
-            .map(|c| c.chunk.id.clone())
-            .collect();
+        tele.injected_chunk_ids = plan.injected.iter().map(|c| c.chunk.id.clone()).collect();
         let mut uniq_sources: Vec<String> = Vec::new();
         for c in &plan.injected {
             if !uniq_sources.iter().any(|s| s == &c.chunk.source) {
@@ -352,7 +352,11 @@ fn score_distribution(hits: &[ScoredChunk]) -> Option<ScoreDist> {
     // tiebreak policy yields nondeterministic ordering. A NaN in the
     // retrieval path is a bug upstream; we record nothing rather than
     // serve a misleading distribution.
-    let mut scores: Vec<f32> = hits.iter().map(|h| h.score).filter(|s| !s.is_nan()).collect();
+    let mut scores: Vec<f32> = hits
+        .iter()
+        .map(|h| h.score)
+        .filter(|s| !s.is_nan())
+        .collect();
     if scores.is_empty() {
         return None;
     }
@@ -360,7 +364,11 @@ fn score_distribution(hits: &[ScoredChunk]) -> Option<ScoreDist> {
     let n = scores.len();
     let min = scores[0];
     // Nearest-rank percentile: index = max(0, ceil(p * n) - 1).
-    let pct_idx = |p: f32| ((n as f32 * p).ceil() as usize).saturating_sub(1).min(n - 1);
+    let pct_idx = |p: f32| {
+        ((n as f32 * p).ceil() as usize)
+            .saturating_sub(1)
+            .min(n - 1)
+    };
     let p10 = scores[pct_idx(0.10)];
     // Proper median: average the two middle values for even n.
     let median = if n % 2 == 0 {
@@ -566,11 +574,7 @@ mod tests {
     #[test]
     fn score_distribution_filters_nan() {
         // NaN scores are dropped; distribution is computed from the rest.
-        let hits = vec![
-            scored("a", 0.2),
-            scored("nan", f32::NAN),
-            scored("b", 0.8),
-        ];
+        let hits = vec![scored("a", 0.2), scored("nan", f32::NAN), scored("b", 0.8)];
         let d = super::score_distribution(&hits).expect("non-NaN scores remain");
         assert!((d.min - 0.2).abs() < 1e-6);
         assert!((d.median - 0.5).abs() < 1e-6, "median={}", d.median);
@@ -592,9 +596,8 @@ mod tests {
             sources: vec![],
             context: ctx_with_min_score(0.5),
         };
-        let retriever: Arc<RetrieverFn> = Arc::new(|_q| {
-            Ok(vec![scored("ok", 0.9), scored("bad", f32::NAN)])
-        });
+        let retriever: Arc<RetrieverFn> =
+            Arc::new(|_q| Ok(vec![scored("ok", 0.9), scored("bad", f32::NAN)]));
         let injector = ContextInjector::new(&sources, retriever);
         let req = InjectionRequest {
             file_path: "x.rs".into(),
@@ -606,8 +609,10 @@ mod tests {
         let out = injector.inject(&req);
         assert_eq!(out.telemetry.nan_scores_dropped, 1);
         assert_eq!(out.telemetry.retrieved_chunk_count, 2);
-        assert_eq!(out.telemetry.suppressed_by_floor, 0,
-            "NaN was counted as a NaN drop, not as a floor drop");
+        assert_eq!(
+            out.telemetry.suppressed_by_floor, 0,
+            "NaN was counted as a NaN drop, not as a floor drop"
+        );
     }
 
     #[test]
@@ -616,9 +621,8 @@ mod tests {
             sources: vec![],
             context: ctx_with_min_score(0.5),
         };
-        let retriever: Arc<RetrieverFn> = Arc::new(|_q| {
-            Ok(vec![scored("a", f32::NAN), scored("b", f32::NAN)])
-        });
+        let retriever: Arc<RetrieverFn> =
+            Arc::new(|_q| Ok(vec![scored("a", f32::NAN), scored("b", f32::NAN)]));
         let injector = ContextInjector::new(&sources, retriever);
         let req = InjectionRequest {
             file_path: "x.rs".into(),
@@ -630,7 +634,9 @@ mod tests {
         let out = injector.inject(&req);
         assert_eq!(out.telemetry.nan_scores_dropped, 2);
         assert!(out.rendered.is_none());
-        assert!(out.telemetry.rerank_score_median.is_none(),
-            "score distribution must not be populated when every score was NaN");
+        assert!(
+            out.telemetry.rerank_score_median.is_none(),
+            "score distribution must not be populated when every score was NaN"
+        );
     }
 }

--- a/src/context/inject/plan_tests.rs
+++ b/src/context/inject/plan_tests.rs
@@ -1,4 +1,4 @@
-use super::plan::{plan_injection, TokenCounter};
+use super::plan::{TokenCounter, plan_injection};
 use crate::context::config::ContextConfig;
 use crate::context::retrieve::{ScoreBreakdown, ScoredChunk};
 use crate::context::types::{Chunk, ChunkKind, ChunkMeta, LineRange, Provenance};
@@ -122,14 +122,7 @@ fn unused_symbol_budget_spills_to_prose() {
         scored("s2", ChunkKind::Symbol, &tokens(200), 0.8),
     ];
     let prose: Vec<_> = (0..4)
-        .map(|i| {
-            scored(
-                &format!("p{i}"),
-                ChunkKind::Doc,
-                &tokens(250),
-                0.7,
-            )
-        })
+        .map(|i| scored(&format!("p{i}"), ChunkKind::Doc, &tokens(250), 0.7))
         .collect();
     let plan = plan_injection(symbols, prose, &cfg, &*counter);
     assert_eq!(plan.injected.len(), 6);

--- a/src/context/inject/render.rs
+++ b/src/context/inject/render.rs
@@ -85,9 +85,8 @@ fn render_card(
             let _ = writeln!(out, "### Doc: {path}:{start}-{end}");
         }
         ChunkKind::Symbol | ChunkKind::Schema => {
-            let qname = sanitize_inline_metadata(
-                chunk.qualified_name.as_deref().unwrap_or("<anonymous>"),
-            );
+            let qname =
+                sanitize_inline_metadata(chunk.qualified_name.as_deref().unwrap_or("<anonymous>"));
             let label = if matches!(chunk.kind, ChunkKind::Schema) {
                 "Schema"
             } else {

--- a/src/context/inject/stale_tests.rs
+++ b/src/context/inject/stale_tests.rs
@@ -44,12 +44,7 @@ fn timestamp_returns_none_for_clean_repo() {
     let clock = now_fixed();
     let git = FakeGit::with_dirty(false);
     let root = PathBuf::from("/tmp/repo");
-    let annotator = TimestampStaleness::new(
-        Some("local"),
-        Some(root.as_path()),
-        &git,
-        &clock,
-    );
+    let annotator = TimestampStaleness::new(Some("local"), Some(root.as_path()), &git, &clock);
     let chunk = chunk_with("local", clock.now() - Duration::hours(1));
     assert!(annotator.annotate(&chunk).is_none());
 }
@@ -59,12 +54,7 @@ fn timestamp_returns_some_for_dirty_local_chunk() {
     let clock = now_fixed();
     let git = FakeGit::with_dirty(true);
     let root = PathBuf::from("/tmp/repo");
-    let annotator = TimestampStaleness::new(
-        Some("local"),
-        Some(root.as_path()),
-        &git,
-        &clock,
-    );
+    let annotator = TimestampStaleness::new(Some("local"), Some(root.as_path()), &git, &clock);
     let chunk = chunk_with("local", clock.now() - Duration::hours(2));
     let msg = annotator.annotate(&chunk).expect("expected staleness");
     assert!(msg.contains("source has edits"), "msg: {msg}");
@@ -76,12 +66,7 @@ fn timestamp_returns_none_for_non_current_source() {
     let clock = now_fixed();
     let git = FakeGit::with_dirty(true);
     let root = PathBuf::from("/tmp/repo");
-    let annotator = TimestampStaleness::new(
-        Some("local"),
-        Some(root.as_path()),
-        &git,
-        &clock,
-    );
+    let annotator = TimestampStaleness::new(Some("local"), Some(root.as_path()), &git, &clock);
     let chunk = chunk_with("registry-foo", clock.now() - Duration::hours(2));
     assert!(annotator.annotate(&chunk).is_none());
 }
@@ -90,12 +75,7 @@ fn timestamp_returns_none_for_non_current_source() {
 fn timestamp_returns_none_when_no_current_source() {
     let clock = now_fixed();
     let git = FakeGit::with_dirty(true);
-    let annotator = TimestampStaleness::new(
-        None,
-        None,
-        &git,
-        &clock,
-    );
+    let annotator = TimestampStaleness::new(None, None, &git, &clock);
     let chunk = chunk_with("local", clock.now() - Duration::hours(2));
     assert!(annotator.annotate(&chunk).is_none());
 }
@@ -105,12 +85,7 @@ fn format_age_renders_days() {
     let clock = now_fixed();
     let git = FakeGit::with_dirty(true);
     let root = PathBuf::from("/tmp/repo");
-    let annotator = TimestampStaleness::new(
-        Some("local"),
-        Some(root.as_path()),
-        &git,
-        &clock,
-    );
+    let annotator = TimestampStaleness::new(Some("local"), Some(root.as_path()), &git, &clock);
     let chunk = chunk_with("local", clock.now() - Duration::days(3));
     let msg = annotator.annotate(&chunk).unwrap();
     assert!(msg.contains("3d"), "msg: {msg}");
@@ -121,12 +96,7 @@ fn format_age_renders_just_now_under_one_minute() {
     let clock = now_fixed();
     let git = FakeGit::with_dirty(true);
     let root = PathBuf::from("/tmp/repo");
-    let annotator = TimestampStaleness::new(
-        Some("local"),
-        Some(root.as_path()),
-        &git,
-        &clock,
-    );
+    let annotator = TimestampStaleness::new(Some("local"), Some(root.as_path()), &git, &clock);
     let chunk = chunk_with("local", clock.now() - Duration::seconds(30));
     let msg = annotator.annotate(&chunk).unwrap();
     assert!(msg.contains("just now"), "msg: {msg}");
@@ -137,12 +107,7 @@ fn format_age_renders_singular_units() {
     let clock = now_fixed();
     let git = FakeGit::with_dirty(true);
     let root = PathBuf::from("/tmp/repo");
-    let annotator = TimestampStaleness::new(
-        Some("local"),
-        Some(root.as_path()),
-        &git,
-        &clock,
-    );
+    let annotator = TimestampStaleness::new(Some("local"), Some(root.as_path()), &git, &clock);
 
     let chunk_hr = chunk_with("local", clock.now() - Duration::hours(1));
     let msg_hr = annotator.annotate(&chunk_hr).unwrap();
@@ -169,12 +134,7 @@ fn git_error_is_swallowed_returning_none() {
     let clock = now_fixed();
     let git = FailingGit;
     let root = PathBuf::from("/tmp/repo");
-    let annotator = TimestampStaleness::new(
-        Some("local"),
-        Some(root.as_path()),
-        &git,
-        &clock,
-    );
+    let annotator = TimestampStaleness::new(Some("local"), Some(root.as_path()), &git, &clock);
     let chunk = chunk_with("local", clock.now() - Duration::hours(2));
     assert!(annotator.annotate(&chunk).is_none());
 }
@@ -213,14 +173,12 @@ impl GitOps for CountingGit {
 #[test]
 fn timestamp_calls_git_status_only_once_per_annotator() {
     let clock = now_fixed();
-    let git = CountingGit { dirty: true, calls: std::cell::Cell::new(0) };
+    let git = CountingGit {
+        dirty: true,
+        calls: std::cell::Cell::new(0),
+    };
     let root = PathBuf::from("/tmp/repo");
-    let annotator = TimestampStaleness::new(
-        Some("local"),
-        Some(root.as_path()),
-        &git,
-        &clock,
-    );
+    let annotator = TimestampStaleness::new(Some("local"), Some(root.as_path()), &git, &clock);
     for _ in 0..5 {
         let chunk = chunk_with("local", clock.now() - Duration::hours(1));
         assert!(annotator.annotate(&chunk).is_some());

--- a/src/context/integration_tests.rs
+++ b/src/context/integration_tests.rs
@@ -16,8 +16,11 @@ fn example_sources_fixture_loads_all_three_mini_repos() {
     let config = SourcesConfig::load(path).unwrap();
     assert_eq!(config.sources.len(), 3);
 
-    let by_name: std::collections::HashMap<_, _> =
-        config.sources.iter().map(|s| (s.name.as_str(), s)).collect();
+    let by_name: std::collections::HashMap<_, _> = config
+        .sources
+        .iter()
+        .map(|s| (s.name.as_str(), s))
+        .collect();
     assert!(by_name.contains_key("mini-rust"));
     assert!(by_name.contains_key("mini-ts"));
     assert!(by_name.contains_key("mini-terraform"));

--- a/src/context/phase2_integration_tests.rs
+++ b/src/context/phase2_integration_tests.rs
@@ -6,7 +6,7 @@ use std::path::PathBuf;
 use tempfile::tempdir;
 
 use super::config::{SourceEntry, SourceKind, SourceLocation};
-use super::extract::dispatch::{extract_source, ExtractConfig, FixedClock};
+use super::extract::dispatch::{ExtractConfig, FixedClock, extract_source};
 use super::store::ChunkStore;
 use super::types::ChunkKind;
 
@@ -38,13 +38,13 @@ fn extract_source_writes_jsonl_that_loads_back_mini_rust() {
     let loaded = ChunkStore::load_all(&chunks_path).unwrap();
     assert_eq!(loaded.len(), result.chunks.len());
     assert_eq!(loaded, result.chunks);
-    assert!(loaded
-        .iter()
-        .any(|c| c.qualified_name.as_deref() == Some("verify_token")));
+    assert!(
+        loaded
+            .iter()
+            .any(|c| c.qualified_name.as_deref() == Some("verify_token"))
+    );
     assert!(loaded.iter().any(|c| matches!(c.kind, ChunkKind::Doc)));
-    assert!(loaded
-        .iter()
-        .any(|c| c.subtype.as_deref() == Some("ADR")));
+    assert!(loaded.iter().any(|c| c.subtype.as_deref() == Some("ADR")));
 }
 
 #[test]
@@ -101,13 +101,19 @@ fn validation_passes_on_combined_multi_source_extraction() {
     );
 
     // Spot-check a symbol from each source appears.
-    assert!(loaded
-        .iter()
-        .any(|c| c.qualified_name.as_deref() == Some("verify_token")));
-    assert!(loaded
-        .iter()
-        .any(|c| c.qualified_name.as_deref() == Some("verifyToken")));
-    assert!(loaded
-        .iter()
-        .any(|c| c.qualified_name.as_deref() == Some("aws_vpc.this")));
+    assert!(
+        loaded
+            .iter()
+            .any(|c| c.qualified_name.as_deref() == Some("verify_token"))
+    );
+    assert!(
+        loaded
+            .iter()
+            .any(|c| c.qualified_name.as_deref() == Some("verifyToken"))
+    );
+    assert!(
+        loaded
+            .iter()
+            .any(|c| c.qualified_name.as_deref() == Some("aws_vpc.this"))
+    );
 }

--- a/src/context/phase3_integration_tests.rs
+++ b/src/context/phase3_integration_tests.rs
@@ -7,7 +7,7 @@ use rusqlite::Connection;
 use tempfile::tempdir;
 
 use super::config::{SourceEntry, SourceKind, SourceLocation};
-use super::extract::dispatch::{extract_source, ExtractConfig};
+use super::extract::dispatch::{ExtractConfig, extract_source};
 use super::index::builder::IndexBuilder;
 use super::index::state::{IndexState, StateCheck};
 use super::index::traits::{Embedder, FixedClock, HashEmbedder};
@@ -45,9 +45,7 @@ fn extracted_chunks_become_queryable_via_fts_and_vec() {
     let clock = FixedClock::epoch();
     let emb = HashEmbedder::new(384);
     let mut builder = IndexBuilder::new(&db, &clock, &emb).unwrap();
-    let report = builder
-        .rebuild_from_jsonl("mini-rust", &jsonl)
-        .unwrap();
+    let report = builder.rebuild_from_jsonl("mini-rust", &jsonl).unwrap();
     assert_eq!(report.chunks_loaded, extracted.chunks.len());
     assert_eq!(report.chunks_inserted, extracted.chunks.len());
 
@@ -66,9 +64,7 @@ fn extracted_chunks_become_queryable_via_fts_and_vec() {
         .unwrap();
     assert!(!fts_rows.is_empty());
     assert!(
-        fts_rows
-            .iter()
-            .any(|(id, _)| id.contains("verify_token")),
+        fts_rows.iter().any(|(id, _)| id.contains("verify_token")),
         "expected FTS hit id containing verify_token, got {fts_rows:?}"
     );
     assert!(
@@ -95,7 +91,9 @@ fn extracted_chunks_become_queryable_via_fts_and_vec() {
              ORDER BY distance",
         )
         .unwrap()
-        .query_map([q_bytes], |r| Ok((r.get::<_, String>(0)?, r.get::<_, f32>(1)?)))
+        .query_map([q_bytes], |r| {
+            Ok((r.get::<_, String>(0)?, r.get::<_, f32>(1)?))
+        })
         .unwrap()
         .collect::<Result<_, _>>()
         .unwrap();

--- a/src/context/phase4_integration_tests.rs
+++ b/src/context/phase4_integration_tests.rs
@@ -7,7 +7,7 @@ use rusqlite::Connection;
 use tempfile::tempdir;
 
 use super::config::{SourceEntry, SourceKind, SourceLocation};
-use super::extract::dispatch::{extract_source, ExtractConfig};
+use super::extract::dispatch::{ExtractConfig, extract_source};
 use super::index::builder::IndexBuilder;
 use super::index::traits::{FixedClock, HashEmbedder};
 use super::retrieve::{Filters, RetrievalQuery, Retriever};
@@ -27,7 +27,9 @@ fn fixture_source(name: &str) -> SourceEntry {
     }
 }
 
-fn build_retriever_for(source_name: &str) -> (tempfile::TempDir, Connection, HashEmbedder, FixedClock) {
+fn build_retriever_for(
+    source_name: &str,
+) -> (tempfile::TempDir, Connection, HashEmbedder, FixedClock) {
     let dir = tempdir().unwrap();
     let jsonl = dir.path().join("chunks.jsonl");
     let db = dir.path().join("index.db");
@@ -35,7 +37,10 @@ fn build_retriever_for(source_name: &str) -> (tempfile::TempDir, Connection, Has
     let source = fixture_source(source_name);
     let extracted =
         extract_source(&source, &ExtractConfig::default(), &FixedClock::epoch()).unwrap();
-    assert!(!extracted.chunks.is_empty(), "empty extraction for {source_name}");
+    assert!(
+        !extracted.chunks.is_empty(),
+        "empty extraction for {source_name}"
+    );
 
     let mut store = ChunkStore::new(&jsonl);
     for c in &extracted.chunks {
@@ -46,9 +51,7 @@ fn build_retriever_for(source_name: &str) -> (tempfile::TempDir, Connection, Has
     let emb = HashEmbedder::new(384);
     {
         let mut builder = IndexBuilder::new(&db, &clock, &emb).unwrap();
-        builder
-            .rebuild_from_jsonl(source_name, &jsonl)
-            .unwrap();
+        builder.rebuild_from_jsonl(source_name, &jsonl).unwrap();
     }
     let conn = Connection::open(&db).unwrap();
     (dir, conn, emb, clock)
@@ -61,7 +64,7 @@ fn retrieval_over_mini_rust_returns_verify_token_for_jwt_query() {
     let q = RetrievalQuery {
         text: "jwt validation signing key".to_string(),
         identifiers: vec!["verify_token".to_string()],
-            structural_names: vec![],
+        structural_names: vec![],
         filters: Filters::default(),
         k: 5,
         min_score: 0.0,
@@ -86,7 +89,7 @@ fn retrieval_over_mini_ts_finds_verify_token_export() {
     let q = RetrievalQuery {
         text: "jwt signing key verifier".to_string(),
         identifiers: vec!["verifyToken".to_string()],
-            structural_names: vec![],
+        structural_names: vec![],
         filters: Filters::default(),
         k: 5,
         min_score: 0.0,
@@ -111,7 +114,7 @@ fn kind_filter_restricts_to_docs() {
     let q = RetrievalQuery {
         text: "authentication design decision".to_string(),
         identifiers: Vec::new(),
-            structural_names: vec![],
+        structural_names: vec![],
         filters: Filters {
             sources: Vec::new(),
             kinds: vec![ChunkKind::Doc],
@@ -135,7 +138,7 @@ fn unrelated_query_respects_min_score_threshold() {
     let q = RetrievalQuery {
         text: "zzzzzzzzzz totally unrelated string".to_string(),
         identifiers: Vec::new(),
-            structural_names: vec![],
+        structural_names: vec![],
         filters: Filters::default(),
         k: 5,
         min_score: 2.0,

--- a/src/context/phase5_integration_tests.rs
+++ b/src/context/phase5_integration_tests.rs
@@ -6,13 +6,15 @@ use rusqlite::Connection;
 use tempfile::tempdir;
 
 use super::config::{ContextConfig, SourceEntry, SourceKind, SourceLocation};
-use super::extract::dispatch::{extract_source, ExtractConfig};
+use super::extract::dispatch::{ExtractConfig, extract_source};
 use super::index::builder::IndexBuilder;
 use super::index::traits::{FixedClock, HashEmbedder};
-use super::inject::plan::{plan_injection, InjectionPlan};
+use super::inject::plan::{InjectionPlan, plan_injection};
 use super::inject::render::render_context_block;
 use super::inject::stale::NoStaleness;
-use super::retrieve::{resolve_precedence, Filters, PrecedenceLog, RetrievalQuery, Retriever, SourceWeights};
+use super::retrieve::{
+    Filters, PrecedenceLog, RetrievalQuery, Retriever, SourceWeights, resolve_precedence,
+};
 use super::store::ChunkStore;
 use super::types::ChunkKind;
 
@@ -91,7 +93,10 @@ fn retrieve_plan_render_pipeline_produces_markdown_block() {
 
     let config = context_config_with_budget(50, 0.0);
     let plan = plan_injection(symbols, prose, &config, &token_count);
-    assert!(!plan.injected.is_empty(), "plan should inject at least one chunk");
+    assert!(
+        !plan.injected.is_empty(),
+        "plan should inject at least one chunk"
+    );
 
     let output = render_context_block(&plan, &NoStaleness, &PrecedenceLog::new());
     assert!(
@@ -102,7 +107,10 @@ fn retrieve_plan_render_pipeline_produces_markdown_block() {
         output.contains("# Context"),
         "output must contain # Context header, got: {output}"
     );
-    assert!(output.contains("verify_token"), "output should mention verify_token");
+    assert!(
+        output.contains("verify_token"),
+        "output should mention verify_token"
+    );
     assert!(
         output.contains("tokens across") && output.contains("chunks from"),
         "footer missing: {output}"

--- a/src/context/phase6_integration_tests.rs
+++ b/src/context/phase6_integration_tests.rs
@@ -8,7 +8,7 @@ use rusqlite::Connection;
 use tempfile::tempdir;
 
 use super::config::{ContextConfig, SourceEntry, SourceKind, SourceLocation, SourcesConfig};
-use super::extract::dispatch::{extract_source, ExtractConfig};
+use super::extract::dispatch::{ExtractConfig, extract_source};
 use super::index::builder::IndexBuilder;
 use super::index::traits::{FixedClock, HashEmbedder};
 use super::inject::{ContextInjectionSource, ContextInjector, InjectionRequest, RetrieverFn};
@@ -95,13 +95,15 @@ fn retriever_closure(harness: &Harness) -> Arc<RetrieverFn> {
         .conn
         .query_row("PRAGMA database_list", [], |row| row.get::<_, String>(2))
         .expect("database path");
-    Arc::new(move |q: &RetrievalQuery| -> anyhow::Result<Vec<ScoredChunk>> {
-        let conn = Connection::open(&path)?;
-        let embedder = HashEmbedder::new(384);
-        let clock = FixedClock::epoch();
-        let retriever = Retriever::new(&conn, &embedder, &clock);
-        retriever.query(q.clone())
-    })
+    Arc::new(
+        move |q: &RetrievalQuery| -> anyhow::Result<Vec<ScoredChunk>> {
+            let conn = Connection::open(&path)?;
+            let embedder = HashEmbedder::new(384);
+            let clock = FixedClock::epoch();
+            let retriever = Retriever::new(&conn, &embedder, &clock);
+            retriever.query(q.clone())
+        },
+    )
 }
 
 #[test]
@@ -114,7 +116,7 @@ fn injector_produces_context_block_when_auto_inject_enabled() {
         file_path: "src/auth.rs".to_string(),
         language: Some("rust".to_string()),
         identifiers: vec!["verify_token".to_string()],
-            structural_names: vec![],
+        structural_names: vec![],
         text: "jwt validation signing key".to_string(),
     };
 
@@ -150,7 +152,7 @@ fn injector_returns_none_when_auto_inject_disabled() {
         file_path: "src/auth.rs".to_string(),
         language: Some("rust".to_string()),
         identifiers: vec!["verify_token".to_string()],
-            structural_names: vec![],
+        structural_names: vec![],
         text: "jwt validation signing key".to_string(),
     };
 
@@ -174,7 +176,7 @@ fn injector_returns_none_when_query_yields_no_hits() {
         file_path: "src/auth.rs".to_string(),
         language: Some("rust".to_string()),
         identifiers: Vec::new(),
-            structural_names: vec![],
+        structural_names: vec![],
         text: String::new(),
     };
 
@@ -198,7 +200,7 @@ fn injector_returns_none_when_retriever_closure_returns_empty_vec() {
         file_path: "src/auth.rs".to_string(),
         language: Some("rust".to_string()),
         identifiers: vec!["verify_token".to_string()],
-            structural_names: vec![],
+        structural_names: vec![],
         text: "jwt validation".to_string(),
     };
 
@@ -223,7 +225,7 @@ fn injector_returns_none_when_retriever_errors() {
         file_path: "src/auth.rs".to_string(),
         language: Some("rust".to_string()),
         identifiers: vec!["verify_token".to_string()],
-            structural_names: vec![],
+        structural_names: vec![],
         text: "jwt validation".to_string(),
     };
 
@@ -256,7 +258,7 @@ fn retriever_errored_flag_is_false_when_retriever_returns_zero_hits() {
         file_path: "src/auth.rs".to_string(),
         language: Some("rust".to_string()),
         identifiers: vec!["verify_token".to_string()],
-            structural_names: vec![],
+        structural_names: vec![],
         text: "jwt validation".to_string(),
     };
 
@@ -280,7 +282,7 @@ async fn end_to_end_review_with_context_injection_logs_telemetry() {
     use tempfile::TempDir;
 
     use crate::parser::{self, Language};
-    use crate::pipeline::{review_file, PipelineConfig};
+    use crate::pipeline::{PipelineConfig, review_file};
     use crate::review_log::{Flags, ReviewLog, ReviewRecord, SeverityCounts};
     use crate::test_support::fakes::FakeReviewer;
 
@@ -325,7 +327,10 @@ async fn end_to_end_review_with_context_injection_logs_telemetry() {
     assert!(tele.auto_inject_enabled, "auto_inject=true in config");
     assert!(tele.injector_available);
     assert!(!tele.retriever_errored);
-    assert!(tele.injected_chunk_count > 0, "retrieve+plan delivered chunks");
+    assert!(
+        tele.injected_chunk_count > 0,
+        "retrieve+plan delivered chunks"
+    );
     assert!(tele.rendered_prompt_hash.is_some(), "render hash present");
     assert!(!tele.injected_chunk_ids.is_empty(), "chunk ids recorded");
     assert!(
@@ -384,7 +389,7 @@ fn verify_token_request() -> InjectionRequest {
         file_path: "src/auth.rs".to_string(),
         language: Some("rust".to_string()),
         identifiers: vec!["verify_token".to_string()],
-            structural_names: vec![],
+        structural_names: vec![],
         text: "jwt validation signing key".to_string(),
     }
 }
@@ -425,8 +430,8 @@ fn previously_retrieved_chunk_disappears_from_results_after_3_context_misleading
 
     // 3. Re-run retrieval with the same fixture but a calibrator-gated
     //    injector. The blamed chunks must be gone.
-    let gated = ContextInjector::new(&sources, retriever_closure(&harness))
-        .with_calibrator(Arc::new(cal));
+    let gated =
+        ContextInjector::new(&sources, retriever_closure(&harness)).with_calibrator(Arc::new(cal));
     let gated_outcome = gated.inject(&verify_token_request());
 
     let gated_ids = &gated_outcome.telemetry.injected_chunk_ids;
@@ -488,8 +493,8 @@ fn telemetry_counts_chunks_suppressed_by_calibrator() {
         cal.record_misleading(id, "seal");
     }
 
-    let gated = ContextInjector::new(&sources, retriever_closure(&harness))
-        .with_calibrator(Arc::new(cal));
+    let gated =
+        ContextInjector::new(&sources, retriever_closure(&harness)).with_calibrator(Arc::new(cal));
     let gated_outcome = gated.inject(&verify_token_request());
 
     // Every sealed chunk that was retrieved is suppressed at the gate, so
@@ -518,10 +523,7 @@ fn partially_raised_threshold_keeps_high_score_chunks_and_drops_low_ones() {
 
     let baseline = ContextInjector::new(&sources, retriever_closure(&harness));
     let baseline_outcome = baseline.inject(&verify_token_request());
-    let blamed_ids: Vec<String> = baseline_outcome
-        .telemetry
-        .injected_chunk_ids
-        .clone();
+    let blamed_ids: Vec<String> = baseline_outcome.telemetry.injected_chunk_ids.clone();
     assert!(!blamed_ids.is_empty());
 
     // Single confirmation per chunk -> raised but not sealed.
@@ -530,8 +532,8 @@ fn partially_raised_threshold_keeps_high_score_chunks_and_drops_low_ones() {
         cal.record_misleading(id, "one-shot");
     }
 
-    let gated = ContextInjector::new(&sources, retriever_closure(&harness))
-        .with_calibrator(Arc::new(cal));
+    let gated =
+        ContextInjector::new(&sources, retriever_closure(&harness)).with_calibrator(Arc::new(cal));
     let gated_outcome = gated.inject(&verify_token_request());
 
     // We don't assert exact survivorship here (score distribution is

--- a/src/context/retrieve/bm25_tests.rs
+++ b/src/context/retrieve/bm25_tests.rs
@@ -68,7 +68,12 @@ fn empty_query_returns_no_hits() {
     let dir = tempdir().unwrap();
     let conn = build_test_db(
         dir.path(),
-        vec![sample_chunk("a", "src", "verify_token helps", ChunkKind::Symbol)],
+        vec![sample_chunk(
+            "a",
+            "src",
+            "verify_token helps",
+            ChunkKind::Symbol,
+        )],
     );
     let hits = bm25_search(&conn, "", &Filters::default(), 10).unwrap();
     assert!(hits.is_empty());
@@ -80,14 +85,23 @@ fn single_term_match_returns_relevant_chunk() {
     let conn = build_test_db(
         dir.path(),
         vec![
-            sample_chunk("a", "src", "verify_token helps secure things", ChunkKind::Symbol),
+            sample_chunk(
+                "a",
+                "src",
+                "verify_token helps secure things",
+                ChunkKind::Symbol,
+            ),
             sample_chunk("b", "src", "random code doing stuff", ChunkKind::Symbol),
             sample_chunk("c", "src", "database query with params", ChunkKind::Symbol),
         ],
     );
     let expr = build_match_expression(&["verify_token".to_string()]).unwrap();
     let hits = bm25_search(&conn, &expr, &Filters::default(), 10).unwrap();
-    assert!(ids(&hits).contains(&"a"), "expected 'a' in hits {:?}", ids(&hits));
+    assert!(
+        ids(&hits).contains(&"a"),
+        "expected 'a' in hits {:?}",
+        ids(&hits)
+    );
     assert!(hits.iter().all(|h| h.chunk_id != "b" && h.chunk_id != "c"));
 }
 
@@ -205,11 +219,7 @@ fn match_expression_empty_list_returns_none() {
 
 #[test]
 fn match_expression_filters_whitespace() {
-    let expr = build_match_expression(&[
-        "foo".to_string(),
-        "  ".to_string(),
-        "".to_string(),
-    ]);
+    let expr = build_match_expression(&["foo".to_string(), "  ".to_string(), "".to_string()]);
     assert_eq!(expr.as_deref(), Some("\"foo\""));
 }
 

--- a/src/context/retrieve/identifiers.rs
+++ b/src/context/retrieve/identifiers.rs
@@ -66,9 +66,8 @@ const MAX_IDENTIFIERS: usize = 32;
 
 /// Path segments that are structural noise, not meaningful identifiers.
 const PATH_NOISE: &[&str] = &[
-    "src", "lib", "tests", "test", "mod", "main",
-    "rs", "py", "ts", "js", "tsx", "jsx", "mjs", "cjs",
-    "yaml", "yml", "sh", "bash", "zsh", "tf", "tfvars",
+    "src", "lib", "tests", "test", "mod", "main", "rs", "py", "ts", "js", "tsx", "jsx", "mjs",
+    "cjs", "yaml", "yml", "sh", "bash", "zsh", "tf", "tfvars",
 ];
 
 fn is_path_noise(s: &str) -> bool {
@@ -158,8 +157,7 @@ pub fn harvest_identifiers(
     }
 
     // 3. Decide augmentation.
-    let all_generic = !ref_names.is_empty()
-        && ref_names.iter().all(|n| stoplist.is_generic(n));
+    let all_generic = !ref_names.is_empty() && ref_names.iter().all(|n| stoplist.is_generic(n));
     let augment = ref_names.is_empty() || ref_names.len() < 2 || all_generic;
 
     if !augment {
@@ -198,18 +196,28 @@ fn cap(mut v: Vec<String>) -> Vec<String> {
 pub fn load_stoplist(language: &str) -> GenericStoplist {
     let names: &[&str] = match language.to_ascii_lowercase().as_str() {
         "rust" => &[
-            "Client", "Handler", "Error", "Builder", "Result", "Option",
-            "Default", "Config", "Context", "Service", "Manager", "Engine",
-            "State", "Request", "Response",
+            "Client", "Handler", "Error", "Builder", "Result", "Option", "Default", "Config",
+            "Context", "Service", "Manager", "Engine", "State", "Request", "Response",
         ],
         "typescript" | "javascript" | "ts" | "js" | "tsx" | "jsx" => &[
-            "Client", "Handler", "Error", "Builder", "Service", "Config",
-            "Manager", "Component", "Provider", "Context", "Props", "State",
-            "Request", "Response",
+            "Client",
+            "Handler",
+            "Error",
+            "Builder",
+            "Service",
+            "Config",
+            "Manager",
+            "Component",
+            "Provider",
+            "Context",
+            "Props",
+            "State",
+            "Request",
+            "Response",
         ],
         "python" | "py" => &[
-            "Client", "Handler", "Error", "Builder", "Manager", "Service",
-            "Config", "Base", "Context",
+            "Client", "Handler", "Error", "Builder", "Manager", "Service", "Config", "Base",
+            "Context",
         ],
         "terraform" | "tf" | "hcl" => &[
             "Resource", "Provider", "Module", "Variable", "Output", "Data",

--- a/src/context/retrieve/identifiers_tests.rs
+++ b/src/context/retrieve/identifiers_tests.rs
@@ -1,6 +1,4 @@
-use super::identifiers::{
-    harvest_identifiers, load_stoplist, ReviewedFile, Symbol,
-};
+use super::identifiers::{ReviewedFile, Symbol, harvest_identifiers, load_stoplist};
 
 fn sym(names: &[&str]) -> Vec<Symbol> {
     names.iter().map(|n| Symbol::new(*n)).collect()
@@ -97,8 +95,7 @@ fn duplicate_refs_are_deduped_preserving_order() {
 #[test]
 fn generic_refs_mix_with_specific_keeps_refs_only() {
     let refs = sym(&["Client", "process_payment"]);
-    let file = ReviewedFile::new("src/foo.rs", "rust")
-        .with_neighbors(["shouldNotAppear"]);
+    let file = ReviewedFile::new("src/foo.rs", "rust").with_neighbors(["shouldNotAppear"]);
     let ids = harvest_identifiers(&refs, &file, &load_stoplist("rust"));
     assert_eq!(
         ids,

--- a/src/context/retrieve/mod.rs
+++ b/src/context/retrieve/mod.rs
@@ -29,7 +29,7 @@ pub mod vector;
 // Public re-exports for consumers of the retrieve module. Clippy's unused
 // analysis treats these as dead in a binary crate; suppress that noise.
 #[allow(unused_imports)]
-pub use precedence::{resolve_precedence, PrecedenceLog, SourceWeights};
+pub use precedence::{PrecedenceLog, SourceWeights, resolve_precedence};
 #[allow(unused_imports)]
 pub use rerank::{RerankConfig, ScoreBreakdown};
 #[allow(unused_imports)]

--- a/src/context/retrieve/precedence.rs
+++ b/src/context/retrieve/precedence.rs
@@ -98,8 +98,7 @@ pub fn resolve_precedence(
     }
 
     // For each competition group, pick the winner index and record losers.
-    let mut loser_indices: std::collections::HashSet<usize> =
-        std::collections::HashSet::new();
+    let mut loser_indices: std::collections::HashSet<usize> = std::collections::HashSet::new();
 
     for (qname, indices) in &groups {
         if indices.len() < 2 {
@@ -147,11 +146,7 @@ pub fn resolve_precedence(
 /// `std::cmp::Ordering` comparator: `a` "less" means `a` ranks before `b`
 /// (i.e. `a` is the preferred winner). Using `min_by` with this yields the
 /// winner.
-fn compare_chunks(
-    a: &ScoredChunk,
-    b: &ScoredChunk,
-    weights: &SourceWeights,
-) -> std::cmp::Ordering {
+fn compare_chunks(a: &ScoredChunk, b: &ScoredChunk, weights: &SourceWeights) -> std::cmp::Ordering {
     let wa = weights.get(&a.chunk.source);
     let wb = weights.get(&b.chunk.source);
     // Weight desc: higher weight ranks earlier.
@@ -160,7 +155,12 @@ fn compare_chunks(
         non_eq => return non_eq,
     }
     // indexed_at desc: newer ranks earlier.
-    match b.chunk.metadata.indexed_at.cmp(&a.chunk.metadata.indexed_at) {
+    match b
+        .chunk
+        .metadata
+        .indexed_at
+        .cmp(&a.chunk.metadata.indexed_at)
+    {
         std::cmp::Ordering::Equal => {}
         non_eq => return non_eq,
     }

--- a/src/context/retrieve/precedence_tests.rs
+++ b/src/context/retrieve/precedence_tests.rs
@@ -1,6 +1,6 @@
 use chrono::{DateTime, Utc};
 
-use crate::context::retrieve::precedence::{resolve_precedence, SourceWeights};
+use crate::context::retrieve::precedence::{SourceWeights, resolve_precedence};
 use crate::context::retrieve::{ScoreBreakdown, ScoredChunk};
 use crate::context::types::{Chunk, ChunkKind, ChunkMeta, LineRange, Provenance};
 
@@ -46,9 +46,7 @@ fn scored(
 }
 
 fn t(s: &str) -> DateTime<Utc> {
-    DateTime::parse_from_rfc3339(s)
-        .unwrap()
-        .with_timezone(&Utc)
+    DateTime::parse_from_rfc3339(s).unwrap().with_timezone(&Utc)
 }
 
 #[test]
@@ -136,11 +134,7 @@ fn alphabetical_breaks_tie_when_weights_and_indexed_at_equal() {
 
 #[test]
 fn three_way_competition_picks_one_winner() {
-    let weights = SourceWeights::new([
-        ("A".into(), 10),
-        ("B".into(), 5),
-        ("C".into(), 1),
-    ]);
+    let weights = SourceWeights::new([("A".into(), 10), ("B".into(), 5), ("C".into(), 1)]);
     let ts = t("2025-01-01T00:00:00Z");
     let input = vec![
         scored("1", "A", Some("foo"), ts, 0.5),
@@ -239,7 +233,11 @@ fn precedence_log_entries_ordered_by_qualified_name() {
         scored("6", "B", Some("mu"), ts, 0.9),
     ];
     let (_, log) = resolve_precedence(input, &weights);
-    let names: Vec<_> = log.entries().iter().map(|e| e.qualified_name.as_str()).collect();
+    let names: Vec<_> = log
+        .entries()
+        .iter()
+        .map(|e| e.qualified_name.as_str())
+        .collect();
     assert_eq!(
         names,
         vec!["alpha", "mu", "zeta"],

--- a/src/context/retrieve/rerank.rs
+++ b/src/context/retrieve/rerank.rs
@@ -89,15 +89,15 @@ fn normalize(values: &[f32]) -> Vec<f32> {
 
 /// Recency decay: `max(exp(-ln2 * age_days / halflife), floor)`.
 /// Negative ages (clock skew) clamp to 0 (→ decay = 1.0).
-fn recency_multiplier(
-    now: DateTime<Utc>,
-    indexed_at: DateTime<Utc>,
-    config: &RerankConfig,
-) -> f32 {
+fn recency_multiplier(now: DateTime<Utc>, indexed_at: DateTime<Utc>, config: &RerankConfig) -> f32 {
     let age_days = (now - indexed_at).num_days().max(0) as f32;
     let halflife = config.recency_halflife_days.max(1) as f32;
     let decay = (-std::f32::consts::LN_2 * age_days / halflife).exp();
-    let value = if decay.is_finite() { decay } else { config.recency_floor };
+    let value = if decay.is_finite() {
+        decay
+    } else {
+        config.recency_floor
+    };
     value.max(config.recency_floor)
 }
 
@@ -130,7 +130,11 @@ pub(crate) fn rerank(
             let bn = bm25_norm[i];
             let vn = vec_norm[i];
             let id_boost = if input.id_exact_match { ID_BOOST } else { 0.0 };
-            let path_boost = if input.language_match { PATH_BOOST } else { 0.0 };
+            let path_boost = if input.language_match {
+                PATH_BOOST
+            } else {
+                0.0
+            };
             let blended = BM25_WEIGHT * bn + VEC_WEIGHT * vn;
             let recency_mul = recency_multiplier(now, input.indexed_at, &config);
             let score = (blended + id_boost + path_boost) * recency_mul;

--- a/src/context/retrieve/rerank_tests.rs
+++ b/src/context/retrieve/rerank_tests.rs
@@ -1,4 +1,4 @@
-use super::rerank::{rerank, RerankConfig, RerankInput};
+use super::rerank::{RerankConfig, RerankInput, rerank};
 use chrono::{DateTime, Duration, Utc};
 
 fn input(
@@ -20,9 +20,7 @@ fn input(
 }
 
 fn t(s: &str) -> DateTime<Utc> {
-    DateTime::parse_from_rfc3339(s)
-        .unwrap()
-        .with_timezone(&Utc)
+    DateTime::parse_from_rfc3339(s).unwrap().with_timezone(&Utc)
 }
 
 fn now() -> DateTime<Utc> {

--- a/src/context/retrieve/retriever.rs
+++ b/src/context/retrieve/retriever.rs
@@ -10,10 +10,10 @@ use std::collections::HashMap;
 
 use rusqlite::Connection;
 
+use super::Filters;
 use super::bm25::{Bm25Hit, bm25_search, build_match_expression};
 use super::rerank::{RerankConfig, RerankInput, ScoreBreakdown, rerank};
 use super::vector::{VecHit, vec_search};
-use super::Filters;
 use crate::context::index::traits::{Clock, Embedder};
 use crate::context::types::{Chunk, ChunkKind, ChunkMeta, LineRange, Provenance};
 
@@ -89,14 +89,10 @@ impl<'a, E: Embedder, C: Clock> Retriever<'a, E, C> {
         let structural_hits: Vec<String> = if q.structural_names.is_empty() {
             Vec::new()
         } else {
-            super::structural::structural_search(
-                self.conn,
-                &q.structural_names,
-                &q.filters,
-            )?
-            .into_iter()
-            .map(|h| h.chunk_id)
-            .collect()
+            super::structural::structural_search(self.conn, &q.structural_names, &q.filters)?
+                .into_iter()
+                .map(|h| h.chunk_id)
+                .collect()
         };
 
         if bm25_hits.is_empty() && vec_hits.is_empty() && structural_hits.is_empty() {

--- a/src/context/retrieve/retriever_tests.rs
+++ b/src/context/retrieve/retriever_tests.rs
@@ -173,13 +173,29 @@ fn respects_source_filter() {
     let (conn, emb, clock) = mk_retriever_ctx(
         dir.path(),
         vec![
-            mk_chunk("a1", "A", "token flow", Some("a1"), ChunkKind::Symbol, "rust", n),
-            mk_chunk("b1", "B", "token flow", Some("b1"), ChunkKind::Symbol, "rust", n),
+            mk_chunk(
+                "a1",
+                "A",
+                "token flow",
+                Some("a1"),
+                ChunkKind::Symbol,
+                "rust",
+                n,
+            ),
+            mk_chunk(
+                "b1",
+                "B",
+                "token flow",
+                Some("b1"),
+                ChunkKind::Symbol,
+                "rust",
+                n,
+            ),
         ],
     );
     let r = Retriever::new(&conn, &emb, &clock);
     let q = RetrievalQuery {
-            structural_names: vec![],
+        structural_names: vec![],
         text: "token".into(),
         filters: Filters {
             sources: vec!["A".into()],
@@ -203,13 +219,29 @@ fn respects_kind_filter() {
     let (conn, emb, clock) = mk_retriever_ctx(
         dir.path(),
         vec![
-            mk_chunk("sym", "s", "token rotation", Some("sym"), ChunkKind::Symbol, "rust", n),
-            mk_chunk("doc", "s", "token rotation", Some("doc"), ChunkKind::Doc, "rust", n),
+            mk_chunk(
+                "sym",
+                "s",
+                "token rotation",
+                Some("sym"),
+                ChunkKind::Symbol,
+                "rust",
+                n,
+            ),
+            mk_chunk(
+                "doc",
+                "s",
+                "token rotation",
+                Some("doc"),
+                ChunkKind::Doc,
+                "rust",
+                n,
+            ),
         ],
     );
     let r = Retriever::new(&conn, &emb, &clock);
     let q = RetrievalQuery {
-            structural_names: vec![],
+        structural_names: vec![],
         text: "token".into(),
         filters: Filters {
             sources: vec![],
@@ -233,8 +265,24 @@ fn language_match_boost_applies() {
     let (conn, emb, clock) = mk_retriever_ctx(
         dir.path(),
         vec![
-            mk_chunk("rs", "s", "alpha content token", Some("rs"), ChunkKind::Symbol, "rust", n),
-            mk_chunk("py", "s", "alpha content token", Some("py"), ChunkKind::Symbol, "python", n),
+            mk_chunk(
+                "rs",
+                "s",
+                "alpha content token",
+                Some("rs"),
+                ChunkKind::Symbol,
+                "rust",
+                n,
+            ),
+            mk_chunk(
+                "py",
+                "s",
+                "alpha content token",
+                Some("py"),
+                ChunkKind::Symbol,
+                "python",
+                n,
+            ),
         ],
     );
     let r = Retriever::new(&conn, &emb, &clock);
@@ -258,8 +306,24 @@ fn recency_decay_applies() {
     let (conn, emb, clock) = mk_retriever_ctx(
         dir.path(),
         vec![
-            mk_chunk("new", "s", "alpha beta gamma", Some("new"), ChunkKind::Symbol, "rust", n),
-            mk_chunk("old", "s", "alpha beta gamma", Some("old"), ChunkKind::Symbol, "rust", old),
+            mk_chunk(
+                "new",
+                "s",
+                "alpha beta gamma",
+                Some("new"),
+                ChunkKind::Symbol,
+                "rust",
+                n,
+            ),
+            mk_chunk(
+                "old",
+                "s",
+                "alpha beta gamma",
+                Some("old"),
+                ChunkKind::Symbol,
+                "rust",
+                old,
+            ),
         ],
     );
     let r = Retriever::new(&conn, &emb, &clock);
@@ -330,7 +394,11 @@ fn score_components_exposed_in_breakdown() {
     let br = &hits[0].components;
     assert!((0.0..=1.0).contains(&br.bm25_norm));
     assert!((0.0..=1.0).contains(&br.vec_norm));
-    assert!(br.recency_mul >= 0.25, "recency below floor: {}", br.recency_mul);
+    assert!(
+        br.recency_mul >= 0.25,
+        "recency below floor: {}",
+        br.recency_mul
+    );
     assert!(br.score.is_finite());
     assert_eq!(br.score, hits[0].score);
 }
@@ -384,7 +452,15 @@ fn empty_query_returns_empty() {
     let n = now_ts();
     let (conn, emb, clock) = mk_retriever_ctx(
         dir.path(),
-        vec![mk_chunk("a", "s", "alpha", Some("a"), ChunkKind::Symbol, "rust", n)],
+        vec![mk_chunk(
+            "a",
+            "s",
+            "alpha",
+            Some("a"),
+            ChunkKind::Symbol,
+            "rust",
+            n,
+        )],
     );
     let r = Retriever::new(&conn, &emb, &clock);
     let q = RetrievalQuery::default();
@@ -436,9 +512,33 @@ fn duplicate_chunk_ids_dont_inflate_results() {
     let (conn, emb, clock) = mk_retriever_ctx(
         dir.path(),
         vec![
-            mk_chunk("a", "s", "unique-token-alpha content", Some("a"), ChunkKind::Symbol, "rust", n),
-            mk_chunk("b", "s", "unique-token-alpha content", Some("b"), ChunkKind::Symbol, "rust", n),
-            mk_chunk("c", "s", "unique-token-alpha content", Some("c"), ChunkKind::Symbol, "rust", n),
+            mk_chunk(
+                "a",
+                "s",
+                "unique-token-alpha content",
+                Some("a"),
+                ChunkKind::Symbol,
+                "rust",
+                n,
+            ),
+            mk_chunk(
+                "b",
+                "s",
+                "unique-token-alpha content",
+                Some("b"),
+                ChunkKind::Symbol,
+                "rust",
+                n,
+            ),
+            mk_chunk(
+                "c",
+                "s",
+                "unique-token-alpha content",
+                Some("c"),
+                ChunkKind::Symbol,
+                "rust",
+                n,
+            ),
         ],
     );
     let r = Retriever::new(&conn, &emb, &clock);
@@ -468,15 +568,29 @@ fn respects_exclude_source_paths_filter() {
         vec![
             // Both chunks match "token flow" by BM25 + vector; only the
             // exclude filter should break the tie.
-            mk_chunk("under_review", "S", "token flow", Some("under_review"),
-                     ChunkKind::Symbol, "rust", n),
-            mk_chunk("peer", "S", "token flow", Some("peer"),
-                     ChunkKind::Symbol, "rust", n),
+            mk_chunk(
+                "under_review",
+                "S",
+                "token flow",
+                Some("under_review"),
+                ChunkKind::Symbol,
+                "rust",
+                n,
+            ),
+            mk_chunk(
+                "peer",
+                "S",
+                "token flow",
+                Some("peer"),
+                ChunkKind::Symbol,
+                "rust",
+                n,
+            ),
         ],
     );
     let r = Retriever::new(&conn, &emb, &clock);
     let q = RetrievalQuery {
-            structural_names: vec![],
+        structural_names: vec![],
         text: "token flow".into(),
         filters: Filters {
             sources: vec![],
@@ -639,24 +753,19 @@ fn structural_only_hit_survives_topk_against_strong_bm25_competitors() {
             n,
         ));
     }
-    let (conn, emb, clock) = mk_retriever_ctx(
-        dir.path(),
-        {
-            let mut v = vec![
-                mk_chunk(
-                    "structural_target",
-                    "S",
-                    "fn validate(x: &str) -> bool { !x.is_empty() }",
-                    Some("validate"),
-                    ChunkKind::Symbol,
-                    "rust",
-                    n,
-                ),
-            ];
-            v.extend(extra);
-            v
-        },
-    );
+    let (conn, emb, clock) = mk_retriever_ctx(dir.path(), {
+        let mut v = vec![mk_chunk(
+            "structural_target",
+            "S",
+            "fn validate(x: &str) -> bool { !x.is_empty() }",
+            Some("validate"),
+            ChunkKind::Symbol,
+            "rust",
+            n,
+        )];
+        v.extend(extra);
+        v
+    });
     let r = Retriever::new(&conn, &emb, &clock);
     let q = RetrievalQuery {
         text: "orchestrate pipeline flow tokens bytes flags".into(),

--- a/src/context/retrieve/structural_tests.rs
+++ b/src/context/retrieve/structural_tests.rs
@@ -94,8 +94,7 @@ fn no_match_returns_empty() {
         "fn validate() {}",
     )];
     let conn = build_test_db(dir.path(), chunks);
-    let hits =
-        structural_search(&conn, &["nonexistent::fn".into()], &Filters::default()).unwrap();
+    let hits = structural_search(&conn, &["nonexistent::fn".into()], &Filters::default()).unwrap();
     assert!(hits.is_empty());
 }
 
@@ -107,7 +106,12 @@ fn multiple_qnames_mixed_hit_and_miss() {
         sample_symbol("c2", "repo", "a::two", "fn two() {}"),
     ];
     let conn = build_test_db(dir.path(), chunks);
-    let hits = structural_search(&conn, &["a::one".into(), "never::seen".into(), "a::two".into()], &Filters::default()).unwrap();
+    let hits = structural_search(
+        &conn,
+        &["a::one".into(), "never::seen".into(), "a::two".into()],
+        &Filters::default(),
+    )
+    .unwrap();
     assert_eq!(hits.len(), 2);
     // Order follows the input qname order, not DB order.
     assert_eq!(hits[0].qualified_name, "a::one");
@@ -169,11 +173,9 @@ fn many_qnames_do_not_exceed_sqlite_parameter_limit() {
     let dir = tempdir().unwrap();
     let chunks = vec![sample_symbol("c1", "r", "hit", "fn hit(){}")];
     let conn = build_test_db(dir.path(), chunks);
-    let mut qnames: Vec<String> =
-        (0..2000).map(|i| format!("miss_{i}")).collect();
+    let mut qnames: Vec<String> = (0..2000).map(|i| format!("miss_{i}")).collect();
     qnames.push("hit".into());
-    let hits =
-        structural_search(&conn, &qnames, &Filters::default()).unwrap();
+    let hits = structural_search(&conn, &qnames, &Filters::default()).unwrap();
     assert_eq!(hits.len(), 1);
     assert_eq!(hits[0].chunk_id, "c1");
 }
@@ -202,12 +204,7 @@ fn qname_with_sql_metachars_is_safely_bound() {
     // as SQL. If this were vulnerable, the test DB would be
     // dropped and subsequent queries would fail.
     let dir = tempdir().unwrap();
-    let chunks = vec![sample_symbol(
-        "c1",
-        "repo",
-        "harmless",
-        "fn harmless() {}",
-    )];
+    let chunks = vec![sample_symbol("c1", "repo", "harmless", "fn harmless() {}")];
     let conn = build_test_db(dir.path(), chunks);
     let payload = "'); DROP TABLE chunks;--".to_string();
     let hits = structural_search(&conn, &[payload], &Filters::default()).unwrap();

--- a/src/context/retrieve/vector.rs
+++ b/src/context/retrieve/vector.rs
@@ -94,8 +94,9 @@ fn apply_filters(
     let allowed_ids: std::collections::HashSet<String> = if no_filters {
         rows.iter().map(|(id, _)| id.clone()).collect()
     } else {
-        let id_placeholders =
-            std::iter::repeat_n("?", rows.len()).collect::<Vec<_>>().join(",");
+        let id_placeholders = std::iter::repeat_n("?", rows.len())
+            .collect::<Vec<_>>()
+            .join(",");
 
         let mut sql = format!("SELECT id FROM chunks WHERE id IN ({id_placeholders})");
 

--- a/src/context/retrieve/vector_tests.rs
+++ b/src/context/retrieve/vector_tests.rs
@@ -71,7 +71,12 @@ fn knn_returns_nearest_chunks_first() {
     let chunks = vec![
         mk_chunk("s", "jwt", "jwt auth signing", ChunkKind::Symbol),
         mk_chunk("s", "db", "database query", ChunkKind::Symbol),
-        mk_chunk("s", "weather", "unrelated text about weather", ChunkKind::Symbol),
+        mk_chunk(
+            "s",
+            "weather",
+            "unrelated text about weather",
+            ChunkKind::Symbol,
+        ),
     ];
     let conn = build_test_db_with_embeddings(dir.path(), chunks);
 
@@ -158,7 +163,11 @@ fn kind_filter_limits_results() {
 
     assert!(!hits.is_empty());
     for h in &hits {
-        assert!(h.chunk_id.starts_with("doc"), "unexpected id: {}", h.chunk_id);
+        assert!(
+            h.chunk_id.starts_with("doc"),
+            "unexpected id: {}",
+            h.chunk_id
+        );
     }
 }
 

--- a/src/context/store.rs
+++ b/src/context/store.rs
@@ -93,10 +93,7 @@ impl ChunkStore {
                 continue;
             }
             let chunk: Chunk = serde_json::from_str(trimmed).map_err(|e| {
-                io::Error::new(
-                    io::ErrorKind::InvalidData,
-                    format!("line {}: {e}", idx + 1),
-                )
+                io::Error::new(io::ErrorKind::InvalidData, format!("line {}: {e}", idx + 1))
             })?;
             chunks.push(chunk);
         }

--- a/src/context/types_tests.rs
+++ b/src/context/types_tests.rs
@@ -226,8 +226,10 @@ fn provenance_rejects_nan_confidence() {
     let json_inf = r#"{"extractor": "x", "confidence": 1.0e300, "source_uri": "u"}"#;
     // 1.0e300 as f32 is infinity
     let err = serde_json::from_str::<Provenance>(json_inf).unwrap_err();
-    assert!(err.to_string().contains("finite") || err.to_string().contains("[0.0, 1.0]"),
-        "got: {err}");
+    assert!(
+        err.to_string().contains("finite") || err.to_string().contains("[0.0, 1.0]"),
+        "got: {err}"
+    );
 }
 
 #[test]

--- a/src/context_enrichment.rs
+++ b/src/context_enrichment.rs
@@ -82,7 +82,9 @@ pub(crate) fn normalize_import_to_dep_names(imp: &str) -> Vec<String> {
 /// `normalize_clean` on a malformed-but-recognized statement.
 fn strip_verb<'a>(rest: &'a str, verb: &str) -> Option<&'a str> {
     let tail = rest.strip_prefix(verb)?;
-    if tail.is_empty() { return Some(""); }
+    if tail.is_empty() {
+        return Some("");
+    }
     let first = tail.chars().next()?;
     if first.is_whitespace() {
         Some(tail.trim_start())
@@ -119,7 +121,9 @@ fn parse_python_from(stmt: &str) -> Vec<String> {
     // stmt = "os.path import join"
     let module = stmt.split_whitespace().next().unwrap_or("");
     let head = module.split('.').next().unwrap_or("");
-    if head.is_empty() { return Vec::new(); }
+    if head.is_empty() {
+        return Vec::new();
+    }
     vec![head.to_string()]
 }
 
@@ -162,7 +166,9 @@ fn normalize_ts_package(pkg: &str) -> Vec<String> {
         return vec![pkg.to_string()];
     }
     let head = pkg.split('/').next().unwrap_or(pkg);
-    if head.is_empty() { return Vec::new(); }
+    if head.is_empty() {
+        return Vec::new();
+    }
     vec![head.to_string()]
 }
 
@@ -212,16 +218,36 @@ pub fn enrich_for_review(
     }
 
     for dep in import_matched.into_iter().take(ENRICH_K) {
-        if seen.contains(&dep.name) { continue; }
+        if seen.contains(&dep.name) {
+            continue;
+        }
         let query = curated_query_for(&dep.name)
             .unwrap_or_else(|| generic_query_for_language(&dep.language).into());
-        try_fetch_one(&dep.name, &query, imports, fetcher, &mut docs, &mut metrics, &mut seen);
+        try_fetch_one(
+            &dep.name,
+            &query,
+            imports,
+            fetcher,
+            &mut docs,
+            &mut metrics,
+            &mut seen,
+        );
     }
 
     for fw in curated_frameworks {
-        if seen.contains(fw) { continue; }
+        if seen.contains(fw) {
+            continue;
+        }
         if let Some(query) = curated_query_for(fw) {
-            try_fetch_one(fw, &query, imports, fetcher, &mut docs, &mut metrics, &mut seen);
+            try_fetch_one(
+                fw,
+                &query,
+                imports,
+                fetcher,
+                &mut docs,
+                &mut metrics,
+                &mut seen,
+            );
         }
     }
 
@@ -259,12 +285,17 @@ fn try_fetch_one(
             metrics.context7_resolved += 1;
             let enriched = build_code_aware_query(query, imports);
             if let Some(content) = fetcher.query_docs(&lib_id, &enriched, 5000) {
-                docs.push(ContextDoc { library: name.into(), content });
+                docs.push(ContextDoc {
+                    library: name.into(),
+                    content,
+                });
             } else {
                 metrics.context7_query_failed += 1;
             }
         }
-        None => { metrics.context7_resolve_failed += 1; }
+        None => {
+            metrics.context7_resolve_failed += 1;
+        }
     }
 }
 
@@ -291,7 +322,9 @@ pub fn curated_query_for(name: &str) -> Option<String> {
         "express" => "middleware security input validation",
         "vue" => "reactivity composition API common pitfalls",
         "fastify" => "plugin system validation security hooks",
-        "home-assistant" => "automations templates blueprints Jinja2 states triggers conditions actions",
+        "home-assistant" => {
+            "automations templates blueprints Jinja2 states triggers conditions actions"
+        }
         "esphome" => "yaml components lambda sensors substitutions",
         "terraform" => "provider resource data module security best practices",
         _ => return None,
@@ -305,7 +338,8 @@ pub fn build_code_aware_query(base_query: &str, import_targets: &[String]) -> St
     if import_targets.is_empty() {
         return base_query.to_string();
     }
-    let keywords: Vec<String> = import_targets.iter()
+    let keywords: Vec<String> = import_targets
+        .iter()
         .filter_map(|imp| extract_query_keyword(imp))
         .filter(|s| s.len() > 2) // skip very short names like "os", "re"
         .take(10)
@@ -334,13 +368,17 @@ fn extract_query_keyword(imp: &str) -> Option<String> {
             || rest_trim.starts_with("import ")
         {
             let symbol = symbol.trim();
-            if !symbol.is_empty() { return Some(symbol.to_string()); }
+            if !symbol.is_empty() {
+                return Some(symbol.to_string());
+            }
         }
     }
     if let Some(stripped) = imp.strip_prefix('@') {
         return stripped.split('/').next().map(|s| s.to_string());
     }
-    imp.split(&['.', '/', ':'][..]).next_back().map(|s| s.to_string())
+    imp.split(&['.', '/', ':'][..])
+        .next_back()
+        .map(|s| s.to_string())
 }
 
 /// Format context docs as a prompt section.
@@ -356,7 +394,10 @@ pub fn format_context_section(docs: &[ContextDoc]) -> String {
         // explicit `text` keeps Markdown renderers from highlighting as Bash by
         // default and makes the intent ("opaque blob, do not parse") explicit (N2).
         let sanitized = doc.content.replace("```", "'''");
-        section.push_str(&format!("### {}\n```text\n{}\n```\n\n", doc.library, sanitized));
+        section.push_str(&format!(
+            "### {}\n```text\n{}\n```\n\n",
+            doc.library, sanitized
+        ));
     }
     section
 }
@@ -386,7 +427,12 @@ pub struct CachedContextFetcher<'a> {
 
 impl<'a> CachedContextFetcher<'a> {
     pub fn new(inner: &'a dyn ContextFetcher, max_entries: usize) -> Self {
-        Self::new_with_clock(inner, max_entries, DEFAULT_RESOLVE_TTL, std::time::Instant::now)
+        Self::new_with_clock(
+            inner,
+            max_entries,
+            DEFAULT_RESOLVE_TTL,
+            std::time::Instant::now,
+        )
     }
 
     pub fn new_with_clock(
@@ -424,10 +470,13 @@ impl<'a> ContextFetcher for CachedContextFetcher<'a> {
             // LruCache::put auto-evicts the LRU entry at capacity — preserves
             // hot entries instead of dropping the entire cache like the prior
             // `clear()` did.
-            cache.put(name.to_string(), ResolveCacheEntry {
-                result: result.clone(),
-                cached_at: now,
-            });
+            cache.put(
+                name.to_string(),
+                ResolveCacheEntry {
+                    result: result.clone(),
+                    cached_at: now,
+                },
+            );
         }
         result
     }
@@ -472,7 +521,8 @@ impl Context7HttpFetcher {
             .filter(|k| !k.trim().is_empty())
             .or_else(|| {
                 let home = std::env::var("HOME").ok()?;
-                std::fs::read_to_string(format!("{}/.context7_key", home)).ok()
+                std::fs::read_to_string(format!("{}/.context7_key", home))
+                    .ok()
                     .map(|s| s.trim().to_string())
                     .filter(|k| !k.is_empty())
             });
@@ -501,7 +551,7 @@ impl ContextFetcher for Context7HttpFetcher {
                 .get("https://context7.com/api/v1/search")
                 .query(&[("libraryName", name), ("query", name)])
                 .header("Authorization", format!("Bearer {}", api_key))
-                .send()
+                .send(),
         ) {
             Ok(r) => r,
             Err(e) => {
@@ -536,13 +586,19 @@ impl ContextFetcher for Context7HttpFetcher {
 
         let resp = match self.block_on(
             self.http
-                .get(format!("https://context7.com/api/v1/{}",
-                    library_id.trim_start_matches('/').split('/')
-                        .map(|seg| url::form_urlencoded::byte_serialize(seg.as_bytes()).collect::<String>())
-                        .collect::<Vec<_>>().join("/")))
+                .get(format!(
+                    "https://context7.com/api/v1/{}",
+                    library_id
+                        .trim_start_matches('/')
+                        .split('/')
+                        .map(|seg| url::form_urlencoded::byte_serialize(seg.as_bytes())
+                            .collect::<String>())
+                        .collect::<Vec<_>>()
+                        .join("/")
+                ))
                 .query(&[("query", query), ("tokens", &max_tokens.to_string())])
                 .header("Authorization", format!("Bearer {}", api_key))
-                .send()
+                .send(),
         ) {
             Ok(r) => r,
             Err(e) => {
@@ -554,7 +610,11 @@ impl ContextFetcher for Context7HttpFetcher {
         let status = resp.status();
         if !status.is_success() {
             let body = self.block_on(resp.text()).unwrap_or_default();
-            eprintln!("Context7 query_docs: HTTP {} - {}", status, &body[..200.min(body.len())]);
+            eprintln!(
+                "Context7 query_docs: HTTP {} - {}",
+                status,
+                &body[..200.min(body.len())]
+            );
             return None;
         }
 
@@ -578,7 +638,8 @@ impl ContextFetcher for Context7HttpFetcher {
                 }
             }
             if let Some(snippets) = json["snippets"].as_array() {
-                let combined: String = snippets.iter()
+                let combined: String = snippets
+                    .iter()
                     .filter_map(|s| s["content"].as_str())
                     .collect::<Vec<_>>()
                     .join("\n\n---\n\n");
@@ -600,20 +661,33 @@ mod test_support {
 
     pub struct Spy;
     impl ContextFetcher for Spy {
-        fn resolve_library(&self, name: &str) -> Option<String> { Some(format!("/lib/{name}")) }
+        fn resolve_library(&self, name: &str) -> Option<String> {
+            Some(format!("/lib/{name}"))
+        }
         fn query_docs(&self, lib: &str, _: &str, _: usize) -> Option<String> {
             Some(format!("docs for {lib}"))
         }
     }
 
-    pub struct CapturingSpy { pub queries: Mutex<Vec<(String, String)>> }
+    pub struct CapturingSpy {
+        pub queries: Mutex<Vec<(String, String)>>,
+    }
     impl CapturingSpy {
-        pub fn new() -> Self { Self { queries: Mutex::new(Vec::new()) } }
+        pub fn new() -> Self {
+            Self {
+                queries: Mutex::new(Vec::new()),
+            }
+        }
     }
     impl ContextFetcher for CapturingSpy {
-        fn resolve_library(&self, name: &str) -> Option<String> { Some(name.into()) }
+        fn resolve_library(&self, name: &str) -> Option<String> {
+            Some(name.into())
+        }
         fn query_docs(&self, lib: &str, query: &str, _: usize) -> Option<String> {
-            self.queries.lock().unwrap().push((lib.into(), query.into()));
+            self.queries
+                .lock()
+                .unwrap()
+                .push((lib.into(), query.into()));
             Some("doc".into())
         }
     }
@@ -644,8 +718,10 @@ mod tests {
         for (name, marker) in cases {
             let q = curated_query_for(name)
                 .unwrap_or_else(|| panic!("missing curated query for {name}"));
-            assert!(q.contains(marker),
-                "curated query for {name} missing marker '{marker}': got {q:?}");
+            assert!(
+                q.contains(marker),
+                "curated query for {name} missing marker '{marker}': got {q:?}"
+            );
         }
     }
 
@@ -682,7 +758,10 @@ mod tests {
     #[test]
     fn generic_query_for_unknown_language_falls_back_to_minimal_security() {
         let q = generic_query_for_language("brainfuck");
-        assert!(q.contains("security"), "fallback must mention security: {q:?}");
+        assert!(
+            q.contains("security"),
+            "fallback must mention security: {q:?}"
+        );
     }
 
     // --- normalize_import_to_dep_names: direct unit tests ---
@@ -694,8 +773,14 @@ mod tests {
 
     #[test]
     fn normalize_module_path_returns_root_segment() {
-        assert_eq!(normalize_import_to_dep_names("tokio::sync::Mutex"), vec!["tokio"]);
-        assert_eq!(normalize_import_to_dep_names("fastapi.routing"), vec!["fastapi"]);
+        assert_eq!(
+            normalize_import_to_dep_names("tokio::sync::Mutex"),
+            vec!["tokio"]
+        );
+        assert_eq!(
+            normalize_import_to_dep_names("fastapi.routing"),
+            vec!["fastapi"]
+        );
     }
 
     #[test]
@@ -711,8 +796,10 @@ mod tests {
     #[test]
     fn normalize_leading_colon_does_not_yield_empty_string() {
         let out = normalize_import_to_dep_names("::std::ptr");
-        assert!(out.iter().all(|s| !s.is_empty()),
-            "leading :: must not yield empty head: {out:?}");
+        assert!(
+            out.iter().all(|s| !s.is_empty()),
+            "leading :: must not yield empty head: {out:?}"
+        );
     }
 
     #[test]
@@ -793,9 +880,8 @@ mod tests {
         // one entry per imported symbol, so callers see N copies of the same
         // statement; each must extract every crate so dep-name lookup matches
         // any of them.
-        let mut got = normalize_import_to_dep_names(
-            "Mutex: use {tokio::sync::Mutex, serde::Serialize};",
-        );
+        let mut got =
+            normalize_import_to_dep_names("Mutex: use {tokio::sync::Mutex, serde::Serialize};");
         got.sort();
         assert_eq!(got, vec!["serde", "tokio"]);
     }
@@ -805,9 +891,7 @@ mod tests {
         // Same fix applied per-segment: empty leading segments inside the
         // group must be skipped, so `use {::tokio::A, ::serde::B};` yields
         // both crates, not `["{"]`.
-        let mut got = normalize_import_to_dep_names(
-            "A: use {::tokio::A, ::serde::B};",
-        );
+        let mut got = normalize_import_to_dep_names("A: use {::tokio::A, ::serde::B};");
         got.sort();
         assert_eq!(got, vec!["serde", "tokio"]);
     }
@@ -963,8 +1047,14 @@ mod tests {
         // A future change that breaks bare `tokio` / `tokio::sync::Mutex` would
         // also break the test fixtures used by other modules.
         assert_eq!(normalize_import_to_dep_names("tokio"), vec!["tokio"]);
-        assert_eq!(normalize_import_to_dep_names("tokio::sync::Mutex"), vec!["tokio"]);
-        assert_eq!(normalize_import_to_dep_names("fastapi.routing"), vec!["fastapi"]);
+        assert_eq!(
+            normalize_import_to_dep_names("tokio::sync::Mutex"),
+            vec!["tokio"]
+        );
+        assert_eq!(
+            normalize_import_to_dep_names("fastapi.routing"),
+            vec!["fastapi"]
+        );
     }
 
     // --- enrich_for_review: behavior tests ---
@@ -974,16 +1064,28 @@ mod tests {
         use crate::dep_manifest::Dependency;
         use test_support::Spy;
         let deps = vec![
-            Dependency { name: "tokio".into(), language: "rust".into() },
-            Dependency { name: "serde".into(), language: "rust".into() },
-            Dependency { name: "axum".into(), language: "rust".into() },
+            Dependency {
+                name: "tokio".into(),
+                language: "rust".into(),
+            },
+            Dependency {
+                name: "serde".into(),
+                language: "rust".into(),
+            },
+            Dependency {
+                name: "axum".into(),
+                language: "rust".into(),
+            },
         ];
         let imports = vec!["tokio::sync::Mutex".into(), "serde::Serialize".into()];
         let result = enrich_for_review(&deps, &[], &imports, &Spy);
         let libs: Vec<_> = result.docs.iter().map(|d| d.library.as_str()).collect();
         assert!(libs.contains(&"tokio"));
         assert!(libs.contains(&"serde"));
-        assert!(!libs.contains(&"axum"), "axum not in imports — must be skipped");
+        assert!(
+            !libs.contains(&"axum"),
+            "axum not in imports — must be skipped"
+        );
     }
 
     #[test]
@@ -991,12 +1093,17 @@ mod tests {
         use crate::dep_manifest::Dependency;
         use test_support::CapturingSpy;
         let spy = CapturingSpy::new();
-        let deps = vec![Dependency { name: "react".into(), language: "javascript".into() }];
+        let deps = vec![Dependency {
+            name: "react".into(),
+            language: "javascript".into(),
+        }];
         let imports = vec!["react".into()];
         let _ = enrich_for_review(&deps, &[], &imports, &spy);
         let captured = spy.queries.lock().unwrap();
-        assert!(captured.iter().any(|(_, q)| q.contains("hooks")),
-            "curated query expected, got {captured:?}");
+        assert!(
+            captured.iter().any(|(_, q)| q.contains("hooks")),
+            "curated query expected, got {captured:?}"
+        );
     }
 
     #[test]
@@ -1004,20 +1111,29 @@ mod tests {
         use crate::dep_manifest::Dependency;
         use test_support::CapturingSpy;
         let spy = CapturingSpy::new();
-        let deps = vec![Dependency { name: "tokio".into(), language: "rust".into() }];
+        let deps = vec![Dependency {
+            name: "tokio".into(),
+            language: "rust".into(),
+        }];
         let imports = vec!["tokio::spawn".into()];
         let _ = enrich_for_review(&deps, &[], &imports, &spy);
         let captured = spy.queries.lock().unwrap();
-        assert!(captured.iter().any(|(_, q)| q.contains("async")),
-            "rust generic query expected, got {captured:?}");
+        assert!(
+            captured.iter().any(|(_, q)| q.contains("async")),
+            "rust generic query expected, got {captured:?}"
+        );
     }
 
     #[test]
     fn enrich_for_review_with_empty_inputs_returns_no_docs_and_zero_metrics() {
         struct Spy;
         impl ContextFetcher for Spy {
-            fn resolve_library(&self, _: &str) -> Option<String> { None }
-            fn query_docs(&self, _: &str, _: &str, _: usize) -> Option<String> { None }
+            fn resolve_library(&self, _: &str) -> Option<String> {
+                None
+            }
+            fn query_docs(&self, _: &str, _: &str, _: usize) -> Option<String> {
+                None
+            }
         }
         let result = enrich_for_review(&[], &[], &[], &Spy);
         assert!(result.docs.is_empty());
@@ -1030,9 +1146,12 @@ mod tests {
     fn enrich_with_exactly_five_matched_deps_returns_five_docs() {
         use crate::dep_manifest::Dependency;
         use test_support::Spy;
-        let deps: Vec<_> = (0..5).map(|i| Dependency {
-            name: format!("dep{i}"), language: "rust".into(),
-        }).collect();
+        let deps: Vec<_> = (0..5)
+            .map(|i| Dependency {
+                name: format!("dep{i}"),
+                language: "rust".into(),
+            })
+            .collect();
         let imports: Vec<_> = (0..5).map(|i| format!("dep{i}::x")).collect();
         let result = enrich_for_review(&deps, &[], &imports, &Spy);
         assert_eq!(result.docs.len(), 5);
@@ -1042,36 +1161,50 @@ mod tests {
     fn enrich_with_six_matched_drops_the_last_in_import_order() {
         use crate::dep_manifest::Dependency;
         use test_support::Spy;
-        let deps: Vec<_> = (0..6).map(|i| Dependency {
-            name: format!("dep{i}"), language: "rust".into(),
-        }).collect();
+        let deps: Vec<_> = (0..6)
+            .map(|i| Dependency {
+                name: format!("dep{i}"),
+                language: "rust".into(),
+            })
+            .collect();
         let imports: Vec<_> = (0..6).map(|i| format!("dep{i}::x")).collect();
         let result = enrich_for_review(&deps, &[], &imports, &Spy);
         let libs: Vec<_> = result.docs.iter().map(|d| d.library.clone()).collect();
         assert_eq!(libs.len(), 5);
-        assert!(!libs.contains(&"dep5".to_string()),
-            "dep5 should be dropped; got {libs:?}");
+        assert!(
+            !libs.contains(&"dep5".to_string()),
+            "dep5 should be dropped; got {libs:?}"
+        );
     }
 
     #[test]
     fn enrich_returns_first_five_in_import_occurrence_order() {
         use crate::dep_manifest::Dependency;
         use test_support::Spy;
-        let deps: Vec<_> = (0..10).map(|i| Dependency {
-            name: format!("dep{i}"), language: "rust".into(),
-        }).collect();
+        let deps: Vec<_> = (0..10)
+            .map(|i| Dependency {
+                name: format!("dep{i}"),
+                language: "rust".into(),
+            })
+            .collect();
         let imports: Vec<_> = (0..10).map(|i| format!("dep{i}::x")).collect();
         let result = enrich_for_review(&deps, &[], &imports, &Spy);
         let libs: Vec<_> = result.docs.iter().map(|d| d.library.clone()).collect();
-        assert_eq!(libs, vec!["dep0", "dep1", "dep2", "dep3", "dep4"],
-            "must be import-order, not HashMap iteration order");
+        assert_eq!(
+            libs,
+            vec!["dep0", "dep1", "dep2", "dep3", "dep4"],
+            "must be import-order, not HashMap iteration order"
+        );
     }
 
     #[test]
     fn enrich_dedupes_curated_framework_already_in_deps() {
         use crate::dep_manifest::Dependency;
         use test_support::Spy;
-        let deps = vec![Dependency { name: "react".into(), language: "javascript".into() }];
+        let deps = vec![Dependency {
+            name: "react".into(),
+            language: "javascript".into(),
+        }];
         let imports = vec!["react".into()];
         let frameworks = vec!["react".into()];
         let result = enrich_for_review(&deps, &frameworks, &imports, &Spy);
@@ -1097,7 +1230,9 @@ mod tests {
         use test_support::CapturingSpy;
 
         let dir = TempDir::new().unwrap();
-        std::fs::write(dir.path().join("Cargo.toml"), r#"
+        std::fs::write(
+            dir.path().join("Cargo.toml"),
+            r#"
 [package]
 name = "x"
 version = "0.1.0"
@@ -1106,7 +1241,9 @@ version = "0.1.0"
 tokio = "1"
 serde = "1"
 axum = "0.7"
-"#).unwrap();
+"#,
+        )
+        .unwrap();
 
         let spy = CapturingSpy::new();
         let imports = vec!["tokio::sync::Mutex".into(), "serde::Serialize".into()];
@@ -1115,7 +1252,10 @@ axum = "0.7"
         let libs: Vec<_> = result.docs.iter().map(|d| d.library.clone()).collect();
         assert!(libs.contains(&"tokio".to_string()));
         assert!(libs.contains(&"serde".to_string()));
-        assert!(!libs.contains(&"axum".to_string()), "axum not in imports — must be skipped");
+        assert!(
+            !libs.contains(&"axum".to_string()),
+            "axum not in imports — must be skipped"
+        );
 
         // Telemetry: 2 deps were import-matched and resolved.
         assert_eq!(result.metrics.context7_resolved, 2);
@@ -1126,35 +1266,50 @@ axum = "0.7"
     #[test]
     fn cached_fetcher_negative_resolve_result_is_cached() {
         use std::sync::Mutex;
-        struct CountingSpy { calls: Mutex<u32> }
+        struct CountingSpy {
+            calls: Mutex<u32>,
+        }
         impl ContextFetcher for CountingSpy {
             fn resolve_library(&self, _: &str) -> Option<String> {
                 *self.calls.lock().unwrap() += 1;
                 None
             }
-            fn query_docs(&self, _: &str, _: &str, _: usize) -> Option<String> { None }
+            fn query_docs(&self, _: &str, _: &str, _: usize) -> Option<String> {
+                None
+            }
         }
-        let inner = CountingSpy { calls: Mutex::new(0) };
+        let inner = CountingSpy {
+            calls: Mutex::new(0),
+        };
         let cached = CachedContextFetcher::new(&inner, 16);
         assert!(cached.resolve_library("missing").is_none());
         assert!(cached.resolve_library("missing").is_none());
         assert!(cached.resolve_library("missing").is_none());
-        assert_eq!(*inner.calls.lock().unwrap(), 1,
-            "subsequent calls must hit negative cache");
+        assert_eq!(
+            *inner.calls.lock().unwrap(),
+            1,
+            "subsequent calls must hit negative cache"
+        );
     }
 
     #[test]
     fn cached_fetcher_positive_resolve_result_is_cached() {
         use std::sync::Mutex;
-        struct CountingSpy { calls: Mutex<u32> }
+        struct CountingSpy {
+            calls: Mutex<u32>,
+        }
         impl ContextFetcher for CountingSpy {
             fn resolve_library(&self, name: &str) -> Option<String> {
                 *self.calls.lock().unwrap() += 1;
                 Some(format!("/lib/{name}"))
             }
-            fn query_docs(&self, _: &str, _: &str, _: usize) -> Option<String> { None }
+            fn query_docs(&self, _: &str, _: &str, _: usize) -> Option<String> {
+                None
+            }
         }
-        let inner = CountingSpy { calls: Mutex::new(0) };
+        let inner = CountingSpy {
+            calls: Mutex::new(0),
+        };
         let cached = CachedContextFetcher::new(&inner, 16);
         assert_eq!(cached.resolve_library("react"), Some("/lib/react".into()));
         assert_eq!(cached.resolve_library("react"), Some("/lib/react".into()));
@@ -1165,29 +1320,36 @@ axum = "0.7"
     fn cached_fetcher_negative_resolve_cache_expires_after_ttl() {
         use std::sync::{Arc, Mutex};
         use std::time::{Duration, Instant};
-        struct CountingSpy { calls: Mutex<u32> }
+        struct CountingSpy {
+            calls: Mutex<u32>,
+        }
         impl ContextFetcher for CountingSpy {
             fn resolve_library(&self, _: &str) -> Option<String> {
                 *self.calls.lock().unwrap() += 1;
                 None
             }
-            fn query_docs(&self, _: &str, _: &str, _: usize) -> Option<String> { None }
+            fn query_docs(&self, _: &str, _: &str, _: usize) -> Option<String> {
+                None
+            }
         }
-        let inner = CountingSpy { calls: Mutex::new(0) };
+        let inner = CountingSpy {
+            calls: Mutex::new(0),
+        };
         let now = Instant::now();
         let time = Arc::new(Mutex::new(now));
         let time_clone = time.clone();
-        let cached = CachedContextFetcher::new_with_clock(
-            &inner,
-            16,
-            Duration::from_secs(60),
-            move || *time_clone.lock().unwrap(),
-        );
+        let cached =
+            CachedContextFetcher::new_with_clock(&inner, 16, Duration::from_secs(60), move || {
+                *time_clone.lock().unwrap()
+            });
         let _ = cached.resolve_library("missing");
         *time.lock().unwrap() = now + Duration::from_secs(120);
         let _ = cached.resolve_library("missing");
-        assert_eq!(*inner.calls.lock().unwrap(), 2,
-            "expired entry must trigger fresh inner call");
+        assert_eq!(
+            *inner.calls.lock().unwrap(),
+            2,
+            "expired entry must trigger fresh inner call"
+        );
     }
 
     #[test]
@@ -1198,17 +1360,28 @@ axum = "0.7"
         use crate::dep_manifest::Dependency;
         struct ResolveOkButQueryFails;
         impl ContextFetcher for ResolveOkButQueryFails {
-            fn resolve_library(&self, name: &str) -> Option<String> { Some(format!("/lib/{name}")) }
-            fn query_docs(&self, _: &str, _: &str, _: usize) -> Option<String> { None }
+            fn resolve_library(&self, name: &str) -> Option<String> {
+                Some(format!("/lib/{name}"))
+            }
+            fn query_docs(&self, _: &str, _: &str, _: usize) -> Option<String> {
+                None
+            }
         }
-        let deps = vec![Dependency { name: "react".into(), language: "javascript".into() }];
+        let deps = vec![Dependency {
+            name: "react".into(),
+            language: "javascript".into(),
+        }];
         let imports = vec!["react".into()];
         let frameworks = vec!["react".into()];
         let result = enrich_for_review(&deps, &frameworks, &imports, &ResolveOkButQueryFails);
-        assert_eq!(result.metrics.context7_resolved, 1,
-            "resolve must not double-count");
-        assert_eq!(result.metrics.context7_query_failed, 1,
-            "query_failed must not double-count");
+        assert_eq!(
+            result.metrics.context7_resolved, 1,
+            "resolve must not double-count"
+        );
+        assert_eq!(
+            result.metrics.context7_query_failed, 1,
+            "query_failed must not double-count"
+        );
     }
 
     #[test]
@@ -1217,18 +1390,35 @@ axum = "0.7"
         struct PartialSpy;
         impl ContextFetcher for PartialSpy {
             fn resolve_library(&self, name: &str) -> Option<String> {
-                if name == "good" { Some("/lib/good".into()) }
-                else if name == "query_fails" { Some("/lib/qf".into()) }
-                else { None }
+                if name == "good" {
+                    Some("/lib/good".into())
+                } else if name == "query_fails" {
+                    Some("/lib/qf".into())
+                } else {
+                    None
+                }
             }
             fn query_docs(&self, lib: &str, _: &str, _: usize) -> Option<String> {
-                if lib == "/lib/good" { Some("doc".into()) } else { None }
+                if lib == "/lib/good" {
+                    Some("doc".into())
+                } else {
+                    None
+                }
             }
         }
         let deps = vec![
-            Dependency { name: "good".into(), language: "rust".into() },
-            Dependency { name: "missing".into(), language: "rust".into() },
-            Dependency { name: "query_fails".into(), language: "rust".into() },
+            Dependency {
+                name: "good".into(),
+                language: "rust".into(),
+            },
+            Dependency {
+                name: "missing".into(),
+                language: "rust".into(),
+            },
+            Dependency {
+                name: "query_fails".into(),
+                language: "rust".into(),
+            },
         ];
         let imports = vec!["good".into(), "missing".into(), "query_fails".into()];
         let result = enrich_for_review(&deps, &[], &imports, &PartialSpy);
@@ -1242,14 +1432,18 @@ axum = "0.7"
         // @nestjs/core should yield "nestjs" (the framework hint), not "core" (useless).
         let query = build_code_aware_query("base", &["@nestjs/core".into()]);
         assert!(query.contains("nestjs"), "got: {query}");
-        assert!(!query.split_whitespace().any(|w| w == "core"), "got: {query}");
+        assert!(
+            !query.split_whitespace().any(|w| w == "core"),
+            "got: {query}"
+        );
     }
 
     #[test]
     fn format_context_section_with_docs() {
-        let docs = vec![
-            ContextDoc { library: "react".into(), content: "useEffect requires deps array".into() },
-        ];
+        let docs = vec![ContextDoc {
+            library: "react".into(),
+            content: "useEffect requires deps array".into(),
+        }];
         let section = format_context_section(&docs);
         assert!(section.contains("react"));
         assert!(section.contains("useEffect"));
@@ -1282,9 +1476,13 @@ axum = "0.7"
     #[test]
     fn build_code_aware_query_appends_imports() {
         let base = "hooks rules component lifecycle common pitfalls";
-        let imports = vec!["useEffect".to_string(), "useState".to_string(), "useCallback".to_string()];
+        let imports = vec![
+            "useEffect".to_string(),
+            "useState".to_string(),
+            "useCallback".to_string(),
+        ];
         let query = build_code_aware_query(base, &imports);
-        assert!(query.contains("hooks rules"));  // baseline preserved
+        assert!(query.contains("hooks rules")); // baseline preserved
         assert!(query.contains("useEffect"));
         assert!(query.contains("useState"));
     }
@@ -1308,7 +1506,10 @@ axum = "0.7"
     #[test]
     fn build_code_aware_query_extracts_short_names() {
         let base = "ORM security";
-        let imports = vec!["os.path.join".to_string(), "collections.OrderedDict".to_string()];
+        let imports = vec![
+            "os.path.join".to_string(),
+            "collections.OrderedDict".to_string(),
+        ];
         let query = build_code_aware_query(base, &imports);
         assert!(query.contains("join"));
         assert!(query.contains("OrderedDict"));
@@ -1338,22 +1539,31 @@ axum = "0.7"
         let query = build_code_aware_query("base", &imports);
         // Imported-symbol keywords are present.
         assert!(query.contains("Mutex"), "missing Mutex: {query}");
-        assert!(query.contains("Deserialize"), "missing Deserialize: {query}");
+        assert!(
+            query.contains("Deserialize"),
+            "missing Deserialize: {query}"
+        );
         assert!(query.contains("useState"), "missing useState: {query}");
         assert!(query.contains("join"), "missing join: {query}");
         // Garbage tokens from naive splitting are absent.
-        assert!(!query.contains("Mutex;"), "leaked trailing semicolon: {query}");
+        assert!(
+            !query.contains("Mutex;"),
+            "leaked trailing semicolon: {query}"
+        );
         assert!(!query.contains("react'"), "leaked closing quote: {query}");
         // Trash tokens from the use-statement body must not leak in.
         for trash in [" import ", "use ", " from "] {
-            assert!(!query.contains(trash), "leaked statement keyword {trash:?}: {query}");
+            assert!(
+                !query.contains(trash),
+                "leaked statement keyword {trash:?}: {query}"
+            );
         }
     }
 
     #[test]
     fn cached_fetcher_avoids_duplicate_calls() {
-        use std::sync::atomic::{AtomicUsize, Ordering};
         use std::sync::Arc;
+        use std::sync::atomic::{AtomicUsize, Ordering};
 
         struct CountingFetcher {
             calls: Arc<AtomicUsize>,
@@ -1362,14 +1572,21 @@ axum = "0.7"
             fn resolve_library(&self, name: &str) -> Option<String> {
                 Some(format!("/lib/{}", name))
             }
-            fn query_docs(&self, library_id: &str, _query: &str, _max_tokens: usize) -> Option<String> {
+            fn query_docs(
+                &self,
+                library_id: &str,
+                _query: &str,
+                _max_tokens: usize,
+            ) -> Option<String> {
                 self.calls.fetch_add(1, Ordering::SeqCst);
                 Some(format!("docs for {}", library_id))
             }
         }
 
         let calls = Arc::new(AtomicUsize::new(0));
-        let inner = CountingFetcher { calls: calls.clone() };
+        let inner = CountingFetcher {
+            calls: calls.clone(),
+        };
         let cached = CachedContextFetcher::new(&inner, 16);
 
         // First call hits inner
@@ -1393,20 +1610,26 @@ axum = "0.7"
         // max_entries, dropping every entry at once. With LRU semantics, only
         // the *least-recently-used* entry should be evicted. Most-recently-used
         // entries must still hit cache after the wrap.
-        use std::sync::atomic::{AtomicUsize, Ordering};
         use std::sync::Arc;
+        use std::sync::atomic::{AtomicUsize, Ordering};
 
-        struct CountingResolver { calls: Arc<AtomicUsize> }
+        struct CountingResolver {
+            calls: Arc<AtomicUsize>,
+        }
         impl ContextFetcher for CountingResolver {
             fn resolve_library(&self, name: &str) -> Option<String> {
                 self.calls.fetch_add(1, Ordering::SeqCst);
                 Some(format!("/lib/{}", name))
             }
-            fn query_docs(&self, _: &str, _: &str, _: usize) -> Option<String> { None }
+            fn query_docs(&self, _: &str, _: &str, _: usize) -> Option<String> {
+                None
+            }
         }
 
         let calls = Arc::new(AtomicUsize::new(0));
-        let inner = CountingResolver { calls: calls.clone() };
+        let inner = CountingResolver {
+            calls: calls.clone(),
+        };
         let cached = CachedContextFetcher::new(&inner, 3);
 
         // Fill cache to capacity.
@@ -1438,12 +1661,16 @@ axum = "0.7"
     #[test]
     fn cached_fetcher_query_docs_evicts_lru_entry_at_capacity() {
         // Same regression check for query_docs cache.
-        use std::sync::atomic::{AtomicUsize, Ordering};
         use std::sync::Arc;
+        use std::sync::atomic::{AtomicUsize, Ordering};
 
-        struct CountingQuery { calls: Arc<AtomicUsize> }
+        struct CountingQuery {
+            calls: Arc<AtomicUsize>,
+        }
         impl ContextFetcher for CountingQuery {
-            fn resolve_library(&self, name: &str) -> Option<String> { Some(name.into()) }
+            fn resolve_library(&self, name: &str) -> Option<String> {
+                Some(name.into())
+            }
             fn query_docs(&self, lib: &str, _: &str, _: usize) -> Option<String> {
                 self.calls.fetch_add(1, Ordering::SeqCst);
                 Some(format!("docs:{lib}"))
@@ -1451,7 +1678,9 @@ axum = "0.7"
         }
 
         let calls = Arc::new(AtomicUsize::new(0));
-        let inner = CountingQuery { calls: calls.clone() };
+        let inner = CountingQuery {
+            calls: calls.clone(),
+        };
         let cached = CachedContextFetcher::new(&inner, 2);
 
         let _ = cached.query_docs("a", "q", 5000);
@@ -1464,8 +1693,11 @@ axum = "0.7"
 
         // "b" must hit cache.
         let _ = cached.query_docs("b", "q", 5000);
-        assert_eq!(calls.load(Ordering::SeqCst), 3,
-            "LRU eviction must keep hot entries; old clear() would push this to 4");
+        assert_eq!(
+            calls.load(Ordering::SeqCst),
+            3,
+            "LRU eviction must keep hot entries; old clear() would push this to 4"
+        );
     }
 
     #[test]
@@ -1482,6 +1714,9 @@ axum = "0.7"
 
         let inner = StubFetcher;
         let cached = CachedContextFetcher::new(&inner, 16);
-        assert_eq!(cached.resolve_library("react"), Some("/resolved/react".into()));
+        assert_eq!(
+            cached.resolve_library("react"),
+            Some("/resolved/react".into())
+        );
     }
 }

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -1,7 +1,6 @@
 /// Daemon mode: persistent background process with warm caches and file watching.
 /// Keeps ParseCache warm, invalidates on file changes, accepts review requests
 /// via the MCP server (stdio transport).
-
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
@@ -58,10 +57,7 @@ pub fn start_watcher(
 }
 
 /// Process daemon events: invalidate cache on file changes.
-pub async fn run_event_loop(
-    mut rx: mpsc::UnboundedReceiver<DaemonEvent>,
-    _cache: Arc<ParseCache>,
-) {
+pub async fn run_event_loop(mut rx: mpsc::UnboundedReceiver<DaemonEvent>, _cache: Arc<ParseCache>) {
     while let Some(event) = rx.recv().await {
         match event {
             DaemonEvent::FileChanged(path) => {
@@ -107,7 +103,8 @@ mod tests {
         let (tx, rx) = mpsc::unbounded_channel();
         let cache = Arc::new(ParseCache::new(10));
 
-        tx.send(DaemonEvent::FileChanged(PathBuf::from("test.rs"))).unwrap();
+        tx.send(DaemonEvent::FileChanged(PathBuf::from("test.rs")))
+            .unwrap();
         tx.send(DaemonEvent::Shutdown).unwrap();
 
         run_event_loop(rx, cache).await;
@@ -134,15 +131,21 @@ mod tests {
         let v1 = "fn original() {}";
         let v2 = "fn modified() {}";
 
-        cache.get_or_parse(v1, crate::parser::Language::Rust).unwrap();
+        cache
+            .get_or_parse(v1, crate::parser::Language::Rust)
+            .unwrap();
         assert_eq!(cache.stats().misses, 1);
 
         // Same content = hit
-        cache.get_or_parse(v1, crate::parser::Language::Rust).unwrap();
+        cache
+            .get_or_parse(v1, crate::parser::Language::Rust)
+            .unwrap();
         assert_eq!(cache.stats().hits, 1);
 
         // Different content = miss (auto-invalidation)
-        cache.get_or_parse(v2, crate::parser::Language::Rust).unwrap();
+        cache
+            .get_or_parse(v2, crate::parser::Language::Rust)
+            .unwrap();
         assert_eq!(cache.stats().misses, 2);
     }
 }

--- a/src/dep_manifest.rs
+++ b/src/dep_manifest.rs
@@ -22,11 +22,16 @@ fn parse_cargo(path: &Path) -> Vec<Dependency> {
     };
     let mut out = Vec::new();
     let mut seen = std::collections::HashSet::new();
-    let push_table = |table: &toml::value::Table, out: &mut Vec<Dependency>, seen: &mut std::collections::HashSet<String>| {
+    let push_table = |table: &toml::value::Table,
+                      out: &mut Vec<Dependency>,
+                      seen: &mut std::collections::HashSet<String>| {
         for name in table.keys() {
             let normalized = name.replace('-', "_");
             if seen.insert(normalized.clone()) {
-                out.push(Dependency { name: normalized, language: "rust".into() });
+                out.push(Dependency {
+                    name: normalized,
+                    language: "rust".into(),
+                });
             }
         }
     };
@@ -62,18 +67,30 @@ fn parse_package_json(path: &Path, has_tsconfig: bool) -> Vec<Dependency> {
             return Vec::new();
         }
     };
-    let lang = if has_tsconfig { "typescript" } else { "javascript" };
+    let lang = if has_tsconfig {
+        "typescript"
+    } else {
+        "javascript"
+    };
     let mut out = Vec::new();
     let mut seen = std::collections::HashSet::new();
     // Dedupe across sections — a package legitimately appearing in
     // both `dependencies` and `peerDependencies` (common during
     // migrations) used to emit duplicate entries. Mirrors parse_cargo's
     // HashSet-based dedup for parser-symmetry.
-    for key in &["dependencies", "devDependencies", "peerDependencies", "optionalDependencies"] {
+    for key in &[
+        "dependencies",
+        "devDependencies",
+        "peerDependencies",
+        "optionalDependencies",
+    ] {
         if let Some(obj) = parsed.get(*key).and_then(|v| v.as_object()) {
             for name in obj.keys() {
                 if seen.insert(name.clone()) {
-                    out.push(Dependency { name: name.clone(), language: lang.into() });
+                    out.push(Dependency {
+                        name: name.clone(),
+                        language: lang.into(),
+                    });
                 }
             }
         }
@@ -90,7 +107,11 @@ fn strip_python_dep_spec(raw: &str) -> Option<String> {
         .find(|c: char| matches!(c, '<' | '>' | '=' | '!' | '~' | ' ' | ';' | '@'))
         .unwrap_or(no_extras.len());
     let name = no_extras[..name_end].trim();
-    if name.is_empty() { None } else { Some(name.to_string()) }
+    if name.is_empty() {
+        None
+    } else {
+        Some(name.to_string())
+    }
 }
 
 /// Parse `pyproject.toml`.
@@ -116,9 +137,7 @@ fn parse_pyproject(path: &Path) -> Option<Vec<Dependency>> {
     // user tried to declare deps and got it wrong — do NOT fall through to
     // requirements.txt and surface stale deps. Treat malformed-but-present as
     // "explicitly declared empty".
-    let project_dependencies_value = parsed
-        .get("project")
-        .and_then(|p| p.get("dependencies"));
+    let project_dependencies_value = parsed.get("project").and_then(|p| p.get("dependencies"));
     let pep621_array = project_dependencies_value.and_then(|d| d.as_array());
     if let Some(arr) = pep621_array {
         let mut out = Vec::new();
@@ -136,7 +155,10 @@ fn parse_pyproject(path: &Path) -> Option<Vec<Dependency>> {
                     continue;
                 }
                 if let Some(name) = strip_python_dep_spec(s) {
-                    out.push(Dependency { name, language: "python".into() });
+                    out.push(Dependency {
+                        name,
+                        language: "python".into(),
+                    });
                 }
             }
         }
@@ -213,9 +235,14 @@ fn parse_pyproject(path: &Path) -> Option<Vec<Dependency>> {
                       out: &mut Vec<Dependency>,
                       seen: &mut std::collections::HashSet<String>| {
         for name in table.keys() {
-            if name == "python" { continue; }
+            if name == "python" {
+                continue;
+            }
             if seen.insert(name.clone()) {
-                out.push(Dependency { name: name.clone(), language: "python".into() });
+                out.push(Dependency {
+                    name: name.clone(),
+                    language: "python".into(),
+                });
             }
         }
     };
@@ -293,9 +320,8 @@ fn parse_requirements_txt(path: &Path) -> Vec<Dependency> {
     let mut out = Vec::new();
     for raw_line in content.lines() {
         let line = raw_line.trim();
-        if line.is_empty()
-            || line.starts_with('#')
-            || line.starts_with('-')   // pip options: -r, -e, --find-links, --no-binary, -c, --pre, etc.
+        if line.is_empty() || line.starts_with('#') || line.starts_with('-')
+        // pip options: -r, -e, --find-links, --no-binary, -c, --pre, etc.
         {
             continue;
         }
@@ -311,7 +337,10 @@ fn parse_requirements_txt(path: &Path) -> Vec<Dependency> {
             let looks_like_url = lhs_trim.contains("://") || lhs_trim.starts_with("git+");
             if !lhs_trim.is_empty() && !looks_like_url {
                 if let Some(name) = strip_python_dep_spec(lhs_trim) {
-                    out.push(Dependency { name, language: "python".into() });
+                    out.push(Dependency {
+                        name,
+                        language: "python".into(),
+                    });
                 }
                 continue;
             }
@@ -337,7 +366,10 @@ fn parse_requirements_txt(path: &Path) -> Vec<Dependency> {
             continue;
         }
         if let Some(name) = strip_python_dep_spec(line) {
-            out.push(Dependency { name, language: "python".into() });
+            out.push(Dependency {
+                name,
+                language: "python".into(),
+            });
         }
     }
     out
@@ -356,12 +388,18 @@ pub fn parse_dependencies(project_dir: &Path) -> Vec<Dependency> {
     }
     let pyp = project_dir.join("pyproject.toml");
     let req = project_dir.join("requirements.txt");
-    let pyproject_deps = if pyp.exists() { parse_pyproject(&pyp) } else { None };
+    let pyproject_deps = if pyp.exists() {
+        parse_pyproject(&pyp)
+    } else {
+        None
+    };
     match pyproject_deps {
         Some(deps) => out.extend(deps),
-        None => if req.exists() {
-            out.extend(parse_requirements_txt(&req));
-        },
+        None => {
+            if req.exists() {
+                out.extend(parse_requirements_txt(&req));
+            }
+        }
     }
     out
 }
@@ -377,7 +415,8 @@ mod tests {
 
     /// Test helper: write a Cargo.toml with the given (name, version) dep pairs in [dependencies].
     fn cargo_with(deps: &[(&str, &str)]) -> String {
-        let mut s = String::from("[package]\nname = \"x\"\nversion = \"0.1.0\"\n\n[dependencies]\n");
+        let mut s =
+            String::from("[package]\nname = \"x\"\nversion = \"0.1.0\"\n\n[dependencies]\n");
         for (n, v) in deps {
             s.push_str(&format!("{n} = \"{v}\"\n"));
         }
@@ -387,16 +426,30 @@ mod tests {
     #[test]
     fn cargo_string_dep_is_parsed() {
         let dir = TempDir::new().unwrap();
-        write(dir.path(), "Cargo.toml", &cargo_with(&[("tokio", "1"), ("serde", "1.0")]));
+        write(
+            dir.path(),
+            "Cargo.toml",
+            &cargo_with(&[("tokio", "1"), ("serde", "1.0")]),
+        );
         let deps = parse_dependencies(dir.path());
-        assert!(deps.iter().any(|d| d.name == "tokio" && d.language == "rust"));
-        assert!(deps.iter().any(|d| d.name == "serde" && d.language == "rust"));
+        assert!(
+            deps.iter()
+                .any(|d| d.name == "tokio" && d.language == "rust")
+        );
+        assert!(
+            deps.iter()
+                .any(|d| d.name == "serde" && d.language == "rust")
+        );
     }
 
     #[test]
     fn cargo_table_dep_is_parsed() {
         let dir = TempDir::new().unwrap();
-        write(dir.path(), "Cargo.toml", "[dependencies]\ntokio = { version = \"1\", features = [\"full\"] }\n");
+        write(
+            dir.path(),
+            "Cargo.toml",
+            "[dependencies]\ntokio = { version = \"1\", features = [\"full\"] }\n",
+        );
         let deps = parse_dependencies(dir.path());
         assert!(deps.iter().any(|d| d.name == "tokio"));
     }
@@ -407,7 +460,10 @@ mod tests {
         // are common in real Rust projects. Skipping them silently drops deps
         // like winapi/nix from enrichment.
         let dir = TempDir::new().unwrap();
-        write(dir.path(), "Cargo.toml", r#"
+        write(
+            dir.path(),
+            "Cargo.toml",
+            r#"
 [target.'cfg(unix)'.dependencies]
 nix = "0.27"
 
@@ -419,19 +475,28 @@ inotify = "0.10"
 
 [target.'cfg(target_os = "macos")'.build-dependencies]
 cc = "1"
-"#);
+"#,
+        );
         let names: Vec<_> = parse_dependencies(dir.path())
-            .iter().map(|d| d.name.clone()).collect();
+            .iter()
+            .map(|d| d.name.clone())
+            .collect();
         for expected in ["nix", "winapi", "inotify", "cc"] {
-            assert!(names.contains(&expected.to_string()),
-                "missing {expected} in {names:?}");
+            assert!(
+                names.contains(&expected.to_string()),
+                "missing {expected} in {names:?}"
+            );
         }
     }
 
     #[test]
     fn cargo_dev_and_build_deps_included() {
         let dir = TempDir::new().unwrap();
-        write(dir.path(), "Cargo.toml", "[dev-dependencies]\ntempfile = \"3\"\n\n[build-dependencies]\ncc = \"1\"\n");
+        write(
+            dir.path(),
+            "Cargo.toml",
+            "[dev-dependencies]\ntempfile = \"3\"\n\n[build-dependencies]\ncc = \"1\"\n",
+        );
         let deps = parse_dependencies(dir.path());
         let names: Vec<_> = deps.iter().map(|d| d.name.as_str()).collect();
         assert!(names.contains(&"tempfile"));
@@ -441,7 +506,11 @@ cc = "1"
     #[test]
     fn cargo_workspace_true_extracts_name() {
         let dir = TempDir::new().unwrap();
-        write(dir.path(), "Cargo.toml", "[dependencies]\ntokio = { workspace = true }\n");
+        write(
+            dir.path(),
+            "Cargo.toml",
+            "[dependencies]\ntokio = { workspace = true }\n",
+        );
         let deps = parse_dependencies(dir.path());
         assert!(deps.iter().any(|d| d.name == "tokio"));
     }
@@ -451,7 +520,11 @@ cc = "1"
         // serde-json in manifest becomes serde_json in code.
         // Without normalization, the imports-filter would never match.
         let dir = TempDir::new().unwrap();
-        write(dir.path(), "Cargo.toml", &cargo_with(&[("serde-json", "1"), ("tokio-stream", "0.1")]));
+        write(
+            dir.path(),
+            "Cargo.toml",
+            &cargo_with(&[("serde-json", "1"), ("tokio-stream", "0.1")]),
+        );
         let deps = parse_dependencies(dir.path());
         let names: Vec<_> = deps.iter().map(|d| d.name.as_str()).collect();
         assert!(names.contains(&"serde_json"), "got {names:?}");
@@ -461,7 +534,11 @@ cc = "1"
     #[test]
     fn cargo_workspace_root_with_only_members_returns_empty() {
         let dir = TempDir::new().unwrap();
-        write(dir.path(), "Cargo.toml", "[workspace]\nmembers = [\"a\", \"b\"]\n");
+        write(
+            dir.path(),
+            "Cargo.toml",
+            "[workspace]\nmembers = [\"a\", \"b\"]\n",
+        );
         let deps = parse_dependencies(dir.path());
         assert!(deps.is_empty());
     }
@@ -472,10 +549,16 @@ cc = "1"
         // is an explicit accepted limitation in the design). Pin this so a future
         // change to broaden parsing is a deliberate decision, not a silent regression.
         let dir = TempDir::new().unwrap();
-        write(dir.path(), "Cargo.toml", "[workspace]\nmembers = [\"a\"]\n\n[workspace.dependencies]\ntokio = \"1\"\n");
+        write(
+            dir.path(),
+            "Cargo.toml",
+            "[workspace]\nmembers = [\"a\"]\n\n[workspace.dependencies]\ntokio = \"1\"\n",
+        );
         let deps = parse_dependencies(dir.path());
-        assert!(!deps.iter().any(|d| d.name == "tokio"),
-            "workspace.dependencies parsing is deferred; got {deps:?}");
+        assert!(
+            !deps.iter().any(|d| d.name == "tokio"),
+            "workspace.dependencies parsing is deferred; got {deps:?}"
+        );
     }
 
     #[test]
@@ -485,21 +568,32 @@ cc = "1"
         // assertion was a stale comment from before that change. Pin the
         // actual contract so a future regression is caught.
         let dir = TempDir::new().unwrap();
-        write(dir.path(), "Cargo.toml", "[dependencies]\ntokio = \"1\"\n\n[dev-dependencies]\ntokio = \"1\"\n");
+        write(
+            dir.path(),
+            "Cargo.toml",
+            "[dependencies]\ntokio = \"1\"\n\n[dev-dependencies]\ntokio = \"1\"\n",
+        );
         let deps = parse_dependencies(dir.path());
         let count = deps.iter().filter(|d| d.name == "tokio").count();
-        assert_eq!(count, 1, "tokio should appear exactly once after dedupe: {deps:?}");
+        assert_eq!(
+            count, 1,
+            "tokio should appear exactly once after dedupe: {deps:?}"
+        );
     }
 
     #[test]
     fn package_json_all_dep_kinds_included() {
         let dir = TempDir::new().unwrap();
-        write(dir.path(), "package.json", r#"{
+        write(
+            dir.path(),
+            "package.json",
+            r#"{
             "dependencies": {"react": "^18"},
             "devDependencies": {"vitest": "^1"},
             "peerDependencies": {"@types/react": "^18"},
             "optionalDependencies": {"fsevents": "*"}
-        }"#);
+        }"#,
+        );
         let deps = parse_dependencies(dir.path());
         let names: Vec<_> = deps.iter().map(|d| d.name.as_str()).collect();
         for n in ["react", "vitest", "@types/react", "fsevents"] {
@@ -517,20 +611,31 @@ cc = "1"
         // dedupes by name, so this is a cleanliness/consistency fix
         // rather than a behavioral one.
         let dir = TempDir::new().unwrap();
-        write(dir.path(), "package.json", r#"{
+        write(
+            dir.path(),
+            "package.json",
+            r#"{
             "dependencies": {"react": "^18"},
             "peerDependencies": {"react": "^18"},
             "devDependencies": {"react": "^18"}
-        }"#);
+        }"#,
+        );
         let deps = parse_dependencies(dir.path());
         let count = deps.iter().filter(|d| d.name == "react").count();
-        assert_eq!(count, 1, "react should appear exactly once after dedupe: {deps:?}");
+        assert_eq!(
+            count, 1,
+            "react should appear exactly once after dedupe: {deps:?}"
+        );
     }
 
     #[test]
     fn package_json_scoped_packages_kept_verbatim() {
         let dir = TempDir::new().unwrap();
-        write(dir.path(), "package.json", r#"{"dependencies": {"@nestjs/core": "^10"}}"#);
+        write(
+            dir.path(),
+            "package.json",
+            r#"{"dependencies": {"@nestjs/core": "^10"}}"#,
+        );
         let deps = parse_dependencies(dir.path());
         assert!(deps.iter().any(|d| d.name == "@nestjs/core"));
     }
@@ -538,7 +643,11 @@ cc = "1"
     #[test]
     fn package_json_dependencies_get_typescript_language_when_project_is_typescript() {
         let dir = TempDir::new().unwrap();
-        write(dir.path(), "package.json", r#"{"dependencies": {"react": "^18"}}"#);
+        write(
+            dir.path(),
+            "package.json",
+            r#"{"dependencies": {"react": "^18"}}"#,
+        );
         write(dir.path(), "tsconfig.json", "{}");
         let deps = parse_dependencies(dir.path());
         assert!(deps.iter().all(|d| d.language == "typescript"));
@@ -547,7 +656,11 @@ cc = "1"
     #[test]
     fn package_json_dependencies_get_javascript_language_when_project_is_not_typescript() {
         let dir = TempDir::new().unwrap();
-        write(dir.path(), "package.json", r#"{"dependencies": {"react": "^18"}}"#);
+        write(
+            dir.path(),
+            "package.json",
+            r#"{"dependencies": {"react": "^18"}}"#,
+        );
         let deps = parse_dependencies(dir.path());
         assert!(deps.iter().all(|d| d.language == "javascript"));
     }
@@ -563,11 +676,15 @@ cc = "1"
     #[test]
     fn pyproject_pep621_deps_parsed_with_extras_and_versions_stripped() {
         let dir = TempDir::new().unwrap();
-        write(dir.path(), "pyproject.toml", r#"
+        write(
+            dir.path(),
+            "pyproject.toml",
+            r#"
 [project]
 name = "x"
 dependencies = ["fastapi>=0.100", "pydantic[email]>=2", "httpx"]
-"#);
+"#,
+        );
         let deps = parse_dependencies(dir.path());
         let mut names: Vec<_> = deps.iter().map(|d| d.name.clone()).collect();
         names.sort();
@@ -578,12 +695,16 @@ dependencies = ["fastapi>=0.100", "pydantic[email]>=2", "httpx"]
     #[test]
     fn pyproject_poetry_deps_parsed_excluding_python_key() {
         let dir = TempDir::new().unwrap();
-        write(dir.path(), "pyproject.toml", r#"
+        write(
+            dir.path(),
+            "pyproject.toml",
+            r#"
 [tool.poetry.dependencies]
 python = "^3.11"
 fastapi = "^0.100"
 httpx = { version = "*" }
-"#);
+"#,
+        );
         let deps = parse_dependencies(dir.path());
         let mut names: Vec<_> = deps.iter().map(|d| d.name.clone()).collect();
         names.sort();
@@ -593,24 +714,45 @@ httpx = { version = "*" }
     #[test]
     fn requirements_txt_skips_comments_and_blanks() {
         let dir = TempDir::new().unwrap();
-        write(dir.path(), "requirements.txt", "# top comment\n\nfastapi\n# inline comment after\n");
-        let names: Vec<_> = parse_dependencies(dir.path()).iter().map(|d| d.name.clone()).collect();
+        write(
+            dir.path(),
+            "requirements.txt",
+            "# top comment\n\nfastapi\n# inline comment after\n",
+        );
+        let names: Vec<_> = parse_dependencies(dir.path())
+            .iter()
+            .map(|d| d.name.clone())
+            .collect();
         assert_eq!(names, vec!["fastapi"]);
     }
 
     #[test]
     fn requirements_txt_skips_includes_and_editable() {
         let dir = TempDir::new().unwrap();
-        write(dir.path(), "requirements.txt", "fastapi\n-r dev.txt\n-e .\n");
-        let names: Vec<_> = parse_dependencies(dir.path()).iter().map(|d| d.name.clone()).collect();
+        write(
+            dir.path(),
+            "requirements.txt",
+            "fastapi\n-r dev.txt\n-e .\n",
+        );
+        let names: Vec<_> = parse_dependencies(dir.path())
+            .iter()
+            .map(|d| d.name.clone())
+            .collect();
         assert_eq!(names, vec!["fastapi"]);
     }
 
     #[test]
     fn requirements_txt_skips_vcs_urls() {
         let dir = TempDir::new().unwrap();
-        write(dir.path(), "requirements.txt", "fastapi\ngit+https://github.com/x/y.git\nhttps://example.com/pkg.whl\n");
-        let names: Vec<_> = parse_dependencies(dir.path()).iter().map(|d| d.name.clone()).collect();
+        write(
+            dir.path(),
+            "requirements.txt",
+            "fastapi\ngit+https://github.com/x/y.git\nhttps://example.com/pkg.whl\n",
+        );
+        let names: Vec<_> = parse_dependencies(dir.path())
+            .iter()
+            .map(|d| d.name.clone())
+            .collect();
         assert_eq!(names, vec!["fastapi"]);
     }
 
@@ -622,10 +764,15 @@ httpx = { version = "*" }
     #[test]
     fn requirements_txt_keeps_pep508_named_git_url() {
         let dir = TempDir::new().unwrap();
-        write(dir.path(), "requirements.txt",
-            "fastapi\nmypkg @ git+https://github.com/foo/bar.git\n");
+        write(
+            dir.path(),
+            "requirements.txt",
+            "fastapi\nmypkg @ git+https://github.com/foo/bar.git\n",
+        );
         let mut names: Vec<_> = parse_dependencies(dir.path())
-            .iter().map(|d| d.name.clone()).collect();
+            .iter()
+            .map(|d| d.name.clone())
+            .collect();
         names.sort();
         assert_eq!(names, vec!["fastapi", "mypkg"]);
     }
@@ -633,10 +780,15 @@ httpx = { version = "*" }
     #[test]
     fn requirements_txt_keeps_pep508_named_https_wheel() {
         let dir = TempDir::new().unwrap();
-        write(dir.path(), "requirements.txt",
-            "wheelpkg @ https://example.com/pkg.whl\n");
+        write(
+            dir.path(),
+            "requirements.txt",
+            "wheelpkg @ https://example.com/pkg.whl\n",
+        );
         let names: Vec<_> = parse_dependencies(dir.path())
-            .iter().map(|d| d.name.clone()).collect();
+            .iter()
+            .map(|d| d.name.clone())
+            .collect();
         assert_eq!(names, vec!["wheelpkg"]);
     }
 
@@ -644,10 +796,15 @@ httpx = { version = "*" }
     fn requirements_txt_keeps_pep508_named_url_with_extras() {
         // `mypkg[extra1,extra2] @ git+https://...` -> name `mypkg`, extras dropped.
         let dir = TempDir::new().unwrap();
-        write(dir.path(), "requirements.txt",
-            "mypkg[email,async] @ git+https://github.com/foo/bar.git\n");
+        write(
+            dir.path(),
+            "requirements.txt",
+            "mypkg[email,async] @ git+https://github.com/foo/bar.git\n",
+        );
         let names: Vec<_> = parse_dependencies(dir.path())
-            .iter().map(|d| d.name.clone()).collect();
+            .iter()
+            .map(|d| d.name.clone())
+            .collect();
         assert_eq!(names, vec!["mypkg"]);
     }
 
@@ -657,10 +814,15 @@ httpx = { version = "*" }
         // bare `git+https://...` and `https://...` with no `name @` prefix
         // must still be skipped (no valid dep name to extract).
         let dir = TempDir::new().unwrap();
-        write(dir.path(), "requirements.txt",
-            "fastapi\ngit+https://github.com/x/y.git\nhttps://example.com/pkg.whl\n");
+        write(
+            dir.path(),
+            "requirements.txt",
+            "fastapi\ngit+https://github.com/x/y.git\nhttps://example.com/pkg.whl\n",
+        );
         let names: Vec<_> = parse_dependencies(dir.path())
-            .iter().map(|d| d.name.clone()).collect();
+            .iter()
+            .map(|d| d.name.clone())
+            .collect();
         assert_eq!(names, vec!["fastapi"]);
     }
 
@@ -668,10 +830,15 @@ httpx = { version = "*" }
     fn requirements_txt_skips_at_with_empty_name() {
         // ` @ git+https://...` (no name before @) must NOT yield an empty-string dep.
         let dir = TempDir::new().unwrap();
-        write(dir.path(), "requirements.txt",
-            " @ git+https://github.com/x/y.git\nfastapi\n");
+        write(
+            dir.path(),
+            "requirements.txt",
+            " @ git+https://github.com/x/y.git\nfastapi\n",
+        );
         let names: Vec<_> = parse_dependencies(dir.path())
-            .iter().map(|d| d.name.clone()).collect();
+            .iter()
+            .map(|d| d.name.clone())
+            .collect();
         assert_eq!(names, vec!["fastapi"]);
     }
 
@@ -681,10 +848,15 @@ httpx = { version = "*" }
         // strip_python_dep_spec splits on whitespace first, so it handles this
         // — pin it so a future tightening doesn't regress.
         let dir = TempDir::new().unwrap();
-        write(dir.path(), "requirements.txt",
-            "mypkg [email,async] @ git+https://github.com/foo/bar.git\n");
+        write(
+            dir.path(),
+            "requirements.txt",
+            "mypkg [email,async] @ git+https://github.com/foo/bar.git\n",
+        );
         let names: Vec<_> = parse_dependencies(dir.path())
-            .iter().map(|d| d.name.clone()).collect();
+            .iter()
+            .map(|d| d.name.clone())
+            .collect();
         assert_eq!(names, vec!["mypkg"]);
     }
 
@@ -696,13 +868,18 @@ httpx = { version = "*" }
         // form. Earlier naive split_once('@') yielded bogus deps like
         // "https://user" or "git+ssh://user".
         let dir = TempDir::new().unwrap();
-        write(dir.path(), "requirements.txt",
+        write(
+            dir.path(),
+            "requirements.txt",
             "fastapi\n\
              https://user@example.com/pkg.whl\n\
              git+ssh://git@github.com/foo/bar.git\n\
-             git+https://token:x-oauth-basic@github.com/foo/bar.git\n");
+             git+https://token:x-oauth-basic@github.com/foo/bar.git\n",
+        );
         let names: Vec<_> = parse_dependencies(dir.path())
-            .iter().map(|d| d.name.clone()).collect();
+            .iter()
+            .map(|d| d.name.clone())
+            .collect();
         assert_eq!(names, vec!["fastapi"]);
     }
 
@@ -713,13 +890,18 @@ httpx = { version = "*" }
         // previously be emitted as fake deps named "./dist/pkg.whl" etc.
         // Path-shaped tokens are NOT package names; skip them.
         let dir = TempDir::new().unwrap();
-        write(dir.path(), "requirements.txt",
+        write(
+            dir.path(),
+            "requirements.txt",
             "fastapi\n\
              ./dist/pkg.whl\n\
              ../lib\n\
-             /opt/pkg.tar.gz\n");
+             /opt/pkg.tar.gz\n",
+        );
         let names: Vec<_> = parse_dependencies(dir.path())
-            .iter().map(|d| d.name.clone()).collect();
+            .iter()
+            .map(|d| d.name.clone())
+            .collect();
         assert_eq!(names, vec!["fastapi"]);
     }
 
@@ -730,15 +912,20 @@ httpx = { version = "*" }
         // `--find-links`, `--no-binary`, `--index-url`, `-c constraints.txt`
         // all currently fell through to strip_python_dep_spec and were emitted.
         let dir = TempDir::new().unwrap();
-        write(dir.path(), "requirements.txt",
+        write(
+            dir.path(),
+            "requirements.txt",
             "--find-links ./wheels\n\
              --no-binary :all:\n\
              --index-url https://pypi.example.com/simple\n\
              -c constraints.txt\n\
              --pre\n\
-             fastapi\n");
+             fastapi\n",
+        );
         let names: Vec<_> = parse_dependencies(dir.path())
-            .iter().map(|d| d.name.clone()).collect();
+            .iter()
+            .map(|d| d.name.clone())
+            .collect();
         assert_eq!(names, vec!["fastapi"]);
     }
 
@@ -748,15 +935,21 @@ httpx = { version = "*" }
         // form already survives via strip_python_dep_spec stopping at the space,
         // but pin it explicitly so a future tighter URL filter doesn't regress it.
         let dir = TempDir::new().unwrap();
-        write(dir.path(), "pyproject.toml", r#"
+        write(
+            dir.path(),
+            "pyproject.toml",
+            r#"
 [project]
 dependencies = [
   "fastapi",
   "name @ git+https://github.com/a/b.git",
 ]
-"#);
+"#,
+        );
         let mut names: Vec<_> = parse_dependencies(dir.path())
-            .iter().map(|d| d.name.clone()).collect();
+            .iter()
+            .map(|d| d.name.clone())
+            .collect();
         names.sort();
         assert_eq!(names, vec!["fastapi", "name"]);
     }
@@ -768,16 +961,22 @@ dependencies = [
         // strip_python_dep_spec lacked `@` in its terminator list, so the
         // no-spaces form returned the literal "name@url" as the package name.
         let dir = TempDir::new().unwrap();
-        write(dir.path(), "pyproject.toml", r#"
+        write(
+            dir.path(),
+            "pyproject.toml",
+            r#"
 [project]
 dependencies = [
   "fastapi",
   "mypkg@https://example.com/pkg.whl",
   "other@git+https://github.com/a/b.git",
 ]
-"#);
+"#,
+        );
         let mut names: Vec<_> = parse_dependencies(dir.path())
-            .iter().map(|d| d.name.clone()).collect();
+            .iter()
+            .map(|d| d.name.clone())
+            .collect();
         names.sort();
         assert_eq!(names, vec!["fastapi", "mypkg", "other"]);
     }
@@ -785,8 +984,15 @@ dependencies = [
     #[test]
     fn requirements_txt_strips_version_specifiers() {
         let dir = TempDir::new().unwrap();
-        write(dir.path(), "requirements.txt", "fastapi>=0.100\nrequests==2.31.0\n");
-        let mut names: Vec<_> = parse_dependencies(dir.path()).iter().map(|d| d.name.clone()).collect();
+        write(
+            dir.path(),
+            "requirements.txt",
+            "fastapi>=0.100\nrequests==2.31.0\n",
+        );
+        let mut names: Vec<_> = parse_dependencies(dir.path())
+            .iter()
+            .map(|d| d.name.clone())
+            .collect();
         names.sort();
         assert_eq!(names, vec!["fastapi", "requests"]);
     }
@@ -794,9 +1000,16 @@ dependencies = [
     #[test]
     fn requirements_txt_skipped_when_pyproject_present() {
         let dir = TempDir::new().unwrap();
-        write(dir.path(), "pyproject.toml", "[project]\ndependencies = [\"fastapi\"]\n");
+        write(
+            dir.path(),
+            "pyproject.toml",
+            "[project]\ndependencies = [\"fastapi\"]\n",
+        );
         write(dir.path(), "requirements.txt", "django\n");
-        let names: Vec<_> = parse_dependencies(dir.path()).iter().map(|d| d.name.clone()).collect();
+        let names: Vec<_> = parse_dependencies(dir.path())
+            .iter()
+            .map(|d| d.name.clone())
+            .collect();
         assert_eq!(names, vec!["fastapi"]);
     }
 
@@ -807,17 +1020,24 @@ dependencies = [
         // silently fell through to [tool.poetry.dependencies], merging two
         // dep-source-of-truth sections.
         let dir = TempDir::new().unwrap();
-        write(dir.path(), "pyproject.toml", r#"
+        write(
+            dir.path(),
+            "pyproject.toml",
+            r#"
 [project]
 dependencies = []
 
 [tool.poetry.dependencies]
 django = "*"
-"#);
+"#,
+        );
         let deps = parse_dependencies(dir.path());
         let names: Vec<_> = deps.iter().map(|d| d.name.clone()).collect();
-        assert_eq!(names, Vec::<String>::new(),
-            "empty PEP 621 array must win, not fall through to Poetry: {names:?}");
+        assert_eq!(
+            names,
+            Vec::<String>::new(),
+            "empty PEP 621 array must win, not fall through to Poetry: {names:?}"
+        );
     }
 
     // --- Bug 2: pyproject without recognized section silently dropped requirements.txt ---
@@ -830,9 +1050,16 @@ django = "*"
         // Build-system-only pyproject: no [project] AND no [tool.poetry] →
         // pyproject yields nothing useful → requirements.txt should win.
         let dir = TempDir::new().unwrap();
-        write(dir.path(), "pyproject.toml", "[build-system]\nrequires = [\"setuptools\"]\n");
+        write(
+            dir.path(),
+            "pyproject.toml",
+            "[build-system]\nrequires = [\"setuptools\"]\n",
+        );
         write(dir.path(), "requirements.txt", "fastapi\n");
-        let names: Vec<_> = parse_dependencies(dir.path()).iter().map(|d| d.name.clone()).collect();
+        let names: Vec<_> = parse_dependencies(dir.path())
+            .iter()
+            .map(|d| d.name.clone())
+            .collect();
         assert_eq!(names, vec!["fastapi"]);
     }
 
@@ -843,7 +1070,10 @@ django = "*"
         let dir = TempDir::new().unwrap();
         write(dir.path(), "pyproject.toml", "this is not valid toml ===\n");
         write(dir.path(), "requirements.txt", "django\n");
-        let names: Vec<_> = parse_dependencies(dir.path()).iter().map(|d| d.name.clone()).collect();
+        let names: Vec<_> = parse_dependencies(dir.path())
+            .iter()
+            .map(|d| d.name.clone())
+            .collect();
         assert_eq!(names, vec!["django"]);
     }
 
@@ -856,16 +1086,25 @@ django = "*"
         // `[project]` with a malformed dependencies key as "explicitly
         // declared zero deps" and stop there.
         let dir = TempDir::new().unwrap();
-        write(dir.path(), "pyproject.toml", r#"
+        write(
+            dir.path(),
+            "pyproject.toml",
+            r#"
 [project]
 name = "broken"
 dependencies = "this should be an array"
-"#);
+"#,
+        );
         write(dir.path(), "requirements.txt", "fastapi\n");
         let names: Vec<_> = parse_dependencies(dir.path())
-            .iter().map(|d| d.name.clone()).collect();
-        assert_eq!(names, Vec::<String>::new(),
-            "wrong-type dependencies must NOT fall through to requirements.txt");
+            .iter()
+            .map(|d| d.name.clone())
+            .collect();
+        assert_eq!(
+            names,
+            Vec::<String>::new(),
+            "wrong-type dependencies must NOT fall through to requirements.txt"
+        );
     }
 
     #[test]
@@ -876,16 +1115,25 @@ dependencies = "this should be an array"
         // the user *tried* to declare Poetry deps. Falling through to
         // requirements.txt would surface stale or wrong deps.
         let dir = TempDir::new().unwrap();
-        write(dir.path(), "pyproject.toml", r#"
+        write(
+            dir.path(),
+            "pyproject.toml",
+            r#"
 [tool.poetry]
 name = "broken"
 dependencies = "this should be a table"
-"#);
+"#,
+        );
         write(dir.path(), "requirements.txt", "fastapi\n");
         let names: Vec<_> = parse_dependencies(dir.path())
-            .iter().map(|d| d.name.clone()).collect();
-        assert_eq!(names, Vec::<String>::new(),
-            "Poetry wrong-type dependencies must NOT fall through to requirements.txt");
+            .iter()
+            .map(|d| d.name.clone())
+            .collect();
+        assert_eq!(
+            names,
+            Vec::<String>::new(),
+            "Poetry wrong-type dependencies must NOT fall through to requirements.txt"
+        );
     }
 
     #[test]
@@ -895,14 +1143,20 @@ dependencies = "this should be a table"
         // is "no Poetry deps section" — should still fall through to
         // requirements.txt.
         let dir = TempDir::new().unwrap();
-        write(dir.path(), "pyproject.toml", r#"
+        write(
+            dir.path(),
+            "pyproject.toml",
+            r#"
 [tool.poetry]
 name = "myproj"
 version = "0.1.0"
-"#);
+"#,
+        );
         write(dir.path(), "requirements.txt", "django\n");
         let names: Vec<_> = parse_dependencies(dir.path())
-            .iter().map(|d| d.name.clone()).collect();
+            .iter()
+            .map(|d| d.name.clone())
+            .collect();
         assert_eq!(names, vec!["django"]);
     }
 
@@ -913,7 +1167,10 @@ version = "0.1.0"
         // The parser used to ignore that section entirely, missing
         // pytest/black/etc. in any project still on the legacy layout.
         let dir = TempDir::new().unwrap();
-        write(dir.path(), "pyproject.toml", r#"
+        write(
+            dir.path(),
+            "pyproject.toml",
+            r#"
 [tool.poetry]
 name = "legacy"
 
@@ -924,9 +1181,12 @@ fastapi = "^0.100"
 [tool.poetry.dev-dependencies]
 pytest = "^7"
 black = "^23"
-"#);
+"#,
+        );
         let names: Vec<_> = parse_dependencies(dir.path())
-            .iter().map(|d| d.name.clone()).collect();
+            .iter()
+            .map(|d| d.name.clone())
+            .collect();
         for n in ["fastapi", "pytest", "black"] {
             assert!(names.contains(&n.to_string()), "missing {n} in {names:?}");
         }
@@ -939,7 +1199,10 @@ black = "^23"
         // group (dev, test, lint, docs, ...) contributes deps. The
         // parser used to ignore them entirely.
         let dir = TempDir::new().unwrap();
-        write(dir.path(), "pyproject.toml", r#"
+        write(
+            dir.path(),
+            "pyproject.toml",
+            r#"
 [tool.poetry]
 name = "modern"
 
@@ -952,9 +1215,12 @@ pytest = "^8"
 
 [tool.poetry.group.lint.dependencies]
 ruff = "^0.5"
-"#);
+"#,
+        );
         let names: Vec<_> = parse_dependencies(dir.path())
-            .iter().map(|d| d.name.clone()).collect();
+            .iter()
+            .map(|d| d.name.clone())
+            .collect();
         for n in ["django", "pytest", "ruff"] {
             assert!(names.contains(&n.to_string()), "missing {n} in {names:?}");
         }
@@ -969,18 +1235,27 @@ ruff = "^0.5"
         // the requirements.txt fallback. Now we only count groups that
         // actually contain a `dependencies` key.
         let dir = TempDir::new().unwrap();
-        write(dir.path(), "pyproject.toml", r#"
+        write(
+            dir.path(),
+            "pyproject.toml",
+            r#"
 [tool.poetry]
 name = "metadata-only-groups"
 
 [tool.poetry.group.dev]
 optional = true
-"#);
+"#,
+        );
         write(dir.path(), "requirements.txt", "django\n");
         let names: Vec<_> = parse_dependencies(dir.path())
-            .iter().map(|d| d.name.clone()).collect();
-        assert_eq!(names, vec!["django"],
-            "metadata-only Poetry groups should not block requirements.txt: {names:?}");
+            .iter()
+            .map(|d| d.name.clone())
+            .collect();
+        assert_eq!(
+            names,
+            vec!["django"],
+            "metadata-only Poetry groups should not block requirements.txt: {names:?}"
+        );
     }
 
     #[test]
@@ -991,15 +1266,24 @@ optional = true
         // probe-all-three guard falls through to requirements.txt.
         // The user *clearly* intended Poetry; warn and treat as empty.
         let dir = TempDir::new().unwrap();
-        write(dir.path(), "pyproject.toml", r#"
+        write(
+            dir.path(),
+            "pyproject.toml",
+            r#"
 [tool]
 poetry = "this should be a table"
-"#);
+"#,
+        );
         write(dir.path(), "requirements.txt", "WRONG_SHOULD_NOT_APPEAR\n");
         let names: Vec<_> = parse_dependencies(dir.path())
-            .iter().map(|d| d.name.clone()).collect();
-        assert_eq!(names, Vec::<String>::new(),
-            "wrong-type [tool.poetry] root must NOT fall through: {names:?}");
+            .iter()
+            .map(|d| d.name.clone())
+            .collect();
+        assert_eq!(
+            names,
+            Vec::<String>::new(),
+            "wrong-type [tool.poetry] root must NOT fall through: {names:?}"
+        );
     }
 
     #[test]
@@ -1012,28 +1296,41 @@ poetry = "this should be a table"
         // for any project with a malformed main table — strictly worse
         // than the prior state. Warn but continue.
         let dir = TempDir::new().unwrap();
-        write(dir.path(), "pyproject.toml", r#"
+        write(
+            dir.path(),
+            "pyproject.toml",
+            r#"
 [tool.poetry]
 name = "broken-main-good-dev"
 dependencies = "this should be a table"
 
 [tool.poetry.dev-dependencies]
 pytest = "^7"
-"#);
+"#,
+        );
         write(dir.path(), "requirements.txt", "WRONG_SHOULD_NOT_APPEAR\n");
         let names: Vec<_> = parse_dependencies(dir.path())
-            .iter().map(|d| d.name.clone()).collect();
-        assert!(names.contains(&"pytest".into()),
-            "valid dev-deps must still be parsed when main is malformed: {names:?}");
-        assert!(!names.contains(&"WRONG_SHOULD_NOT_APPEAR".into()),
-            "must not fall through to requirements.txt: {names:?}");
+            .iter()
+            .map(|d| d.name.clone())
+            .collect();
+        assert!(
+            names.contains(&"pytest".into()),
+            "valid dev-deps must still be parsed when main is malformed: {names:?}"
+        );
+        assert!(
+            !names.contains(&"WRONG_SHOULD_NOT_APPEAR".into()),
+            "must not fall through to requirements.txt: {names:?}"
+        );
     }
 
     #[test]
     fn pyproject_wrong_type_main_poetry_deps_still_picks_up_valid_groups() {
         // Same shape with modern Poetry 1.2+ groups.
         let dir = TempDir::new().unwrap();
-        write(dir.path(), "pyproject.toml", r#"
+        write(
+            dir.path(),
+            "pyproject.toml",
+            r#"
 [tool.poetry]
 name = "broken-main-good-groups"
 dependencies = ["should", "be", "a", "table", "not", "array"]
@@ -1043,16 +1340,23 @@ pytest = "^8"
 
 [tool.poetry.group.lint.dependencies]
 ruff = "^0.5"
-"#);
+"#,
+        );
         write(dir.path(), "requirements.txt", "WRONG_SHOULD_NOT_APPEAR\n");
         let names: Vec<_> = parse_dependencies(dir.path())
-            .iter().map(|d| d.name.clone()).collect();
+            .iter()
+            .map(|d| d.name.clone())
+            .collect();
         for n in ["pytest", "ruff"] {
-            assert!(names.contains(&n.to_string()),
-                "valid group {n} must be parsed when main is malformed: {names:?}");
+            assert!(
+                names.contains(&n.to_string()),
+                "valid group {n} must be parsed when main is malformed: {names:?}"
+            );
         }
-        assert!(!names.contains(&"WRONG_SHOULD_NOT_APPEAR".into()),
-            "must not fall through to requirements.txt: {names:?}");
+        assert!(
+            !names.contains(&"WRONG_SHOULD_NOT_APPEAR".into()),
+            "must not fall through to requirements.txt: {names:?}"
+        );
     }
 
     #[test]
@@ -1064,7 +1368,10 @@ ruff = "^0.5"
         // explicitly empty, matching the existing wrong-type guards on
         // [project].dependencies and [tool.poetry.dependencies] (CR7).
         let dir = TempDir::new().unwrap();
-        write(dir.path(), "pyproject.toml", r#"
+        write(
+            dir.path(),
+            "pyproject.toml",
+            r#"
 [tool.poetry]
 name = "broken-dev"
 
@@ -1072,14 +1379,21 @@ name = "broken-dev"
 fastapi = "^0.100"
 
 dev-dependencies = "this should be a table"
-"#);
+"#,
+        );
         write(dir.path(), "requirements.txt", "WRONG_SHOULD_NOT_APPEAR\n");
         let names: Vec<_> = parse_dependencies(dir.path())
-            .iter().map(|d| d.name.clone()).collect();
-        assert!(names.contains(&"fastapi".into()),
-            "main deps must still parse: {names:?}");
-        assert!(!names.contains(&"WRONG_SHOULD_NOT_APPEAR".into()),
-            "must not fall through to requirements.txt: {names:?}");
+            .iter()
+            .map(|d| d.name.clone())
+            .collect();
+        assert!(
+            names.contains(&"fastapi".into()),
+            "main deps must still parse: {names:?}"
+        );
+        assert!(
+            !names.contains(&"WRONG_SHOULD_NOT_APPEAR".into()),
+            "must not fall through to requirements.txt: {names:?}"
+        );
     }
 
     #[test]
@@ -1087,20 +1401,31 @@ dev-dependencies = "this should be a table"
         // Same shape, applied to the [tool.poetry.group] table itself
         // (e.g. someone wrote `group = "dev"` instead of nested tables).
         let dir = TempDir::new().unwrap();
-        write(dir.path(), "pyproject.toml", r#"
+        write(
+            dir.path(),
+            "pyproject.toml",
+            r#"
 [tool.poetry]
 name = "broken-group"
 group = "this should be a table of groups"
 
 [tool.poetry.dependencies]
 django = "^5"
-"#);
+"#,
+        );
         write(dir.path(), "requirements.txt", "WRONG_SHOULD_NOT_APPEAR\n");
         let names: Vec<_> = parse_dependencies(dir.path())
-            .iter().map(|d| d.name.clone()).collect();
-        assert!(names.contains(&"django".into()), "main deps must still parse: {names:?}");
-        assert!(!names.contains(&"WRONG_SHOULD_NOT_APPEAR".into()),
-            "must not fall through to requirements.txt: {names:?}");
+            .iter()
+            .map(|d| d.name.clone())
+            .collect();
+        assert!(
+            names.contains(&"django".into()),
+            "main deps must still parse: {names:?}"
+        );
+        assert!(
+            !names.contains(&"WRONG_SHOULD_NOT_APPEAR".into()),
+            "must not fall through to requirements.txt: {names:?}"
+        );
     }
 
     #[test]
@@ -1109,7 +1434,10 @@ django = "^5"
         // [tool.poetry.group.dev] should be skipped with a warn while
         // [tool.poetry.group.lint.dependencies] still contributes ruff.
         let dir = TempDir::new().unwrap();
-        write(dir.path(), "pyproject.toml", r#"
+        write(
+            dir.path(),
+            "pyproject.toml",
+            r#"
 [tool.poetry]
 name = "mixed-groups"
 
@@ -1118,11 +1446,16 @@ dev = "this should be a sub-table"
 
 [tool.poetry.group.lint.dependencies]
 ruff = "^0.5"
-"#);
+"#,
+        );
         let names: Vec<_> = parse_dependencies(dir.path())
-            .iter().map(|d| d.name.clone()).collect();
-        assert!(names.contains(&"ruff".into()),
-            "valid sibling group must still parse: {names:?}");
+            .iter()
+            .map(|d| d.name.clone())
+            .collect();
+        assert!(
+            names.contains(&"ruff".into()),
+            "valid sibling group must still parse: {names:?}"
+        );
     }
 
     #[test]
@@ -1133,22 +1466,36 @@ ruff = "^0.5"
         // — losing the dev-deps entirely. The fix must treat any of
         // {main, dev, group} as a valid signal that Poetry owns this project.
         let dir = TempDir::new().unwrap();
-        write(dir.path(), "pyproject.toml", r#"
+        write(
+            dir.path(),
+            "pyproject.toml",
+            r#"
 [tool.poetry]
 name = "devtools-only"
 
 [tool.poetry.dev-dependencies]
 pytest = "^7"
 black = "^23"
-"#);
+"#,
+        );
         // Sentinel: if we incorrectly fall through, this would leak in.
         write(dir.path(), "requirements.txt", "WRONG_SHOULD_NOT_APPEAR\n");
         let names: Vec<_> = parse_dependencies(dir.path())
-            .iter().map(|d| d.name.clone()).collect();
-        assert!(names.contains(&"pytest".into()), "pytest missing in {names:?}");
-        assert!(names.contains(&"black".into()), "black missing in {names:?}");
-        assert!(!names.contains(&"WRONG_SHOULD_NOT_APPEAR".into()),
-            "must not fall through to requirements.txt: {names:?}");
+            .iter()
+            .map(|d| d.name.clone())
+            .collect();
+        assert!(
+            names.contains(&"pytest".into()),
+            "pytest missing in {names:?}"
+        );
+        assert!(
+            names.contains(&"black".into()),
+            "black missing in {names:?}"
+        );
+        assert!(
+            !names.contains(&"WRONG_SHOULD_NOT_APPEAR".into()),
+            "must not fall through to requirements.txt: {names:?}"
+        );
     }
 
     #[test]
@@ -1156,7 +1503,10 @@ black = "^23"
         // Same shape as the legacy-only case, but with modern Poetry 1.2+
         // groups and no main [tool.poetry.dependencies] table.
         let dir = TempDir::new().unwrap();
-        write(dir.path(), "pyproject.toml", r#"
+        write(
+            dir.path(),
+            "pyproject.toml",
+            r#"
 [tool.poetry]
 name = "groups-only"
 
@@ -1165,14 +1515,22 @@ ruff = "^0.5"
 
 [tool.poetry.group.test.dependencies]
 pytest = "^8"
-"#);
+"#,
+        );
         write(dir.path(), "requirements.txt", "WRONG_SHOULD_NOT_APPEAR\n");
         let names: Vec<_> = parse_dependencies(dir.path())
-            .iter().map(|d| d.name.clone()).collect();
+            .iter()
+            .map(|d| d.name.clone())
+            .collect();
         assert!(names.contains(&"ruff".into()), "ruff missing in {names:?}");
-        assert!(names.contains(&"pytest".into()), "pytest missing in {names:?}");
-        assert!(!names.contains(&"WRONG_SHOULD_NOT_APPEAR".into()),
-            "must not fall through to requirements.txt: {names:?}");
+        assert!(
+            names.contains(&"pytest".into()),
+            "pytest missing in {names:?}"
+        );
+        assert!(
+            !names.contains(&"WRONG_SHOULD_NOT_APPEAR".into()),
+            "must not fall through to requirements.txt: {names:?}"
+        );
     }
 
     #[test]
@@ -1181,7 +1539,10 @@ pytest = "^8"
         // main + override in dev) yields one entry, mirroring parse_cargo
         // and the new package.json contract.
         let dir = TempDir::new().unwrap();
-        write(dir.path(), "pyproject.toml", r#"
+        write(
+            dir.path(),
+            "pyproject.toml",
+            r#"
 [tool.poetry.dependencies]
 requests = "^2"
 
@@ -1190,10 +1551,14 @@ requests = "^2"
 
 [tool.poetry.group.test.dependencies]
 requests = "^2"
-"#);
+"#,
+        );
         let deps = parse_dependencies(dir.path());
         let count = deps.iter().filter(|d| d.name == "requests").count();
-        assert_eq!(count, 1, "requests should appear exactly once after dedupe: {deps:?}");
+        assert_eq!(
+            count, 1,
+            "requests should appear exactly once after dedupe: {deps:?}"
+        );
     }
 
     #[test]
@@ -1202,14 +1567,20 @@ requests = "^2"
         // and NO `dependencies` key at all is "no PEP 621 deps section" —
         // should still fall through to requirements.txt or Poetry.
         let dir = TempDir::new().unwrap();
-        write(dir.path(), "pyproject.toml", r#"
+        write(
+            dir.path(),
+            "pyproject.toml",
+            r#"
 [project]
 name = "myproj"
 version = "0.1.0"
-"#);
+"#,
+        );
         write(dir.path(), "requirements.txt", "fastapi\n");
         let names: Vec<_> = parse_dependencies(dir.path())
-            .iter().map(|d| d.name.clone()).collect();
+            .iter()
+            .map(|d| d.name.clone())
+            .collect();
         assert_eq!(names, vec!["fastapi"]);
     }
 
@@ -1220,14 +1591,19 @@ version = "0.1.0"
         // The previous path heuristic only caught lines with `/` or leading
         // `.`/`/`. Bare filenames slipped through.
         let dir = TempDir::new().unwrap();
-        write(dir.path(), "requirements.txt",
+        write(
+            dir.path(),
+            "requirements.txt",
             "fastapi\n\
              mypkg-1.0.0-py3-none-any.whl\n\
              package.tar.gz\n\
              archive.zip\n\
-             plugin.egg\n");
+             plugin.egg\n",
+        );
         let names: Vec<_> = parse_dependencies(dir.path())
-            .iter().map(|d| d.name.clone()).collect();
+            .iter()
+            .map(|d| d.name.clone())
+            .collect();
         assert_eq!(names, vec!["fastapi"]);
     }
 
@@ -1237,9 +1613,16 @@ version = "0.1.0"
         // explicit `dependencies = []` declares zero deps and must NOT
         // silently fall through to a stray requirements.txt.
         let dir = TempDir::new().unwrap();
-        write(dir.path(), "pyproject.toml", "[project]\ndependencies = []\n");
+        write(
+            dir.path(),
+            "pyproject.toml",
+            "[project]\ndependencies = []\n",
+        );
         write(dir.path(), "requirements.txt", "fastapi\n");
-        let names: Vec<_> = parse_dependencies(dir.path()).iter().map(|d| d.name.clone()).collect();
+        let names: Vec<_> = parse_dependencies(dir.path())
+            .iter()
+            .map(|d| d.name.clone())
+            .collect();
         assert_eq!(names, Vec::<String>::new());
     }
 
@@ -1249,7 +1632,10 @@ version = "0.1.0"
         // garbage names like "git+https". parse_requirements_txt already filters
         // these; parse_pyproject must too.
         let dir = TempDir::new().unwrap();
-        write(dir.path(), "pyproject.toml", r#"
+        write(
+            dir.path(),
+            "pyproject.toml",
+            r#"
 [project]
 dependencies = [
   "fastapi",
@@ -1257,31 +1643,50 @@ dependencies = [
   "https://example.com/pkg.whl",
   "name @ git+https://github.com/a/b.git",
 ]
-"#);
-        let names: Vec<_> = parse_dependencies(dir.path()).iter().map(|d| d.name.clone()).collect();
+"#,
+        );
+        let names: Vec<_> = parse_dependencies(dir.path())
+            .iter()
+            .map(|d| d.name.clone())
+            .collect();
         // Only "fastapi" (a clean PEP 508 name) and "name" (the PEP 508 direct-ref
         // form: `name @ url` — the name half is legitimate) should survive.
         // Bare URLs without a leading `name @` are unusable as Context7 lookup keys.
         let mut sorted = names.clone();
         sorted.sort();
-        assert!(sorted.contains(&"fastapi".to_string()), "fastapi missing: {names:?}");
-        assert!(!sorted.iter().any(|n| n.contains("://") || n.starts_with("git+")),
-            "URL-shaped names must be filtered: {names:?}");
+        assert!(
+            sorted.contains(&"fastapi".to_string()),
+            "fastapi missing: {names:?}"
+        );
+        assert!(
+            !sorted
+                .iter()
+                .any(|n| n.contains("://") || n.starts_with("git+")),
+            "URL-shaped names must be filtered: {names:?}"
+        );
     }
 
     #[test]
     fn pyproject_pep621_wins_when_both_sections_present() {
         let dir = TempDir::new().unwrap();
-        write(dir.path(), "pyproject.toml", r#"
+        write(
+            dir.path(),
+            "pyproject.toml",
+            r#"
 [project]
 dependencies = ["fastapi"]
 
 [tool.poetry.dependencies]
 django = "*"
-"#);
+"#,
+        );
         let deps = parse_dependencies(dir.path());
         let names: Vec<_> = deps.iter().map(|d| d.name.clone()).collect();
-        assert_eq!(names, vec!["fastapi"], "PEP 621 must win, not be merged with Poetry: {names:?}");
+        assert_eq!(
+            names,
+            vec!["fastapi"],
+            "PEP 621 must win, not be merged with Poetry: {names:?}"
+        );
     }
 
     #[test]
@@ -1289,11 +1694,19 @@ django = "*"
         // foo is the import-side name; "real-crate" is what's on crates.io.
         // We must surface "foo" so the import filter matches `use foo::...`.
         let dir = TempDir::new().unwrap();
-        write(dir.path(), "Cargo.toml", "[dependencies]\nfoo = { package = \"real-crate\", version = \"1\" }\n");
+        write(
+            dir.path(),
+            "Cargo.toml",
+            "[dependencies]\nfoo = { package = \"real-crate\", version = \"1\" }\n",
+        );
         let deps = parse_dependencies(dir.path());
-        assert!(deps.iter().any(|d| d.name == "foo"),
-            "renamed dep must surface key: {deps:?}");
-        assert!(!deps.iter().any(|d| d.name == "real_crate"),
-            "must not surface package name: {deps:?}");
+        assert!(
+            deps.iter().any(|d| d.name == "foo"),
+            "renamed dep must surface key: {deps:?}"
+        );
+        assert!(
+            !deps.iter().any(|d| d.name == "real_crate"),
+            "must not surface package name: {deps:?}"
+        );
     }
 }

--- a/src/dimensions.rs
+++ b/src/dimensions.rs
@@ -50,15 +50,28 @@ fn aggregate(key: String, records: &[&ReviewRecord]) -> DimensionSlice {
         sev.info += r.findings_by_severity.info;
         n_findings += r.findings_by_severity.total();
         files_reviewed += r.files_reviewed as u64;
-        suppressed += r.suppressed_by_rule.values().map(|v| *v as u64).sum::<u64>();
+        suppressed += r
+            .suppressed_by_rule
+            .values()
+            .map(|v| *v as u64)
+            .sum::<u64>();
         duration_total_ms += r.duration_ms as u128;
         tokens_in += r.tokens_in;
         tokens_out += r.tokens_out;
         tokens_cache_read += r.tokens_cache_read;
         match (r.lines_added, r.lines_removed) {
-            (Some(a), Some(d)) => { lines_touched += a as u64 + d as u64; has_any_lines = true; }
-            (Some(a), None) => { lines_touched += a as u64; has_any_lines = true; }
-            (None, Some(d)) => { lines_touched += d as u64; has_any_lines = true; }
+            (Some(a), Some(d)) => {
+                lines_touched += a as u64 + d as u64;
+                has_any_lines = true;
+            }
+            (Some(a), None) => {
+                lines_touched += a as u64;
+                has_any_lines = true;
+            }
+            (None, Some(d)) => {
+                lines_touched += d as u64;
+                has_any_lines = true;
+            }
             (None, None) => {}
         }
     }
@@ -140,7 +153,11 @@ fn sparkline_buckets(records: &[&ReviewRecord], n_buckets: usize) -> Vec<f64> {
             findings += r.findings_by_severity.total();
             files += r.files_reviewed as u64;
         }
-        let fpf = if files == 0 { 0.0 } else { findings as f64 / files as f64 };
+        let fpf = if files == 0 {
+            0.0
+        } else {
+            findings as f64 / files as f64
+        };
         out.push(fpf);
     }
     out
@@ -160,7 +177,11 @@ pub fn group_by_repo(records: &[ReviewRecord]) -> Vec<DimensionSlice> {
         .into_iter()
         .map(|(k, v)| aggregate(k.unwrap_or_else(|| NO_REPO_KEY.to_string()), &v))
         .collect();
-    slices.sort_by(|a, b| b.n_reviews.cmp(&a.n_reviews).then_with(|| a.key.cmp(&b.key)));
+    slices.sort_by(|a, b| {
+        b.n_reviews
+            .cmp(&a.n_reviews)
+            .then_with(|| a.key.cmp(&b.key))
+    });
     slices
 }
 
@@ -169,11 +190,12 @@ pub fn group_by_caller(records: &[ReviewRecord]) -> Vec<DimensionSlice> {
     for r in records {
         buckets.entry(r.invoked_from.clone()).or_default().push(r);
     }
-    let mut slices: Vec<_> = buckets
-        .into_iter()
-        .map(|(k, v)| aggregate(k, &v))
-        .collect();
-    slices.sort_by(|a, b| b.n_reviews.cmp(&a.n_reviews).then_with(|| a.key.cmp(&b.key)));
+    let mut slices: Vec<_> = buckets.into_iter().map(|(k, v)| aggregate(k, &v)).collect();
+    slices.sort_by(|a, b| {
+        b.n_reviews
+            .cmp(&a.n_reviews)
+            .then_with(|| a.key.cmp(&b.key))
+    });
     slices
 }
 
@@ -215,8 +237,12 @@ fn aggregate_context_slice(key: String, records: &[&ReviewRecord]) -> ContextDim
     for r in records {
         sum_chunks += r.context.injected_chunk_count as u64;
         sum_tokens += r.context.injected_tokens as u64;
-        if r.context.retriever_errored { errored += 1; }
-        if r.context.adaptive_threshold_applied { adaptive += 1; }
+        if r.context.retriever_errored {
+            errored += 1;
+        }
+        if r.context.adaptive_threshold_applied {
+            adaptive += 1;
+        }
     }
 
     let denom = n_reviews.max(1) as f64;
@@ -247,7 +273,10 @@ fn context_sparkline_buckets(records: &[&ReviewRecord], n_buckets: usize) -> Vec
     for b in 0..n_buckets {
         let start = b * total / n_buckets;
         let end = ((b + 1) * total / n_buckets).max(start + 1).min(total);
-        if start >= end { out.push(0.0); continue; }
+        if start >= end {
+            out.push(0.0);
+            continue;
+        }
         let mut sum = 0u64;
         for r in &records[start..end] {
             sum += r.context.injected_chunk_count as u64;
@@ -270,7 +299,9 @@ fn context_sparkline_buckets(records: &[&ReviewRecord], n_buckets: usize) -> Vec
 pub fn aggregate_by_source(records: &[ReviewRecord]) -> Vec<ContextDimensionSlice> {
     let mut buckets: HashMap<String, Vec<&ReviewRecord>> = HashMap::new();
     for r in records {
-        if !r.context.injector_available { continue; }
+        if !r.context.injector_available {
+            continue;
+        }
         // Defensive dedup: the injector already dedups injected_sources,
         // but legacy or externally-written records could contain
         // duplicates. Counting the same review twice in the same source
@@ -286,7 +317,11 @@ pub fn aggregate_by_source(records: &[ReviewRecord]) -> Vec<ContextDimensionSlic
         .into_iter()
         .map(|(k, v)| aggregate_context_slice(k, &v))
         .collect();
-    out.sort_by(|a, b| b.n_reviews.cmp(&a.n_reviews).then_with(|| a.key.cmp(&b.key)));
+    out.sort_by(|a, b| {
+        b.n_reviews
+            .cmp(&a.n_reviews)
+            .then_with(|| a.key.cmp(&b.key))
+    });
     out
 }
 
@@ -299,14 +334,20 @@ pub fn aggregate_by_source(records: &[ReviewRecord]) -> Vec<ContextDimensionSlic
 pub fn aggregate_by_reviewed_repo(records: &[ReviewRecord]) -> Vec<ContextDimensionSlice> {
     let mut buckets: HashMap<Option<String>, Vec<&ReviewRecord>> = HashMap::new();
     for r in records {
-        if !r.context.injector_available { continue; }
+        if !r.context.injector_available {
+            continue;
+        }
         buckets.entry(r.repo.clone()).or_default().push(r);
     }
     let mut out: Vec<_> = buckets
         .into_iter()
         .map(|(k, v)| aggregate_context_slice(k.unwrap_or_else(|| NO_REPO_KEY.to_string()), &v))
         .collect();
-    out.sort_by(|a, b| b.n_reviews.cmp(&a.n_reviews).then_with(|| a.key.cmp(&b.key)));
+    out.sort_by(|a, b| {
+        b.n_reviews
+            .cmp(&a.n_reviews)
+            .then_with(|| a.key.cmp(&b.key))
+    });
     out
 }
 
@@ -340,10 +381,14 @@ pub fn aggregate_misleading(records: &[ReviewRecord]) -> Vec<ContextDimensionSli
     let mut total: Vec<&ReviewRecord> = Vec::new();
     for r in records {
         let is_err = r.context.retriever_errored;
-        let is_phantom = r.context.rendered_prompt_hash.is_some()
-            && r.context.injected_chunk_count == 0;
-        if is_err { errored.push(r); }
-        if is_phantom { phantom.push(r); }
+        let is_phantom =
+            r.context.rendered_prompt_hash.is_some() && r.context.injected_chunk_count == 0;
+        if is_err {
+            errored.push(r);
+        }
+        if is_phantom {
+            phantom.push(r);
+        }
         if (is_err || is_phantom) && total_seen.insert(r.run_id.as_str()) {
             total.push(r);
         }
@@ -357,7 +402,11 @@ pub fn aggregate_misleading(records: &[ReviewRecord]) -> Vec<ContextDimensionSli
 
 /// Rolling N-record windows over the chronologically-last `n * max_windows` records.
 /// Returns: [last N, prev N, prev 2N, ...]. Records assumed in chronological insertion order.
-pub fn rolling_window(records: &[ReviewRecord], n: usize, max_windows: usize) -> Vec<DimensionSlice> {
+pub fn rolling_window(
+    records: &[ReviewRecord],
+    n: usize,
+    max_windows: usize,
+) -> Vec<DimensionSlice> {
     if n == 0 || max_windows == 0 || records.is_empty() {
         return Vec::new();
     }
@@ -366,7 +415,9 @@ pub fn rolling_window(records: &[ReviewRecord], n: usize, max_windows: usize) ->
     for w in 0..max_windows {
         let offset = w.saturating_mul(n);
         let end = total.saturating_sub(offset);
-        if end == 0 { break; }
+        if end == 0 {
+            break;
+        }
         let start = end.saturating_sub(n);
         let slice: Vec<&ReviewRecord> = records[start..end].iter().collect();
         let label = match w {
@@ -396,7 +447,13 @@ mod tests {
             files_reviewed: files,
             lines_added: None,
             lines_removed: None,
-            findings_by_severity: SeverityCounts { critical: 0, high: findings, medium: 0, low: 0, info: 0 },
+            findings_by_severity: SeverityCounts {
+                critical: 0,
+                high: findings,
+                medium: 0,
+                low: 0,
+                info: 0,
+            },
             suppressed_by_rule: Default::default(),
             tokens_in: 1000,
             tokens_out: 100,
@@ -405,7 +462,7 @@ mod tests {
             flags: Flags::default(),
             mode: None,
             context: Default::default(),
-        finding_ids: Vec::new(),
+            finding_ids: Vec::new(),
         }
     }
 
@@ -441,9 +498,13 @@ mod tests {
         let mut r_none = rec("ignored", "tty", 1, 5);
         r_none.repo = None;
         let slices = group_by_repo(&[r_real, r_none]);
-        let none_slice = slices.iter().find(|s| s.key == "(no repo)")
+        let none_slice = slices
+            .iter()
+            .find(|s| s.key == "(no repo)")
             .expect("None repo should produce a '(no repo)' sentinel, got keys: {:?}");
-        let real_slice = slices.iter().find(|s| s.key == "unknown")
+        let real_slice = slices
+            .iter()
+            .find(|s| s.key == "unknown")
             .expect("real 'unknown' repo must remain addressable by its name");
         assert_eq!(none_slice.n_findings, 5);
         assert_eq!(real_slice.n_findings, 3);
@@ -458,7 +519,11 @@ mod tests {
         let mut r_none = rec("ignored", "tty", 1, 5);
         r_none.repo = None;
         let slices = group_by_repo(&[r_real, r_none]);
-        assert_eq!(slices.len(), 2, "None and real '(no repo)' must bucket separately");
+        assert_eq!(
+            slices.len(),
+            2,
+            "None and real '(no repo)' must bucket separately"
+        );
         let none_total: u32 = slices.iter().map(|s| s.n_findings).sum();
         assert_eq!(none_total, 8);
     }
@@ -475,7 +540,10 @@ mod tests {
         // findings_per_kloc = 1 * 1000 / (2 * u32::MAX) -- tiny but well-defined.
         let fpk = slices[0].findings_per_kloc.expect("kloc set when lines>0");
         let expected = 1000.0 / (2.0 * u32::MAX as f64);
-        assert!((fpk - expected).abs() < 1e-12, "got {fpk}, expected {expected}");
+        assert!(
+            (fpk - expected).abs() < 1e-12,
+            "got {fpk}, expected {expected}"
+        );
     }
 
     #[test]
@@ -504,7 +572,10 @@ mod tests {
     fn low_sample_flagged_below_min_sample() {
         let records: Vec<_> = (0..MIN_SAMPLE - 1).map(|_| rec("x", "tty", 1, 0)).collect();
         let slices = group_by_repo(&records);
-        assert!(slices[0].low_sample, "n < MIN_SAMPLE should set low_sample=true");
+        assert!(
+            slices[0].low_sample,
+            "n < MIN_SAMPLE should set low_sample=true"
+        );
     }
 
     #[test]
@@ -604,7 +675,7 @@ mod tests {
         // returns 0.0 instead of the correct 1.0. Reproduces the bug exactly.
         let mut r = rec("r", "tty", 0, 0);
         r.suppressed_by_rule.insert("a".into(), u32::MAX); // 2^32 - 1
-        r.suppressed_by_rule.insert("b".into(), 1);        // +1 = 2^32 (truncates to 0 as u32)
+        r.suppressed_by_rule.insert("b".into(), 1); // +1 = 2^32 (truncates to 0 as u32)
         let slices = group_by_repo(&[r]);
         assert!(
             (slices[0].suppression_rate - 1.0).abs() < 1e-9,
@@ -672,7 +743,16 @@ mod tests {
         // Verify unique-source row count and per-source review counts.
         let records = vec![
             ctx_rec("r", true, &["mini-rust"], 2, 100, false, false, Some("h1")),
-            ctx_rec("r", true, &["mini-rust", "mini-py"], 4, 200, false, false, Some("h2")),
+            ctx_rec(
+                "r",
+                true,
+                &["mini-rust", "mini-py"],
+                4,
+                200,
+                false,
+                false,
+                Some("h2"),
+            ),
             ctx_rec("r", true, &["mini-py"], 1, 50, false, false, Some("h3")),
             ctx_rec("r", true, &["mini-rust"], 3, 150, false, false, Some("h4")),
         ];
@@ -749,7 +829,16 @@ mod tests {
             records.push(ctx_rec("A", false, &[], 0, 0, false, false, None));
         }
         for _ in 0..2 {
-            records.push(ctx_rec("A", true, &["src"], 2, 100, false, false, Some("h")));
+            records.push(ctx_rec(
+                "A",
+                true,
+                &["src"],
+                2,
+                100,
+                false,
+                false,
+                Some("h"),
+            ));
         }
         let slices = aggregate_by_reviewed_repo(&records);
         assert_eq!(slices.len(), 1, "only repo A with injector-wired reviews");
@@ -787,9 +876,7 @@ mod tests {
         // A single record that is both errored AND phantom must only be
         // counted once in the "total" row (set-union semantics), even
         // though it contributes to both breakdown rows.
-        let records = vec![
-            ctx_rec("r", true, &[], 0, 0, true, false, Some("dual")),
-        ];
+        let records = vec![ctx_rec("r", true, &[], 0, 0, true, false, Some("dual"))];
         let slices = aggregate_misleading(&records);
         assert_eq!(slices[0].n_reviews, 1, "total must dedupe on run_id");
         assert_eq!(slices[1].n_reviews, 1);
@@ -846,7 +933,16 @@ mod tests {
         }
         // 5 recent records with source "new"
         for _ in 0..5 {
-            records.push(ctx_rec("r", true, &["new"], 2, 100, false, false, Some("h")));
+            records.push(ctx_rec(
+                "r",
+                true,
+                &["new"],
+                2,
+                100,
+                false,
+                false,
+                Some("h"),
+            ));
         }
         let recent: Vec<_> = records[records.len() - 5..].to_vec();
         let slices = aggregate_by_source(&recent);

--- a/src/domain.rs
+++ b/src/domain.rs
@@ -1,6 +1,5 @@
 /// Domain/framework detection: scan project for framework markers.
 /// Detected domains enrich review prompts with framework-specific context.
-
 use std::collections::HashSet;
 use std::path::Path;
 
@@ -155,9 +154,7 @@ pub fn detect_domain(project_dir: &Path) -> DomainInfo {
                 let path = entry.path();
                 if path.extension().and_then(|e| e.to_str()) == Some("yaml") {
                     if let Ok(content) = std::fs::read_to_string(&path) {
-                        if content.starts_with("esphome:")
-                            || content.contains("\nesphome:")
-                        {
+                        if content.starts_with("esphome:") || content.contains("\nesphome:") {
                             frameworks.insert("esphome".into());
                             break;
                         }
@@ -173,9 +170,7 @@ pub fn detect_domain(project_dir: &Path) -> DomainInfo {
                 let path = entry.path();
                 if path.extension().and_then(|e| e.to_str()) == Some("yaml") {
                     if let Ok(content) = std::fs::read_to_string(&path) {
-                        if content.starts_with("esphome:")
-                            || content.contains("\nesphome:")
-                        {
+                        if content.starts_with("esphome:") || content.contains("\nesphome:") {
                             frameworks.insert("esphome".into());
                             break;
                         }
@@ -264,9 +259,7 @@ mod tests {
 
     #[test]
     fn detect_react_framework() {
-        let dir = create_project(&[
-            ("package.json", r#"{"dependencies":{"react":"^18.0.0"}}"#),
-        ]);
+        let dir = create_project(&[("package.json", r#"{"dependencies":{"react":"^18.0.0"}}"#)]);
         let info = detect_domain(dir.path());
         assert!(info.frameworks.contains(&"react".to_string()));
     }
@@ -283,18 +276,17 @@ mod tests {
 
     #[test]
     fn detect_nextjs_framework() {
-        let dir = create_project(&[
-            ("package.json", r#"{"dependencies":{"next":"^14.0.0"}}"#),
-        ]);
+        let dir = create_project(&[("package.json", r#"{"dependencies":{"next":"^14.0.0"}}"#)]);
         let info = detect_domain(dir.path());
         assert!(info.frameworks.contains(&"nextjs".to_string()));
     }
 
     #[test]
     fn detect_fastapi_framework() {
-        let dir = create_project(&[
-            ("pyproject.toml", "[project]\ndependencies = [\"fastapi\"]\n"),
-        ]);
+        let dir = create_project(&[(
+            "pyproject.toml",
+            "[project]\ndependencies = [\"fastapi\"]\n",
+        )]);
         let info = detect_domain(dir.path());
         assert!(info.frameworks.contains(&"fastapi".to_string()));
     }
@@ -309,7 +301,10 @@ mod tests {
         .unwrap();
         let domain = detect_domain(dir.path());
         assert!(
-            domain.frameworks.iter().any(|f| f.contains("home-assistant")),
+            domain
+                .frameworks
+                .iter()
+                .any(|f| f.contains("home-assistant")),
             "Should detect Home Assistant. Got: {:?}",
             domain.frameworks
         );
@@ -321,7 +316,10 @@ mod tests {
         std::fs::write(dir.path().join(".HA_VERSION"), "2024.1.0\n").unwrap();
         let domain = detect_domain(dir.path());
         assert!(
-            domain.frameworks.iter().any(|f| f.contains("home-assistant")),
+            domain
+                .frameworks
+                .iter()
+                .any(|f| f.contains("home-assistant")),
             "Should detect HA from .HA_VERSION. Got: {:?}",
             domain.frameworks
         );
@@ -343,7 +341,10 @@ mod tests {
         .unwrap();
         let domain = detect_domain(dir.path());
         assert!(
-            domain.frameworks.iter().any(|f| f.contains("home-assistant")),
+            domain
+                .frameworks
+                .iter()
+                .any(|f| f.contains("home-assistant")),
             "Should detect HA from automations.yaml. Got: {:?}",
             domain.frameworks
         );
@@ -407,10 +408,14 @@ mod tests {
         std::fs::write(
             dir.path().join("configuration/configuration.yaml"),
             "homeassistant:\n  name: Home\n",
-        ).unwrap();
+        )
+        .unwrap();
         let domain = detect_domain(dir.path());
         assert!(
-            domain.frameworks.iter().any(|f| f.contains("home-assistant")),
+            domain
+                .frameworks
+                .iter()
+                .any(|f| f.contains("home-assistant")),
             "Should detect HA from configuration/configuration.yaml. Got: {:?}",
             domain.frameworks
         );
@@ -424,7 +429,10 @@ mod tests {
         std::fs::write(dir.path().join("secrets.yaml"), "key: val\n").unwrap();
         let domain = detect_domain(dir.path());
         assert!(
-            domain.frameworks.iter().any(|f| f.contains("home-assistant")),
+            domain
+                .frameworks
+                .iter()
+                .any(|f| f.contains("home-assistant")),
             "Should detect HA from custom_components/ + secrets.yaml. Got: {:?}",
             domain.frameworks
         );
@@ -438,7 +446,8 @@ mod tests {
         std::fs::write(
             dir.path().join("esphome/device.yaml"),
             "esphome:\n  name: test\n",
-        ).unwrap();
+        )
+        .unwrap();
         let domain = detect_domain(dir.path());
         assert!(
             domain.frameworks.iter().any(|f| f.contains("esphome")),
@@ -455,7 +464,10 @@ mod tests {
         std::fs::write(dir.path().join("secrets.yaml"), "api_key: xxx\n").unwrap();
         let domain = detect_domain(dir.path());
         assert!(
-            domain.frameworks.iter().any(|f| f.contains("home-assistant")),
+            domain
+                .frameworks
+                .iter()
+                .any(|f| f.contains("home-assistant")),
             "2 weak HA signals should detect HA. Got: {:?}",
             domain.frameworks
         );
@@ -468,7 +480,10 @@ mod tests {
         std::fs::create_dir_all(dir.path().join("blueprints")).unwrap();
         let domain = detect_domain(dir.path());
         assert!(
-            !domain.frameworks.iter().any(|f| f.contains("home-assistant")),
+            !domain
+                .frameworks
+                .iter()
+                .any(|f| f.contains("home-assistant")),
             "Single weak signal should NOT detect HA. Got: {:?}",
             domain.frameworks
         );
@@ -482,7 +497,10 @@ mod tests {
         std::fs::create_dir_all(dir.path().join("packages")).unwrap();
         let domain = detect_domain(dir.path());
         assert!(
-            domain.frameworks.iter().any(|f| f.contains("home-assistant")),
+            domain
+                .frameworks
+                .iter()
+                .any(|f| f.contains("home-assistant")),
             "custom_components + packages should detect HA. Got: {:?}",
             domain.frameworks
         );
@@ -495,7 +513,10 @@ mod tests {
         std::fs::create_dir_all(dir.path().join("custom_components")).unwrap();
         let domain = detect_domain(dir.path());
         assert!(
-            !domain.frameworks.iter().any(|f| f.contains("home-assistant")),
+            !domain
+                .frameworks
+                .iter()
+                .any(|f| f.contains("home-assistant")),
             "custom_components alone should NOT detect HA. Got: {:?}",
             domain.frameworks
         );
@@ -508,9 +529,15 @@ mod tests {
         std::fs::write(
             dir.path().join("configuration.yaml"),
             "homeassistant:\n  name: Home\n",
-        ).unwrap();
+        )
+        .unwrap();
         let domain = detect_domain(dir.path());
-        assert!(domain.frameworks.iter().any(|f| f.contains("home-assistant")));
+        assert!(
+            domain
+                .frameworks
+                .iter()
+                .any(|f| f.contains("home-assistant"))
+        );
     }
 
     #[test]
@@ -520,10 +547,14 @@ mod tests {
         std::fs::write(
             dir.path().join("configuration.yaml"),
             "# homeassistant: is configured elsewhere\nsome_key: value\n",
-        ).unwrap();
+        )
+        .unwrap();
         let domain = detect_domain(dir.path());
         assert!(
-            !domain.frameworks.iter().any(|f| f.contains("home-assistant")),
+            !domain
+                .frameworks
+                .iter()
+                .any(|f| f.contains("home-assistant")),
             "Commented homeassistant: should NOT detect HA. Got: {:?}",
             domain.frameworks
         );
@@ -552,7 +583,11 @@ mod tests {
     #[test]
     fn detect_terraform_from_tfvars() {
         let dir = tempfile::tempdir().unwrap();
-        std::fs::write(dir.path().join("terraform.tfvars"), "region = \"us-east-1\"").unwrap();
+        std::fs::write(
+            dir.path().join("terraform.tfvars"),
+            "region = \"us-east-1\"",
+        )
+        .unwrap();
         let info = detect_domain(dir.path());
         assert!(info.frameworks.contains(&"terraform".to_string()));
     }
@@ -560,7 +595,11 @@ mod tests {
     #[test]
     fn detect_terraform_from_tf_files() {
         let dir = tempfile::tempdir().unwrap();
-        std::fs::write(dir.path().join("main.tf"), "resource \"aws_instance\" \"web\" {}").unwrap();
+        std::fs::write(
+            dir.path().join("main.tf"),
+            "resource \"aws_instance\" \"web\" {}",
+        )
+        .unwrap();
         let info = detect_domain(dir.path());
         assert!(info.frameworks.contains(&"terraform".to_string()));
         assert!(info.languages.contains(&"hcl".to_string()));

--- a/src/embeddings.rs
+++ b/src/embeddings.rs
@@ -4,7 +4,7 @@
 //! Model auto-downloaded on first use, cached in ~/.quorum/models/
 
 #[cfg(feature = "embeddings")]
-use fastembed::{TextEmbedding, InitOptions, EmbeddingModel};
+use fastembed::{EmbeddingModel, InitOptions, TextEmbedding};
 
 #[cfg(feature = "embeddings")]
 pub struct LocalEmbedder {
@@ -23,7 +23,9 @@ impl LocalEmbedder {
 
     pub fn embed(&mut self, text: &str) -> anyhow::Result<Vec<f32>> {
         let results = self.model.embed(vec![text], None)?;
-        results.into_iter().next()
+        results
+            .into_iter()
+            .next()
             .ok_or_else(|| anyhow::anyhow!("No embedding result"))
     }
 
@@ -33,11 +35,15 @@ impl LocalEmbedder {
 }
 
 pub fn cosine_similarity(a: &[f32], b: &[f32]) -> f32 {
-    if a.len() != b.len() || a.is_empty() { return 0.0; }
+    if a.len() != b.len() || a.is_empty() {
+        return 0.0;
+    }
     let dot: f32 = a.iter().zip(b.iter()).map(|(x, y)| x * y).sum();
     let norm_a: f32 = a.iter().map(|x| x * x).sum::<f32>().sqrt();
     let norm_b: f32 = b.iter().map(|x| x * x).sum::<f32>().sqrt();
-    if norm_a == 0.0 || norm_b == 0.0 { return 0.0; }
+    if norm_a == 0.0 || norm_b == 0.0 {
+        return 0.0;
+    }
     dot / (norm_a * norm_b)
 }
 
@@ -80,7 +86,16 @@ mod tests {
         let c = embedder.embed("Unused import os").unwrap();
         let ab = cosine_similarity(&a, &b);
         let ac = cosine_similarity(&a, &c);
-        assert!(ab > 0.7, "Similar texts should have high similarity: {}", ab);
-        assert!(ac < ab, "Different texts should have lower similarity: {} vs {}", ac, ab);
+        assert!(
+            ab > 0.7,
+            "Similar texts should have high similarity: {}",
+            ab
+        );
+        assert!(
+            ac < ab,
+            "Different texts should have lower similarity: {} vs {}",
+            ac,
+            ab
+        );
     }
 }

--- a/src/feedback.rs
+++ b/src/feedback.rs
@@ -1,3 +1,5 @@
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
 /// Feedback storage: JSONL file for recording TP/FP verdicts on findings.
 ///
 /// Verdict on-disk schema (backward-compatible):
@@ -6,10 +8,7 @@
 ///   object: `{"context_misleading": {"blamed_chunk_ids": ["c1", "c2"]}}`.
 ///
 /// Legacy entries without the struct variant continue to deserialize unchanged.
-
 use std::path::PathBuf;
-use chrono::{DateTime, Utc};
-use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -20,15 +19,17 @@ pub enum Verdict {
     Wontfix,
     /// Recorded when the injected retrieval context misled the reviewer.
     /// `blamed_chunk_ids` may be empty (defaults to "last-injected" downstream).
-    ContextMisleading { blamed_chunk_ids: Vec<String> },
+    ContextMisleading {
+        blamed_chunk_ids: Vec<String>,
+    },
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum Provenance {
     Human,
-    PostFix,                // verdict recorded after applying a fix (strongest signal)
-    AutoCalibrate(String),  // model name used for auto-calibration
+    PostFix,               // verdict recorded after applying a fix (strongest signal)
+    AutoCalibrate(String), // model name used for auto-calibration
     /// Verdict from another review agent (pal, third-opinion, gemini, reviewdog, ...).
     /// Calibrator weight: 0.7x (see calibrator.rs). `confidence` is stored but
     /// IGNORED by the calibrator in v1 — reserved for future confidence-aware weighting.
@@ -274,11 +275,7 @@ pub(crate) fn rename_or_tolerate_race(
             // If src is still present, the NotFound came from somewhere
             // else (missing dst parent, missing intermediate dir, etc.) —
             // propagate so the misconfiguration surfaces.
-            if src.exists() {
-                Err(e)
-            } else {
-                Ok(false)
-            }
+            if src.exists() { Err(e) } else { Ok(false) }
         }
         Err(e) => Err(e),
     }
@@ -304,8 +301,7 @@ const MAX_INBOX_FILE_BYTES: u64 = 1024 * 1024;
 /// on Unix via `O_NOFOLLOW | O_NONBLOCK` and is the authoritative
 /// handle-bound check.
 fn classify_inbox_entry(path: &std::path::Path) -> Result<(), String> {
-    let meta = std::fs::symlink_metadata(path)
-        .map_err(|e| format!("stat failed: {e}"))?;
+    let meta = std::fs::symlink_metadata(path).map_err(|e| format!("stat failed: {e}"))?;
     let ft = meta.file_type();
     if ft.is_symlink() {
         return Err("symlink".into());
@@ -392,7 +388,8 @@ fn read_inbox_file(path: &std::path::Path) -> std::io::Result<String> {
         ));
     }
     let mut buf = String::new();
-    file.take(MAX_INBOX_FILE_BYTES + 1).read_to_string(&mut buf)?;
+    file.take(MAX_INBOX_FILE_BYTES + 1)
+        .read_to_string(&mut buf)?;
     if buf.len() as u64 > MAX_INBOX_FILE_BYTES {
         return Err(std::io::Error::new(
             std::io::ErrorKind::InvalidInput,
@@ -463,9 +460,8 @@ impl FeedbackStore {
         // informative.
         let unlock_result = FileExt::unlock(&file);
         write_result?;
-        unlock_result.with_context(|| {
-            format!("Failed to unlock feedback file: {}", self.path.display())
-        })?;
+        unlock_result
+            .with_context(|| format!("Failed to unlock feedback file: {}", self.path.display()))?;
         Ok(())
     }
 
@@ -515,17 +511,18 @@ impl FeedbackStore {
             }
         };
         FileExt::lock_shared(&file).with_context(|| {
-            format!("Failed to lock feedback file for read: {}", self.path.display())
+            format!(
+                "Failed to lock feedback file for read: {}",
+                self.path.display()
+            )
         })?;
         let mut content = String::new();
         let read_result = file.read_to_string(&mut content);
         let unlock_result = FileExt::unlock(&file);
-        read_result.with_context(|| {
-            format!("Failed to read feedback file: {}", self.path.display())
-        })?;
-        unlock_result.with_context(|| {
-            format!("Failed to unlock feedback file: {}", self.path.display())
-        })?;
+        read_result
+            .with_context(|| format!("Failed to read feedback file: {}", self.path.display()))?;
+        unlock_result
+            .with_context(|| format!("Failed to unlock feedback file: {}", self.path.display()))?;
         let mut entries = Vec::new();
         let mut skipped = 0usize;
         for line in content.lines() {
@@ -613,8 +610,7 @@ impl FeedbackStore {
         // Issue #103: surface per-entry iteration errors via report.errors
         // instead of silently filter-mapping them to nothing. A permission
         // glitch on one entry must not invisibly strand subsequent ingestion.
-        let (entries, iter_errors) =
-            drain_inbox_entries(read.map(|r| r.map(|e| e.path())));
+        let (entries, iter_errors) = drain_inbox_entries(read.map(|r| r.map(|e| e.path())));
         report.errors.extend(iter_errors);
         let candidates: Vec<PathBuf> = entries
             .into_iter()
@@ -654,7 +650,10 @@ impl FeedbackStore {
         for file in files {
             // STEP A: CLAIM. Atomic rename into processing/. ENOENT → another
             // process already claimed it; skip.
-            let fname = file.file_name().and_then(|n| n.to_str()).unwrap_or("unknown.jsonl");
+            let fname = file
+                .file_name()
+                .and_then(|n| n.to_str())
+                .unwrap_or("unknown.jsonl");
             let claim_ulid = ulid::Ulid::new().to_string();
             let claimed = processing_dir.join(format!("{fname}.{claim_ulid}.jsonl"));
             match rename_or_tolerate_race(&file, &claimed) {
@@ -722,9 +721,7 @@ impl FeedbackStore {
                     report.errors.push(DrainError {
                         file: claimed.clone(),
                         line: 0,
-                        message: format!(
-                            "archive rename failed: {e}; file left in processing/"
-                        ),
+                        message: format!("archive rename failed: {e}; file left in processing/"),
                     });
                     // File stays in processing/ — operator resolves manually.
                 }
@@ -886,7 +883,8 @@ mod tests {
 
         // Round-trip equality: re-deserialize must reproduce the original
         // (no silent data loss beyond the absent fp_kind key).
-        let round_trip: FeedbackEntry = serde_json::from_str(&reserialized).expect("re-deserialize");
+        let round_trip: FeedbackEntry =
+            serde_json::from_str(&reserialized).expect("re-deserialize");
         assert_eq!(round_trip.fp_kind, entry.fp_kind);
         assert_eq!(round_trip.file_path, entry.file_path);
         assert_eq!(round_trip.finding_title, entry.finding_title);
@@ -899,10 +897,18 @@ mod tests {
         let cases = vec![
             FpKind::Hallucination,
             FpKind::TrustModelAssumption,
-            FpKind::CompensatingControl { reference: "PR #99 line 42".into() },
-            FpKind::PatternOvergeneralization { discriminator_hint: Some("hint text".into()) },
-            FpKind::PatternOvergeneralization { discriminator_hint: None },
-            FpKind::OutOfScope { tracked_in: Some("#456".into()) },
+            FpKind::CompensatingControl {
+                reference: "PR #99 line 42".into(),
+            },
+            FpKind::PatternOvergeneralization {
+                discriminator_hint: Some("hint text".into()),
+            },
+            FpKind::PatternOvergeneralization {
+                discriminator_hint: None,
+            },
+            FpKind::OutOfScope {
+                tracked_in: Some("#456".into()),
+            },
             FpKind::OutOfScope { tracked_in: None },
         ];
         for original in cases {
@@ -974,10 +980,7 @@ mod tests {
 
     #[test]
     fn fp_kind_utilization_rate_zero_when_none_tagged() {
-        let entries = vec![
-            make_entry(Verdict::Fp, None),
-            make_entry(Verdict::Fp, None),
-        ];
+        let entries = vec![make_entry(Verdict::Fp, None), make_entry(Verdict::Fp, None)];
         let rate = compute_fp_kind_utilization_rate(&entries).expect("denominator > 0");
         assert!((rate - 0.0).abs() < 1e-6, "expected 0.0, got {}", rate);
     }
@@ -995,7 +998,8 @@ mod tests {
             "agent": "pal",
             "agent_model": null,
             "confidence": null
-        })).unwrap()
+        }))
+        .unwrap()
     }
 
     // Issue #93: handler tests need to inspect the path a handler-owned
@@ -1038,8 +1042,16 @@ mod tests {
             vec![PathBuf::from("/tmp/a.jsonl"), PathBuf::from("/tmp/b.jsonl")],
             "ok paths must still be drained"
         );
-        assert_eq!(errors.len(), 1, "iteration error must be surfaced; got: {:?}", errors);
-        assert_eq!(errors[0].line, 0, "iteration errors are file-level (line 0)");
+        assert_eq!(
+            errors.len(),
+            1,
+            "iteration error must be surfaced; got: {:?}",
+            errors
+        );
+        assert_eq!(
+            errors[0].line, 0,
+            "iteration errors are file-level (line 0)"
+        );
     }
 
     #[test]
@@ -1158,7 +1170,11 @@ mod tests {
     #[test]
     fn record_creates_missing_parent_directory() {
         let dir = TempDir::new().unwrap();
-        let path = dir.path().join("missing").join("nested").join("feedback.jsonl");
+        let path = dir
+            .path()
+            .join("missing")
+            .join("nested")
+            .join("feedback.jsonl");
         assert!(
             !path.parent().unwrap().exists(),
             "precondition: parent dir must not pre-exist"
@@ -1189,7 +1205,9 @@ mod tests {
         let err = store
             .record(&sample_entry(Verdict::Tp))
             .expect_err("record must fail when parent cannot be created");
-        let has_io_cause = err.chain().any(|e| e.downcast_ref::<std::io::Error>().is_some());
+        let has_io_cause = err
+            .chain()
+            .any(|e| e.downcast_ref::<std::io::Error>().is_some());
         assert!(
             has_io_cause,
             "error chain must include io::Error (got: {err:#})"
@@ -1206,7 +1224,10 @@ mod tests {
     #[test]
     fn provenance_serializes_correctly() {
         assert_eq!(serde_json::to_value(&Provenance::Human).unwrap(), "human");
-        assert_eq!(serde_json::to_value(&Provenance::PostFix).unwrap(), "post_fix");
+        assert_eq!(
+            serde_json::to_value(&Provenance::PostFix).unwrap(),
+            "post_fix"
+        );
     }
 
     #[test]
@@ -1233,7 +1254,10 @@ mod tests {
         assert_eq!(all.len(), 1);
         match &all[0].verdict {
             Verdict::ContextMisleading { blamed_chunk_ids } => {
-                assert_eq!(blamed_chunk_ids, &vec!["chunk-abc".to_string(), "chunk-def".to_string()]);
+                assert_eq!(
+                    blamed_chunk_ids,
+                    &vec!["chunk-abc".to_string(), "chunk-def".to_string()]
+                );
             }
             other => panic!("expected ContextMisleading, got {:?}", other),
         }
@@ -1314,7 +1338,11 @@ mod tests {
         let all = store.load_all().unwrap();
         assert_eq!(all.len(), 1);
         match &all[0].provenance {
-            Provenance::External { agent, model, confidence } => {
+            Provenance::External {
+                agent,
+                model,
+                confidence,
+            } => {
                 assert_eq!(agent, "pal");
                 assert_eq!(model.as_deref(), Some("gemini-3-pro-preview"));
                 assert_eq!(*confidence, Some(0.9));
@@ -1332,13 +1360,19 @@ mod tests {
         };
         let v = serde_json::to_value(&p).unwrap();
         // Externally tagged: {"external": {...}}
-        assert!(v.get("external").is_some(), "expected 'external' tag, got {v}");
+        assert!(
+            v.get("external").is_some(),
+            "expected 'external' tag, got {v}"
+        );
         let inner = v.get("external").unwrap();
         assert_eq!(inner.get("agent").and_then(|x| x.as_str()), Some("pal"));
         // `confidence: None` may serialize as `null` OR be absent (if serde is
         // later configured with skip_serializing_if). Both are valid wire forms.
-        assert!(inner.get("confidence").map_or(true, |c| c.is_null()),
-            "confidence must be null or absent, got {:?}", inner.get("confidence"));
+        assert!(
+            inner.get("confidence").map_or(true, |c| c.is_null()),
+            "confidence must be null or absent, got {:?}",
+            inner.get("confidence")
+        );
     }
 
     #[test]
@@ -1348,7 +1382,11 @@ mod tests {
         let json = r#"{"external":{"agent":"pal","model":"gpt-5.4"}}"#;
         let p: Provenance = serde_json::from_str(json).unwrap();
         match p {
-            Provenance::External { agent, model, confidence } => {
+            Provenance::External {
+                agent,
+                model,
+                confidence,
+            } => {
                 assert_eq!(agent, "pal");
                 assert_eq!(model.as_deref(), Some("gpt-5.4"));
                 assert_eq!(confidence, None);
@@ -1373,9 +1411,21 @@ mod tests {
     fn clamp_confidence_rejects_nan_inf() {
         // f32::clamp is NOT NaN-safe — it returns NaN for NaN input.
         // clamp_confidence must detect non-finite values explicitly.
-        assert_eq!(clamp_confidence(Some(f32::NAN)), None, "NaN must become None");
-        assert_eq!(clamp_confidence(Some(f32::INFINITY)), None, "+inf must become None");
-        assert_eq!(clamp_confidence(Some(f32::NEG_INFINITY)), None, "-inf must become None");
+        assert_eq!(
+            clamp_confidence(Some(f32::NAN)),
+            None,
+            "NaN must become None"
+        );
+        assert_eq!(
+            clamp_confidence(Some(f32::INFINITY)),
+            None,
+            "+inf must become None"
+        );
+        assert_eq!(
+            clamp_confidence(Some(f32::NEG_INFINITY)),
+            None,
+            "-inf must become None"
+        );
     }
 
     #[test]
@@ -1395,29 +1445,38 @@ mod tests {
         let all = store.load_all().unwrap();
         assert_eq!(all.len(), 1);
         match &all[0].provenance {
-            Provenance::External { agent, model, confidence } => {
+            Provenance::External {
+                agent,
+                model,
+                confidence,
+            } => {
                 assert_eq!(agent, "pal");
                 assert_eq!(model.as_deref(), Some("gemini-3-pro-preview"));
                 assert_eq!(*confidence, Some(0.85));
             }
             o => panic!("expected External, got {o:?}"),
         }
-        assert!(all[0].model.is_none(), "entry.model should be None (reviewer model, not agent model)");
+        assert!(
+            all[0].model.is_none(),
+            "entry.model should be None (reviewer model, not agent model)"
+        );
     }
 
     #[test]
     fn record_external_normalizes_agent_name() {
         let (store, _dir) = test_store();
-        store.record_external(ExternalVerdictInput {
-            file_path: "a.rs".into(),
-            finding_title: "t".into(),
-            finding_category: None,
-            verdict: Verdict::Tp,
-            reason: "r".into(),
-            agent: "  PaL  ".into(),
-            agent_model: None,
-            confidence: None,
-        }).unwrap();
+        store
+            .record_external(ExternalVerdictInput {
+                file_path: "a.rs".into(),
+                finding_title: "t".into(),
+                finding_category: None,
+                verdict: Verdict::Tp,
+                reason: "r".into(),
+                agent: "  PaL  ".into(),
+                agent_model: None,
+                confidence: None,
+            })
+            .unwrap();
         let all = store.load_all().unwrap();
         match &all[0].provenance {
             Provenance::External { agent, .. } => assert_eq!(agent, "pal"),
@@ -1428,33 +1487,39 @@ mod tests {
     #[test]
     fn record_external_rejects_empty_agent() {
         let (store, _dir) = test_store();
-        let err = store.record_external(ExternalVerdictInput {
-            file_path: "a.rs".into(),
-            finding_title: "t".into(),
-            finding_category: None,
-            verdict: Verdict::Tp,
-            reason: "r".into(),
-            agent: "   ".into(),
-            agent_model: None,
-            confidence: None,
-        }).expect_err("empty agent must be rejected");
-        assert!(err.to_string().to_lowercase().contains("agent"),
-            "error message should mention agent: {err}");
+        let err = store
+            .record_external(ExternalVerdictInput {
+                file_path: "a.rs".into(),
+                finding_title: "t".into(),
+                finding_category: None,
+                verdict: Verdict::Tp,
+                reason: "r".into(),
+                agent: "   ".into(),
+                agent_model: None,
+                confidence: None,
+            })
+            .expect_err("empty agent must be rejected");
+        assert!(
+            err.to_string().to_lowercase().contains("agent"),
+            "error message should mention agent: {err}"
+        );
     }
 
     #[test]
     fn record_external_defaults_missing_category_to_unknown() {
         let (store, _dir) = test_store();
-        store.record_external(ExternalVerdictInput {
-            file_path: "a.rs".into(),
-            finding_title: "t".into(),
-            finding_category: None,
-            verdict: Verdict::Tp,
-            reason: "r".into(),
-            agent: "pal".into(),
-            agent_model: None,
-            confidence: None,
-        }).unwrap();
+        store
+            .record_external(ExternalVerdictInput {
+                file_path: "a.rs".into(),
+                finding_title: "t".into(),
+                finding_category: None,
+                verdict: Verdict::Tp,
+                reason: "r".into(),
+                agent: "pal".into(),
+                agent_model: None,
+                confidence: None,
+            })
+            .unwrap();
         let all = store.load_all().unwrap();
         assert_eq!(all[0].finding_category, "unknown");
     }
@@ -1462,16 +1527,18 @@ mod tests {
     #[test]
     fn record_external_applies_clamp_confidence() {
         let (store, _dir) = test_store();
-        store.record_external(ExternalVerdictInput {
-            file_path: "a.rs".into(),
-            finding_title: "t".into(),
-            finding_category: None,
-            verdict: Verdict::Tp,
-            reason: "r".into(),
-            agent: "pal".into(),
-            agent_model: None,
-            confidence: Some(1.5),
-        }).unwrap();
+        store
+            .record_external(ExternalVerdictInput {
+                file_path: "a.rs".into(),
+                finding_title: "t".into(),
+                finding_category: None,
+                verdict: Verdict::Tp,
+                reason: "r".into(),
+                agent: "pal".into(),
+                agent_model: None,
+                confidence: Some(1.5),
+            })
+            .unwrap();
         let all = store.load_all().unwrap();
         match &all[0].provenance {
             Provenance::External { confidence, .. } => {
@@ -1487,16 +1554,20 @@ mod tests {
         // injected context — an external agent can't credibly produce them.
         // Reject at ingest to avoid polluting the calibrator's retrieval signal.
         let (store, _dir) = test_store();
-        let err = store.record_external(ExternalVerdictInput {
-            file_path: "a.rs".into(),
-            finding_title: "t".into(),
-            finding_category: None,
-            verdict: Verdict::ContextMisleading { blamed_chunk_ids: vec!["c1".into()] },
-            reason: "r".into(),
-            agent: "pal".into(),
-            agent_model: None,
-            confidence: None,
-        }).expect_err("ContextMisleading must be rejected for External provenance");
+        let err = store
+            .record_external(ExternalVerdictInput {
+                file_path: "a.rs".into(),
+                finding_title: "t".into(),
+                finding_category: None,
+                verdict: Verdict::ContextMisleading {
+                    blamed_chunk_ids: vec!["c1".into()],
+                },
+                reason: "r".into(),
+                agent: "pal".into(),
+                agent_model: None,
+                confidence: None,
+            })
+            .expect_err("ContextMisleading must be rejected for External provenance");
         assert!(
             err.to_string().to_lowercase().contains("context"),
             "error message must mention context_misleading: {err}"
@@ -1512,8 +1583,7 @@ mod tests {
         // a field, or accept the breakage explicitly with a migration plan.
         // Issue #98.
         let raw = r#"{"file_path":"src/x.rs","finding_title":"Bug","finding_category":"security","verdict":"tp","reason":"r","model":null,"timestamp":"2026-04-24T17:00:00Z","provenance":{"external":{"agent":"pal","model":"gpt-5.4","confidence":0.9}}}"#;
-        let entry: FeedbackEntry =
-            serde_json::from_str(raw).expect("frozen row must deserialize");
+        let entry: FeedbackEntry = serde_json::from_str(raw).expect("frozen row must deserialize");
         match &entry.provenance {
             Provenance::External {
                 agent,
@@ -1539,8 +1609,8 @@ mod tests {
         // Same pin as above but with optional model/confidence omitted.
         // Tests that #[serde(default)] on those fields holds across versions.
         let raw = r#"{"file_path":"a.rs","finding_title":"t","finding_category":"unknown","verdict":"fp","reason":"r","timestamp":"2026-04-24T17:00:00Z","provenance":{"external":{"agent":"third-opinion"}}}"#;
-        let entry: FeedbackEntry = serde_json::from_str(raw)
-            .expect("frozen minimal-optional row must deserialize");
+        let entry: FeedbackEntry =
+            serde_json::from_str(raw).expect("frozen minimal-optional row must deserialize");
         match &entry.provenance {
             Provenance::External {
                 agent,
@@ -1605,7 +1675,10 @@ mod tests {
         assert_eq!(report.drained_files, 0);
         assert_eq!(report.entries, 0);
         assert!(report.errors.is_empty());
-        assert!(!processed.exists(), "processed/ must not be created when inbox is absent");
+        assert!(
+            !processed.exists(),
+            "processed/ must not be created when inbox is absent"
+        );
     }
 
     #[test]
@@ -1620,7 +1693,10 @@ mod tests {
         assert_eq!(report.entries, 0);
         assert!(report.errors.is_empty());
         assert_eq!(report.processed_dir_total_bytes, 0);
-        assert!(!processed.exists(), "processed/ should not be created when inbox is empty");
+        assert!(
+            !processed.exists(),
+            "processed/ should not be created when inbox is empty"
+        );
     }
 
     #[test]
@@ -1639,7 +1715,8 @@ mod tests {
             "agent": "pal",
             "agent_model": "gemini-3-pro-preview",
             "confidence": 0.9
-        })).unwrap();
+        }))
+        .unwrap();
         let inbox_file = inbox.join("pal-run-1.jsonl");
         std::fs::write(&inbox_file, format!("{line}\n")).unwrap();
 
@@ -1653,21 +1730,35 @@ mod tests {
         assert_eq!(all.len(), 1);
         assert!(matches!(all[0].provenance, Provenance::External { .. }));
 
-        assert!(!inbox_file.exists(), "inbox file should be moved after drain");
+        assert!(
+            !inbox_file.exists(),
+            "inbox file should be moved after drain"
+        );
 
-        let processed_files: Vec<_> = std::fs::read_dir(&processed).unwrap().collect::<Result<_,_>>().unwrap();
+        let processed_files: Vec<_> = std::fs::read_dir(&processed)
+            .unwrap()
+            .collect::<Result<_, _>>()
+            .unwrap();
         assert_eq!(processed_files.len(), 1);
         let name = processed_files[0].file_name().into_string().unwrap();
-        assert!(name.starts_with("pal-run-1.jsonl."), "expected ulid-suffixed name, got {name}");
+        assert!(
+            name.starts_with("pal-run-1.jsonl."),
+            "expected ulid-suffixed name, got {name}"
+        );
         assert!(name.ends_with(".jsonl"));
 
         // Claim-then-ingest invariant: processing/ must be empty on success.
         let processing = inbox.join("processing");
         if processing.exists() {
-            let leftover: Vec<_> = std::fs::read_dir(&processing).unwrap().collect::<Result<_,_>>().unwrap();
-            assert!(leftover.is_empty(),
+            let leftover: Vec<_> = std::fs::read_dir(&processing)
+                .unwrap()
+                .collect::<Result<_, _>>()
+                .unwrap();
+            assert!(
+                leftover.is_empty(),
                 "processing/ must be empty after successful drain, found {:?}",
-                leftover.iter().map(|e| e.path()).collect::<Vec<_>>());
+                leftover.iter().map(|e| e.path()).collect::<Vec<_>>()
+            );
         }
     }
 
@@ -1687,7 +1778,8 @@ mod tests {
             "agent": "pal",
             "agent_model": null,
             "confidence": null
-        })).unwrap();
+        }))
+        .unwrap();
         let bad = "{not json";
         std::fs::write(inbox.join("mix.jsonl"), format!("{good}\n{bad}\n{good}\n")).unwrap();
 
@@ -1752,9 +1844,15 @@ mod tests {
 
         let report = store.drain_inbox(&inbox, &processed).unwrap();
 
-        assert_eq!(report.entries, 0, "symlinked inbox file must not be ingested");
+        assert_eq!(
+            report.entries, 0,
+            "symlinked inbox file must not be ingested"
+        );
         assert!(
-            report.errors.iter().any(|e| e.message.starts_with("rejected:")),
+            report
+                .errors
+                .iter()
+                .any(|e| e.message.starts_with("rejected:")),
             "expected 'rejected: ...' error, got: {:?}",
             report.errors
         );
@@ -1782,11 +1880,17 @@ mod tests {
 
         assert_eq!(report.entries, 0);
         assert!(
-            report.errors.iter().any(|e| e.message.starts_with("rejected:")),
+            report
+                .errors
+                .iter()
+                .any(|e| e.message.starts_with("rejected:")),
             "expected 'rejected: ...' error, got: {:?}",
             report.errors
         );
-        assert!(inbox.join("huge.jsonl").exists(), "oversized file must remain in inbox/ (fail-closed)");
+        assert!(
+            inbox.join("huge.jsonl").exists(),
+            "oversized file must remain in inbox/ (fail-closed)"
+        );
     }
 
     #[test]
@@ -1806,11 +1910,17 @@ mod tests {
 
         assert_eq!(report.entries, 0);
         assert!(
-            report.errors.iter().any(|e| e.message.starts_with("rejected:")),
+            report
+                .errors
+                .iter()
+                .any(|e| e.message.starts_with("rejected:")),
             "expected 'rejected: ...' error for non-regular file, got: {:?}",
             report.errors
         );
-        assert!(sock_path.exists(), "non-regular file must remain in inbox/ (fail-closed)");
+        assert!(
+            sock_path.exists(),
+            "non-regular file must remain in inbox/ (fail-closed)"
+        );
     }
 
     #[test]
@@ -1832,11 +1942,17 @@ mod tests {
 
         assert_eq!(report.entries, 0);
         assert!(
-            report.errors.iter().any(|e| e.message.starts_with("rejected:")),
+            report
+                .errors
+                .iter()
+                .any(|e| e.message.starts_with("rejected:")),
             "expected 'rejected: ...' error for FIFO, got: {:?}",
             report.errors
         );
-        assert!(fifo_path.exists(), "FIFO must remain in inbox/ (fail-closed)");
+        assert!(
+            fifo_path.exists(),
+            "FIFO must remain in inbox/ (fail-closed)"
+        );
         assert!(!inbox.join("processing").join("evil.jsonl").exists());
     }
 
@@ -1862,7 +1978,11 @@ mod tests {
 
         let report = store.drain_inbox(&inbox, &processed).unwrap();
         assert_eq!(report.entries, 1, "exactly-at-cap file must be accepted");
-        assert!(report.errors.is_empty(), "no errors expected, got: {:?}", report.errors);
+        assert!(
+            report.errors.is_empty(),
+            "no errors expected, got: {:?}",
+            report.errors
+        );
     }
 
     #[test]
@@ -1880,11 +2000,17 @@ mod tests {
         let report = store.drain_inbox(&inbox, &processed).unwrap();
         assert_eq!(report.entries, 0);
         assert!(
-            report.errors.iter().any(|e| e.message.starts_with("rejected:")),
+            report
+                .errors
+                .iter()
+                .any(|e| e.message.starts_with("rejected:")),
             "expected 'rejected: ...' error, got: {:?}",
             report.errors
         );
-        assert!(inbox.join("over.jsonl").exists(), "off-by-one file must remain in inbox/ (fail-closed)");
+        assert!(
+            inbox.join("over.jsonl").exists(),
+            "off-by-one file must remain in inbox/ (fail-closed)"
+        );
     }
 
     #[test]
@@ -1997,11 +2123,19 @@ mod tests {
         let inbox = dir.path().join("inbox");
         let processed = dir.path().join("processed");
         std::fs::create_dir_all(&inbox).unwrap();
-        std::fs::write(inbox.join("ok.jsonl"), format!("{}\n", valid_external_jsonl_line())).unwrap();
+        std::fs::write(
+            inbox.join("ok.jsonl"),
+            format!("{}\n", valid_external_jsonl_line()),
+        )
+        .unwrap();
 
         let report = store.drain_inbox(&inbox, &processed).unwrap();
         assert_eq!(report.entries, 1);
-        assert!(report.errors.is_empty(), "no errors expected, got: {:?}", report.errors);
+        assert!(
+            report.errors.is_empty(),
+            "no errors expected, got: {:?}",
+            report.errors
+        );
     }
 
     #[test]
@@ -2063,10 +2197,7 @@ mod tests {
             h.join().unwrap();
         }
         let content = std::fs::read_to_string(&path).unwrap();
-        let lines: Vec<_> = content
-            .lines()
-            .filter(|l| !l.trim().is_empty())
-            .collect();
+        let lines: Vec<_> = content.lines().filter(|l| !l.trim().is_empty()).collect();
         assert_eq!(
             lines.len(),
             THREADS * PER_THREAD,
@@ -2152,7 +2283,10 @@ mod tests {
             "rename must propagate Err when src still exists; got {:?}",
             result
         );
-        assert!(src.exists(), "src must remain in place after a failed rename");
+        assert!(
+            src.exists(),
+            "src must remain in place after a failed rename"
+        );
     }
 
     #[test]
@@ -2174,8 +2308,11 @@ mod tests {
         assert_eq!(report.entries, 1, "only the valid line was appended");
         assert_eq!(report.errors.len(), 1, "uppercase TP must land in errors");
         let msg = report.errors[0].message.to_lowercase();
-        assert!(msg.contains("tp") || msg.contains("verdict") || msg.contains("unknown variant"),
-            "error must reference the bad verdict: {}", report.errors[0].message);
+        assert!(
+            msg.contains("tp") || msg.contains("verdict") || msg.contains("unknown variant"),
+            "error must reference the bad verdict: {}",
+            report.errors[0].message
+        );
     }
 
     // ─── Stats redesign Phase 0: finding_id / rule_id schema additions ───
@@ -2189,8 +2326,8 @@ mod tests {
     fn legacy_jsonl_row_loads_with_none_finding_id_and_rule_id() {
         // A row written before the schema bump — no finding_id or rule_id keys.
         let legacy_json = r#"{"file_path":"x.rs","finding_title":"t","finding_category":"security","verdict":"tp","reason":"r","model":"gpt","timestamp":"2026-01-01T00:00:00Z"}"#;
-        let entry: FeedbackEntry = serde_json::from_str(legacy_json)
-            .expect("legacy row must still deserialize");
+        let entry: FeedbackEntry =
+            serde_json::from_str(legacy_json).expect("legacy row must still deserialize");
         assert_eq!(entry.finding_id, None);
         assert_eq!(entry.rule_id, None);
     }
@@ -2214,8 +2351,14 @@ mod tests {
             rule_id: None,
         };
         let json = serde_json::to_string(&entry).expect("serialize");
-        assert!(!json.contains("\"finding_id\""), "json must not contain finding_id key when None: {json}");
-        assert!(!json.contains("\"rule_id\""), "json must not contain rule_id key when None: {json}");
+        assert!(
+            !json.contains("\"finding_id\""),
+            "json must not contain finding_id key when None: {json}"
+        );
+        assert!(
+            !json.contains("\"rule_id\""),
+            "json must not contain rule_id key when None: {json}"
+        );
     }
 
     #[test]
@@ -2235,7 +2378,10 @@ mod tests {
         };
         let json = serde_json::to_string(&entry).expect("serialize");
         let back: FeedbackEntry = serde_json::from_str(&json).expect("deserialize");
-        assert_eq!(back.finding_id.as_deref(), Some("01HXYZ1234567890ABCDEFGHJK"));
+        assert_eq!(
+            back.finding_id.as_deref(),
+            Some("01HXYZ1234567890ABCDEFGHJK")
+        );
         assert_eq!(back.rule_id.as_deref(), Some("python/eval-non-literal"));
     }
 
@@ -2257,9 +2403,14 @@ mod tests {
             rule_id: Some("python/md5-usage".into()),
         };
         let json = serde_json::to_string(&entry).expect("serialize");
-        assert!(!json.contains("\"finding_id\""), "finding_id should be omitted: {json}");
-        assert!(json.contains("\"rule_id\":\"python/md5-usage\""),
-            "rule_id must be present in json: {json}");
+        assert!(
+            !json.contains("\"finding_id\""),
+            "finding_id should be omitted: {json}"
+        );
+        assert!(
+            json.contains("\"rule_id\":\"python/md5-usage\""),
+            "rule_id must be present in json: {json}"
+        );
         let back: FeedbackEntry = serde_json::from_str(&json).expect("deserialize");
         assert_eq!(back.finding_id, None);
         assert_eq!(back.rule_id.as_deref(), Some("python/md5-usage"));
@@ -2271,7 +2422,10 @@ mod tests {
         // Catches accidental refactors to Option<serde_json::Value>.
         let bad_json = r#"{"file_path":"x.rs","finding_title":"t","finding_category":"c","verdict":"tp","reason":"r","model":null,"timestamp":"2026-01-01T00:00:00Z","finding_id":42}"#;
         let result: Result<FeedbackEntry, _> = serde_json::from_str(bad_json);
-        assert!(result.is_err(), "non-string finding_id must fail to deserialize");
+        assert!(
+            result.is_err(),
+            "non-string finding_id must fail to deserialize"
+        );
     }
 
     #[test]
@@ -2285,10 +2439,14 @@ mod tests {
         let legacy = r#"{"file_path":"x.rs","finding_title":"t","finding_category":"security","verdict":"tp","reason":"r","model":"gpt","timestamp":"2026-01-01T00:00:00Z"}"#;
         let entry: FeedbackEntry = serde_json::from_str(legacy).expect("legacy load");
         let resaved = serde_json::to_string(&entry).expect("resave");
-        assert!(!resaved.contains("\"finding_id\""),
-            "resave must not introduce finding_id key: {resaved}");
-        assert!(!resaved.contains("\"rule_id\""),
-            "resave must not introduce rule_id key: {resaved}");
+        assert!(
+            !resaved.contains("\"finding_id\""),
+            "resave must not introduce finding_id key: {resaved}"
+        );
+        assert!(
+            !resaved.contains("\"rule_id\""),
+            "resave must not introduce rule_id key: {resaved}"
+        );
     }
 }
 

--- a/src/feedback_index.rs
+++ b/src/feedback_index.rs
@@ -75,11 +75,8 @@ impl FeedbackIndex {
                 let texts: Vec<String> = entries
                     .iter()
                     .map(|e| {
-                        let pattern = patterns::classify_pattern(
-                            &e.finding_title,
-                            "",
-                            &e.finding_category,
-                        );
+                        let pattern =
+                            patterns::classify_pattern(&e.finding_title, "", &e.finding_category);
                         patterns::embedding_text_enriched(
                             &e.finding_title,
                             &e.finding_category,
@@ -183,9 +180,14 @@ impl FeedbackIndex {
         {
             match crate::embeddings::LocalEmbedder::new() {
                 Ok(mut embedder) => {
-                    let texts: Vec<String> = entries.iter()
+                    let texts: Vec<String> = entries
+                        .iter()
                         .map(|e| {
-                            let pattern = patterns::classify_pattern(&e.finding_title, "", &e.finding_category);
+                            let pattern = patterns::classify_pattern(
+                                &e.finding_title,
+                                "",
+                                &e.finding_category,
+                            );
                             patterns::embedding_text_enriched(
                                 &e.finding_title,
                                 &e.finding_category,
@@ -219,11 +221,22 @@ impl FeedbackIndex {
                         entries.len(),
                         vectors.len(),
                     );
-                    tracing::debug!(entries = entries.len(), "FeedbackIndex: embedded with bge-small-en-v1.5");
-                    return Ok(Self { entries, vectors, embedder: Some(embedder), bm25_engine });
+                    tracing::debug!(
+                        entries = entries.len(),
+                        "FeedbackIndex: embedded with bge-small-en-v1.5"
+                    );
+                    return Ok(Self {
+                        entries,
+                        vectors,
+                        embedder: Some(embedder),
+                        bm25_engine,
+                    });
                 }
                 Err(e) => {
-                    eprintln!("FeedbackIndex: embedding model unavailable ({}), falling back to BM25+Jaccard", e);
+                    eprintln!(
+                        "FeedbackIndex: embedding model unavailable ({}), falling back to BM25+Jaccard",
+                        e
+                    );
                 }
             }
         }
@@ -256,7 +269,8 @@ impl FeedbackIndex {
         // Build an enriched query once. Downstream methods that need plain title
         // (e.g. BM25 tokenization) accept the whole string; BM25 tokenizes and
         // IDF self-weights so the extra tokens don't hurt rare-title matches.
-        let extras: Vec<&str> = discriminators.iter()
+        let extras: Vec<&str> = discriminators
+            .iter()
             .copied()
             .map(str::trim)
             .filter(|s| !s.is_empty())
@@ -268,13 +282,15 @@ impl FeedbackIndex {
         self.find_similar(&enriched_query, category, top_k)
     }
 
-    pub fn find_similar(&mut self, finding_title: &str, category: &str, top_k: usize) -> Vec<SimilarEntry> {
+    pub fn find_similar(
+        &mut self,
+        finding_title: &str,
+        category: &str,
+        top_k: usize,
+    ) -> Vec<SimilarEntry> {
         // Hybrid path: both BM25 and embeddings present → RRF fuse.
         #[cfg(feature = "embeddings")]
-        if self.bm25_engine.is_some()
-            && self.embedder.is_some()
-            && !self.vectors.is_empty()
-        {
+        if self.bm25_engine.is_some() && self.embedder.is_some() && !self.vectors.is_empty() {
             return self.find_similar_hybrid_rrf(finding_title, category, top_k);
         }
 
@@ -295,7 +311,12 @@ impl FeedbackIndex {
     /// the tail of each retriever gets a chance to surface items the other
     /// missed.
     #[cfg(feature = "embeddings")]
-    fn find_similar_hybrid_rrf(&mut self, finding_title: &str, category: &str, top_k: usize) -> Vec<SimilarEntry> {
+    fn find_similar_hybrid_rrf(
+        &mut self,
+        finding_title: &str,
+        category: &str,
+        top_k: usize,
+    ) -> Vec<SimilarEntry> {
         const K: f32 = 60.0;
         let pool = (top_k * 3).max(20);
 
@@ -344,7 +365,12 @@ impl FeedbackIndex {
             .collect()
     }
 
-    fn find_similar_bm25(&self, finding_title: &str, _category: &str, top_k: usize) -> Vec<SimilarEntry> {
+    fn find_similar_bm25(
+        &self,
+        finding_title: &str,
+        _category: &str,
+        top_k: usize,
+    ) -> Vec<SimilarEntry> {
         let engine = match &self.bm25_engine {
             Some(e) => e,
             None => return Vec::new(),
@@ -372,11 +398,19 @@ impl FeedbackIndex {
             .collect()
     }
 
-    fn find_similar_jaccard(&self, finding_title: &str, category: &str, top_k: usize) -> Vec<SimilarEntry> {
+    fn find_similar_jaccard(
+        &self,
+        finding_title: &str,
+        category: &str,
+        top_k: usize,
+    ) -> Vec<SimilarEntry> {
         self.jaccard_rank_indices(finding_title, category, top_k)
             .into_iter()
             .filter_map(|(idx, sim)| {
-                self.entries.get(idx).map(|e| SimilarEntry { entry: e.clone(), similarity: sim })
+                self.entries.get(idx).map(|e| SimilarEntry {
+                    entry: e.clone(),
+                    similarity: sim,
+                })
             })
             .collect()
     }
@@ -384,11 +418,24 @@ impl FeedbackIndex {
     /// Rank entries by Jaccard + category match, returning (entry_index, sim).
     /// Index-preserving (mirrors `embed_rank_indices`) so duplicate-title
     /// entries stay distinct during RRF fusion.
-    fn jaccard_rank_indices(&self, finding_title: &str, category: &str, top_k: usize) -> Vec<(usize, f32)> {
-        let mut scored: Vec<(usize, f32)> = self.entries.iter().enumerate()
+    fn jaccard_rank_indices(
+        &self,
+        finding_title: &str,
+        category: &str,
+        top_k: usize,
+    ) -> Vec<(usize, f32)> {
+        let mut scored: Vec<(usize, f32)> = self
+            .entries
+            .iter()
+            .enumerate()
             .map(|(i, e)| {
                 let title_sim = word_jaccard(finding_title, &e.finding_title);
-                let cat_match = if !e.finding_category.is_empty() && category == e.finding_category { 0.4 } else { 0.0 };
+                let cat_match = if !e.finding_category.is_empty() && category == e.finding_category
+                {
+                    0.4
+                } else {
+                    0.0
+                };
                 (i, (title_sim * 0.6 + cat_match) as f32)
             })
             .collect();
@@ -398,11 +445,19 @@ impl FeedbackIndex {
     }
 
     #[cfg(feature = "embeddings")]
-    fn find_similar_embedding(&mut self, finding_title: &str, category: &str, top_k: usize) -> Vec<SimilarEntry> {
+    fn find_similar_embedding(
+        &mut self,
+        finding_title: &str,
+        category: &str,
+        top_k: usize,
+    ) -> Vec<SimilarEntry> {
         self.embed_rank_indices(finding_title, category, top_k)
             .into_iter()
             .filter_map(|(idx, sim)| {
-                self.entries.get(idx).map(|e| SimilarEntry { entry: e.clone(), similarity: sim })
+                self.entries.get(idx).map(|e| SimilarEntry {
+                    entry: e.clone(),
+                    similarity: sim,
+                })
             })
             .collect()
     }
@@ -412,7 +467,12 @@ impl FeedbackIndex {
     /// later) is load-bearing for RRF: duplicate (title, category, timestamp)
     /// entries would otherwise collapse to the first match.
     #[cfg(feature = "embeddings")]
-    fn embed_rank_indices(&mut self, finding_title: &str, category: &str, top_k: usize) -> Vec<(usize, f32)> {
+    fn embed_rank_indices(
+        &mut self,
+        finding_title: &str,
+        category: &str,
+        top_k: usize,
+    ) -> Vec<(usize, f32)> {
         let pattern = patterns::classify_pattern(finding_title, "", category);
         let query_text = patterns::embedding_text(finding_title, category, pattern.as_deref());
 
@@ -441,7 +501,9 @@ impl FeedbackIndex {
 }
 
 fn word_jaccard(a: &str, b: &str) -> f64 {
-    if a.is_empty() || b.is_empty() { return 0.0; }
+    if a.is_empty() || b.is_empty() {
+        return 0.0;
+    }
     // Lowercase so equivalent titles like "SQL Injection" / "sql injection"
     // don't split into disjoint token sets.
     let al = a.to_lowercase();
@@ -456,9 +518,9 @@ fn word_jaccard(a: &str, b: &str) -> f64 {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::feedback::{FeedbackStore, Verdict, Provenance};
-    use tempfile::TempDir;
+    use crate::feedback::{FeedbackStore, Provenance, Verdict};
     use chrono::Utc;
+    use tempfile::TempDir;
 
     fn make_entry(title: &str, category: &str, verdict: Verdict) -> FeedbackEntry {
         FeedbackEntry {
@@ -484,7 +546,13 @@ mod tests {
         // shipped as the default.
         let dir = TempDir::new().unwrap();
         let store = FeedbackStore::new(dir.path().join("fb.jsonl"));
-        store.record(&make_entry("SQL injection in auth", "security", Verdict::Tp)).unwrap();
+        store
+            .record(&make_entry(
+                "SQL injection in auth",
+                "security",
+                Verdict::Tp,
+            ))
+            .unwrap();
         let index = FeedbackIndex::build(&store).unwrap();
         assert!(
             index.embedder.is_some(),
@@ -581,14 +649,20 @@ mod tests {
             2,
         );
         assert_eq!(similar.len(), 2);
-        assert_eq!(similar[0].entry.reason, e_b.reason,
+        assert_eq!(
+            similar[0].entry.reason, e_b.reason,
             "JWT-reason entry must rank ahead despite being inserted second; \
              if you see the API-body reason here, the corpus is not enriched with reason text. \
-             got top reason: {:?}", similar[0].entry.reason);
+             got top reason: {:?}",
+            similar[0].entry.reason
+        );
         // And B's similarity should exceed A's, not tie.
-        assert!(similar[0].similarity > similar[1].similarity,
+        assert!(
+            similar[0].similarity > similar[1].similarity,
             "top sim {} must exceed second {}, else the ranking was an insertion-order tie",
-            similar[0].similarity, similar[1].similarity);
+            similar[0].similarity,
+            similar[1].similarity
+        );
     }
 
     #[test]
@@ -618,9 +692,11 @@ mod tests {
             2,
         );
         assert_eq!(with_jwt.len(), 2);
-        assert_eq!(with_jwt[0].entry.reason, e_jwt.reason,
+        assert_eq!(
+            with_jwt[0].entry.reason, e_jwt.reason,
             "JWT discriminators must rank JWT-reason first; got: {:?}",
-            with_jwt[0].entry.reason);
+            with_jwt[0].entry.reason
+        );
 
         // API-flavored discriminators must flip the ranking — API-reason first.
         // Proves the discriminators are actually steering retrieval, not just
@@ -632,9 +708,11 @@ mod tests {
             2,
         );
         assert_eq!(with_api.len(), 2);
-        assert_eq!(with_api[0].entry.reason, e_api.reason,
+        assert_eq!(
+            with_api[0].entry.reason, e_api.reason,
             "API discriminators must rank API-reason first; got: {:?}",
-            with_api[0].entry.reason);
+            with_api[0].entry.reason
+        );
     }
 
     #[test]
@@ -642,7 +720,9 @@ mod tests {
         let dir = TempDir::new().unwrap();
         let store = FeedbackStore::new(dir.path().join("fb.jsonl"));
         for t in &["SQL injection in query", "Unused import"] {
-            store.record(&make_entry(t, "security", Verdict::Fp)).unwrap();
+            store
+                .record(&make_entry(t, "security", Verdict::Fp))
+                .unwrap();
         }
         let mut index = FeedbackIndex::build_bm25(&store).unwrap();
         let plain = index.find_similar("SQL injection risk", "security", 2);
@@ -669,7 +749,11 @@ mod tests {
         let mut index = FeedbackIndex::build_bm25(&store).unwrap();
         let similar = index.find_similar("SQL injection risk", "security", 2);
         assert!(similar[0].similarity > 0.0);
-        assert!(similar[0].similarity <= 1.0, "similarity must be <= 1.0, got {}", similar[0].similarity);
+        assert!(
+            similar[0].similarity <= 1.0,
+            "similarity must be <= 1.0, got {}",
+            similar[0].similarity
+        );
     }
 
     #[test]
@@ -678,12 +762,21 @@ mod tests {
         // and ~100x startup-time reduction for single-shot CLI use.
         let dir = TempDir::new().unwrap();
         let store = FeedbackStore::new(dir.path().join("fb.jsonl"));
-        store.record(&make_entry("SQL injection in auth", "security", Verdict::Tp)).unwrap();
+        store
+            .record(&make_entry(
+                "SQL injection in auth",
+                "security",
+                Verdict::Tp,
+            ))
+            .unwrap();
         let index = FeedbackIndex::build_jaccard_only(&store).unwrap();
         #[cfg(feature = "embeddings")]
         {
             assert!(index.embedder.is_none(), "fast mode must not load embedder");
-            assert!(index.vectors.is_empty(), "fast mode must not compute vectors");
+            assert!(
+                index.vectors.is_empty(),
+                "fast mode must not compute vectors"
+            );
         }
         assert_eq!(index.entries.len(), 1);
     }
@@ -692,8 +785,16 @@ mod tests {
     fn build_jaccard_only_retrieval_works() {
         let dir = TempDir::new().unwrap();
         let store = FeedbackStore::new(dir.path().join("fb.jsonl"));
-        store.record(&make_entry("SQL injection in auth", "security", Verdict::Tp)).unwrap();
-        store.record(&make_entry("Unused import os", "style", Verdict::Fp)).unwrap();
+        store
+            .record(&make_entry(
+                "SQL injection in auth",
+                "security",
+                Verdict::Tp,
+            ))
+            .unwrap();
+        store
+            .record(&make_entry("Unused import os", "style", Verdict::Fp))
+            .unwrap();
         let mut index = FeedbackIndex::build_jaccard_only(&store).unwrap();
         let similar = index.find_similar("SQL injection in query", "security", 2);
         assert!(!similar.is_empty());
@@ -704,9 +805,23 @@ mod tests {
     fn jaccard_retrieval_finds_similar() {
         let dir = TempDir::new().unwrap();
         let store = FeedbackStore::new(dir.path().join("fb.jsonl"));
-        store.record(&make_entry("SQL injection in auth", "security", Verdict::Tp)).unwrap();
-        store.record(&make_entry("Unused import os", "style", Verdict::Fp)).unwrap();
-        store.record(&make_entry("SQL injection via f-string", "security", Verdict::Tp)).unwrap();
+        store
+            .record(&make_entry(
+                "SQL injection in auth",
+                "security",
+                Verdict::Tp,
+            ))
+            .unwrap();
+        store
+            .record(&make_entry("Unused import os", "style", Verdict::Fp))
+            .unwrap();
+        store
+            .record(&make_entry(
+                "SQL injection via f-string",
+                "security",
+                Verdict::Tp,
+            ))
+            .unwrap();
 
         let mut index = FeedbackIndex::build(&store).unwrap();
         let similar = index.find_similar("SQL injection in query", "security", 2);
@@ -747,20 +862,36 @@ mod tests {
             finding_id: None,
             rule_id: None,
         };
-        let e_fp = FeedbackEntry { verdict: Verdict::Fp, reason: "false alarm".into(), ..e_tp.clone() };
+        let e_fp = FeedbackEntry {
+            verdict: Verdict::Fp,
+            reason: "false alarm".into(),
+            ..e_tp.clone()
+        };
         store.record(&e_tp).unwrap();
         store.record(&e_fp).unwrap();
         // Unrelated filler
-        store.record(&make_entry("Unused import", "style", Verdict::Fp)).unwrap();
+        store
+            .record(&make_entry("Unused import", "style", Verdict::Fp))
+            .unwrap();
 
         let mut index = FeedbackIndex::build(&store).unwrap();
         let similar = index.find_similar("SQL injection risk", "security", 5);
         // Both near-duplicate rows should survive RRF, not collapse to one.
-        let sql_count = similar.iter().filter(|s| s.entry.finding_title.contains("SQL")).count();
-        assert_eq!(sql_count, 2,
-            "duplicate-title entries with opposite verdicts must both be returned; got {}", sql_count);
-        let has_tp = similar.iter().any(|s| s.entry.finding_title.contains("SQL") && s.entry.verdict == Verdict::Tp);
-        let has_fp = similar.iter().any(|s| s.entry.finding_title.contains("SQL") && s.entry.verdict == Verdict::Fp);
+        let sql_count = similar
+            .iter()
+            .filter(|s| s.entry.finding_title.contains("SQL"))
+            .count();
+        assert_eq!(
+            sql_count, 2,
+            "duplicate-title entries with opposite verdicts must both be returned; got {}",
+            sql_count
+        );
+        let has_tp = similar
+            .iter()
+            .any(|s| s.entry.finding_title.contains("SQL") && s.entry.verdict == Verdict::Tp);
+        let has_fp = similar
+            .iter()
+            .any(|s| s.entry.finding_title.contains("SQL") && s.entry.verdict == Verdict::Fp);
         assert!(has_tp && has_fp, "both TP and FP copies must be preserved");
     }
 
@@ -787,6 +918,10 @@ mod tests {
         // Retrieval must treat title casing as equivalent; "SQL Injection" and
         // "sql injection" represent the same finding and should fully overlap.
         let sim = word_jaccard("SQL Injection in auth", "sql injection in auth");
-        assert!((sim - 1.0).abs() < 1e-6, "case-insensitive overlap expected, got {}", sim);
+        assert!(
+            (sim - 1.0).abs() < 1e-6,
+            "case-insensitive overlap expected, got {}",
+            sim
+        );
     }
 }

--- a/src/finding.rs
+++ b/src/finding.rs
@@ -613,12 +613,19 @@ mod tests {
     fn finding_builder_assigns_unique_ulid_id() {
         let a = FindingBuilder::new().build();
         let b = FindingBuilder::new().build();
-        assert_eq!(a.id.len(), 26, "ULID is 26 chars in canonical Crockford encoding");
+        assert_eq!(
+            a.id.len(),
+            26,
+            "ULID is 26 chars in canonical Crockford encoding"
+        );
         assert_ne!(a.id, b.id, "each FindingBuilder produces a fresh ULID");
         // ULID monotonicity isn't guaranteed across rapid calls; just check
         // both are valid Crockford-base32 — alphanumeric, no I/L/O/U.
         for c in a.id.chars() {
-            assert!(c.is_ascii_alphanumeric(), "ULID char must be alphanumeric: {c}");
+            assert!(
+                c.is_ascii_alphanumeric(),
+                "ULID char must be alphanumeric: {c}"
+            );
         }
     }
 
@@ -644,7 +651,10 @@ mod tests {
     fn finding_serializes_id_into_json() {
         let f = FindingBuilder::new().id("01HXYZ").build();
         let json = serde_json::to_string(&f).unwrap();
-        assert!(json.contains("\"id\":\"01HXYZ\""), "id must appear in JSON: {json}");
+        assert!(
+            json.contains("\"id\":\"01HXYZ\""),
+            "id must appear in JSON: {json}"
+        );
     }
 
     #[test]

--- a/src/formatting.rs
+++ b/src/formatting.rs
@@ -1,5 +1,4 @@
 /// Numeric formatting: human-readable k/M suffixes per DESIGN.md section 11.
-
 use std::time::Duration;
 
 pub fn format_count(n: u64) -> String {
@@ -95,7 +94,11 @@ mod tests {
             (Duration::from_secs(62), "62.0s"),
         ];
         for (input, expected) in cases {
-            assert_eq!(format_duration(input), expected, "format_duration({input:?})");
+            assert_eq!(
+                format_duration(input),
+                expected,
+                "format_duration({input:?})"
+            );
         }
     }
 

--- a/src/glyphs.rs
+++ b/src/glyphs.rs
@@ -35,13 +35,22 @@ pub fn sparkline(points: &[f64], unicode: bool) -> String {
     }
     // Scale over finite values only. NaN/±∞ render as the lowest level so they
     // don't swamp the scale and make real trends unreadable.
-    let (min, max) = points.iter().copied().filter(|p| p.is_finite())
-        .fold((f64::INFINITY, f64::NEG_INFINITY), |(lo, hi), p| (lo.min(p), hi.max(p)));
+    let (min, max) = points
+        .iter()
+        .copied()
+        .filter(|p| p.is_finite())
+        .fold((f64::INFINITY, f64::NEG_INFINITY), |(lo, hi), p| {
+            (lo.min(p), hi.max(p))
+        });
     let range = max - min;
 
     let unicode_levels: [char; 8] = ['▁', '▂', '▃', '▄', '▅', '▆', '▇', '█'];
     let ascii_levels: [char; 5] = ['_', '.', '-', '=', '^'];
-    let levels: &[char] = if unicode { &unicode_levels } else { &ascii_levels };
+    let levels: &[char] = if unicode {
+        &unicode_levels
+    } else {
+        &ascii_levels
+    };
 
     let mut out = String::with_capacity(points.len() * 3);
     for &p in points {
@@ -154,8 +163,12 @@ mod tests {
         assert_eq!(chars.len(), 5);
         // Each char's unicode codepoint should be >= the previous (8 levels, monotone).
         for pair in chars.windows(2) {
-            assert!(pair[1] as u32 >= pair[0] as u32,
-                "non-monotone: {:?} -> {:?}", pair[0], pair[1]);
+            assert!(
+                pair[1] as u32 >= pair[0] as u32,
+                "non-monotone: {:?} -> {:?}",
+                pair[0],
+                pair[1]
+            );
         }
     }
 
@@ -167,8 +180,11 @@ mod tests {
         let s = sparkline(&[1.0, f64::NAN, 3.0, 5.0], true);
         assert_eq!(s.chars().count(), 4);
         let unique: std::collections::BTreeSet<char> = s.chars().collect();
-        assert!(unique.len() > 1,
-            "finite points 1,3,5 should produce >1 distinct levels even with NaN, got {:?}", s);
+        assert!(
+            unique.len() > 1,
+            "finite points 1,3,5 should produce >1 distinct levels even with NaN, got {:?}",
+            s
+        );
     }
 
     #[test]
@@ -176,8 +192,11 @@ mod tests {
         let s = sparkline(&[1.0, f64::INFINITY, 3.0, 5.0], true);
         assert_eq!(s.chars().count(), 4);
         let unique: std::collections::BTreeSet<char> = s.chars().collect();
-        assert!(unique.len() > 1,
-            "finite points 1,3,5 should produce >1 distinct levels even with ∞, got {:?}", s);
+        assert!(
+            unique.len() > 1,
+            "finite points 1,3,5 should produce >1 distinct levels even with ∞, got {:?}",
+            s
+        );
     }
 
     #[test]
@@ -186,8 +205,12 @@ mod tests {
         for c in s.chars() {
             // U+2581..=U+2588 are the 8 lower-block variants
             let cp = c as u32;
-            assert!((0x2581..=0x2588).contains(&cp),
-                "char {:?} codepoint {:04X} is outside U+2581-2588", c, cp);
+            assert!(
+                (0x2581..=0x2588).contains(&cp),
+                "char {:?} codepoint {:04X} is outside U+2581-2588",
+                c,
+                cp
+            );
         }
     }
 
@@ -197,7 +220,11 @@ mod tests {
         assert_eq!(s.chars().count(), 5);
         // Fallback chars must be printable ASCII
         for c in s.chars() {
-            assert!(c.is_ascii() && !c.is_ascii_control(), "{:?} not printable ascii", c);
+            assert!(
+                c.is_ascii() && !c.is_ascii_control(),
+                "{:?} not printable ascii",
+                c
+            );
         }
     }
 

--- a/src/grounding.rs
+++ b/src/grounding.rs
@@ -8,16 +8,54 @@ static BACKTICK_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"`([^`]+)`").
 static STOPWORDS: LazyLock<HashSet<&'static str>> = LazyLock::new(|| {
     [
         // Rust
-        "self", "Self", "super", "crate", "true", "false", "None", "Some",
-        "unwrap", "expect", "clone", "iter", "into", "from", "default",
-        "push", "is_empty", "map", "filter", "collect", "Result", "Option",
-        "String", "Vec", "Box", "Arc", "Mutex",
+        "self",
+        "Self",
+        "super",
+        "crate",
+        "true",
+        "false",
+        "None",
+        "Some",
+        "unwrap",
+        "expect",
+        "clone",
+        "iter",
+        "into",
+        "from",
+        "default",
+        "push",
+        "is_empty",
+        "map",
+        "filter",
+        "collect",
+        "Result",
+        "Option",
+        "String",
+        "Vec",
+        "Box",
+        "Arc",
+        "Mutex",
         // Python
-        "True", "False", "print", "list", "dict", "str", "int", "float",
-        "bool", "type", "init",
+        "True",
+        "False",
+        "print",
+        "list",
+        "dict",
+        "str",
+        "int",
+        "float",
+        "bool",
+        "type",
+        "init",
         // TypeScript/JS
-        "this", "null", "undefined", "console", "log",
-        "length", "toString", "Promise",
+        "this",
+        "null",
+        "undefined",
+        "console",
+        "log",
+        "length",
+        "toString",
+        "Promise",
     ]
     .into_iter()
     .collect()
@@ -44,7 +82,10 @@ pub fn extract_identifiers(text: &str) -> Vec<&str> {
         .collect()
 }
 
-pub fn extract_identifiers_from_finding_text<'a>(title: &'a str, _description: &'a str) -> Vec<&'a str> {
+pub fn extract_identifiers_from_finding_text<'a>(
+    title: &'a str,
+    _description: &'a str,
+) -> Vec<&'a str> {
     extract_identifiers(title)
 }
 
@@ -79,9 +120,15 @@ fn contains_symbol(text: &str, id: &str) -> bool {
     let needs_trailing_boundary = id.ends_with(is_word_char);
     text.match_indices(id).any(|(idx, _)| {
         let before_ok = !needs_leading_boundary
-            || text[..idx].chars().next_back().is_none_or(|c| !is_word_char(c));
+            || text[..idx]
+                .chars()
+                .next_back()
+                .is_none_or(|c| !is_word_char(c));
         let after_ok = !needs_trailing_boundary
-            || text[idx + id.len()..].chars().next().is_none_or(|c| !is_word_char(c));
+            || text[idx + id.len()..]
+                .chars()
+                .next()
+                .is_none_or(|c| !is_word_char(c));
         before_ok && after_ok
     })
 }
@@ -255,12 +302,17 @@ mod tests {
             "Missing error handling",
             "The function `process_data` at line 42 swallows the error",
         );
-        assert!(ids.is_empty(), "description identifiers should not be used as fallback");
+        assert!(
+            ids.is_empty(),
+            "description identifiers should not be used as fallback"
+        );
     }
 
     #[test]
     fn multibyte_utf8_identifier() {
-        let ids = extract_identifiers("`some_func` and `\u{65e5}\u{672c}\u{8a9e}\u{30c6}\u{30b9}\u{30c8}` both present");
+        let ids = extract_identifiers(
+            "`some_func` and `\u{65e5}\u{672c}\u{8a9e}\u{30c6}\u{30b9}\u{30c8}` both present",
+        );
         assert_eq!(ids.len(), 2);
     }
 
@@ -362,7 +414,12 @@ mod tests {
                 .severity(input.clone())
                 .build();
             let result = verify_grounding(&f, sample_source());
-            assert_eq!(result.severity_change, Some(expected), "failed for {:?}", input);
+            assert_eq!(
+                result.severity_change,
+                Some(expected),
+                "failed for {:?}",
+                input
+            );
         }
     }
 
@@ -505,7 +562,10 @@ mod tests {
         let result = apply_grounding(findings, source, false);
         assert_eq!(result[0].grounding_status, Some(GroundingStatus::Verified));
         assert_eq!(result[0].severity, Severity::High);
-        assert_eq!(result[1].grounding_status, Some(GroundingStatus::SymbolNotFound));
+        assert_eq!(
+            result[1].grounding_status,
+            Some(GroundingStatus::SymbolNotFound)
+        );
         assert_eq!(result[1].severity, Severity::Medium); // demoted
         assert!(result[2].grounding_status.is_none()); // LocalAst untouched
         assert_eq!(result[2].severity, Severity::Medium);
@@ -635,6 +695,9 @@ mod tests {
             GroundingStatus::NotChecked,
             "title has no backticked IDs; description fallback should not cause SymbolNotFound"
         );
-        assert!(result.severity_change.is_none(), "severity should not change");
+        assert!(
+            result.severity_change.is_none(),
+            "severity should not change"
+        );
     }
 }

--- a/src/http_server.rs
+++ b/src/http_server.rs
@@ -1,14 +1,13 @@
 /// HTTP daemon: serves review requests over localhost.
 /// CLI clients can connect via `quorum review --daemon` instead of parsing locally.
-
 use std::path::PathBuf;
 use std::sync::Arc;
 
 use axum::{
+    Json, Router,
     extract::State,
     http::StatusCode,
     routing::{get, post},
-    Json, Router,
 };
 use serde::{Deserialize, Serialize};
 
@@ -103,8 +102,12 @@ async fn review(
     State(state): State<Arc<DaemonState>>,
     Json(req): Json<ReviewRequest>,
 ) -> Result<Json<ReviewResponse>, (StatusCode, String)> {
-    let lang = Language::from_path(std::path::Path::new(&req.file_path))
-        .ok_or_else(|| (StatusCode::BAD_REQUEST, format!("Unsupported file type: {}", req.file_path)))?;
+    let lang = Language::from_path(std::path::Path::new(&req.file_path)).ok_or_else(|| {
+        (
+            StatusCode::BAD_REQUEST,
+            format!("Unsupported file type: {}", req.file_path),
+        )
+    })?;
 
     let cache_before = state.parse_cache.stats().hits;
 
@@ -124,7 +127,12 @@ async fn review(
         Some(&state.parse_cache),
     )
     .await
-    .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, format!("Review error: {}", e)))?;
+    .map_err(|e| {
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            format!("Review error: {}", e),
+        )
+    })?;
 
     let cache_hit = state.parse_cache.stats().hits > cache_before;
 
@@ -136,8 +144,7 @@ async fn review(
 
 /// Default socket path for the daemon.
 pub fn default_socket_path() -> PathBuf {
-    let dir = std::env::var("XDG_RUNTIME_DIR")
-        .unwrap_or_else(|_| "/tmp".into());
+    let dir = std::env::var("XDG_RUNTIME_DIR").unwrap_or_else(|_| "/tmp".into());
     PathBuf::from(dir).join("quorum.sock")
 }
 
@@ -194,7 +201,9 @@ mod tests {
             .unwrap();
         let resp = app.oneshot(req).await.unwrap();
         assert_eq!(resp.status(), StatusCode::OK);
-        let body = axum::body::to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
         let health: HealthResponse = serde_json::from_slice(&body).unwrap();
         assert_eq!(health.status, "ok");
     }
@@ -230,7 +239,9 @@ mod tests {
         let resp = app.oneshot(req).await.unwrap();
         assert_eq!(resp.status(), StatusCode::OK);
 
-        let body = axum::body::to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
         let review: ReviewResponse = serde_json::from_slice(&body).unwrap();
         assert!(!review.cache_hit, "First request should be a cache miss");
 
@@ -247,7 +258,9 @@ mod tests {
             .body(Body::from(serde_json::to_string(&body2).unwrap()))
             .unwrap();
         let resp2 = app2.oneshot(req2).await.unwrap();
-        let body2 = axum::body::to_bytes(resp2.into_body(), usize::MAX).await.unwrap();
+        let body2 = axum::body::to_bytes(resp2.into_body(), usize::MAX)
+            .await
+            .unwrap();
         let review2: ReviewResponse = serde_json::from_slice(&body2).unwrap();
         assert!(review2.cache_hit, "Second request should be a cache hit");
     }
@@ -266,9 +279,14 @@ mod tests {
             .body(Body::from(serde_json::to_string(&body).unwrap()))
             .unwrap();
         let resp = app.oneshot(req).await.unwrap();
-        let body = axum::body::to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
         let review: ReviewResponse = serde_json::from_slice(&body).unwrap();
-        assert!(!review.findings.is_empty(), "Should find issues in vulnerable Python");
+        assert!(
+            !review.findings.is_empty(),
+            "Should find issues in vulnerable Python"
+        );
     }
 
     #[tokio::test]

--- a/src/hydration.rs
+++ b/src/hydration.rs
@@ -44,19 +44,46 @@ pub fn hydrate(
     let mut all_imports: Vec<(String, String)> = Vec::new(); // (imported_name, full_text)
 
     // Gather definitions
-    collect_definitions(&root, source, &func_kinds, &type_kinds, &import_kinds,
-        &mut all_funcs, &mut all_types, &mut all_imports);
+    collect_definitions(
+        &root,
+        source,
+        &func_kinds,
+        &type_kinds,
+        &import_kinds,
+        &mut all_funcs,
+        &mut all_types,
+        &mut all_imports,
+    );
 
     // For each changed region, find function calls and resolve callees
     let mut seen_callees = std::collections::HashSet::new();
     let mut seen_types = std::collections::HashSet::new();
 
     for &(start, end) in changed_lines {
-        collect_calls_in_range(&root, source, lang, &call_kinds, start, end,
-            &all_funcs, &mut ctx.callee_signatures, &mut ctx.qualified_names, &mut seen_callees);
+        collect_calls_in_range(
+            &root,
+            source,
+            lang,
+            &call_kinds,
+            start,
+            end,
+            &all_funcs,
+            &mut ctx.callee_signatures,
+            &mut ctx.qualified_names,
+            &mut seen_callees,
+        );
 
-        collect_type_refs_in_range(&root, source, lang, &type_kinds, start, end,
-            &all_types, &mut ctx.type_definitions, &mut seen_types);
+        collect_type_refs_in_range(
+            &root,
+            source,
+            lang,
+            &type_kinds,
+            start,
+            end,
+            &all_types,
+            &mut ctx.type_definitions,
+            &mut seen_types,
+        );
 
         // Walk identifier-like leaf nodes (NOT comments / string literals) in the
         // changed range so import filtering can avoid matching tokens that look
@@ -64,9 +91,17 @@ pub fn hydrate(
         let mut idents_in_range = std::collections::HashSet::new();
         collect_identifiers_in_range(&root, source, start, end, &mut idents_in_range);
 
-        collect_import_refs_in_range(&root, source, &import_kinds, start, end,
-            &all_imports, &idents_in_range,
-            &mut ctx.import_targets, &mut ctx.qualified_names);
+        collect_import_refs_in_range(
+            &root,
+            source,
+            &import_kinds,
+            start,
+            end,
+            &all_imports,
+            &idents_in_range,
+            &mut ctx.import_targets,
+            &mut ctx.qualified_names,
+        );
     }
 
     // Caller blast radius: if changed lines contain a function definition,
@@ -75,7 +110,15 @@ pub fn hydrate(
         for (name, _, fstart, _fend) in &all_funcs {
             if *fstart >= start && *fstart <= end {
                 // This function's signature is in the changed region
-                find_callers_of(&root, source, lang, &call_kinds, name, &all_funcs, &mut ctx.callers);
+                find_callers_of(
+                    &root,
+                    source,
+                    lang,
+                    &call_kinds,
+                    name,
+                    &all_funcs,
+                    &mut ctx.callers,
+                );
             }
         }
     }
@@ -99,7 +142,11 @@ fn type_def_kinds(lang: Language) -> Vec<&'static str> {
     match lang {
         Language::Rust => vec!["struct_item", "enum_item", "type_item"],
         Language::Python => vec!["class_definition"],
-        Language::TypeScript | Language::Tsx => vec!["interface_declaration", "type_alias_declaration", "class_declaration"],
+        Language::TypeScript | Language::Tsx => vec![
+            "interface_declaration",
+            "type_alias_declaration",
+            "class_declaration",
+        ],
         Language::Yaml => vec![],
         Language::Bash => vec![],
         Language::Dockerfile => vec![],
@@ -174,8 +221,16 @@ fn collect_definitions(
 
     for i in 0..node.child_count() {
         if let Some(child) = node.child(i as u32) {
-            collect_definitions(&child, source, func_kinds, type_kinds, import_kinds_list,
-                funcs, types, imports);
+            collect_definitions(
+                &child,
+                source,
+                func_kinds,
+                type_kinds,
+                import_kinds_list,
+                funcs,
+                types,
+                imports,
+            );
         }
     }
 }
@@ -237,7 +292,10 @@ fn extract_imported_names(import_text: &str) -> Vec<String> {
     } else if text.starts_with("from ") {
         // Python: from X import a, b, c  /  from X import (a, b as c)
         if let Some(after_import) = text.split(" import ").nth(1) {
-            let cleaned = after_import.trim().trim_start_matches('(').trim_end_matches(')');
+            let cleaned = after_import
+                .trim()
+                .trim_start_matches('(')
+                .trim_end_matches(')');
             for part in cleaned.split(',') {
                 let part = part.trim();
                 if part.is_empty() {
@@ -274,7 +332,11 @@ fn extract_imported_names(import_text: &str) -> Vec<String> {
                     } else {
                         None
                     };
-                    let head = clause[..open].trim().trim_end_matches(',').trim().to_string();
+                    let head = clause[..open]
+                        .trim()
+                        .trim_end_matches(',')
+                        .trim()
+                        .to_string();
                     (head, inner)
                 }
                 None => (clause.to_string(), None),
@@ -364,7 +426,9 @@ fn collect_calls_in_range(
         if let Some(func_node) = node.child_by_field_name("function") {
             let func_text = &source[func_node.byte_range()];
             // Get the simple name (last identifier)
-            let call_name = func_text.rsplit('.').next()
+            let call_name = func_text
+                .rsplit('.')
+                .next()
                 .unwrap_or(func_text)
                 .rsplit("::")
                 .next()
@@ -391,8 +455,10 @@ fn collect_calls_in_range(
     // open before the changed range.
     for i in 0..node.child_count() {
         if let Some(child) = node.child(i as u32) {
-            collect_calls_in_range(&child, source, _lang, call_kinds, start_line, end_line,
-                all_funcs, out, qnames_out, seen);
+            collect_calls_in_range(
+                &child, source, _lang, call_kinds, start_line, end_line, all_funcs, out,
+                qnames_out, seen,
+            );
         }
     }
 }
@@ -427,8 +493,17 @@ fn collect_type_refs_in_range(
 
     for i in 0..node.child_count() {
         if let Some(child) = node.child(i as u32) {
-            collect_type_refs_in_range(&child, source, _lang, _type_kinds, start_line, end_line,
-                all_types, out, seen);
+            collect_type_refs_in_range(
+                &child,
+                source,
+                _lang,
+                _type_kinds,
+                start_line,
+                end_line,
+                all_types,
+                out,
+                seen,
+            );
         }
     }
 }
@@ -550,10 +625,7 @@ pub fn parse_unified_diff(diff: &str) -> Vec<(String, Vec<(u32, u32)>)> {
                     if let Ok(s) = start_str.parse::<u32>() {
                         // Count is optional in unified diff format (defaults to 1).
                         // "@@ -10 +10 @@" means a single-line change at line 10.
-                        let count = nums
-                            .get(1)
-                            .and_then(|c| c.parse::<u32>().ok())
-                            .unwrap_or(1);
+                        let count = nums.get(1).and_then(|c| c.parse::<u32>().ok()).unwrap_or(1);
                         // Pure-deletion hunks (+N,0) have count==0 and contribute no
                         // changed lines on the new side — skip rather than emit a
                         // garbage (N, N-1) range from saturating_sub underflow.
@@ -587,7 +659,9 @@ fn find_callers_of(
     if call_kinds.contains(&node.kind()) {
         if let Some(func_node) = node.child_by_field_name("function") {
             let func_text = &source[func_node.byte_range()];
-            let call_name = func_text.rsplit('.').next()
+            let call_name = func_text
+                .rsplit('.')
+                .next()
                 .unwrap_or(func_text)
                 .rsplit("::")
                 .next()
@@ -610,7 +684,15 @@ fn find_callers_of(
 
     for i in 0..node.child_count() {
         if let Some(child) = node.child(i as u32) {
-            find_callers_of(&child, source, _lang, call_kinds, target_name, all_funcs, callers);
+            find_callers_of(
+                &child,
+                source,
+                _lang,
+                call_kinds,
+                target_name,
+                all_funcs,
+                callers,
+            );
         }
     }
 }
@@ -618,7 +700,7 @@ fn find_callers_of(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::parser::{parse, Language};
+    use crate::parser::{Language, parse};
 
     // -- Callee signatures --
 
@@ -639,7 +721,9 @@ fn process(data: &str) {
         // Changed lines: process() at lines 5-8
         let ctx = hydrate(&tree, source, Language::Rust, &[(5, 8)]);
         assert!(
-            ctx.callee_signatures.iter().any(|s| s.contains("validate") && s.contains("&str")),
+            ctx.callee_signatures
+                .iter()
+                .any(|s| s.contains("validate") && s.contains("&str")),
             "Should find callee signature for validate(). Got: {:?}",
             ctx.callee_signatures
         );
@@ -849,7 +933,13 @@ fn process() {
         let tree = parse(source, Language::Rust).unwrap();
         let ctx = hydrate(&tree, source, Language::Rust, &[(1, 3)]);
         // external_crate_fn not defined in file — should not crash, just empty
-        assert!(ctx.callee_signatures.is_empty() || ctx.callee_signatures.iter().all(|s| !s.contains("fn external_crate_fn")));
+        assert!(
+            ctx.callee_signatures.is_empty()
+                || ctx
+                    .callee_signatures
+                    .iter()
+                    .all(|s| !s.contains("fn external_crate_fn"))
+        );
     }
 
     #[test]
@@ -890,7 +980,11 @@ fn another_unrelated() -> i32 { 99 }
         let diff = hydrate(&tree, source, Language::Rust, &[(5, 9)]);
 
         // Diff hydration should find callee (validate) but NOT unrelated functions
-        assert!(diff.callee_signatures.iter().any(|s| s.contains("validate")));
+        assert!(
+            diff.callee_signatures
+                .iter()
+                .any(|s| s.contains("validate"))
+        );
         // Full hydration gets everything
         assert!(full.callee_signatures.len() >= diff.callee_signatures.len());
     }
@@ -938,8 +1032,8 @@ fn another_unrelated() -> i32 { 99 }
         assert_eq!(parsed.len(), 1);
         assert_eq!(parsed[0].0, "src/main.rs");
         assert_eq!(parsed[0].1.len(), 2);
-        assert_eq!(parsed[0].1[0], (5, 8));   // +5,4
-        assert_eq!(parsed[0].1[1], (21, 25));  // +21,5
+        assert_eq!(parsed[0].1[0], (5, 8)); // +5,4
+        assert_eq!(parsed[0].1[1], (21, 25)); // +21,5
     }
 
     #[test]
@@ -978,7 +1072,9 @@ fn process(data: &str) {
                       \x20   input.to_string()\n\
                       }\n";
         let mut parser = tree_sitter::Parser::new();
-        parser.set_language(&tree_sitter_rust::LANGUAGE.into()).unwrap();
+        parser
+            .set_language(&tree_sitter_rust::LANGUAGE.into())
+            .unwrap();
         let tree = parser.parse(source, None).unwrap();
 
         // Range [(4,4)] covers `let _ = helper();`. Line 1's multibyte chars
@@ -989,7 +1085,9 @@ fn process(data: &str) {
         // expected results. Without this, a swallowed panic returning
         // Default would pass a no-panic check vacuously.
         assert!(
-            ctx.callee_signatures.iter().any(|s| s.starts_with("fn helper")),
+            ctx.callee_signatures
+                .iter()
+                .any(|s| s.starts_with("fn helper")),
             "expected `helper` callee even when source contains multibyte UTF-8; got {:?}",
             ctx.callee_signatures
         );
@@ -1002,7 +1100,9 @@ fn process(data: &str) {
                       }\n\
                       fn caller() { greet(); }\n";
         let mut parser = tree_sitter::Parser::new();
-        parser.set_language(&tree_sitter_rust::LANGUAGE.into()).unwrap();
+        parser
+            .set_language(&tree_sitter_rust::LANGUAGE.into())
+            .unwrap();
         let tree = parser.parse(source, None).unwrap();
         let ctx = hydrate(&tree, source, Language::Rust, &[(2, 2)]); // emoji line
         // Hydration may or may not pick up greet's signature here — but it MUST NOT panic.
@@ -1022,19 +1122,38 @@ fn process(data: &str) {
                       \x20   let _: HashMap<String, u32> = HashMap::new();\n\
                       }\n";
         let mut parser = tree_sitter::Parser::new();
-        parser.set_language(&tree_sitter_rust::LANGUAGE.into()).unwrap();
+        parser
+            .set_language(&tree_sitter_rust::LANGUAGE.into())
+            .unwrap();
         let tree = parser.parse(source, None).unwrap();
         // Only line 4 (Arc usage in `touched`) changes.
         let ctx = hydrate(&tree, source, Language::Rust, &[(4, 4)]);
-        let arc_count = ctx.import_targets.iter()
+        let arc_count = ctx
+            .import_targets
+            .iter()
             .filter(|i| i.ends_with("::Arc") || i.as_str() == "Arc" || i.starts_with("Arc:"))
             .count();
-        let hashmap_count = ctx.import_targets.iter()
-            .filter(|i| i.ends_with("::HashMap") || i.as_str() == "HashMap" || i.starts_with("HashMap:"))
+        let hashmap_count = ctx
+            .import_targets
+            .iter()
+            .filter(|i| {
+                i.ends_with("::HashMap") || i.as_str() == "HashMap" || i.starts_with("HashMap:")
+            })
             .count();
-        assert_eq!(arc_count, 1, "Arc must be hydrated exactly once; got {:?}", ctx.import_targets);
-        assert_eq!(hashmap_count, 0, "HashMap must NOT be hydrated; got {:?}", ctx.import_targets);
-        assert!(!ctx.import_targets.is_empty(), "import_targets unexpectedly empty");
+        assert_eq!(
+            arc_count, 1,
+            "Arc must be hydrated exactly once; got {:?}",
+            ctx.import_targets
+        );
+        assert_eq!(
+            hashmap_count, 0,
+            "HashMap must NOT be hydrated; got {:?}",
+            ctx.import_targets
+        );
+        assert!(
+            !ctx.import_targets.is_empty(),
+            "import_targets unexpectedly empty"
+        );
     }
 
     #[test]
@@ -1048,17 +1167,32 @@ fn process(data: &str) {
                       \x20   let _: HashMap<String, u32> = HashMap::new();\n\
                       }\n";
         let mut parser = tree_sitter::Parser::new();
-        parser.set_language(&tree_sitter_rust::LANGUAGE.into()).unwrap();
+        parser
+            .set_language(&tree_sitter_rust::LANGUAGE.into())
+            .unwrap();
         let tree = parser.parse(source, None).unwrap();
         let ctx = hydrate(&tree, source, Language::Rust, &[(7, 7)]); // HashMap line
-        let arc_count = ctx.import_targets.iter()
+        let arc_count = ctx
+            .import_targets
+            .iter()
             .filter(|i| i.ends_with("::Arc") || i.as_str() == "Arc" || i.starts_with("Arc:"))
             .count();
-        let hashmap_count = ctx.import_targets.iter()
-            .filter(|i| i.ends_with("::HashMap") || i.as_str() == "HashMap" || i.starts_with("HashMap:"))
+        let hashmap_count = ctx
+            .import_targets
+            .iter()
+            .filter(|i| {
+                i.ends_with("::HashMap") || i.as_str() == "HashMap" || i.starts_with("HashMap:")
+            })
             .count();
-        assert_eq!(arc_count, 0, "Arc must NOT be hydrated when HashMap line is changed");
-        assert_eq!(hashmap_count, 1, "HashMap must be hydrated; got {:?}", ctx.import_targets);
+        assert_eq!(
+            arc_count, 0,
+            "Arc must NOT be hydrated when HashMap line is changed"
+        );
+        assert_eq!(
+            hashmap_count, 1,
+            "HashMap must be hydrated; got {:?}",
+            ctx.import_targets
+        );
     }
 
     // -- #173: TypeScript default/namespace import bindings --
@@ -1072,8 +1206,11 @@ fn process(data: &str) {
     #[test]
     fn extract_imported_names_typescript_mixed_default_and_named() {
         let names = extract_imported_names("import foo, { bar, baz } from \"x\";");
-        assert_eq!(names, vec!["foo".to_string(), "bar".to_string(), "baz".to_string()],
-            "mixed default+named must yield local binding plus named members; got {names:?}");
+        assert_eq!(
+            names,
+            vec!["foo".to_string(), "bar".to_string(), "baz".to_string()],
+            "mixed default+named must yield local binding plus named members; got {names:?}"
+        );
     }
 
     #[test]
@@ -1085,7 +1222,11 @@ fn process(data: &str) {
     #[test]
     fn extract_imported_names_typescript_default_with_namespace() {
         let names = extract_imported_names("import foo, * as ns from \"x\";");
-        assert_eq!(names, vec!["foo".to_string(), "ns".to_string()], "got {names:?}");
+        assert_eq!(
+            names,
+            vec!["foo".to_string(), "ns".to_string()],
+            "got {names:?}"
+        );
     }
 
     // -- #172: extract_imported_names splits Rust grouped use --
@@ -1109,14 +1250,22 @@ fn process(data: &str) {
                       }\n";
         // helper() spans lines 3..=6 (the call expression). Only line 4 (the "1," argument) is in the changed range.
         let mut parser = tree_sitter::Parser::new();
-        parser.set_language(&tree_sitter_rust::LANGUAGE.into()).unwrap();
+        parser
+            .set_language(&tree_sitter_rust::LANGUAGE.into())
+            .unwrap();
         let tree = parser.parse(source, None).unwrap();
         let ctx = hydrate(&tree, source, Language::Rust, &[(4, 4)]);
-        let helper_sigs: Vec<_> = ctx.callee_signatures.iter()
+        let helper_sigs: Vec<_> = ctx
+            .callee_signatures
+            .iter()
             .filter(|s| s.starts_with("fn helper"))
             .collect();
-        assert_eq!(helper_sigs.len(), 1,
-            "expected exactly one `fn helper` signature; got {:?}", ctx.callee_signatures);
+        assert_eq!(
+            helper_sigs.len(),
+            1,
+            "expected exactly one `fn helper` signature; got {:?}",
+            ctx.callee_signatures
+        );
     }
 
     #[test]
@@ -1131,11 +1280,18 @@ fn process(data: &str) {
                       \x20   );\n\
                       }\n";
         let mut parser = tree_sitter::Parser::new();
-        parser.set_language(&tree_sitter_rust::LANGUAGE.into()).unwrap();
+        parser
+            .set_language(&tree_sitter_rust::LANGUAGE.into())
+            .unwrap();
         let tree = parser.parse(source, None).unwrap();
         let ctx = hydrate(&tree, source, Language::Rust, &[(1, 1)]);
-        assert!(ctx.callee_signatures.iter().all(|s| !s.starts_with("fn helper")),
-            "range [(1,1)] should not hydrate `helper` as a callee; got {:?}", ctx.callee_signatures);
+        assert!(
+            ctx.callee_signatures
+                .iter()
+                .all(|s| !s.starts_with("fn helper")),
+            "range [(1,1)] should not hydrate `helper` as a callee; got {:?}",
+            ctx.callee_signatures
+        );
     }
 
     // -- #171: parse_unified_diff omitted-count handling --
@@ -1147,7 +1303,11 @@ fn process(data: &str) {
         let result = parse_unified_diff(diff);
         assert_eq!(result.len(), 1, "expected one file");
         assert_eq!(result[0].0, "file.rs");
-        assert_eq!(result[0].1, vec![(10, 10)], "single-line hunk should yield (10, 10)");
+        assert_eq!(
+            result[0].1,
+            vec![(10, 10)],
+            "single-line hunk should yield (10, 10)"
+        );
     }
 
     #[test]
@@ -1206,7 +1366,10 @@ fn uses_map() {
         // Only line 2 (body) is changed -- should NOT trigger caller search
         let tree = parse(source, Language::Rust).unwrap();
         let ctx = hydrate(&tree, source, Language::Rust, &[(2, 2)]);
-        assert!(ctx.callers.is_empty(), "body-only edit should not trigger caller blast radius");
+        assert!(
+            ctx.callers.is_empty(),
+            "body-only edit should not trigger caller blast radius"
+        );
     }
 
     #[test]
@@ -1215,7 +1378,10 @@ fn uses_map() {
         // Line 1 = signature of `helper` -- SHOULD trigger caller search
         let tree = parse(source, Language::Rust).unwrap();
         let ctx = hydrate(&tree, source, Language::Rust, &[(1, 1)]);
-        assert!(!ctx.callers.is_empty(), "signature edit should trigger caller blast radius");
+        assert!(
+            !ctx.callers.is_empty(),
+            "signature edit should trigger caller blast radius"
+        );
     }
 
     #[test]
@@ -1224,7 +1390,10 @@ fn uses_map() {
         // Lines 2-5 are body only, signature is line 1
         let tree = parse(source, Language::Rust).unwrap();
         let ctx = hydrate(&tree, source, Language::Rust, &[(2, 5)]);
-        assert!(ctx.callers.is_empty(), "wide body edit should not trigger caller blast radius");
+        assert!(
+            ctx.callers.is_empty(),
+            "wide body edit should not trigger caller blast radius"
+        );
     }
 
     // -- #179: Python import parsing returns correct local names --
@@ -1303,7 +1472,9 @@ fn uses_map() {
                       \x20   let _ = helper();\n\
                       }";
         let mut parser = tree_sitter::Parser::new();
-        parser.set_language(&tree_sitter_rust::LANGUAGE.into()).unwrap();
+        parser
+            .set_language(&tree_sitter_rust::LANGUAGE.into())
+            .unwrap();
         let tree = parser.parse(source, None).unwrap();
 
         let res = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
@@ -1382,11 +1553,13 @@ fn uses_map() {
         // Only line 3 (the "1," argument) is in the changed range.
         let ctx = hydrate(&tree, source, Language::TypeScript, &[(3, 3)]);
         assert_eq!(
-            ctx.callee_signatures.iter().filter(|s| s.contains("g")).count(),
+            ctx.callee_signatures
+                .iter()
+                .filter(|s| s.contains("g"))
+                .count(),
             1,
             "expected exactly one signature containing 'g'; got {:?}",
             ctx.callee_signatures,
         );
     }
-
 }

--- a/src/linter.rs
+++ b/src/linter.rs
@@ -890,7 +890,10 @@ mod tests {
         assert!(findings[0].title.contains("F401"));
         assert_eq!(findings[0].line_start, 1);
         assert_eq!(findings[0].source, Source::Linter("ruff".into()));
-        assert!(!findings[0].id.is_empty(), "linter findings must carry a non-empty id for linkage");
+        assert!(
+            !findings[0].id.is_empty(),
+            "linter findings must carry a non-empty id for linkage"
+        );
     }
 
     #[test]

--- a/src/llm_client.rs
+++ b/src/llm_client.rs
@@ -750,7 +750,12 @@ impl OpenAiClient {
         RESPONSES_API_MODELS.iter().any(|m| *m == model)
     }
 
-    async fn call_model(&self, model: &str, prompt: &str, system_prompt: &str) -> anyhow::Result<LlmResponse> {
+    async fn call_model(
+        &self,
+        model: &str,
+        prompt: &str,
+        system_prompt: &str,
+    ) -> anyhow::Result<LlmResponse> {
         if Self::needs_responses_api(model) {
             self.responses_api(model, prompt, system_prompt).await
         } else {
@@ -866,7 +871,12 @@ impl OpenAiClient {
         unreachable!("send_with_retry loop invariant violated")
     }
 
-    async fn chat_completion(&self, model: &str, prompt: &str, system_prompt: &str) -> anyhow::Result<LlmResponse> {
+    async fn chat_completion(
+        &self,
+        model: &str,
+        prompt: &str,
+        system_prompt: &str,
+    ) -> anyhow::Result<LlmResponse> {
         let mut body = serde_json::json!({
             "model": model,
             "messages": [
@@ -929,7 +939,12 @@ impl OpenAiClient {
     }
 
     /// OpenAI Responses API (/v1/responses) for codex and other responses-only models.
-    async fn responses_api(&self, model: &str, prompt: &str, system_prompt: &str) -> anyhow::Result<LlmResponse> {
+    async fn responses_api(
+        &self,
+        model: &str,
+        prompt: &str,
+        system_prompt: &str,
+    ) -> anyhow::Result<LlmResponse> {
         let mut body = serde_json::json!({
             "model": model,
             "instructions": system_prompt,
@@ -1184,7 +1199,12 @@ where
 }
 
 impl LlmReviewer for OpenAiClient {
-    fn review(&self, prompt: &str, model: &str, system_prompt: &str) -> anyhow::Result<LlmResponse> {
+    fn review(
+        &self,
+        prompt: &str,
+        model: &str,
+        system_prompt: &str,
+    ) -> anyhow::Result<LlmResponse> {
         block_on_async(self.call_model(model, prompt, system_prompt))
     }
 }
@@ -2523,7 +2543,9 @@ mod tests {
             .await;
 
         let client = build_test_client(&server.uri());
-        let res = client.chat_completion("gpt-5.4", "test prompt", "system").await;
+        let res = client
+            .chat_completion("gpt-5.4", "test prompt", "system")
+            .await;
         assert!(res.is_ok(), "expected success after retry, got {res:?}");
     }
 
@@ -2545,7 +2567,9 @@ mod tests {
             .await;
 
         let client = build_test_client(&server.uri());
-        let res = client.chat_completion("gpt-5.4", "test prompt", "system").await;
+        let res = client
+            .chat_completion("gpt-5.4", "test prompt", "system")
+            .await;
         assert!(res.is_ok(), "expected success after 503 retry, got {res:?}");
     }
 
@@ -2561,7 +2585,9 @@ mod tests {
             .await;
 
         let client = build_test_client(&server.uri());
-        let res = client.chat_completion("gpt-5.4", "test prompt", "system").await;
+        let res = client
+            .chat_completion("gpt-5.4", "test prompt", "system")
+            .await;
         assert!(res.is_err(), "400 should bail; got {res:?}");
         let received = server
             .received_requests()
@@ -2589,7 +2615,9 @@ mod tests {
             .await;
 
         let client = build_test_client(&server.uri());
-        let res = client.chat_completion("gpt-5.4", "test prompt", "system").await;
+        let res = client
+            .chat_completion("gpt-5.4", "test prompt", "system")
+            .await;
         assert!(res.is_err(), "400 should bail; got {res:?}");
         let received = server
             .received_requests()
@@ -2616,7 +2644,9 @@ mod tests {
             .await;
 
         let client = build_test_client(&server.uri());
-        let res = client.chat_completion("gpt-5.4", "test prompt", "system").await;
+        let res = client
+            .chat_completion("gpt-5.4", "test prompt", "system")
+            .await;
         assert!(
             res.is_ok(),
             "expected success after backoff retry, got {res:?}"
@@ -2641,7 +2671,9 @@ mod tests {
             .await;
 
         let client = build_test_client(&server.uri());
-        let res = client.chat_completion("gpt-5.4", "test prompt", "system").await;
+        let res = client
+            .chat_completion("gpt-5.4", "test prompt", "system")
+            .await;
         assert!(
             res.is_ok(),
             "garbage Retry-After must not panic; expected success, got {res:?}"
@@ -2697,7 +2729,9 @@ mod tests {
 
         let mut client = build_test_client(&server.uri());
         client.set_overall_retry_deadline_for_test(Duration::from_secs(2));
-        let res = client.chat_completion("gpt-5.4", "test prompt", "system").await;
+        let res = client
+            .chat_completion("gpt-5.4", "test prompt", "system")
+            .await;
         assert!(
             res.is_err(),
             "expected error after retry budget exhausted, got {res:?}"
@@ -2724,7 +2758,9 @@ mod tests {
 
         let started = std::time::Instant::now();
         let client = build_test_client(&server.uri());
-        let res = client.chat_completion("gpt-5.4", "test prompt", "system").await;
+        let res = client
+            .chat_completion("gpt-5.4", "test prompt", "system")
+            .await;
         assert!(
             res.is_ok(),
             "expected success after Retry-After-honored retry, got {res:?}"

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,7 +26,6 @@ pub use quorum::review_mode;
 
 mod agent;
 mod analytics;
-mod stats_math;
 mod cache;
 mod cli;
 mod cli_io;
@@ -48,6 +47,7 @@ mod progress;
 mod review;
 mod review_log;
 mod stats;
+mod stats_math;
 mod suppress;
 mod telemetry;
 #[cfg(test)]
@@ -2121,10 +2121,12 @@ fn run_calibrate(opts: cli::CalibrateOpts) -> i32 {
             .ok()
             .map(|v| matches!(v.as_str(), "1" | "true" | "yes" | "on"))
             .unwrap_or(false);
-    let (samples, join_stats) =
-        quorum::calibrate::join_feedback_and_traces_with_options(
-            &feedback, &traces, &filter, disable_fuzzy,
-        );
+    let (samples, join_stats) = quorum::calibrate::join_feedback_and_traces_with_options(
+        &feedback,
+        &traces,
+        &filter,
+        disable_fuzzy,
+    );
     let positives = samples.iter().filter(|(_, l)| *l).count();
     let negatives = samples.len() - positives;
 
@@ -2583,19 +2585,33 @@ mod join_health_tests {
         let dir = TempDir::new().unwrap();
         // 1 review with 1 finding_id; 2 feedback entries (1 linked, 1 legacy).
         // Linkage = 50% → below threshold.
-        write_jsonl(dir.path(), "reviews.jsonl", &[
-            r#"{"run_id":"R1","timestamp":"2026-01-01T00:00:00Z","quorum_version":"0.1","repo":null,"invoked_from":"tty","model":"gpt","files_reviewed":1,"lines_added":null,"lines_removed":null,"findings_by_severity":{"critical":0,"high":0,"medium":0,"low":0,"info":0},"tokens_in":0,"tokens_out":0,"duration_ms":0,"finding_ids":["FID-LINKED"]}"#,
-        ]);
-        write_jsonl(dir.path(), "feedback.jsonl", &[
-            r#"{"file_path":"x.rs","finding_title":"t","finding_category":"c","verdict":"tp","reason":"r","model":null,"timestamp":"2026-01-01T00:00:00Z","provenance":"human","finding_id":"FID-LINKED"}"#,
-            r#"{"file_path":"y.rs","finding_title":"t","finding_category":"c","verdict":"fp","reason":"r","model":null,"timestamp":"2026-01-01T00:00:00Z","provenance":"human"}"#,
-        ]);
+        write_jsonl(
+            dir.path(),
+            "reviews.jsonl",
+            &[
+                r#"{"run_id":"R1","timestamp":"2026-01-01T00:00:00Z","quorum_version":"0.1","repo":null,"invoked_from":"tty","model":"gpt","files_reviewed":1,"lines_added":null,"lines_removed":null,"findings_by_severity":{"critical":0,"high":0,"medium":0,"low":0,"info":0},"tokens_in":0,"tokens_out":0,"duration_ms":0,"finding_ids":["FID-LINKED"]}"#,
+            ],
+        );
+        write_jsonl(
+            dir.path(),
+            "feedback.jsonl",
+            &[
+                r#"{"file_path":"x.rs","finding_title":"t","finding_category":"c","verdict":"tp","reason":"r","model":null,"timestamp":"2026-01-01T00:00:00Z","provenance":"human","finding_id":"FID-LINKED"}"#,
+                r#"{"file_path":"y.rs","finding_title":"t","finding_category":"c","verdict":"fp","reason":"r","model":null,"timestamp":"2026-01-01T00:00:00Z","provenance":"human"}"#,
+            ],
+        );
 
         let out = format_join_health(dir.path());
         assert!(out.contains("Reviews: 1 with 1 findings"), "got:\n{out}");
-        assert!(out.contains("Feedback: 2 entries (1 linked, 1 unlinked legacy)"), "got:\n{out}");
+        assert!(
+            out.contains("Feedback: 2 entries (1 linked, 1 unlinked legacy)"),
+            "got:\n{out}"
+        );
         assert!(out.contains("50%"), "rate must show as 50%: got:\n{out}");
-        assert!(out.contains("below 85% threshold"), "fallback banner missing: got:\n{out}");
+        assert!(
+            out.contains("below 85% threshold"),
+            "fallback banner missing: got:\n{out}"
+        );
     }
 
     #[test]
@@ -2628,9 +2644,14 @@ mod join_health_tests {
         let dir = TempDir::new().unwrap();
         let ids: Vec<String> = (0..169).map(|i| format!("\"FID-{i}\"")).collect();
         let id_array = format!("[{}]", ids.join(","));
-        write_jsonl(dir.path(), "reviews.jsonl", &[
-            &format!(r#"{{"run_id":"R1","timestamp":"2026-01-01T00:00:00Z","quorum_version":"0.1","repo":null,"invoked_from":"tty","model":"gpt","files_reviewed":1,"lines_added":null,"lines_removed":null,"findings_by_severity":{{"critical":0,"high":0,"medium":0,"low":0,"info":0}},"tokens_in":0,"tokens_out":0,"duration_ms":0,"finding_ids":{}}}"#, id_array),
-        ]);
+        write_jsonl(
+            dir.path(),
+            "reviews.jsonl",
+            &[&format!(
+                r#"{{"run_id":"R1","timestamp":"2026-01-01T00:00:00Z","quorum_version":"0.1","repo":null,"invoked_from":"tty","model":"gpt","files_reviewed":1,"lines_added":null,"lines_removed":null,"findings_by_severity":{{"critical":0,"high":0,"medium":0,"low":0,"info":0}},"tokens_in":0,"tokens_out":0,"duration_ms":0,"finding_ids":{}}}"#,
+                id_array
+            )],
+        );
         let mut fb_lines: Vec<String> = (0..169).map(|i| {
             format!(r#"{{"file_path":"x.rs","finding_title":"t","finding_category":"c","verdict":"tp","reason":"r","model":null,"timestamp":"2026-01-01T00:00:00Z","provenance":"human","finding_id":"FID-{}"}}"#, i)
         }).collect();
@@ -2653,13 +2674,20 @@ mod join_health_tests {
         // 9 linked + 1 legacy = 90% linkage, above threshold.
         let mut review_ids = String::from("[");
         for i in 0..9 {
-            if i > 0 { review_ids.push(','); }
+            if i > 0 {
+                review_ids.push(',');
+            }
             review_ids.push_str(&format!("\"FID-{}\"", i));
         }
         review_ids.push(']');
-        write_jsonl(dir.path(), "reviews.jsonl", &[
-            &format!(r#"{{"run_id":"R1","timestamp":"2026-01-01T00:00:00Z","quorum_version":"0.1","repo":null,"invoked_from":"tty","model":"gpt","files_reviewed":1,"lines_added":null,"lines_removed":null,"findings_by_severity":{{"critical":0,"high":0,"medium":0,"low":0,"info":0}},"tokens_in":0,"tokens_out":0,"duration_ms":0,"finding_ids":{}}}"#, review_ids),
-        ]);
+        write_jsonl(
+            dir.path(),
+            "reviews.jsonl",
+            &[&format!(
+                r#"{{"run_id":"R1","timestamp":"2026-01-01T00:00:00Z","quorum_version":"0.1","repo":null,"invoked_from":"tty","model":"gpt","files_reviewed":1,"lines_added":null,"lines_removed":null,"findings_by_severity":{{"critical":0,"high":0,"medium":0,"low":0,"info":0}},"tokens_in":0,"tokens_out":0,"duration_ms":0,"finding_ids":{}}}"#,
+                review_ids
+            )],
+        );
 
         let mut fb_lines: Vec<String> = (0..9).map(|i| {
             format!(r#"{{"file_path":"x.rs","finding_title":"t","finding_category":"c","verdict":"tp","reason":"r","model":null,"timestamp":"2026-01-01T00:00:00Z","provenance":"human","finding_id":"FID-{}"}}"#, i)
@@ -2670,7 +2698,13 @@ mod join_health_tests {
 
         let out = format_join_health(dir.path());
         assert!(out.contains("90%"), "rate must show as 90%: got:\n{out}");
-        assert!(!out.contains("below 85% threshold"), "must NOT show fallback banner at 90%: got:\n{out}");
-        assert!(out.contains("per-finding precision math active"), "got:\n{out}");
+        assert!(
+            !out.contains("below 85% threshold"),
+            "must NOT show fallback banner at 90%: got:\n{out}"
+        );
+        assert!(
+            out.contains("per-finding precision math active"),
+            "got:\n{out}"
+        );
     }
 }

--- a/src/mcp/handler.rs
+++ b/src/mcp/handler.rs
@@ -1,5 +1,4 @@
 /// MCP server handler — dispatches tool calls to quorum pipeline.
-
 use std::path::PathBuf;
 use std::sync::Arc;
 
@@ -7,8 +6,7 @@ use async_trait::async_trait;
 use rust_mcp_sdk::McpServer;
 use rust_mcp_sdk::mcp_server::ServerHandler;
 use rust_mcp_sdk::schema::{
-    CallToolRequestParams, CallToolResult, ListToolsResult, PaginatedRequestParams,
-    RpcError,
+    CallToolRequestParams, CallToolResult, ListToolsResult, PaginatedRequestParams, RpcError,
 };
 
 use crate::cache::ParseCache;
@@ -16,9 +14,9 @@ use crate::config::{Config, EnvConfigSource};
 use crate::feedback::{FeedbackEntry, FeedbackStore, Verdict};
 use crate::llm_client::OpenAiClient;
 use crate::mcp::tools::{CatalogTool, ChatTool, DebugTool, FeedbackTool, ReviewTool, TestgenTool};
-use crate::redact;
 use crate::parser::Language;
 use crate::pipeline::{self, LlmReviewer, PipelineConfig};
+use crate::redact;
 
 pub struct QuorumHandler {
     config: Config,
@@ -37,11 +35,12 @@ impl QuorumHandler {
         let feedback_path = dirs_path()?.join("feedback.jsonl");
         let feedback_store = FeedbackStore::new(feedback_path);
 
-        let llm_reviewer: Option<Arc<dyn LlmReviewer>> = if let Ok(api_key) = config.require_api_key() {
-            Some(Arc::new(OpenAiClient::new(&config.base_url, api_key)?))
-        } else {
-            None
-        };
+        let llm_reviewer: Option<Arc<dyn LlmReviewer>> =
+            if let Ok(api_key) = config.require_api_key() {
+                Some(Arc::new(OpenAiClient::new(&config.base_url, api_key)?))
+            } else {
+                None
+            };
 
         Ok(Self {
             config,
@@ -140,8 +139,7 @@ impl QuorumHandler {
         // fp_kind through ExternalVerdictInput yet — keeps the wire
         // contract uniform across ingestion surfaces).
         let fp_kind = if matches!(verdict, Verdict::Fp) {
-            if let Some(crate::feedback::FpKind::OutOfScope { tracked_in: None }) =
-                &params.fp_kind
+            if let Some(crate::feedback::FpKind::OutOfScope { tracked_in: None }) = &params.fp_kind
             {
                 tracing::warn!(
                     "MCP feedback: out_of_scope fp_kind recorded without tracked_in; \
@@ -212,7 +210,11 @@ impl QuorumHandler {
             .map_err(|e| format!("Failed to record feedback: {}", e))?;
 
         let count = self.feedback_store.count().unwrap_or(0);
-        let msg = format!("Recorded {} feedback. Total entries: {}", verdict_label(&entry), count);
+        let msg = format!(
+            "Recorded {} feedback. Total entries: {}",
+            verdict_label(&entry),
+            count
+        );
         Ok(CallToolResult::text_content(vec![msg.into()]))
     }
 
@@ -273,7 +275,9 @@ impl QuorumHandler {
         let mut prompt = format!("Question: {}\n\n", redact::redact_secrets(&params.question));
         if let Some(code) = &params.code {
             let redacted = redact::redact_secrets(code);
-            let lang = params.file_path.as_deref()
+            let lang = params
+                .file_path
+                .as_deref()
                 .and_then(|p| Language::from_path(std::path::Path::new(p)))
                 .map(|l| match l {
                     Language::Rust => "rust",
@@ -291,13 +295,14 @@ impl QuorumHandler {
 
         let model = self.config.model.clone();
         let sys_prompt = crate::llm_client::OpenAiClient::system_prompt().to_string();
-        let resp = tokio::task::spawn_blocking(move || reviewer.review(&prompt, &model, &sys_prompt))
-            .await
-            .map_err(|e| {
-                tracing::warn!(error = %e, tool = "chat", "blocking review task failed");
-                format!("review task failed: {}", e)
-            })?
-            .map_err(|e| format!("LLM error: {}", e))?;
+        let resp =
+            tokio::task::spawn_blocking(move || reviewer.review(&prompt, &model, &sys_prompt))
+                .await
+                .map_err(|e| {
+                    tracing::warn!(error = %e, tool = "chat", "blocking review task failed");
+                    format!("review task failed: {}", e)
+                })?
+                .map_err(|e| format!("LLM error: {}", e))?;
 
         Ok(CallToolResult::text_content(vec![resp.content.into()]))
     }
@@ -318,13 +323,14 @@ impl QuorumHandler {
 
         let model = self.config.model.clone();
         let sys_prompt = crate::llm_client::OpenAiClient::system_prompt().to_string();
-        let resp = tokio::task::spawn_blocking(move || reviewer.review(&prompt, &model, &sys_prompt))
-            .await
-            .map_err(|e| {
-                tracing::warn!(error = %e, tool = "debug", "blocking review task failed");
-                format!("review task failed: {}", e)
-            })?
-            .map_err(|e| format!("LLM error: {}", e))?;
+        let resp =
+            tokio::task::spawn_blocking(move || reviewer.review(&prompt, &model, &sys_prompt))
+                .await
+                .map_err(|e| {
+                    tracing::warn!(error = %e, tool = "debug", "blocking review task failed");
+                    format!("review task failed: {}", e)
+                })?
+                .map_err(|e| format!("LLM error: {}", e))?;
 
         Ok(CallToolResult::text_content(vec![resp.content.into()]))
     }
@@ -350,7 +356,11 @@ impl QuorumHandler {
             Language::Terraform => "terraform",
         };
 
-        let framework_hint = params.framework.as_deref().map(|f| format!(" using the {} framework", f)).unwrap_or_default();
+        let framework_hint = params
+            .framework
+            .as_deref()
+            .map(|f| format!(" using the {} framework", f))
+            .unwrap_or_default();
         let redacted_code = redact::redact_secrets(&params.code);
         let prompt = format!(
             "Generate comprehensive tests{} for this {} code from `{}`.\n\n```{}\n{}\n```\n\nInclude: happy path, edge cases, error cases. Return ONLY the test code.",
@@ -359,13 +369,14 @@ impl QuorumHandler {
 
         let model = self.config.model.clone();
         let sys_prompt = crate::llm_client::OpenAiClient::system_prompt().to_string();
-        let resp = tokio::task::spawn_blocking(move || reviewer.review(&prompt, &model, &sys_prompt))
-            .await
-            .map_err(|e| {
-                tracing::warn!(error = %e, tool = "testgen", "blocking review task failed");
-                format!("review task failed: {}", e)
-            })?
-            .map_err(|e| format!("LLM error: {}", e))?;
+        let resp =
+            tokio::task::spawn_blocking(move || reviewer.review(&prompt, &model, &sys_prompt))
+                .await
+                .map_err(|e| {
+                    tracing::warn!(error = %e, tool = "testgen", "blocking review task failed");
+                    format!("review task failed: {}", e)
+                })?
+                .map_err(|e| format!("LLM error: {}", e))?;
 
         Ok(CallToolResult::text_content(vec![resp.content.into()]))
     }
@@ -440,33 +451,39 @@ impl ServerHandler for QuorumHandler {
         let args_value = serde_json::Value::Object(params.arguments.unwrap_or_default());
         let result = match params.name.as_str() {
             "review" => {
-                let tool: ReviewTool = serde_json::from_value(args_value)
-                    .map_err(|e| CallToolError::from_message(format!("Invalid parameters: {}", e)))?;
+                let tool: ReviewTool = serde_json::from_value(args_value).map_err(|e| {
+                    CallToolError::from_message(format!("Invalid parameters: {}", e))
+                })?;
                 self.handle_review(tool).await
             }
             "feedback" => {
-                let tool: FeedbackTool = serde_json::from_value(args_value)
-                    .map_err(|e| CallToolError::from_message(format!("Invalid parameters: {}", e)))?;
+                let tool: FeedbackTool = serde_json::from_value(args_value).map_err(|e| {
+                    CallToolError::from_message(format!("Invalid parameters: {}", e))
+                })?;
                 self.handle_feedback(tool)
             }
             "catalog" => {
-                let tool: CatalogTool = serde_json::from_value(args_value)
-                    .map_err(|e| CallToolError::from_message(format!("Invalid parameters: {}", e)))?;
+                let tool: CatalogTool = serde_json::from_value(args_value).map_err(|e| {
+                    CallToolError::from_message(format!("Invalid parameters: {}", e))
+                })?;
                 self.handle_catalog(tool)
             }
             "chat" => {
-                let tool: ChatTool = serde_json::from_value(args_value)
-                    .map_err(|e| CallToolError::from_message(format!("Invalid parameters: {}", e)))?;
+                let tool: ChatTool = serde_json::from_value(args_value).map_err(|e| {
+                    CallToolError::from_message(format!("Invalid parameters: {}", e))
+                })?;
                 self.handle_chat(tool).await
             }
             "debug" => {
-                let tool: DebugTool = serde_json::from_value(args_value)
-                    .map_err(|e| CallToolError::from_message(format!("Invalid parameters: {}", e)))?;
+                let tool: DebugTool = serde_json::from_value(args_value).map_err(|e| {
+                    CallToolError::from_message(format!("Invalid parameters: {}", e))
+                })?;
                 self.handle_debug(tool).await
             }
             "testgen" => {
-                let tool: TestgenTool = serde_json::from_value(args_value)
-                    .map_err(|e| CallToolError::from_message(format!("Invalid parameters: {}", e)))?;
+                let tool: TestgenTool = serde_json::from_value(args_value).map_err(|e| {
+                    CallToolError::from_message(format!("Invalid parameters: {}", e))
+                })?;
                 self.handle_testgen(tool).await
             }
             _ => return Err(CallToolError::unknown_tool(params.name)),
@@ -610,8 +627,10 @@ mod tests {
         assert_eq!(all.len(), 1);
         match &all[0].verdict {
             Verdict::ContextMisleading { blamed_chunk_ids } => {
-                assert_eq!(blamed_chunk_ids,
-                    &vec!["chunk-abc".to_string(), "chunk-def".to_string()]);
+                assert_eq!(
+                    blamed_chunk_ids,
+                    &vec!["chunk-abc".to_string(), "chunk-def".to_string()]
+                );
             }
             other => panic!("expected ContextMisleading, got {:?}", other),
         }
@@ -690,7 +709,11 @@ mod tests {
         let all = store.load_all().unwrap();
         assert_eq!(all.len(), 1);
         match &all[0].provenance {
-            crate::feedback::Provenance::External { agent, model, confidence } => {
+            crate::feedback::Provenance::External {
+                agent,
+                model,
+                confidence,
+            } => {
                 assert_eq!(agent, "pal");
                 assert_eq!(model.as_deref(), Some("gemini-3-pro-preview"));
                 assert_eq!(*confidence, Some(0.9));
@@ -804,7 +827,12 @@ mod tests {
 
         struct FakeLlm;
         impl LlmReviewer for FakeLlm {
-            fn review(&self, _prompt: &str, _model: &str, _system_prompt: &str) -> anyhow::Result<crate::llm_client::LlmResponse> {
+            fn review(
+                &self,
+                _prompt: &str,
+                _model: &str,
+                _system_prompt: &str,
+            ) -> anyhow::Result<crate::llm_client::LlmResponse> {
                 Ok(crate::llm_client::LlmResponse {
                     content: "This is a helpful response about the code.".into(),
                     usage: None,
@@ -989,9 +1017,8 @@ mod tests {
                 .expect("build runtime");
             rt.block_on(async move {
                 let barrier = std::sync::Arc::new(std::sync::Barrier::new(N));
-                let handler = std::sync::Arc::new(handler_with_barrier_llm(
-                    std::sync::Arc::clone(&barrier),
-                ));
+                let handler =
+                    std::sync::Arc::new(handler_with_barrier_llm(std::sync::Arc::clone(&barrier)));
 
                 let mut joins = Vec::new();
                 for _ in 0..N {
@@ -1173,7 +1200,11 @@ mod tests {
             focus: None,
         };
         handler.handle_review(params).await.unwrap();
-        assert_eq!(cache.stats().misses, 1, "First review should be a cache miss");
+        assert_eq!(
+            cache.stats().misses,
+            1,
+            "First review should be a cache miss"
+        );
 
         // Second review with same code should hit cache
         let params2 = ReviewTool {

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -1,6 +1,5 @@
 /// MCP tool definitions for quorum.
-
-use rust_mcp_sdk::macros::{mcp_tool, JsonSchema};
+use rust_mcp_sdk::macros::{JsonSchema, mcp_tool};
 use serde::{Deserialize, Serialize};
 
 #[mcp_tool(
@@ -211,7 +210,10 @@ mod tests {
             (r#""fp""#, FeedbackVerdict::Fp),
             (r#""partial""#, FeedbackVerdict::Partial),
             (r#""wontfix""#, FeedbackVerdict::Wontfix),
-            (r#""context_misleading""#, FeedbackVerdict::ContextMisleading),
+            (
+                r#""context_misleading""#,
+                FeedbackVerdict::ContextMisleading,
+            ),
         ] {
             let v: FeedbackVerdict =
                 serde_json::from_str(s).unwrap_or_else(|e| panic!("{s} should parse: {e}"));
@@ -347,7 +349,8 @@ mod tests {
             "category":"security",
             "fpKind":"hallucination"
         }"#;
-        let tool: FeedbackTool = serde_json::from_str(json).expect("all declared fields must parse");
+        let tool: FeedbackTool =
+            serde_json::from_str(json).expect("all declared fields must parse");
         assert_eq!(tool.verdict, FeedbackVerdict::Fp);
         assert_eq!(tool.from_agent.as_deref(), Some("pal"));
     }

--- a/src/merge.rs
+++ b/src/merge.rs
@@ -45,7 +45,9 @@ pub fn merge_findings(groups: Vec<Vec<Finding>>, similarity_threshold: f64) -> V
     }
 
     merged.sort_by(|a, b| {
-        b.severity.cmp(&a.severity).then(a.line_start.cmp(&b.line_start))
+        b.severity
+            .cmp(&a.severity)
+            .then(a.line_start.cmp(&b.line_start))
     });
 
     merged
@@ -220,7 +222,11 @@ mod tests {
             .lines(150, 150)
             .build();
         let result = merge_findings(vec![vec![f1], vec![f2], vec![f3]], 0.8);
-        assert_eq!(result.len(), 1, "exact title+category matches must collapse");
+        assert_eq!(
+            result.len(),
+            1,
+            "exact title+category matches must collapse"
+        );
         assert_eq!(result[0].line_start, 10);
         assert_eq!(result[0].line_end, 150);
         let joined = result[0].evidence.join(" ");

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -81,12 +81,7 @@ mod tests {
     #[test]
     fn pr_curve_trivial_four_samples() {
         // Scores: 0.9(TP), 0.7(FP), 0.5(TP), 0.3(FP)
-        let samples = vec![
-            (0.9, true),
-            (0.7, false),
-            (0.5, true),
-            (0.3, false),
-        ];
+        let samples = vec![(0.9, true), (0.7, false), (0.5, true), (0.3, false)];
         let curve = precision_recall_curve(&samples);
         // At threshold 0.9: TP=1, FP=0, FN=1 -> P=1.0, R=0.5
         // At threshold 0.7: TP=1, FP=1, FN=1 -> P=0.5, R=0.5
@@ -101,11 +96,7 @@ mod tests {
 
     #[test]
     fn pr_curve_tied_scores_produces_one_point_per_distinct_score() {
-        let samples = vec![
-            (0.8, true),
-            (0.8, false),
-            (0.5, true),
-        ];
+        let samples = vec![(0.8, true), (0.8, false), (0.5, true)];
         let curve = precision_recall_curve(&samples);
         assert_eq!(curve.len(), 2, "tied scores should collapse to one point");
     }
@@ -135,11 +126,7 @@ mod tests {
 
     #[test]
     fn pr_curve_filters_nan_scores() {
-        let samples = vec![
-            (f64::NAN, true),
-            (0.9, true),
-            (0.5, false),
-        ];
+        let samples = vec![(f64::NAN, true), (0.9, true), (0.5, false)];
         let curve = precision_recall_curve(&samples);
         // NaN entry should be filtered; remaining 2 samples yield curve
         assert!(!curve.is_empty());
@@ -150,12 +137,7 @@ mod tests {
 
     #[test]
     fn threshold_at_precision_finds_lowest_meeting_target() {
-        let samples = vec![
-            (0.9, true),
-            (0.7, false),
-            (0.5, true),
-            (0.3, false),
-        ];
+        let samples = vec![(0.9, true), (0.7, false), (0.5, true), (0.3, false)];
         let curve = precision_recall_curve(&samples);
         // Only threshold 0.9 achieves P>=0.95
         let t = threshold_at_precision(&curve, 0.95);
@@ -174,26 +156,19 @@ mod tests {
     #[test]
     fn threshold_at_precision_picks_lowest_for_max_recall() {
         // Multiple thresholds achieve target -- pick lowest (highest recall)
-        let samples = vec![
-            (0.9, true),
-            (0.8, true),
-            (0.7, true),
-            (0.3, false),
-        ];
+        let samples = vec![(0.9, true), (0.8, true), (0.7, true), (0.3, false)];
         let curve = precision_recall_curve(&samples);
         // At 0.9: P=1.0, at 0.8: P=1.0, at 0.7: P=1.0, at 0.3: P=0.75
         let t = threshold_at_precision(&curve, 0.95);
-        assert!((t.unwrap() - 0.7).abs() < 1e-9, "should pick lowest threshold achieving P>=0.95");
+        assert!(
+            (t.unwrap() - 0.7).abs() < 1e-9,
+            "should pick lowest threshold achieving P>=0.95"
+        );
     }
 
     #[test]
     fn f1_optimal_threshold_picks_best_f1() {
-        let samples = vec![
-            (0.9, true),
-            (0.7, false),
-            (0.5, true),
-            (0.3, false),
-        ];
+        let samples = vec![(0.9, true), (0.7, false), (0.5, true), (0.3, false)];
         let curve = precision_recall_curve(&samples);
         let t = f1_optimal_threshold(&curve);
         // At 0.9: F1=2*(1.0*0.5)/(1.0+0.5)=0.667

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -126,7 +126,10 @@ pub fn format_finding(f: &Finding, style: &Style) -> String {
 
     if let Some(ref status) = f.grounding_status {
         use crate::finding::GroundingStatus;
-        if matches!(status, GroundingStatus::SymbolNotFound | GroundingStatus::LineOutOfRange) {
+        if matches!(
+            status,
+            GroundingStatus::SymbolNotFound | GroundingStatus::LineOutOfRange
+        ) {
             output.push_str(&format!(
                 "    {dim}[ungrounded] cited symbol not verified in source{reset}\n",
                 dim = style.dim,
@@ -887,7 +890,10 @@ mod tests {
             .grounding_status(GroundingStatus::SymbolNotFound)
             .build();
         let output = format_finding(&f, &Style::plain());
-        assert!(output.contains("[ungrounded]"), "Expected [ungrounded] in output: {output}");
+        assert!(
+            output.contains("[ungrounded]"),
+            "Expected [ungrounded] in output: {output}"
+        );
     }
 
     #[test]
@@ -898,7 +904,10 @@ mod tests {
             .grounding_status(GroundingStatus::LineOutOfRange)
             .build();
         let output = format_finding(&f, &Style::plain());
-        assert!(output.contains("[ungrounded]"), "Expected [ungrounded] in output: {output}");
+        assert!(
+            output.contains("[ungrounded]"),
+            "Expected [ungrounded] in output: {output}"
+        );
     }
 
     #[test]
@@ -909,7 +918,10 @@ mod tests {
             .grounding_status(GroundingStatus::Verified)
             .build();
         let output = format_finding(&f, &Style::plain());
-        assert!(!output.contains("[ungrounded]"), "Verified should NOT show [ungrounded]: {output}");
+        assert!(
+            !output.contains("[ungrounded]"),
+            "Verified should NOT show [ungrounded]: {output}"
+        );
     }
 
     #[test]
@@ -920,7 +932,10 @@ mod tests {
             .grounding_status(GroundingStatus::NotChecked)
             .build();
         let output = format_finding(&f, &Style::plain());
-        assert!(!output.contains("[ungrounded]"), "NotChecked should NOT show [ungrounded]: {output}");
+        assert!(
+            !output.contains("[ungrounded]"),
+            "NotChecked should NOT show [ungrounded]: {output}"
+        );
     }
 
     #[test]
@@ -930,7 +945,10 @@ mod tests {
             .severity(Severity::Medium)
             .build();
         let output = format_finding(&f, &Style::plain());
-        assert!(!output.contains("[ungrounded]"), "None grounding should NOT show [ungrounded]: {output}");
+        assert!(
+            !output.contains("[ungrounded]"),
+            "None grounding should NOT show [ungrounded]: {output}"
+        );
     }
 
     #[test]
@@ -940,8 +958,14 @@ mod tests {
             .grounding_status(GroundingStatus::SymbolNotFound)
             .build();
         let json = serde_json::to_string(&f).unwrap();
-        assert!(json.contains("grounding_status"), "JSON should contain grounding_status: {json}");
-        assert!(json.contains("symbol-not-found"), "JSON should contain kebab-case status: {json}");
+        assert!(
+            json.contains("grounding_status"),
+            "JSON should contain grounding_status: {json}"
+        );
+        assert!(
+            json.contains("symbol-not-found"),
+            "JSON should contain kebab-case status: {json}"
+        );
     }
 
     #[test]
@@ -969,7 +993,10 @@ mod tests {
             .build();
         let style = Style::plain();
         let output = format_finding(&f, &style);
-        assert!(!output.contains("\x1b[31m"), "ANSI escape leaked through suggested_fix");
+        assert!(
+            !output.contains("\x1b[31m"),
+            "ANSI escape leaked through suggested_fix"
+        );
         assert!(output.contains("parameterized"));
     }
 
@@ -982,7 +1009,10 @@ mod tests {
             .build();
         let style = Style::plain();
         let output = format_finding(&f, &style);
-        assert!(!output.contains("\x1b[0m"), "ANSI escape leaked through based_on_excerpt");
+        assert!(
+            !output.contains("\x1b[0m"),
+            "ANSI escape leaked through based_on_excerpt"
+        );
         assert!(output.contains("lines 1-50"));
     }
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -50,10 +50,11 @@ impl Language {
             Language::Dockerfile => {
                 // Grammar is vendored and compiled via build.rs to avoid
                 // linking tree-sitter 0.20 (which the crate depends on).
-                unsafe extern "C" { fn tree_sitter_dockerfile() -> *const (); }
-                let lang_fn = unsafe {
-                    tree_sitter_language::LanguageFn::from_raw(tree_sitter_dockerfile)
-                };
+                unsafe extern "C" {
+                    fn tree_sitter_dockerfile() -> *const ();
+                }
+                let lang_fn =
+                    unsafe { tree_sitter_language::LanguageFn::from_raw(tree_sitter_dockerfile) };
                 lang_fn.into()
             }
             Language::Terraform => tree_sitter_hcl::LANGUAGE.into(),
@@ -64,10 +65,7 @@ impl Language {
         match self {
             Language::Rust => &["function_item"],
             Language::Python => &["function_definition"],
-            Language::TypeScript | Language::Tsx => &[
-                "function_declaration",
-                "method_definition",
-            ],
+            Language::TypeScript | Language::Tsx => &["function_declaration", "method_definition"],
             Language::Yaml => &[],
             Language::Bash => &["function_definition"],
             Language::Dockerfile => &[],
@@ -219,7 +217,11 @@ mod tests {
 
     #[test]
     fn parse_valid_typescript() {
-        let tree = parse("function hello(): void { console.log('hi'); }", Language::TypeScript).unwrap();
+        let tree = parse(
+            "function hello(): void { console.log('hi'); }",
+            Language::TypeScript,
+        )
+        .unwrap();
         assert_eq!(tree.root_node().kind(), "program");
         assert!(!tree.root_node().has_error());
     }
@@ -292,7 +294,10 @@ mod tests {
         let tree = parse(source, Language::Python).unwrap();
         let fns = extract_functions(&tree, source, Language::Python);
         let names: Vec<&str> = fns.iter().map(|f| f.name.as_str()).collect();
-        assert!(names.contains(&"fetch"), "async functions should be extracted");
+        assert!(
+            names.contains(&"fetch"),
+            "async functions should be extracted"
+        );
         assert!(names.contains(&"sync"));
     }
 
@@ -302,17 +307,24 @@ mod tests {
         let tree = parse(source, Language::TypeScript).unwrap();
         let fns = extract_functions(&tree, source, Language::TypeScript);
         let names: Vec<&str> = fns.iter().map(|f| f.name.as_str()).collect();
-        assert!(names.contains(&"greet"), "arrow functions assigned to const should be extracted");
+        assert!(
+            names.contains(&"greet"),
+            "arrow functions assigned to const should be extracted"
+        );
         assert!(names.contains(&"foo"));
     }
 
     #[test]
     fn extract_functions_typescript_method() {
-        let source = "class Greeter {\n  greet() { return 'hi'; }\n  farewell() { return 'bye'; }\n}";
+        let source =
+            "class Greeter {\n  greet() { return 'hi'; }\n  farewell() { return 'bye'; }\n}";
         let tree = parse(source, Language::TypeScript).unwrap();
         let fns = extract_functions(&tree, source, Language::TypeScript);
         let names: Vec<&str> = fns.iter().map(|f| f.name.as_str()).collect();
-        assert!(names.contains(&"greet"), "class methods should be extracted");
+        assert!(
+            names.contains(&"greet"),
+            "class methods should be extracted"
+        );
         assert!(names.contains(&"farewell"));
     }
 
@@ -337,7 +349,10 @@ mod tests {
 
     #[test]
     fn detect_language_bash_from_path() {
-        assert_eq!(Language::from_path(std::path::Path::new("deploy.sh")), Some(Language::Bash));
+        assert_eq!(
+            Language::from_path(std::path::Path::new("deploy.sh")),
+            Some(Language::Bash)
+        );
     }
 
     #[test]
@@ -357,7 +372,8 @@ mod tests {
 
     #[test]
     fn extract_functions_bash() {
-        let source = "#!/bin/bash\nmy_func() {\n  echo \"inside\"\n}\n\nanother() {\n  return 1\n}\n";
+        let source =
+            "#!/bin/bash\nmy_func() {\n  echo \"inside\"\n}\n\nanother() {\n  return 1\n}\n";
         let tree = parse(source, Language::Bash).unwrap();
         let fns = extract_functions(&tree, source, Language::Bash);
         let names: Vec<&str> = fns.iter().map(|f| f.name.as_str()).collect();
@@ -368,19 +384,32 @@ mod tests {
 
     #[test]
     fn detect_language_dockerfile_from_path() {
-        assert_eq!(Language::from_path(std::path::Path::new("Dockerfile")), Some(Language::Dockerfile));
-        assert_eq!(Language::from_path(std::path::Path::new("Dockerfile.prod")), Some(Language::Dockerfile));
-        assert_eq!(Language::from_path(std::path::Path::new("dockerfile")), Some(Language::Dockerfile));
+        assert_eq!(
+            Language::from_path(std::path::Path::new("Dockerfile")),
+            Some(Language::Dockerfile)
+        );
+        assert_eq!(
+            Language::from_path(std::path::Path::new("Dockerfile.prod")),
+            Some(Language::Dockerfile)
+        );
+        assert_eq!(
+            Language::from_path(std::path::Path::new("dockerfile")),
+            Some(Language::Dockerfile)
+        );
     }
 
     #[test]
     fn detect_language_dockerfile_extension() {
-        assert_eq!(Language::from_extension("dockerfile"), Some(Language::Dockerfile));
+        assert_eq!(
+            Language::from_extension("dockerfile"),
+            Some(Language::Dockerfile)
+        );
     }
 
     #[test]
     fn parse_valid_dockerfile() {
-        let source = "FROM node:18-alpine\nRUN npm install\nCOPY . /app\nCMD [\"node\", \"server.js\"]\n";
+        let source =
+            "FROM node:18-alpine\nRUN npm install\nCOPY . /app\nCMD [\"node\", \"server.js\"]\n";
         let tree = parse(source, Language::Dockerfile).unwrap();
         assert_eq!(tree.root_node().kind(), "source_file");
         assert!(!tree.root_node().has_error());
@@ -448,7 +477,10 @@ mod tests {
     #[test]
     fn detect_language_terraform() {
         assert_eq!(Language::from_extension("tf"), Some(Language::Terraform));
-        assert_eq!(Language::from_extension("tfvars"), Some(Language::Terraform));
+        assert_eq!(
+            Language::from_extension("tfvars"),
+            Some(Language::Terraform)
+        );
         assert_eq!(Language::from_extension("TF"), Some(Language::Terraform));
     }
 

--- a/src/patterns.rs
+++ b/src/patterns.rs
@@ -3,27 +3,107 @@
 
 /// Known patterns with keywords that identify them.
 const PATTERN_RULES: &[(&str, &[&str])] = &[
-    ("sql_injection", &["sql injection", "sql query", "execute(", "cursor.execute"]),
-    ("xss", &["innerhtml", "outerhtml", "document.write", "dangerouslysetinnerhtml", "cross-site scripting"]),
+    (
+        "sql_injection",
+        &["sql injection", "sql query", "execute(", "cursor.execute"],
+    ),
+    (
+        "xss",
+        &[
+            "innerhtml",
+            "outerhtml",
+            "document.write",
+            "dangerouslysetinnerhtml",
+            "cross-site scripting",
+        ],
+    ),
     ("eval_exec", &["eval(", "exec(", "code injection"]),
-    ("hardcoded_secret", &["hardcoded secret", "hardcoded key", "hardcoded password", "secret_key"]),
+    (
+        "hardcoded_secret",
+        &[
+            "hardcoded secret",
+            "hardcoded key",
+            "hardcoded password",
+            "secret_key",
+        ],
+    ),
     ("debug_mode", &["debug=true", "debug mode"]),
-    ("open_binding", &["0.0.0.0", "all interfaces", "all network"]),
+    (
+        "open_binding",
+        &["0.0.0.0", "all interfaces", "all network"],
+    ),
     ("bare_except", &["bare except", "broad except"]),
-    ("blocking_in_async", &["block_in_place", "future.result()", "blocking call", "stall.*reactor", "stall.*event loop"]),
-    ("resource_leak", &["resource leak", "tab.*leak", "connection.*leak", "file.*leak", "not closed"]),
-    ("race_condition", &["race condition", "not synchronized", "not thread-safe", "thread safety"]),
-    ("missing_timeout", &["no timeout", "missing timeout", "hang indefinitely"]),
-    ("exception_disclosure", &["exception detail", "str(e)", "internal error.*client", "error.*expose"]),
-    ("mutate_while_iterate", &["mutating.*while.*iterating", "mutating.*while.*iterate"]),
+    (
+        "blocking_in_async",
+        &[
+            "block_in_place",
+            "future.result()",
+            "blocking call",
+            "stall.*reactor",
+            "stall.*event loop",
+        ],
+    ),
+    (
+        "resource_leak",
+        &[
+            "resource leak",
+            "tab.*leak",
+            "connection.*leak",
+            "file.*leak",
+            "not closed",
+        ],
+    ),
+    (
+        "race_condition",
+        &[
+            "race condition",
+            "not synchronized",
+            "not thread-safe",
+            "thread safety",
+        ],
+    ),
+    (
+        "missing_timeout",
+        &["no timeout", "missing timeout", "hang indefinitely"],
+    ),
+    (
+        "exception_disclosure",
+        &[
+            "exception detail",
+            "str(e)",
+            "internal error.*client",
+            "error.*expose",
+        ],
+    ),
+    (
+        "mutate_while_iterate",
+        &["mutating.*while.*iterating", "mutating.*while.*iterate"],
+    ),
     ("mutable_default", &["mutable default"]),
     ("complexity_high", &["cyclomatic complexity", "complexity"]),
     ("unsafe_code", &["unsafe block", "unsafe code"]),
     ("unwrap_panic", &["unwrap()", "may panic"]),
-    ("ssrf", &["ssrf", "server-side request", "unvalidated.*url", "arbitrary.*url"]),
-    ("path_traversal", &["path traversal", "directory traversal", "../"]),
-    ("weak_crypto", &["md5", "sha1", "weak.*hash", "weak.*crypto"]),
-    ("unused_code", &["unused import", "unused variable", "dead code"]),
+    (
+        "ssrf",
+        &[
+            "ssrf",
+            "server-side request",
+            "unvalidated.*url",
+            "arbitrary.*url",
+        ],
+    ),
+    (
+        "path_traversal",
+        &["path traversal", "directory traversal", "../"],
+    ),
+    (
+        "weak_crypto",
+        &["md5", "sha1", "weak.*hash", "weak.*crypto"],
+    ),
+    (
+        "unused_code",
+        &["unused import", "unused variable", "dead code"],
+    ),
     ("non_atomic_write", &["non-atomic", "atomic write"]),
 ];
 
@@ -40,7 +120,11 @@ pub fn classify_pattern(title: &str, description: &str, category: &str) -> Optio
 
 /// Format a finding for embedding: "{pattern} {category} {title}"
 /// This normalized format improves embedding similarity for semantically similar findings.
-pub fn embedding_text(finding_title: &str, category: &str, canonical_pattern: Option<&str>) -> String {
+pub fn embedding_text(
+    finding_title: &str,
+    category: &str,
+    canonical_pattern: Option<&str>,
+) -> String {
     match canonical_pattern {
         Some(pattern) => format!("{} {} {}", pattern, category, finding_title),
         None => format!("{} {}", category, finding_title),
@@ -66,7 +150,8 @@ pub fn embedding_text_enriched(
     discriminators: &[&str],
 ) -> String {
     let base = embedding_text(finding_title, category, canonical_pattern);
-    let extras: Vec<&str> = discriminators.iter()
+    let extras: Vec<&str> = discriminators
+        .iter()
         .copied()
         .map(str::trim)
         .filter(|s| !s.is_empty())
@@ -84,25 +169,51 @@ mod tests {
 
     #[test]
     fn classify_sql_injection_variants() {
-        assert_eq!(classify_pattern("SQL injection via f-string", "", "security"), Some("sql_injection".into()));
-        assert_eq!(classify_pattern("Unvalidated input in SQL query", "", "security"), Some("sql_injection".into()));
-        assert_eq!(classify_pattern("Potential SQL injection via f-string in execute()", "", "security"), Some("sql_injection".into()));
+        assert_eq!(
+            classify_pattern("SQL injection via f-string", "", "security"),
+            Some("sql_injection".into())
+        );
+        assert_eq!(
+            classify_pattern("Unvalidated input in SQL query", "", "security"),
+            Some("sql_injection".into())
+        );
+        assert_eq!(
+            classify_pattern(
+                "Potential SQL injection via f-string in execute()",
+                "",
+                "security"
+            ),
+            Some("sql_injection".into())
+        );
     }
 
     #[test]
     fn classify_xss_variants() {
-        assert_eq!(classify_pattern("innerHTML assignment is XSS risk", "", "security"), Some("xss".into()));
-        assert_eq!(classify_pattern("document.write allows injection", "", "security"), Some("xss".into()));
+        assert_eq!(
+            classify_pattern("innerHTML assignment is XSS risk", "", "security"),
+            Some("xss".into())
+        );
+        assert_eq!(
+            classify_pattern("document.write allows injection", "", "security"),
+            Some("xss".into())
+        );
     }
 
     #[test]
     fn classify_unknown_returns_none() {
-        assert_eq!(classify_pattern("Some random finding", "nothing specific", "misc"), None);
+        assert_eq!(
+            classify_pattern("Some random finding", "nothing specific", "misc"),
+            None
+        );
     }
 
     #[test]
     fn embedding_text_with_pattern() {
-        let text = embedding_text("SQL injection via f-string", "security", Some("sql_injection"));
+        let text = embedding_text(
+            "SQL injection via f-string",
+            "security",
+            Some("sql_injection"),
+        );
         assert!(text.starts_with("sql_injection"));
         assert!(text.contains("security"));
     }
@@ -128,7 +239,10 @@ mod tests {
             None,
             &["jwt.verify", "HS256", "algorithm"],
         );
-        assert!(text.contains("jwt.verify"), "discriminator tokens must be in embed text");
+        assert!(
+            text.contains("jwt.verify"),
+            "discriminator tokens must be in embed text"
+        );
         assert!(text.contains("HS256"));
         assert!(text.contains("algorithm"));
         assert!(text.contains("security"));
@@ -152,12 +266,25 @@ mod tests {
 
     #[test]
     fn classify_blocking_in_async() {
-        assert_eq!(classify_pattern("Blocking future.result() in async", "", "concurrency"), Some("blocking_in_async".into()));
-        assert_eq!(classify_pattern("block_in_place can panic", "", "bug"), Some("blocking_in_async".into()));
+        assert_eq!(
+            classify_pattern("Blocking future.result() in async", "", "concurrency"),
+            Some("blocking_in_async".into())
+        );
+        assert_eq!(
+            classify_pattern("block_in_place can panic", "", "bug"),
+            Some("blocking_in_async".into())
+        );
     }
 
     #[test]
     fn classify_complexity() {
-        assert_eq!(classify_pattern("Function foo has cyclomatic complexity 12", "", "complexity"), Some("complexity_high".into()));
+        assert_eq!(
+            classify_pattern(
+                "Function foo has cyclomatic complexity 12",
+                "",
+                "complexity"
+            ),
+            Some("complexity_high".into())
+        );
     }
 }

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -99,7 +99,12 @@ async fn acquire_llm_permit(
 
 /// Trait for LLM review — allows testing with fake implementations.
 pub trait LlmReviewer: Send + Sync {
-    fn review(&self, prompt: &str, model: &str, system_prompt: &str) -> anyhow::Result<crate::llm_client::LlmResponse>;
+    fn review(
+        &self,
+        prompt: &str,
+        model: &str,
+        system_prompt: &str,
+    ) -> anyhow::Result<crate::llm_client::LlmResponse>;
 }
 
 /// Result of reviewing a single file.
@@ -625,41 +630,41 @@ pub async fn review_file(
                 None
             } else {
                 match pipeline_config.context_injector.as_ref() {
-                Some(inj) => {
-                    let mut identifiers: Vec<String> = redacted_ctx
-                        .callee_signatures
-                        .iter()
-                        .filter_map(|sig| extract_ident_from_signature(sig))
-                        .collect();
-                    identifiers.extend(redacted_ctx.import_targets.iter().cloned());
-                    identifiers.sort();
-                    identifiers.dedup();
-                    let text_sample: String = redacted_code.chars().take(400).collect();
-                    // Structural retrieval keys: bare qualified names of
-                    // callees + imports, drawn from AST hydration. Redact for
-                    // parity with the rest of the request surface.
-                    let structural_names: Vec<String> = {
-                        let mut v: Vec<String> = redacted_ctx
-                            .qualified_names
+                    Some(inj) => {
+                        let mut identifiers: Vec<String> = redacted_ctx
+                            .callee_signatures
                             .iter()
-                            .map(|s| redact::redact_secrets(s))
+                            .filter_map(|sig| extract_ident_from_signature(sig))
                             .collect();
-                        v.sort();
-                        v.dedup();
-                        v
-                    };
-                    let req = crate::context::inject::InjectionRequest {
-                        file_path: file_str.clone(),
-                        language: Some(lang_name(lang).to_string()),
-                        identifiers,
-                        structural_names,
-                        text: text_sample,
-                    };
-                    let outcome = inj.inject(&req);
-                    context_telemetry = Some(outcome.telemetry);
-                    outcome.rendered
-                }
-                None => None,
+                        identifiers.extend(redacted_ctx.import_targets.iter().cloned());
+                        identifiers.sort();
+                        identifiers.dedup();
+                        let text_sample: String = redacted_code.chars().take(400).collect();
+                        // Structural retrieval keys: bare qualified names of
+                        // callees + imports, drawn from AST hydration. Redact for
+                        // parity with the rest of the request surface.
+                        let structural_names: Vec<String> = {
+                            let mut v: Vec<String> = redacted_ctx
+                                .qualified_names
+                                .iter()
+                                .map(|s| redact::redact_secrets(s))
+                                .collect();
+                            v.sort();
+                            v.dedup();
+                            v
+                        };
+                        let req = crate::context::inject::InjectionRequest {
+                            file_path: file_str.clone(),
+                            language: Some(lang_name(lang).to_string()),
+                            identifiers,
+                            structural_names,
+                            text: text_sample,
+                        };
+                        let outcome = inj.inject(&req);
+                        context_telemetry = Some(outcome.telemetry);
+                        outcome.rendered
+                    }
+                    None => None,
                 }
             };
 
@@ -1845,7 +1850,12 @@ mod tests {
 
         struct EmptyReviewer;
         impl LlmReviewer for EmptyReviewer {
-            fn review(&self, _: &str, _: &str, _system_prompt: &str) -> anyhow::Result<crate::llm_client::LlmResponse> {
+            fn review(
+                &self,
+                _: &str,
+                _: &str,
+                _system_prompt: &str,
+            ) -> anyhow::Result<crate::llm_client::LlmResponse> {
                 Ok(crate::llm_client::LlmResponse {
                     content: "[]".into(),
                     usage: None,
@@ -2000,10 +2010,7 @@ mod tests {
             ..Default::default()
         };
         let reason = context7_skip_reason(&cfg);
-        assert_eq!(
-            reason,
-            Some("prose review mode (use --context7 to enable)"),
-        );
+        assert_eq!(reason, Some("prose review mode (use --context7 to enable)"),);
     }
 
     #[test]
@@ -2015,10 +2022,7 @@ mod tests {
             ..Default::default()
         };
         let reason = context7_skip_reason(&cfg);
-        assert_eq!(
-            reason,
-            Some("prose review mode (use --context7 to enable)"),
-        );
+        assert_eq!(reason, Some("prose review mode (use --context7 to enable)"),);
     }
 
     /// Prose mode (Plan) must skip local AST analysis and ast-grep scanning.

--- a/src/progress.rs
+++ b/src/progress.rs
@@ -1,6 +1,5 @@
 /// Interactive terminal progress feedback.
 /// Writes spinner + status to stderr when TTY, silent when piped.
-
 use std::io::{self, IsTerminal, Write};
 
 pub struct ProgressReporter {
@@ -18,35 +17,56 @@ impl ProgressReporter {
     }
 
     pub fn detect() -> Self {
-        Self { is_tty: io::stderr().is_terminal() }
+        Self {
+            is_tty: io::stderr().is_terminal(),
+        }
     }
 
     pub fn start_file(&self, file_path: &str) {
-        if !self.is_tty { return; }
+        if !self.is_tty {
+            return;
+        }
         eprint!("\x1b[2m{}\x1b[0m ", sanitize(file_path));
         let _ = io::stderr().flush();
     }
 
     pub fn update(&self, status: &str) {
-        if !self.is_tty { return; }
+        if !self.is_tty {
+            return;
+        }
         eprint!("\r\x1b[2K\x1b[2m  {} \x1b[0m", sanitize(status));
         let _ = io::stderr().flush();
     }
 
     pub fn model_call(&self, file_path: &str, model: &str) {
-        if !self.is_tty { return; }
-        eprint!("\r\x1b[2K\x1b[2m  {} reviewing with {}...\x1b[0m", sanitize(file_path), sanitize(model));
+        if !self.is_tty {
+            return;
+        }
+        eprint!(
+            "\r\x1b[2K\x1b[2m  {} reviewing with {}...\x1b[0m",
+            sanitize(file_path),
+            sanitize(model)
+        );
         let _ = io::stderr().flush();
     }
 
     pub fn agent_tool_call(&self, file_path: &str, tool_name: &str, iteration: usize) {
-        if !self.is_tty { return; }
-        eprint!("\r\x1b[2K\x1b[2m  {} [iter {}] calling {}...\x1b[0m", sanitize(file_path), iteration, sanitize(tool_name));
+        if !self.is_tty {
+            return;
+        }
+        eprint!(
+            "\r\x1b[2K\x1b[2m  {} [iter {}] calling {}...\x1b[0m",
+            sanitize(file_path),
+            iteration,
+            sanitize(tool_name)
+        );
         let _ = io::stderr().flush();
     }
 
     pub fn finish_file(&self, finding_count: usize) {
-        if !self.is_tty { return; }
+        if !self.is_tty {
+            return;
+        }
         if finding_count == 0 {
             eprintln!("\r\x1b[2K\x1b[32m  clean\x1b[0m");
         } else {
@@ -55,7 +75,9 @@ impl ProgressReporter {
     }
 
     pub fn clear_line(&self) {
-        if !self.is_tty { return; }
+        if !self.is_tty {
+            return;
+        }
         eprint!("\r\x1b[2K");
         let _ = io::stderr().flush();
     }

--- a/src/redact.rs
+++ b/src/redact.rs
@@ -1,6 +1,5 @@
 /// Secret redaction: strip API keys, passwords, tokens from code before sending to LLM.
 /// Always-on — no opt-out.
-
 use regex::Regex;
 use std::sync::LazyLock;
 
@@ -100,19 +99,26 @@ mod tests {
     fn redact_preserves_bare_variable_assignment() {
         let input = "api_key=openai_api_key";
         let output = redact_secrets(input);
-        assert_eq!(input, output, "Bare variable references should NOT be redacted");
+        assert_eq!(
+            input, output,
+            "Bare variable references should NOT be redacted"
+        );
     }
 
     #[test]
     fn redact_preserves_variable_references() {
         let input = "api_key = os.getenv('OPENAI_API_KEY')\nopenai_api_key = config.api_key";
         let output = redact_secrets(input);
-        assert_eq!(input, output, "Variable references and function calls should NOT be redacted");
+        assert_eq!(
+            input, output,
+            "Variable references and function calls should NOT be redacted"
+        );
     }
 
     #[test]
     fn redact_bearer_token() {
-        let input = r#"Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.abc123"#;
+        let input =
+            r#"Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.abc123"#;
         let output = redact_secrets(input);
         assert!(!output.contains("eyJhbGciOiJIUzI1NiJ9"));
     }
@@ -173,7 +179,8 @@ mod tests {
 
     #[test]
     fn redact_private_key_block() {
-        let input = "-----BEGIN RSA PRIVATE KEY-----\nMIIEpAIBAAKCAQEA\n-----END RSA PRIVATE KEY-----";
+        let input =
+            "-----BEGIN RSA PRIVATE KEY-----\nMIIEpAIBAAKCAQEA\n-----END RSA PRIVATE KEY-----";
         let output = redact_secrets(input);
         assert!(!output.contains("MIIEpAIBAAKCAQEA"));
         assert!(output.contains("[REDACTED"));
@@ -236,10 +243,7 @@ mod tests {
         // Issue #68: PASSWORD="pa\"ssword" — the value class [^\n"]{6,}
         // stops at the first " and the {6,} floor fails on the 3-char
         // prefix `pa\`, so the secret leaks through.
-        let cases = [
-            r#"PASSWORD = "pa\"ssword""#,
-            r#"API_KEY = "abc\"def""#,
-        ];
+        let cases = [r#"PASSWORD = "pa\"ssword""#, r#"API_KEY = "abc\"def""#];
         for input in cases {
             let output = redact_secrets(input);
             assert!(
@@ -269,7 +273,10 @@ mod tests {
         // on the line.
         let input = r#"PASSWORD = "pa\"ssword" PUBLIC = "visible""#;
         let output = redact_secrets(input);
-        assert!(output.contains("[REDACTED]"), "expected redaction; got: {output}");
+        assert!(
+            output.contains("[REDACTED]"),
+            "expected redaction; got: {output}"
+        );
         // The non-secret keyword `PUBLIC` is not in the secret-keyword
         // anchor list, so its value should remain literally visible.
         assert!(
@@ -376,10 +383,10 @@ mod tests {
         // Pin the (?i) flag still works for auth_<credential> after dropping
         // bare `auth`. Each case must redact via its credential-shaped suffix.
         for input in [
-            r#"Auth_Token = "tok1""#,       // via `token`
-            r#"AUTH_PASSWORD = "pw1""#,     // via `password`
-            r#"auth-secret = "shh""#,       // via `secret` (hyphen variant)
-            r#"AUTH_API_KEY = "ak""#,       // via `api_key` suffix chain
+            r#"Auth_Token = "tok1""#,   // via `token`
+            r#"AUTH_PASSWORD = "pw1""#, // via `password`
+            r#"auth-secret = "shh""#,   // via `secret` (hyphen variant)
+            r#"AUTH_API_KEY = "ak""#,   // via `api_key` suffix chain
         ] {
             let output = redact_secrets(input);
             assert!(

--- a/src/review.rs
+++ b/src/review.rs
@@ -105,7 +105,10 @@ where
         }
 
         fn visit_map<A: de::MapAccess<'de>>(self, mut map: A) -> Result<Self::Value, A::Error> {
-            while map.next_entry::<de::IgnoredAny, de::IgnoredAny>()?.is_some() {}
+            while map
+                .next_entry::<de::IgnoredAny, de::IgnoredAny>()?
+                .is_some()
+            {}
             Ok(None)
         }
     }
@@ -1832,7 +1835,10 @@ mod tests {
     fn llm_finding_with_reasoning_and_confidence_parses() {
         let json = r#"[{"title":"Bug","description":"D","severity":"high","category":"security","line_start":1,"line_end":1,"reasoning":"The function lacks bounds checking","confidence":0.85}]"#;
         let findings = parse_llm_response(json, "gpt-5.4").unwrap();
-        assert_eq!(findings[0].reasoning.as_deref(), Some("The function lacks bounds checking"));
+        assert_eq!(
+            findings[0].reasoning.as_deref(),
+            Some("The function lacks bounds checking")
+        );
         assert_eq!(findings[0].confidence, Some(0.85));
     }
 

--- a/src/review_log.rs
+++ b/src/review_log.rs
@@ -300,7 +300,9 @@ impl ReviewLog {
         let file = File::open(&self.path)
             .with_context(|| format!("Failed to open review log: {}", self.path.display()))?;
         let reader: Box<dyn BufRead> = Box::new(BufReader::new(file));
-        Ok(ReviewLogIter { inner: Some(reader.lines()) })
+        Ok(ReviewLogIter {
+            inner: Some(reader.lines()),
+        })
     }
 
     /// Convenience: collect all records (suitable for small logs and tests).
@@ -456,10 +458,14 @@ mod tests {
             tokens_out: 678,
             tokens_cache_read: 8_000,
             duration_ms: 4_200,
-            flags: Flags { deep: false, parallel_n: 4, ensemble: false },
+            flags: Flags {
+                deep: false,
+                parallel_n: 4,
+                ensemble: false,
+            },
             mode: None,
             context: ContextTelemetry::default(),
-        finding_ids: Vec::new(),
+            finding_ids: Vec::new(),
         }
     }
 
@@ -505,8 +511,10 @@ mod tests {
         let rec = sample_record();
         assert!(rec.finding_ids.is_empty(), "fixture default must be empty");
         let json = serde_json::to_string(&rec).unwrap();
-        assert!(!json.contains("finding_ids"),
-            "empty finding_ids must not write the key: {json}");
+        assert!(
+            !json.contains("finding_ids"),
+            "empty finding_ids must not write the key: {json}"
+        );
     }
 
     #[test]
@@ -595,9 +603,15 @@ mod tests {
         let got = detect_invoked_from(None);
         // Restore
         unsafe {
-            if let Some(v) = prev_claude { std::env::set_var("CLAUDE_CODE", v); }
-            if let Some(v) = prev_codex { std::env::set_var("CODEX_CI", v); }
-            if let Some(v) = prev_gemini { std::env::set_var("GEMINI_CLI", v); }
+            if let Some(v) = prev_claude {
+                std::env::set_var("CLAUDE_CODE", v);
+            }
+            if let Some(v) = prev_codex {
+                std::env::set_var("CODEX_CI", v);
+            }
+            if let Some(v) = prev_gemini {
+                std::env::set_var("GEMINI_CLI", v);
+            }
             match prev_agent {
                 Some(v) => std::env::set_var("AGENT", v),
                 None => std::env::remove_var("AGENT"),
@@ -613,7 +627,13 @@ mod tests {
         let sub = dir.path().join("src/nested");
         std::fs::create_dir_all(&sub).unwrap();
         let got = detect_repo(&sub).unwrap();
-        let expected = dir.path().file_name().unwrap().to_str().unwrap().to_string();
+        let expected = dir
+            .path()
+            .file_name()
+            .unwrap()
+            .to_str()
+            .unwrap()
+            .to_string();
         assert_eq!(got, expected);
     }
 
@@ -622,7 +642,11 @@ mod tests {
         // Root has no parent with a .git directory (on any reasonable system).
         // Using "/" guarantees we exhaust the parent chain without a match.
         let got = detect_repo(Path::new("/"));
-        assert!(got.is_none(), "filesystem root should yield None, got {:?}", got);
+        assert!(
+            got.is_none(),
+            "filesystem root should yield None, got {:?}",
+            got
+        );
     }
 
     use std::sync::Mutex;
@@ -647,9 +671,7 @@ mod tests {
             ids.push(r.run_id.clone());
             log.record(&r).unwrap();
         }
-        let got: Vec<String> = log.iter().unwrap()
-            .map(|r| r.unwrap().run_id)
-            .collect();
+        let got: Vec<String> = log.iter().unwrap().map(|r| r.unwrap().run_id).collect();
         assert_eq!(got, ids);
     }
 
@@ -667,7 +689,11 @@ mod tests {
         }
         let log = ReviewLog::new(path);
         let records: Vec<_> = log.iter().unwrap().filter_map(|r| r.ok()).collect();
-        assert_eq!(records.len(), 2, "should skip malformed + blank, keep valid");
+        assert_eq!(
+            records.len(),
+            2,
+            "should skip malformed + blank, keep valid"
+        );
     }
 
     #[test]
@@ -722,7 +748,10 @@ mod tests {
         rec.context = populated_context_telemetry();
 
         let json = serde_json::to_string(&rec).unwrap();
-        assert!(json.contains("\"auto_inject_enabled\":true"), "json: {json}");
+        assert!(
+            json.contains("\"auto_inject_enabled\":true"),
+            "json: {json}"
+        );
         assert!(json.contains("\"injector_available\":true"));
         assert!(json.contains("\"retrieved_chunk_count\":5"));
         assert!(json.contains("\"injected_chunk_count\":2"));
@@ -839,7 +868,10 @@ mod tests {
             assert_eq!(c.bm25, 1);
             assert_eq!(c.vector, 1);
             assert_eq!(c.structural, 1);
-            assert_eq!(c.structural_only, 1, "lone Structural tag is structural_only");
+            assert_eq!(
+                c.structural_only, 1,
+                "lone Structural tag is structural_only"
+            );
             assert_eq!(c.total_unique, 3);
         }
 
@@ -850,8 +882,14 @@ mod tests {
             assert_eq!(c.bm25, 1);
             assert_eq!(c.vector, 0);
             assert_eq!(c.structural, 1);
-            assert_eq!(c.structural_only, 0, "Structural+Bm25 is NOT structural_only");
-            assert_eq!(c.total_unique, 1, "multi-leg chunk counts once toward total_unique");
+            assert_eq!(
+                c.structural_only, 0,
+                "Structural+Bm25 is NOT structural_only"
+            );
+            assert_eq!(
+                c.total_unique, 1,
+                "multi-leg chunk counts once toward total_unique"
+            );
         }
 
         #[test]
@@ -927,6 +965,9 @@ mod tests {
         }"#;
         let rec: ReviewRecord = serde_json::from_str(legacy)
             .expect("legacy record without mode field must deserialize");
-        assert!(rec.mode.is_none(), "mode should default to None for legacy records");
+        assert!(
+            rec.mode.is_none(),
+            "mode should default to None for legacy records"
+        );
     }
 }

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -1,13 +1,12 @@
 /// Stats dashboard -- reads local data files and computes metrics.
-
 use crate::analytics;
 use crate::dimensions::{self, ContextDimensionSlice, DimensionSlice};
 use crate::feedback::FeedbackStore;
 use crate::formatting;
 use crate::glyphs;
+use crate::output::Style;
 use crate::review_log::ReviewLog;
 use crate::telemetry::TelemetryStore;
-use crate::output::Style;
 
 /// Highlights cap: we show the most active slices, trimmed hard to keep the
 /// default dashboard compact. Callers wanting everything use --by-repo etc.
@@ -89,7 +88,11 @@ pub fn compute_report(
     let total_wontfix: usize = stats.values().map(|s| s.wontfix).sum();
     let relevant = total_tp + total_partial;
     let precision_denom = relevant + total_fp;
-    let precision = if precision_denom > 0 { relevant as f64 / precision_denom as f64 } else { 0.0 };
+    let precision = if precision_denom > 0 {
+        relevant as f64 / precision_denom as f64
+    } else {
+        0.0
+    };
 
     // Precision trend (7-day windows)
     let precision_trend = analytics::precision_trend(&feedback, 7);
@@ -101,7 +104,8 @@ pub fn compute_report(
     let tokens_in_7d: u64 = recent.iter().map(|e| e.tokens_in).sum();
     let tokens_out_7d: u64 = recent.iter().map(|e| e.tokens_out).sum();
 
-    let total_findings_7d: usize = recent.iter()
+    let total_findings_7d: usize = recent
+        .iter()
         .map(|e| e.findings.values().sum::<usize>())
         .sum();
     let total_suppressed_7d: usize = recent.iter().map(|e| e.suppressed).sum();
@@ -143,7 +147,10 @@ pub fn compute_report(
     // empty vectors, which the renderer treats as "no data" and hides.
     let review_records = review_log.load_all().unwrap_or_default();
     let top_repos = take_top(dimensions::group_by_repo(&review_records), HIGHLIGHT_TOP_N);
-    let top_callers = take_top(dimensions::group_by_caller(&review_records), HIGHLIGHT_TOP_N);
+    let top_callers = take_top(
+        dimensions::group_by_caller(&review_records),
+        HIGHLIGHT_TOP_N,
+    );
     let rolling_windows = dimensions::rolling_window(&review_records, ROLLING_N, ROLLING_WINDOWS);
 
     // Linkage / capture / external overlap (Phase A).
@@ -155,9 +162,7 @@ pub fn compute_report(
     // Capture-labeled = feedback entries timestamped in the 7d window.
     // Coarse but useful — exact would require joining each feedback row
     // to a review timestamp, which we deliberately don't do here.
-    let capture_labeled = feedback.iter()
-        .filter(|e| e.timestamp >= since_7d)
-        .count();
+    let capture_labeled = feedback.iter().filter(|e| e.timestamp >= since_7d).count();
     let capture_rate = if capture_total > 0 {
         (capture_labeled as f64 / capture_total as f64).min(1.0)
     } else {
@@ -304,11 +309,7 @@ pub fn format_headline_trend(report: &StatsReport) -> String {
     let tail = windows.last().unwrap();
     let ci = if tail.count >= MIN_TREND_WINDOW_N && tail.precision_denom > 0 {
         let successes = (tail.precision * tail.precision_denom as f64).round() as usize;
-        let (lo, hi) = crate::stats_math::wilson_interval(
-            successes,
-            tail.precision_denom,
-            0.95,
-        );
+        let (lo, hi) = crate::stats_math::wilson_interval(successes, tail.precision_denom, 0.95);
         format!(
             " [{lo}-{hi}]",
             lo = (lo * 100.0).round() as u32,
@@ -351,11 +352,21 @@ pub fn format_human_with_full(report: &StatsReport, style: &Style, full: bool) -
     let mut out = format_human_core(report, style);
     let unicode = crate::output::unicode_ok_default();
     if !report.top_repos.is_empty() {
-        out.push_str(&format_highlight_block("By repo (top)", &report.top_repos, style, unicode));
+        out.push_str(&format_highlight_block(
+            "By repo (top)",
+            &report.top_repos,
+            style,
+            unicode,
+        ));
     }
     if full {
         if !report.top_callers.is_empty() {
-            out.push_str(&format_highlight_block("By caller (top)", &report.top_callers, style, unicode));
+            out.push_str(&format_highlight_block(
+                "By caller (top)",
+                &report.top_callers,
+                style,
+                unicode,
+            ));
         }
         if !report.rolling_windows.is_empty() {
             out.push_str(&format_highlight_block(
@@ -372,11 +383,18 @@ pub fn format_human_with_full(report: &StatsReport, style: &Style, full: bool) -
 /// One highlight section: a mini-table (up to 3 rows) sized to not compete
 /// with the full --by-repo/--by-caller tables. Intentionally narrower than
 /// format_dimension_table.
-fn format_highlight_block(title: &str, slices: &[DimensionSlice], style: &Style, unicode: bool) -> String {
+fn format_highlight_block(
+    title: &str,
+    slices: &[DimensionSlice],
+    style: &Style,
+    unicode: bool,
+) -> String {
     let mut out = String::new();
     out.push_str(&format!(
         "\n{bold}{title}{reset}\n",
-        bold = style.bold, reset = style.reset, title = title,
+        bold = style.bold,
+        reset = style.reset,
+        title = title,
     ));
     for s in slices {
         let key = if s.key.chars().count() > 18 {
@@ -393,7 +411,11 @@ fn format_highlight_block(title: &str, slices: &[DimensionSlice], style: &Style,
             format!("  {} {}", spark, arrow)
         };
         let low = if s.low_sample {
-            format!("  {dim}(low sample){reset}", dim = style.dim, reset = style.reset)
+            format!(
+                "  {dim}(low sample){reset}",
+                dim = style.dim,
+                reset = style.reset
+            )
         } else {
             String::new()
         };
@@ -414,7 +436,8 @@ fn format_human_core(report: &StatsReport, style: &Style) -> String {
 
     out.push_str(&format!(
         "{bold}Feedback Health{reset}\n",
-        bold = style.bold, reset = style.reset
+        bold = style.bold,
+        reset = style.reset
     ));
     out.push_str(&format!(
         "  Entries: {}  Precision: {}\n",
@@ -443,18 +466,21 @@ fn format_human_core(report: &StatsReport, style: &Style) -> String {
 
     out.push_str(&format!(
         "\n{bold}Activity (last 7 days){reset}\n",
-        bold = style.bold, reset = style.reset
+        bold = style.bold,
+        reset = style.reset
     ));
     out.push_str(&format!(
         "  Reviews: {}  Findings/review: {:.1}  Suppression: {}\n",
-        report.reviews_7d, report.findings_per_review,
+        report.reviews_7d,
+        report.findings_per_review,
         formatting::format_pct(report.suppression_rate),
     ));
 
     if report.tokens_in_7d > 0 || report.tokens_out_7d > 0 {
         out.push_str(&format!(
             "\n{bold}Spend (last 7 days){reset}\n",
-            bold = style.bold, reset = style.reset
+            bold = style.bold,
+            reset = style.reset
         ));
         out.push_str(&format!(
             "  Tokens: {} in / {} out  Cost: {}  Tokens/finding: {}\n",
@@ -516,10 +542,19 @@ pub fn format_dimension_table(
             Some(r) if !s.low_sample => {
                 let bar = glyphs::hbar(r * 100.0, 100.0, unicode);
                 let pct = format!("{:>3}%", (r * 100.0).round() as i64);
-                format!("{}{bar}{reset} {}", color_for_accept(r, style), pct,
-                    bar = bar, reset = style.reset)
+                format!(
+                    "{}{bar}{reset} {}",
+                    color_for_accept(r, style),
+                    pct,
+                    bar = bar,
+                    reset = style.reset
+                )
             }
-            _ => format!("{dim}—                    {reset}", dim = style.dim, reset = style.reset),
+            _ => format!(
+                "{dim}—                    {reset}",
+                dim = style.dim,
+                reset = style.reset
+            ),
         };
 
         let trend_cell = if s.sparkline_points.is_empty() {
@@ -531,7 +566,11 @@ pub fn format_dimension_table(
         };
 
         let low_tag = if s.low_sample {
-            format!("  {dim}(low sample){reset}", dim = style.dim, reset = style.reset)
+            format!(
+                "  {dim}(low sample){reset}",
+                dim = style.dim,
+                reset = style.reset
+            )
         } else {
             String::new()
         };
@@ -559,7 +598,11 @@ pub fn format_dimension_table(
     out.push_str(&format!(
         "\n  {dim}{} {}  {} reviews{}{reset}\n",
         slices.len(),
-        if slices.len() == 1 { unit_label_singular(mode) } else { unit_label_plural(mode) },
+        if slices.len() == 1 {
+            unit_label_singular(mode)
+        } else {
+            unit_label_plural(mode)
+        },
         total_reviews,
         low_note,
         dim = style.dim,
@@ -586,9 +629,13 @@ fn truncate_key(key: &str, width: usize) -> String {
 }
 
 fn color_for_accept(rate: f64, style: &Style) -> &str {
-    if rate >= 0.70 { style.green }
-    else if rate < 0.40 { style.red }
-    else { "" }
+    if rate >= 0.70 {
+        style.green
+    } else if rate < 0.40 {
+        style.red
+    } else {
+        ""
+    }
 }
 
 fn unit_label_singular(mode: &str) -> &'static str {
@@ -616,7 +663,8 @@ pub fn format_dimension_compact(mode: &str, slices: &[DimensionSlice]) -> String
             low_count += 1;
             continue;
         }
-        let acc = s.accept_rate
+        let acc = s
+            .accept_rate
             .map(|r| format!(" acc{}", (r * 100.0).round() as i64))
             .unwrap_or_default();
         parts.push(format!(
@@ -641,33 +689,55 @@ pub fn format_compact(report: &StatsReport) -> String {
     ];
 
     if !report.precision_trend.is_empty() {
-        let trend: Vec<String> = report.precision_trend.iter()
+        let trend: Vec<String> = report
+            .precision_trend
+            .iter()
             .map(|w| formatting::format_pct(w.precision))
             .collect();
         parts.push(format!("trend:{}", trend.join(">")));
     }
 
     parts.push(format!("reviews_7d:{}", report.reviews_7d));
-    parts.push(format!("findings_per_review:{:.1}", report.findings_per_review));
+    parts.push(format!(
+        "findings_per_review:{:.1}",
+        report.findings_per_review
+    ));
 
     if report.tokens_in_7d > 0 {
-        parts.push(format!("tokens_in:{}", formatting::format_count(report.tokens_in_7d)));
-        parts.push(format!("tokens_out:{}", formatting::format_count(report.tokens_out_7d)));
+        parts.push(format!(
+            "tokens_in:{}",
+            formatting::format_count(report.tokens_in_7d)
+        ));
+        parts.push(format!(
+            "tokens_out:{}",
+            formatting::format_count(report.tokens_out_7d)
+        ));
         parts.push(format!("cost:{}", formatting::format_cost(report.cost_7d)));
     }
 
-    parts.push(format!("linkage:{}", formatting::format_pct(report.linkage_rate)));
-    parts.push(format!("capture:{}", formatting::format_pct(report.capture_rate)));
+    parts.push(format!(
+        "linkage:{}",
+        formatting::format_pct(report.linkage_rate)
+    ));
+    parts.push(format!(
+        "capture:{}",
+        formatting::format_pct(report.capture_rate)
+    ));
 
     if !report.external_overlap.per_agent.is_empty() {
-        let agent_parts: Vec<String> = report.external_overlap.per_agent.iter()
+        let agent_parts: Vec<String> = report
+            .external_overlap
+            .per_agent
+            .iter()
             .map(|a| format!("{}:{}/{}", a.agent, a.agree, a.overlap))
             .collect();
         parts.push(format!("external:{}", agent_parts.join(",")));
     }
 
     if !report.precision_trend_per_finding.is_empty() {
-        let pf: Vec<String> = report.precision_trend_per_finding.iter()
+        let pf: Vec<String> = report
+            .precision_trend_per_finding
+            .iter()
             .map(|w| formatting::format_pct(w.precision))
             .collect();
         parts.push(format!("per-finding:{}", pf.join(">")));
@@ -694,7 +764,9 @@ pub fn format_context_dimension_table(
 
     out.push_str(&format!(
         "{bold}~ Stats: {mode}{reset}\n\n",
-        bold = style.bold, reset = style.reset, mode = mode,
+        bold = style.bold,
+        reset = style.reset,
+        mode = mode,
     ));
 
     if slices.is_empty() {
@@ -732,7 +804,11 @@ pub fn format_context_dimension_table(
         };
 
         let low_tag = if s.low_sample {
-            format!("  {dim}(low sample){reset}", dim = style.dim, reset = style.reset)
+            format!(
+                "  {dim}(low sample){reset}",
+                dim = style.dim,
+                reset = style.reset
+            )
         } else {
             String::new()
         };
@@ -861,10 +937,13 @@ pub fn format_json(report: &StatsReport) -> anyhow::Result<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use tempfile::TempDir;
     use std::path::PathBuf;
+    use tempfile::TempDir;
 
-    fn make_review_log(dir: &TempDir, records: &[crate::review_log::ReviewRecord]) -> crate::review_log::ReviewLog {
+    fn make_review_log(
+        dir: &TempDir,
+        records: &[crate::review_log::ReviewRecord],
+    ) -> crate::review_log::ReviewLog {
         let log = crate::review_log::ReviewLog::new(dir.path().join("reviews.jsonl"));
         for r in records {
             log.record(r).unwrap();
@@ -884,14 +963,26 @@ mod tests {
             files_reviewed: 1,
             lines_added: None,
             lines_removed: None,
-            findings_by_severity: SeverityCounts { critical: 0, high: findings, medium: 0, low: 0, info: 0 },
+            findings_by_severity: SeverityCounts {
+                critical: 0,
+                high: findings,
+                medium: 0,
+                low: 0,
+                info: 0,
+            },
             suppressed_by_rule: Default::default(),
-            tokens_in: 0, tokens_out: 0, tokens_cache_read: 0,
+            tokens_in: 0,
+            tokens_out: 0,
+            tokens_cache_read: 0,
             duration_ms: 100,
-            flags: Flags { deep: false, parallel_n: 1, ensemble: false },
+            flags: Flags {
+                deep: false,
+                parallel_n: 1,
+                ensemble: false,
+            },
             mode: None,
             context: Default::default(),
-        finding_ids: Vec::new(),
+            finding_ids: Vec::new(),
         }
     }
 
@@ -933,8 +1024,14 @@ mod tests {
         let report = compute_report(&fb, &tl, &rl).unwrap();
         let out = format_human_with_full(&report, &Style::plain(), false);
         assert!(out.contains("By repo"), "By repo stays in default: {out}");
-        assert!(!out.contains("By caller"), "By caller hides without --full: {out}");
-        assert!(!out.contains("Rolling"), "Rolling hides without --full: {out}");
+        assert!(
+            !out.contains("By caller"),
+            "By caller hides without --full: {out}"
+        );
+        assert!(
+            !out.contains("Rolling"),
+            "Rolling hides without --full: {out}"
+        );
     }
 
     #[test]
@@ -971,13 +1068,18 @@ mod tests {
         StatsReport {
             feedback_count: 0,
             precision: 0.0,
-            tp: 0, fp: 0, partial: 0, wontfix: 0,
+            tp: 0,
+            fp: 0,
+            partial: 0,
+            wontfix: 0,
             precision_trend: vec![],
             reviews_7d: 0,
             findings_per_review: 0.0,
             suppression_rate: 0.0,
-            tokens_in_7d: 0, tokens_out_7d: 0,
-            cost_7d: 0.0, tokens_per_finding: 0.0,
+            tokens_in_7d: 0,
+            tokens_out_7d: 0,
+            cost_7d: 0.0,
+            tokens_per_finding: 0.0,
             model: String::new(),
             top_repos: Vec::new(),
             top_callers: Vec::new(),
@@ -986,7 +1088,11 @@ mod tests {
             linkage_rate: 0.0,
             linkage_linked: 0,
             linkage_unlinked: 0,
-            capture_rate: if capture_total > 0 { capture_labeled as f64 / capture_total as f64 } else { 0.0 },
+            capture_rate: if capture_total > 0 {
+                capture_labeled as f64 / capture_total as f64
+            } else {
+                0.0
+            },
             capture_labeled,
             capture_total,
             headline_trend_uses_finding_id: uses_finding_id,
@@ -1000,21 +1106,31 @@ mod tests {
         // 4-window trend, last window n=145 ≥ 30 → Wilson CI shown.
         let report = make_report_for_trend(
             vec![pw(0.77, 30), pw(0.81, 32), pw(0.78, 90), pw(0.76, 145)],
-            212, 1159, true,
+            212,
+            1159,
+            true,
         );
         let out = format_headline_trend(&report);
         assert!(out.contains("77 → 81"), "trend chain missing: {out}");
         assert!(out.contains("76%"), "current window pct missing: {out}");
         assert!(out.contains("["), "expected CI bracket: {out}");
-        assert!(out.contains("n=145"), "expected sample-size annotation: {out}");
-        assert!(out.contains("capture"), "capture-rate inline missing: {out}");
+        assert!(
+            out.contains("n=145"),
+            "expected sample-size annotation: {out}"
+        );
+        assert!(
+            out.contains("capture"),
+            "capture-rate inline missing: {out}"
+        );
     }
 
     #[test]
     fn headline_trend_replaces_low_n_window_with_n_too_low() {
         let report = make_report_for_trend(
             vec![pw(0.77, 8), pw(0.81, 32), pw(0.78, 90), pw(0.76, 145)],
-            10, 100, true,
+            10,
+            100,
+            true,
         );
         let out = format_headline_trend(&report);
         assert!(
@@ -1078,7 +1194,8 @@ mod tests {
                 fp_kind: None,
                 finding_id: Some(format!("FID-{i}")),
                 rule_id: None,
-            }).unwrap();
+            })
+            .unwrap();
         }
         for _ in 0..3 {
             fb.record(&crate::feedback::FeedbackEntry {
@@ -1093,11 +1210,15 @@ mod tests {
                 fp_kind: None,
                 finding_id: None,
                 rule_id: None,
-            }).unwrap();
+            })
+            .unwrap();
         }
         let report = compute_report(&fb, &tl, &rl).unwrap();
         assert!((report.linkage_rate - 0.85).abs() < 1e-9);
-        assert!(report.headline_trend_uses_finding_id, "85% must flip the gate");
+        assert!(
+            report.headline_trend_uses_finding_id,
+            "85% must flip the gate"
+        );
     }
 
     #[test]
@@ -1121,10 +1242,18 @@ mod tests {
         let fb = FeedbackStore::new(dir.path().join("fb.jsonl"));
         let tl = TelemetryStore::new(dir.path().join("tl.jsonl"));
         let mut records = Vec::new();
-        for _ in 0..5 { records.push(rec("alpha", "tty", 2)); }
-        for _ in 0..3 { records.push(rec("beta", "tty", 1)); }
-        for _ in 0..1 { records.push(rec("gamma", "tty", 1)); }
-        for _ in 0..2 { records.push(rec("delta", "tty", 1)); }
+        for _ in 0..5 {
+            records.push(rec("alpha", "tty", 2));
+        }
+        for _ in 0..3 {
+            records.push(rec("beta", "tty", 1));
+        }
+        for _ in 0..1 {
+            records.push(rec("gamma", "tty", 1));
+        }
+        for _ in 0..2 {
+            records.push(rec("delta", "tty", 1));
+        }
         let rl = make_review_log(&dir, &records);
         let report = compute_report(&fb, &tl, &rl).unwrap();
         assert_eq!(report.top_repos.len(), 3, "should cap at 3");
@@ -1139,9 +1268,15 @@ mod tests {
         let fb = FeedbackStore::new(dir.path().join("fb.jsonl"));
         let tl = TelemetryStore::new(dir.path().join("tl.jsonl"));
         let mut records = Vec::new();
-        for _ in 0..4 { records.push(rec("r", "claude_code", 2)); }
-        for _ in 0..2 { records.push(rec("r", "tty", 1)); }
-        for _ in 0..1 { records.push(rec("r", "codex_ci", 1)); }
+        for _ in 0..4 {
+            records.push(rec("r", "claude_code", 2));
+        }
+        for _ in 0..2 {
+            records.push(rec("r", "tty", 1));
+        }
+        for _ in 0..1 {
+            records.push(rec("r", "codex_ci", 1));
+        }
         let rl = make_review_log(&dir, &records);
         let report = compute_report(&fb, &tl, &rl).unwrap();
         assert_eq!(report.top_callers[0].key, "claude_code");
@@ -1156,7 +1291,10 @@ mod tests {
         let records: Vec<_> = (0..120).map(|_| rec("r", "tty", 1)).collect();
         let rl = make_review_log(&dir, &records);
         let report = compute_report(&fb, &tl, &rl).unwrap();
-        assert!(!report.rolling_windows.is_empty(), "should produce at least one rolling-50 window");
+        assert!(
+            !report.rolling_windows.is_empty(),
+            "should produce at least one rolling-50 window"
+        );
         assert!(report.rolling_windows.len() <= 4);
     }
 
@@ -1184,7 +1322,11 @@ mod tests {
         let rl = make_review_log(&dir, &records);
         let report = compute_report(&fb, &tl, &rl).unwrap();
         let out = format_human_minimal(&report, &Style::plain());
-        assert!(!out.contains("By repo"), "minimal output should omit repo block: {}", out);
+        assert!(
+            !out.contains("By repo"),
+            "minimal output should omit repo block: {}",
+            out
+        );
         assert!(!out.contains("By caller"));
         assert!(out.contains("Feedback Health"), "minimal keeps core blocks");
     }
@@ -1344,8 +1486,8 @@ mod tests {
         assert!(out.contains("Feedback Health"));
         assert!(out.contains("Activity (last 7 days)"));
         assert!(out.contains("Spend (last 7 days)"));
-        assert!(out.contains("2.0k"));  // feedback count
-        assert!(out.contains("74%"));   // precision
+        assert!(out.contains("2.0k")); // feedback count
+        assert!(out.contains("74%")); // precision
     }
 
     fn slice(key: &str, n: u32, findings: u32, files: u64, low_sample: bool) -> DimensionSlice {
@@ -1353,7 +1495,11 @@ mod tests {
             key: key.into(),
             n_reviews: n,
             n_findings: findings,
-            findings_per_file: if files == 0 { 0.0 } else { findings as f64 / files as f64 },
+            findings_per_file: if files == 0 {
+                0.0
+            } else {
+                findings as f64 / files as f64
+            },
             findings_per_kloc: None,
             accept_rate: None,
             severity_mix: Default::default(),
@@ -1406,7 +1552,11 @@ mod tests {
         s.accept_rate = Some(0.78);
         let out = format_dimension_table("by-repo", &[s], &Style::plain(), true);
         // A 78% bar should have some filled and some empty cells.
-        assert!(out.contains('█'), "unicode bar should contain full-block char, got:\n{}", out);
+        assert!(
+            out.contains('█'),
+            "unicode bar should contain full-block char, got:\n{}",
+            out
+        );
     }
 
     #[test]
@@ -1445,10 +1595,16 @@ mod tests {
 
     #[test]
     fn dimension_compact_single_line_no_glyphs() {
-        let slices = vec![slice("alpha", 10, 23, 10, false), slice("beta", 3, 6, 3, true)];
+        let slices = vec![
+            slice("alpha", 10, 23, 10, false),
+            slice("beta", 3, 6, 3, true),
+        ];
         let out = format_dimension_compact("by-repo", &slices);
-        assert!(!out.contains('\n') || out.trim_end().lines().count() == 1,
-            "compact mode must be single-line, got: {:?}", out);
+        assert!(
+            !out.contains('\n') || out.trim_end().lines().count() == 1,
+            "compact mode must be single-line, got: {:?}",
+            out
+        );
         assert!(!out.contains('█'), "compact mode must not use semigraphics");
         assert!(out.contains("alpha"));
     }

--- a/src/suppress.rs
+++ b/src/suppress.rs
@@ -137,7 +137,12 @@ pub fn load_project_suppressions(path: &std::path::Path) -> Vec<SuppressionRule>
 pub fn format_suppressed_finding(finding: &Finding, rule: &SuppressionRule) -> String {
     let reason = rule.reason.as_deref().unwrap_or("no reason given");
     let safe_title: String = finding.title.chars().filter(|c| !c.is_control()).collect();
-    let safe_category: String = finding.category.as_str().chars().filter(|c| !c.is_control()).collect();
+    let safe_category: String = finding
+        .category
+        .as_str()
+        .chars()
+        .filter(|c| !c.is_control())
+        .collect();
     format!(
         "  [SUPPRESSED] {}  [{}]\n    Reason: {}\n",
         safe_title, safe_category, reason
@@ -370,7 +375,10 @@ category = "security"
         assert_eq!(result.kept.len(), 1);
         assert_eq!(result.kept[0].title, "SQL injection risk");
         assert_eq!(result.suppressed.len(), 1);
-        assert_eq!(result.suppressed[0].0.title, "TLS certificate verification disabled");
+        assert_eq!(
+            result.suppressed[0].0.title,
+            "TLS certificate verification disabled"
+        );
     }
 
     #[test]
@@ -407,9 +415,7 @@ category = "security"
             FindingBuilder::new()
                 .title("SQL injection risk in query builder")
                 .build(),
-            FindingBuilder::new()
-                .title("Unused import")
-                .build(),
+            FindingBuilder::new().title("Unused import").build(),
         ];
         let result = apply_suppressions(findings, &rules, "src/main.py");
         assert_eq!(result.kept.len(), 1);
@@ -425,9 +431,11 @@ category = "security"
             file: None,
             reason: Some("Internal service".into()),
         }];
-        let findings = vec![FindingBuilder::new()
-            .title("TLS certificate verification disabled")
-            .build()];
+        let findings = vec![
+            FindingBuilder::new()
+                .title("TLS certificate verification disabled")
+                .build(),
+        ];
         let result = apply_suppressions(findings, &rules, "src/main.py");
         assert_eq!(result.suppressed.len(), 1);
         let (_, matched_rule) = &result.suppressed[0];

--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -1,10 +1,9 @@
-/// Review telemetry: append-only JSONL recording review metadata.
-/// No file contents, no finding text, no code snippets. Just counts and metadata.
-
-use std::path::PathBuf;
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
+/// Review telemetry: append-only JSONL recording review metadata.
+/// No file contents, no finding text, no code snippets. Just counts and metadata.
+use std::path::PathBuf;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct TelemetryEntry {
@@ -16,9 +15,12 @@ pub struct TelemetryEntry {
     pub tokens_out: u64,
     pub duration_ms: u64,
     pub suppressed: usize,
-    #[serde(default)] pub context7_resolved: u32,
-    #[serde(default)] pub context7_resolve_failed: u32,
-    #[serde(default)] pub context7_query_failed: u32,
+    #[serde(default)]
+    pub context7_resolved: u32,
+    #[serde(default)]
+    pub context7_resolve_failed: u32,
+    #[serde(default)]
+    pub context7_query_failed: u32,
     /// #123 Layer 1 (Task 10): fraction of `Verdict::Fp` feedback entries
     /// that carry a `fp_kind` discriminator. Range [0.0, 1.0]. `None` when
     /// the loaded feedback store has no FP entries (denominator zero).
@@ -144,7 +146,11 @@ impl TelemetryStore {
             // real line truly exceeded the cap.
             let payload_len = if buf.ends_with(b"\n") {
                 let n = buf.len() - 1;
-                if n > 0 && buf[n - 1] == b'\r' { n - 1 } else { n }
+                if n > 0 && buf[n - 1] == b'\r' {
+                    n - 1
+                } else {
+                    n
+                }
             } else {
                 buf.len()
             };
@@ -167,10 +173,7 @@ impl TelemetryStore {
                 }
                 stats.skipped += 1;
                 if stats.errors.len() < MAX_PARSE_ERRORS {
-                    let snippet: String = String::from_utf8_lossy(&buf)
-                        .chars()
-                        .take(80)
-                        .collect();
+                    let snippet: String = String::from_utf8_lossy(&buf).chars().take(80).collect();
                     stats.errors.push(ParseError {
                         line_no,
                         snippet,
@@ -183,7 +186,11 @@ impl TelemetryStore {
             // Trim the trailing newline (and \r if CRLF) before parsing.
             let line_bytes = if buf.ends_with(b"\n") {
                 let end = buf.len() - 1;
-                let end = if end > 0 && buf[end - 1] == b'\r' { end - 1 } else { end };
+                let end = if end > 0 && buf[end - 1] == b'\r' {
+                    end - 1
+                } else {
+                    end
+                };
                 &buf[..end]
             } else {
                 &buf[..]
@@ -297,8 +304,8 @@ mod tests {
             "duration_ms": 0,
             "suppressed": 0
         }"#;
-        let entry: TelemetryEntry = serde_json::from_str(old)
-            .expect("old JSONL rows must deserialize after schema bump");
+        let entry: TelemetryEntry =
+            serde_json::from_str(old).expect("old JSONL rows must deserialize after schema bump");
         assert_eq!(entry.context7_resolved, 0);
         assert_eq!(entry.context7_resolve_failed, 0);
         assert_eq!(entry.context7_query_failed, 0);
@@ -346,7 +353,10 @@ mod tests {
         store.record(&sample_entry()).unwrap();
         // Append garbage
         use std::io::Write;
-        let mut f = std::fs::OpenOptions::new().append(true).open(&path).unwrap();
+        let mut f = std::fs::OpenOptions::new()
+            .append(true)
+            .open(&path)
+            .unwrap();
         writeln!(f, "{{garbage}}").unwrap();
         writeln!(f, "not json at all").unwrap();
         store.record(&sample_entry()).unwrap();
@@ -612,14 +622,16 @@ mod tests {
 
         let mut old = sample_entry();
         old.ts = chrono::DateTime::parse_from_rfc3339("2026-01-01T00:00:00Z")
-            .unwrap().with_timezone(&Utc);
+            .unwrap()
+            .with_timezone(&Utc);
         store.record(&old).unwrap();
 
         let recent = sample_entry(); // ts = now
         store.record(&recent).unwrap();
 
         let since = chrono::DateTime::parse_from_rfc3339("2026-04-01T00:00:00Z")
-            .unwrap().with_timezone(&Utc);
+            .unwrap()
+            .with_timezone(&Utc);
         let entries = store.load_since(since).unwrap();
         assert_eq!(entries.len(), 1);
     }

--- a/src/test_support.rs
+++ b/src/test_support.rs
@@ -2,10 +2,10 @@
 
 #[cfg(test)]
 pub mod fakes {
+    use crate::llm_client::LlmTurnResult;
+    use crate::pipeline::LlmReviewer;
     use std::collections::VecDeque;
     use std::sync::Mutex;
-    use crate::pipeline::LlmReviewer;
-    use crate::llm_client::LlmTurnResult;
 
     /// Fake reviewer that returns responses in sequence.
     /// Falls back to last response if sequence exhausted.
@@ -38,15 +38,30 @@ pub mod fakes {
     }
 
     impl LlmReviewer for FakeReviewer {
-        fn review(&self, prompt: &str, _model: &str, _system_prompt: &str) -> anyhow::Result<crate::llm_client::LlmResponse> {
-            self.captured_prompts.lock().unwrap().push(prompt.to_string());
+        fn review(
+            &self,
+            prompt: &str,
+            _model: &str,
+            _system_prompt: &str,
+        ) -> anyhow::Result<crate::llm_client::LlmResponse> {
+            self.captured_prompts
+                .lock()
+                .unwrap()
+                .push(prompt.to_string());
             let mut q = self.responses.lock().unwrap();
             if q.is_empty() {
                 anyhow::bail!("FakeReviewer: no responses configured");
             }
-            let resp = if q.len() > 1 { q.pop_front().unwrap() } else { q.front().cloned().unwrap() };
-            resp.map(|content| crate::llm_client::LlmResponse { content, usage: None })
-                .map_err(|e| anyhow::anyhow!(e))
+            let resp = if q.len() > 1 {
+                q.pop_front().unwrap()
+            } else {
+                q.front().cloned().unwrap()
+            };
+            resp.map(|content| crate::llm_client::LlmResponse {
+                content,
+                usage: None,
+            })
+            .map_err(|e| anyhow::anyhow!(e))
         }
     }
 
@@ -57,7 +72,9 @@ pub mod fakes {
 
     impl FakeAgentReviewer {
         pub fn new(turns: Vec<LlmTurnResult>) -> Self {
-            Self { turns: Mutex::new(turns.into()) }
+            Self {
+                turns: Mutex::new(turns.into()),
+            }
         }
     }
 

--- a/src/threshold_config.rs
+++ b/src/threshold_config.rs
@@ -75,7 +75,9 @@ impl ThresholdConfig {
         if self.suppress.as_ref().is_some_and(|p| !valid(p))
             || self.boost.as_ref().is_some_and(|p| !valid(p))
         {
-            tracing::warn!("calibrator_thresholds.toml contains out-of-range values, using defaults");
+            tracing::warn!(
+                "calibrator_thresholds.toml contains out-of-range values, using defaults"
+            );
             return None;
         }
         if let (Some(s), Some(b)) = (&self.suppress, &self.boost)

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -1,8 +1,7 @@
+use serde::Serialize;
 /// Tool registry for deep review agent.
 /// Provides read_file, grep, list_files — all confined to a repo root for safety.
-
 use std::path::{Path, PathBuf};
-use serde::Serialize;
 
 const MAX_OUTPUT_CHARS: usize = 8000;
 const MAX_GREP_RESULTS: usize = 20;
@@ -38,14 +37,17 @@ pub struct ToolRegistry {
 
 impl ToolRegistry {
     pub fn new(root: &Path) -> Self {
-        Self { root: root.to_path_buf() }
+        Self {
+            root: root.to_path_buf(),
+        }
     }
 
     pub fn tool_definitions(&self) -> Vec<ToolDefinition> {
         vec![
             ToolDefinition {
                 name: "read_file".into(),
-                description: "Read file contents. Use start_line/end_line to read a specific range.".into(),
+                description:
+                    "Read file contents. Use start_line/end_line to read a specific range.".into(),
                 parameters: serde_json::json!({
                     "type": "object",
                     "properties": {
@@ -58,7 +60,9 @@ impl ToolRegistry {
             },
             ToolDefinition {
                 name: "grep".into(),
-                description: "Search for a pattern across files. Returns matching lines with file paths.".into(),
+                description:
+                    "Search for a pattern across files. Returns matching lines with file paths."
+                        .into(),
                 parameters: serde_json::json!({
                     "type": "object",
                     "properties": {
@@ -104,19 +108,33 @@ impl ToolRegistry {
         if relative.starts_with('/') || relative.starts_with('\\') {
             anyhow::bail!("Absolute paths not allowed");
         }
-        let resolved = self.root.join(relative).canonicalize()
+        let resolved = self
+            .root
+            .join(relative)
+            .canonicalize()
             .map_err(|e| anyhow::anyhow!("Cannot resolve path '{}': {}", relative, e))?;
         // Ensure resolved path is within root
-        let canon_root = self.root.canonicalize()
+        let canon_root = self
+            .root
+            .canonicalize()
             .map_err(|e| anyhow::anyhow!("Cannot resolve root: {}", e))?;
         if !resolved.starts_with(&canon_root) {
-            anyhow::bail!("Path traversal blocked: '{}' escapes project root", relative);
+            anyhow::bail!(
+                "Path traversal blocked: '{}' escapes project root",
+                relative
+            );
         }
         Ok(resolved)
     }
 
-    fn exec_read_file(&self, args: &serde_json::Value, max_output_bytes: usize) -> anyhow::Result<String> {
-        let path_str = args["path"].as_str().ok_or_else(|| anyhow::anyhow!("path required"))?;
+    fn exec_read_file(
+        &self,
+        args: &serde_json::Value,
+        max_output_bytes: usize,
+    ) -> anyhow::Result<String> {
+        let path_str = args["path"]
+            .as_str()
+            .ok_or_else(|| anyhow::anyhow!("path required"))?;
         let resolved = self.resolve_path(path_str)?;
 
         let file = std::fs::File::open(&resolved)?;
@@ -147,9 +165,17 @@ impl ToolRegistry {
         Ok(truncate(&selected, max_output_bytes))
     }
 
-    fn exec_grep(&self, args: &serde_json::Value, max_output_bytes: usize) -> anyhow::Result<String> {
-        let pattern = args["pattern"].as_str().ok_or_else(|| anyhow::anyhow!("pattern required"))?;
-        let max = args["max_results"].as_u64().unwrap_or(MAX_GREP_RESULTS as u64) as usize;
+    fn exec_grep(
+        &self,
+        args: &serde_json::Value,
+        max_output_bytes: usize,
+    ) -> anyhow::Result<String> {
+        let pattern = args["pattern"]
+            .as_str()
+            .ok_or_else(|| anyhow::anyhow!("pattern required"))?;
+        let max = args["max_results"]
+            .as_u64()
+            .unwrap_or(MAX_GREP_RESULTS as u64) as usize;
         let path_glob = args["path_glob"].as_str();
 
         let mut results = Vec::new();
@@ -176,10 +202,14 @@ impl ToolRegistry {
         glob: Option<&str>,
         acc: &mut AccumulatorState<'_>,
     ) -> anyhow::Result<()> {
-        if acc.is_full() { return Ok(()); }
+        if acc.is_full() {
+            return Ok(());
+        }
         let entries = std::fs::read_dir(dir)?;
         for entry in entries.flatten() {
-            if acc.is_full() { break; }
+            if acc.is_full() {
+                break;
+            }
             let path = entry.path();
             let name = entry.file_name().to_string_lossy().to_string();
             if name.starts_with('.')
@@ -190,7 +220,11 @@ impl ToolRegistry {
             {
                 continue;
             }
-            if path.symlink_metadata().map(|m| m.file_type().is_symlink()).unwrap_or(false) {
+            if path
+                .symlink_metadata()
+                .map(|m| m.file_type().is_symlink())
+                .unwrap_or(false)
+            {
                 continue;
             }
             if path.is_dir() {
@@ -200,7 +234,9 @@ impl ToolRegistry {
                     if g != "*" {
                         let ext_match = g.trim_start_matches("*.");
                         if let Some(ext) = path.extension() {
-                            if ext.to_string_lossy() != ext_match { continue; }
+                            if ext.to_string_lossy() != ext_match {
+                                continue;
+                            }
                         } else {
                             continue;
                         }
@@ -209,7 +245,9 @@ impl ToolRegistry {
                 if let Ok(content) = std::fs::read_to_string(&path) {
                     let rel = path.strip_prefix(&self.root).unwrap_or(&path);
                     for (i, line) in content.lines().enumerate() {
-                        if acc.is_full() { break; }
+                        if acc.is_full() {
+                            break;
+                        }
                         if line.contains(pattern) {
                             acc.push(format!("{}:{}: {}", rel.display(), i + 1, line.trim()));
                         }
@@ -220,10 +258,18 @@ impl ToolRegistry {
         Ok(())
     }
 
-    fn exec_list_files(&self, args: &serde_json::Value, max_output_bytes: usize) -> anyhow::Result<String> {
+    fn exec_list_files(
+        &self,
+        args: &serde_json::Value,
+        max_output_bytes: usize,
+    ) -> anyhow::Result<String> {
         let subdir = args["path"].as_str().unwrap_or("");
         let pattern = args["pattern"].as_str();
-        let dir = if subdir.is_empty() { self.root.clone() } else { self.resolve_path(subdir)? };
+        let dir = if subdir.is_empty() {
+            self.root.clone()
+        } else {
+            self.resolve_path(subdir)?
+        };
 
         let mut files = Vec::new();
         let mut total_bytes = 0usize;
@@ -248,10 +294,14 @@ impl ToolRegistry {
         glob: Option<&str>,
         acc: &mut AccumulatorState<'_>,
     ) -> anyhow::Result<()> {
-        if acc.is_full() { return Ok(()); }
+        if acc.is_full() {
+            return Ok(());
+        }
         let entries = std::fs::read_dir(dir)?;
         for entry in entries.flatten() {
-            if acc.is_full() { break; }
+            if acc.is_full() {
+                break;
+            }
             let path = entry.path();
             let name = entry.file_name().to_string_lossy().to_string();
             if name.starts_with('.')
@@ -262,7 +312,11 @@ impl ToolRegistry {
             {
                 continue;
             }
-            if path.symlink_metadata().map(|m| m.file_type().is_symlink()).unwrap_or(false) {
+            if path
+                .symlink_metadata()
+                .map(|m| m.file_type().is_symlink())
+                .unwrap_or(false)
+            {
                 continue;
             }
             if path.is_dir() {
@@ -273,7 +327,9 @@ impl ToolRegistry {
                     if g != "*" {
                         let ext = g.trim_start_matches("*.");
                         if let Some(file_ext) = path.extension() {
-                            if file_ext.to_string_lossy() != ext { continue; }
+                            if file_ext.to_string_lossy() != ext {
+                                continue;
+                            }
                         } else {
                             continue;
                         }
@@ -347,7 +403,11 @@ mod tests {
         let dir = setup_repo();
         let reg = ToolRegistry::new(dir.path());
         let result = reg
-            .execute("read_file", &serde_json::json!({"path": "main.py"}), usize::MAX)
+            .execute(
+                "read_file",
+                &serde_json::json!({"path": "main.py"}),
+                usize::MAX,
+            )
             .unwrap();
         assert!(result.contains("def hello"));
     }
@@ -399,9 +459,16 @@ mod tests {
         let reg = ToolRegistry::new(dir.path());
         // Use a concrete budget — with usize::MAX there is no truncation.
         let result = reg
-            .execute("read_file", &serde_json::json!({"path": "big.txt"}), MAX_OUTPUT_CHARS)
+            .execute(
+                "read_file",
+                &serde_json::json!({"path": "big.txt"}),
+                MAX_OUTPUT_CHARS,
+            )
             .unwrap();
-        assert!(result.len() <= MAX_OUTPUT_CHARS, "Should truncate large files");
+        assert!(
+            result.len() <= MAX_OUTPUT_CHARS,
+            "Should truncate large files"
+        );
     }
 
     #[test]
@@ -409,7 +476,11 @@ mod tests {
         let dir = setup_repo();
         let reg = ToolRegistry::new(dir.path());
         let result = reg
-            .execute("grep", &serde_json::json!({"pattern": "SECRET"}), usize::MAX)
+            .execute(
+                "grep",
+                &serde_json::json!({"pattern": "SECRET"}),
+                usize::MAX,
+            )
             .unwrap();
         assert!(result.contains("SECRET"));
         assert!(result.contains("auth.py"));
@@ -446,7 +517,11 @@ mod tests {
         let dir = setup_repo();
         let reg = ToolRegistry::new(dir.path());
         let result = reg
-            .execute("list_files", &serde_json::json!({"pattern": "*.py"}), usize::MAX)
+            .execute(
+                "list_files",
+                &serde_json::json!({"pattern": "*.py"}),
+                usize::MAX,
+            )
             .unwrap();
         assert!(result.contains("main.py"));
     }
@@ -457,9 +532,17 @@ mod tests {
         let reg = ToolRegistry::new(dir.path());
         // Model sends "*" meaning "all files" — should not filter everything out
         let result = reg
-            .execute("list_files", &serde_json::json!({"path": "src", "pattern": "*"}), usize::MAX)
+            .execute(
+                "list_files",
+                &serde_json::json!({"path": "src", "pattern": "*"}),
+                usize::MAX,
+            )
             .unwrap();
-        assert!(result.contains("auth.py"), "Star glob should match all files, got: {}", result);
+        assert!(
+            result.contains("auth.py"),
+            "Star glob should match all files, got: {}",
+            result
+        );
     }
 
     #[test]
@@ -467,7 +550,11 @@ mod tests {
         let dir = setup_repo();
         let reg = ToolRegistry::new(dir.path());
         let result = reg
-            .execute("list_files", &serde_json::json!({"path": "src"}), usize::MAX)
+            .execute(
+                "list_files",
+                &serde_json::json!({"path": "src"}),
+                usize::MAX,
+            )
             .unwrap();
         assert!(result.contains("auth.py"));
         assert!(result.contains("db.py"));
@@ -477,7 +564,10 @@ mod tests {
     fn execute_unknown_tool_errors() {
         let dir = setup_repo();
         let reg = ToolRegistry::new(dir.path());
-        assert!(reg.execute("nonexistent", &serde_json::json!({}), usize::MAX).is_err());
+        assert!(
+            reg.execute("nonexistent", &serde_json::json!({}), usize::MAX)
+                .is_err()
+        );
     }
 
     #[test]
@@ -516,9 +606,16 @@ mod tests {
         let dir = setup_repo();
         let reg = ToolRegistry::new(dir.path());
         let result = reg
-            .execute("read_file", &serde_json::json!({"path": "main.py"}), usize::MAX)
+            .execute(
+                "read_file",
+                &serde_json::json!({"path": "main.py"}),
+                usize::MAX,
+            )
             .unwrap();
-        assert!(result.contains("print"), "full output should include file content");
+        assert!(
+            result.contains("print"),
+            "full output should include file content"
+        );
     }
 
     #[test]
@@ -566,6 +663,10 @@ mod tests {
         let result = reg
             .execute("read_file", &serde_json::json!({"path": "emoji.txt"}), 15)
             .unwrap();
-        assert!(result.len() <= 15, "result {} exceeds budget 15", result.len());
+        assert!(
+            result.len() <= 15,
+            "result {} exceeds budget 15",
+            result.len()
+        );
     }
 }

--- a/src/trace_subscriber.rs
+++ b/src/trace_subscriber.rs
@@ -6,7 +6,9 @@ use std::path::PathBuf;
 
 /// Initialize the tracing subscriber if tracing is enabled.
 /// Returns the guard that must be held for the lifetime of the program.
-pub fn init_trace_subscriber(trace_path: Option<PathBuf>) -> Option<tracing_appender::non_blocking::WorkerGuard> {
+pub fn init_trace_subscriber(
+    trace_path: Option<PathBuf>,
+) -> Option<tracing_appender::non_blocking::WorkerGuard> {
     let path = trace_path?;
 
     if let Some(parent) = path.parent() {

--- a/tests/calibrate_backfill.rs
+++ b/tests/calibrate_backfill.rs
@@ -27,7 +27,11 @@ fn calibrate_backfill_paths_dry_run() {
         .output()
         .unwrap();
 
-    assert!(output.status.success(), "should exit 0, stderr: {}", String::from_utf8_lossy(&output.stderr));
+    assert!(
+        output.status.success(),
+        "should exit 0, stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
 
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(

--- a/tests/calibrator_pre_refactor_snapshot.rs
+++ b/tests/calibrator_pre_refactor_snapshot.rs
@@ -25,9 +25,9 @@ use std::path::PathBuf;
 
 use chrono::{Duration as ChronoDuration, Utc};
 
-use quorum::calibrator::{calibrate, calibrate_with_index, CalibratorConfig};
+use quorum::calibrator::{CalibratorConfig, calibrate, calibrate_with_index};
 use quorum::calibrator_fingerprint::{
-    fingerprints_from_traces, sort_fingerprints, FromIndexPath, TraceFingerprint,
+    FromIndexPath, TraceFingerprint, fingerprints_from_traces, sort_fingerprints,
 };
 use quorum::feedback::{FeedbackEntry, FeedbackStore, FpKind, Provenance, Verdict};
 use quorum::feedback_index::FeedbackIndex;
@@ -70,7 +70,12 @@ fn human_fb(title: &str, category: &str, verdict: Verdict) -> FeedbackEntry {
     }
 }
 
-fn fb_with(title: &str, category: &str, verdict: Verdict, fp_kind: Option<FpKind>) -> FeedbackEntry {
+fn fb_with(
+    title: &str,
+    category: &str,
+    verdict: Verdict,
+    fp_kind: Option<FpKind>,
+) -> FeedbackEntry {
     let mut e = human_fb(title, category, verdict);
     e.fp_kind = fp_kind;
     e
@@ -129,7 +134,11 @@ fn build_scenarios() -> Vec<Scenario> {
     // 3. Single TP, weight below 1.5 boost threshold → BoostWeightTooLow.
     out.push(Scenario {
         name: "03_single_tp_human_no_boost",
-        findings: vec![finding("Race condition in shared HashMap", "concurrency", Severity::Medium)],
+        findings: vec![finding(
+            "Race condition in shared HashMap",
+            "concurrency",
+            Severity::Medium,
+        )],
         feedback: vec![human_fb(
             "Race condition in shared HashMap",
             "concurrency",
@@ -144,9 +153,19 @@ fn build_scenarios() -> Vec<Scenario> {
     //    category) so the gate permits the bump.
     out.push(Scenario {
         name: "04_multiple_tp_human_boost_to_high",
-        findings: vec![finding("Race condition in shared HashMap", "concurrency", Severity::Medium)],
+        findings: vec![finding(
+            "Race condition in shared HashMap",
+            "concurrency",
+            Severity::Medium,
+        )],
         feedback: (0..3)
-            .map(|_| human_fb("Race condition in shared HashMap", "concurrency", Verdict::Tp))
+            .map(|_| {
+                human_fb(
+                    "Race condition in shared HashMap",
+                    "concurrency",
+                    Verdict::Tp,
+                )
+            })
             .collect(),
         config: CalibratorConfig::default(),
         run_index_path: true,
@@ -268,7 +287,13 @@ fn build_scenarios() -> Vec<Scenario> {
             Severity::Medium,
         )],
         feedback: (0..3)
-            .map(|_| human_fb("Race condition in shared HashMap", "concurrency", Verdict::Tp))
+            .map(|_| {
+                human_fb(
+                    "Race condition in shared HashMap",
+                    "concurrency",
+                    Verdict::Tp,
+                )
+            })
             .collect(),
         config: CalibratorConfig::default(),
         run_index_path: true,
@@ -340,7 +365,12 @@ fn capture_scenario(scenario: &Scenario) -> Vec<TraceFingerprint> {
     let mut out = Vec::new();
 
     // Path A: in-memory calibrate()
-    let result_a = calibrate(scenario.findings.clone(), &scenario.feedback, &scenario.config, "");
+    let result_a = calibrate(
+        scenario.findings.clone(),
+        &scenario.feedback,
+        &scenario.config,
+        "",
+    );
     out.extend(fingerprints_from_traces(
         scenario.name,
         &result_a.traces,

--- a/tests/category_enum_test.rs
+++ b/tests/category_enum_test.rs
@@ -32,8 +32,14 @@ fn serde_roundtrip_all_variants() {
 
 #[test]
 fn serde_uses_kebab_case() {
-    assert_eq!(serde_json::to_string(&Category::ErrorHandling).unwrap(), "\"error-handling\"");
-    assert_eq!(serde_json::to_string(&Category::Security).unwrap(), "\"security\"");
+    assert_eq!(
+        serde_json::to_string(&Category::ErrorHandling).unwrap(),
+        "\"error-handling\""
+    );
+    assert_eq!(
+        serde_json::to_string(&Category::Security).unwrap(),
+        "\"security\""
+    );
 }
 
 #[test]

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -97,7 +97,11 @@ fn review_unknown_extension_llm_only_fallback() {
     // Unknown extensions use LLM-only review; without LLM configured, returns 0 findings
     let dir = tempfile::TempDir::new().unwrap();
     let file = dir.path().join("example.go");
-    std::fs::write(&file, "package main\nfunc main() { fmt.Println(\"hello\") }\n").unwrap();
+    std::fs::write(
+        &file,
+        "package main\nfunc main() { fmt.Println(\"hello\") }\n",
+    )
+    .unwrap();
     quorum()
         .arg("review")
         .arg(file.to_str().unwrap())

--- a/tests/cli_context_stdout_handling.rs
+++ b/tests/cli_context_stdout_handling.rs
@@ -106,7 +106,10 @@ fn context_list_with_open_stdout_exits_zero_and_writes_to_stdout() {
         .expect("failed to drain quorum stderr");
     let status = child.wait().expect("failed to wait for quorum child");
 
-    assert!(status.success(), "successful list must exit 0; got {status:?}");
+    assert!(
+        status.success(),
+        "successful list must exit 0; got {status:?}"
+    );
     let stderr = String::from_utf8_lossy(&stderr_buf);
     assert!(
         !stderr.contains("failed to write"),

--- a/tests/cli_feedback_agent.rs
+++ b/tests/cli_feedback_agent.rs
@@ -174,9 +174,8 @@ fn human_path_honors_explicit_json_flag() {
     .stdout
     .clone();
     let stdout = String::from_utf8(out).unwrap();
-    let v: serde_json::Value = serde_json::from_str(stdout.trim()).unwrap_or_else(|e| {
-        panic!("Human --json must emit valid JSON: {stdout:?} ({e})")
-    });
+    let v: serde_json::Value = serde_json::from_str(stdout.trim())
+        .unwrap_or_else(|e| panic!("Human --json must emit valid JSON: {stdout:?} ({e})"));
     assert_eq!(v["verdict"], "tp");
     assert_eq!(v["file_path"], "src/x.rs");
 }
@@ -219,10 +218,14 @@ fn cli_feedback_accepts_uppercase_verdict() {
     run_feedback(
         home.path(),
         &[
-            "--file", "a.rs",
-            "--finding", "X",
-            "--verdict", "TP",
-            "--reason", "r",
+            "--file",
+            "a.rs",
+            "--finding",
+            "X",
+            "--verdict",
+            "TP",
+            "--reason",
+            "r",
         ],
     )
     .success();
@@ -239,10 +242,14 @@ fn cli_feedback_accepts_whitespace_padded_verdict() {
     run_feedback(
         home.path(),
         &[
-            "--file", "a.rs",
-            "--finding", "X",
-            "--verdict", "  tp  ",
-            "--reason", "r",
+            "--file",
+            "a.rs",
+            "--finding",
+            "X",
+            "--verdict",
+            "  tp  ",
+            "--reason",
+            "r",
         ],
     )
     .success();
@@ -259,10 +266,14 @@ fn cli_feedback_rejects_unknown_verdict() {
     run_feedback(
         home.path(),
         &[
-            "--file", "a.rs",
-            "--finding", "X",
-            "--verdict", "maybe",
-            "--reason", "r",
+            "--file",
+            "a.rs",
+            "--finding",
+            "X",
+            "--verdict",
+            "maybe",
+            "--reason",
+            "r",
         ],
     )
     .failure();

--- a/tests/cli_inbox_drain.rs
+++ b/tests/cli_inbox_drain.rs
@@ -46,12 +46,7 @@ fn stats_drains_inbox_before_loading_feedback() {
     let remaining: Vec<_> = std::fs::read_dir(&inbox)
         .unwrap()
         .filter_map(|e| e.ok())
-        .filter(|e| {
-            e.path()
-                .extension()
-                .map(|x| x == "jsonl")
-                .unwrap_or(false)
-        })
+        .filter(|e| e.path().extension().map(|x| x == "jsonl").unwrap_or(false))
         .collect();
     assert_eq!(
         remaining.len(),
@@ -131,12 +126,7 @@ fn concurrent_drain_archives_exactly_once() {
     let leftover: Vec<_> = std::fs::read_dir(&inbox)
         .unwrap()
         .filter_map(|e| e.ok())
-        .filter(|e| {
-            e.path()
-                .extension()
-                .map(|x| x == "jsonl")
-                .unwrap_or(false)
-        })
+        .filter(|e| e.path().extension().map(|x| x == "jsonl").unwrap_or(false))
         .collect();
     assert!(
         leftover.is_empty(),

--- a/tests/doctor_exit_code.rs
+++ b/tests/doctor_exit_code.rs
@@ -21,8 +21,7 @@ fn home_with_no_sources_toml() -> tempfile::TempDir {
 /// can't accidentally leak into the developer's real profile on Windows.
 fn quorum_cmd_with_home(tmp: &tempfile::TempDir) -> Command {
     let mut cmd = Command::cargo_bin("quorum").unwrap();
-    cmd.env("HOME", tmp.path())
-        .env("USERPROFILE", tmp.path());
+    cmd.env("HOME", tmp.path()).env("USERPROFILE", tmp.path());
     cmd
 }
 

--- a/tests/parallel_review.rs
+++ b/tests/parallel_review.rs
@@ -6,9 +6,11 @@ fn parallel_flag_accepted() {
     let path = dir.path().join("test.rs");
     std::fs::write(&path, "fn main() { let x = 1; }\n").unwrap();
 
-    Command::cargo_bin("quorum").unwrap()
+    Command::cargo_bin("quorum")
+        .unwrap()
         .arg("review")
-        .arg("--parallel").arg("4")
+        .arg("--parallel")
+        .arg("4")
         .arg(&path)
         .assert()
         .success();
@@ -20,9 +22,11 @@ fn parallel_1_sequential() {
     let path = dir.path().join("test.py");
     std::fs::write(&path, "x = 1\n").unwrap();
 
-    Command::cargo_bin("quorum").unwrap()
+    Command::cargo_bin("quorum")
+        .unwrap()
         .arg("review")
-        .arg("--parallel").arg("1")
+        .arg("--parallel")
+        .arg("1")
         .arg(&path)
         .assert()
         .success();
@@ -34,9 +38,11 @@ fn parallel_0_unlimited() {
     let path = dir.path().join("test.rs");
     std::fs::write(&path, "fn main() {}\n").unwrap();
 
-    Command::cargo_bin("quorum").unwrap()
+    Command::cargo_bin("quorum")
+        .unwrap()
         .arg("review")
-        .arg("--parallel").arg("0")
+        .arg("--parallel")
+        .arg("0")
         .arg(&path)
         .assert()
         .success();
@@ -50,9 +56,11 @@ fn parallel_json_output_valid() {
         std::fs::write(&path, format!("x = {}\n", i)).unwrap();
     }
 
-    let output = Command::cargo_bin("quorum").unwrap()
+    let output = Command::cargo_bin("quorum")
+        .unwrap()
         .arg("review")
-        .arg("--parallel").arg("2")
+        .arg("--parallel")
+        .arg("2")
         .arg("--json")
         .arg(dir.path().join("file1.py"))
         .arg(dir.path().join("file2.py"))
@@ -62,8 +70,8 @@ fn parallel_json_output_valid() {
 
     let stdout = String::from_utf8_lossy(&output.stdout);
     if !stdout.trim().is_empty() && stdout.trim() != "[]" {
-        let _: serde_json::Value = serde_json::from_str(&stdout)
-            .expect("parallel JSON output should be valid");
+        let _: serde_json::Value =
+            serde_json::from_str(&stdout).expect("parallel JSON output should be valid");
     }
 }
 
@@ -74,17 +82,22 @@ fn parallel_handles_missing_file() {
     std::fs::write(&good, "fn main() {}\n").unwrap();
     let bad = dir.path().join("nonexistent.rs");
 
-    let output = Command::cargo_bin("quorum").unwrap()
+    let output = Command::cargo_bin("quorum")
+        .unwrap()
         .arg("review")
-        .arg("--parallel").arg("2")
+        .arg("--parallel")
+        .arg("2")
         .arg(&good)
         .arg(&bad)
         .output()
         .unwrap();
 
     let stderr = String::from_utf8_lossy(&output.stderr);
-    assert!(stderr.contains("not found") || stderr.contains("nonexistent") || stderr.contains("Error"),
-        "should report missing file, got: {}", stderr);
+    assert!(
+        stderr.contains("not found") || stderr.contains("nonexistent") || stderr.contains("Error"),
+        "should report missing file, got: {}",
+        stderr
+    );
 }
 
 #[test]

--- a/tests/review_log.rs
+++ b/tests/review_log.rs
@@ -34,7 +34,10 @@ fn review_writes_reviews_jsonl_record() {
 
     let rec: Value = serde_json::from_str(lines[0]).unwrap();
     assert_eq!(rec["files_reviewed"], 1);
-    assert!(rec["run_id"].as_str().unwrap().len() == 26, "run_id must be 26-char ULID");
+    assert!(
+        rec["run_id"].as_str().unwrap().len() == 26,
+        "run_id must be 26-char ULID"
+    );
     assert!(rec["timestamp"].is_string());
     assert!(rec["quorum_version"].is_string());
     assert!(rec["findings_by_severity"].is_object());
@@ -76,8 +79,14 @@ fn second_review_appends() {
     let lines: Vec<&str> = content.lines().filter(|l| !l.trim().is_empty()).collect();
     assert_eq!(lines.len(), 2, "second run should append, not replace");
 
-    let ids: Vec<String> = lines.iter()
-        .map(|l| serde_json::from_str::<Value>(l).unwrap()["run_id"].as_str().unwrap().to_string())
+    let ids: Vec<String> = lines
+        .iter()
+        .map(|l| {
+            serde_json::from_str::<Value>(l).unwrap()["run_id"]
+                .as_str()
+                .unwrap()
+                .to_string()
+        })
         .collect();
     assert_ne!(ids[0], ids[1], "each run gets a unique ULID");
 }

--- a/tests/stats_dimensions.rs
+++ b/tests/stats_dimensions.rs
@@ -64,19 +64,40 @@ fn stats_by_caller_json_returns_slices() {
         .args(["stats", "--by-caller", "--json"])
         .output()
         .unwrap();
-    assert!(out.status.success(), "stats --by-caller --json should succeed");
+    assert!(
+        out.status.success(),
+        "stats --by-caller --json should succeed"
+    );
 
     let v: Value = serde_json::from_slice(&out.stdout).unwrap_or_else(|e| {
-        panic!("stdout not JSON: {}\n{}", e, String::from_utf8_lossy(&out.stdout))
+        panic!(
+            "stdout not JSON: {}\n{}",
+            e,
+            String::from_utf8_lossy(&out.stdout)
+        )
     });
     assert_eq!(v["mode"], "by-caller");
     let slices = v["slices"].as_array().expect("slices array");
-    let a = slices.iter().find(|s| s["key"] == "script-a")
-        .unwrap_or_else(|| panic!("expected script-a slice, got {:?}",
-            slices.iter().map(|s| s["key"].as_str()).collect::<Vec<_>>()));
+    let a = slices
+        .iter()
+        .find(|s| s["key"] == "script-a")
+        .unwrap_or_else(|| {
+            panic!(
+                "expected script-a slice, got {:?}",
+                slices.iter().map(|s| s["key"].as_str()).collect::<Vec<_>>()
+            )
+        });
     let b = slices.iter().find(|s| s["key"] == "script-b").unwrap();
-    assert_eq!(a["n_reviews"].as_u64().unwrap(), 3, "script-a seeded 3 reviews");
-    assert_eq!(b["n_reviews"].as_u64().unwrap(), 2, "script-b seeded 2 reviews");
+    assert_eq!(
+        a["n_reviews"].as_u64().unwrap(),
+        3,
+        "script-a seeded 3 reviews"
+    );
+    assert_eq!(
+        b["n_reviews"].as_u64().unwrap(),
+        2,
+        "script-b seeded 2 reviews"
+    );
 }
 
 #[test]
@@ -99,11 +120,21 @@ fn stats_by_repo_json_returns_slices() {
     // containing git repo — so we expect exactly one slice carrying all 5 reviews.
     // Repo name is derived from the test's CWD so a forked checkout still works.
     let repo = current_repo_basename();
-    let repo_slice = slices.iter().find(|s| s["key"] == repo.as_str())
-        .unwrap_or_else(|| panic!("expected a '{}' repo slice, got {:?}", repo,
-            slices.iter().map(|s| s["key"].as_str()).collect::<Vec<_>>()));
-    assert_eq!(repo_slice["n_reviews"].as_u64().unwrap(), 5,
-        "all 5 reviews of fixtures in this repo should group into one slice");
+    let repo_slice = slices
+        .iter()
+        .find(|s| s["key"] == repo.as_str())
+        .unwrap_or_else(|| {
+            panic!(
+                "expected a '{}' repo slice, got {:?}",
+                repo,
+                slices.iter().map(|s| s["key"].as_str()).collect::<Vec<_>>()
+            )
+        });
+    assert_eq!(
+        repo_slice["n_reviews"].as_u64().unwrap(),
+        5,
+        "all 5 reviews of fixtures in this repo should group into one slice"
+    );
     assert_eq!(v["meta"]["total_reviews"].as_u64().unwrap(), 5);
 }
 
@@ -121,9 +152,20 @@ fn stats_by_caller_compact_is_single_line_no_glyphs() {
     let s = String::from_utf8_lossy(&out.stdout);
     // At most one trailing newline; body must be a single line.
     let body = s.trim_end_matches('\n');
-    assert!(!body.contains('\n'), "compact output must be single-line, got:\n{:?}", body);
-    assert!(body.starts_with("by-caller:"), "expected by-caller prefix, got: {:?}", body);
-    assert!(!body.contains('█'), "compact mode must not contain block glyphs");
+    assert!(
+        !body.contains('\n'),
+        "compact output must be single-line, got:\n{:?}",
+        body
+    );
+    assert!(
+        body.starts_with("by-caller:"),
+        "expected by-caller prefix, got: {:?}",
+        body
+    );
+    assert!(
+        !body.contains('█'),
+        "compact mode must not contain block glyphs"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- Apply `cargo fmt --all` to the entire codebase — catches up on accumulated formatting drift

Closes #216

## Test plan

- [x] `cargo fmt --all -- --check` passes (zero diff)
- [x] No behavioral changes — formatting only

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

# Release Notes

* **New Features**
  * Per-chunk calibration/tracking for misleading-context feedback.
  * Automatic terminal detection for progress output.
  * Richer feedback reports that can attribute problematic context.

* **Improvements**
  * Better context enrichment with framework-aware queries and caching (TTL-enabled).
  * Hardened dependency parsing and CLI/config validation.
  * Enhanced retrieval and injection ranking stability.

* **Tests**
  * Vastly expanded test coverage across calibration, retrieval, enrichment, and CLI flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->