### PR TITLE
chore: fix all 166 clippy lints and make clippy blocking

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,9 +37,6 @@ jobs:
   clippy:
     name: clippy
     runs-on: ubuntu-latest
-    # Currently informational: see issue tracker for cleanup of pre-existing
-    # lints surfaced by rust 1.95's clippy. Drop this flag once green.
-    continue-on-error: true
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable (snapshot)

--- a/examples/compare_calibration.rs
+++ b/examples/compare_calibration.rs
@@ -20,11 +20,10 @@ fn load_entries(path: &std::path::Path) -> anyhow::Result<Vec<Entry>> {
         if line.trim().is_empty() {
             continue;
         }
-        if let Ok(e) = serde_json::from_str::<Entry>(line) {
-            if !e.finding_title.is_empty() {
+        if let Ok(e) = serde_json::from_str::<Entry>(line)
+            && !e.finding_title.is_empty() {
                 out.push(e);
             }
-        }
     }
     Ok(out)
 }

--- a/examples/compare_calibration.rs
+++ b/examples/compare_calibration.rs
@@ -8,6 +8,7 @@ use std::path::PathBuf;
 struct Entry {
     finding_title: String,
     #[serde(default)]
+    #[allow(dead_code)]
     finding_category: String,
     #[serde(default)]
     verdict: Option<String>,
@@ -222,7 +223,6 @@ fn main() -> anyhow::Result<()> {
     let top_k = 10;
     let pool = 30;
 
-    let mut diffs = 0;
     let mut action_agreement = 0;
     let mut only_e: std::collections::HashMap<&'static str, usize> = Default::default();
     let mut only_r: std::collections::HashMap<&'static str, usize> = Default::default();
@@ -258,7 +258,6 @@ fn main() -> anyhow::Result<()> {
         if act_e == act_r {
             action_agreement += 1;
         } else {
-            diffs += 1;
             *only_e.entry(act_e).or_insert(0) += 1;
             *only_r.entry(act_r).or_insert(0) += 1;
             println!("\nDIVERGE: {}", qt);

--- a/examples/compare_retrieval.rs
+++ b/examples/compare_retrieval.rs
@@ -22,11 +22,10 @@ fn load_entries(path: &std::path::Path) -> anyhow::Result<Vec<Entry>> {
         if line.trim().is_empty() {
             continue;
         }
-        if let Ok(e) = serde_json::from_str::<Entry>(line) {
-            if !e.finding_title.is_empty() {
+        if let Ok(e) = serde_json::from_str::<Entry>(line)
+            && !e.finding_title.is_empty() {
                 out.push(e);
             }
-        }
     }
     Ok(out)
 }

--- a/examples/compare_retrieval.rs
+++ b/examples/compare_retrieval.rs
@@ -12,6 +12,7 @@ use std::time::Instant;
 struct Entry {
     finding_title: String,
     #[serde(default)]
+    #[allow(dead_code)]
     finding_category: String,
 }
 

--- a/src/analysis.rs
+++ b/src/analysis.rs
@@ -27,7 +27,7 @@ pub fn analyze_complexity(
     for (start, end) in &func_nodes {
         let node = tree.root_node().descendant_for_byte_range(*start, *end);
         if let Some(node) = node {
-            let cc = cyclomatic_complexity(&node, source, lang);
+            let cc = cyclomatic_complexity(&node, source);
             if cc >= threshold {
                 // Extract name directly from the function node
                 let name = node
@@ -101,13 +101,13 @@ fn collect_nodes_by_kind(
     }
 }
 
-pub fn cyclomatic_complexity(node: &tree_sitter::Node, source: &str, lang: Language) -> u32 {
+pub fn cyclomatic_complexity(node: &tree_sitter::Node, source: &str) -> u32 {
     let mut complexity = 1u32; // baseline path
-    count_decisions(node, source, lang, &mut complexity);
+    count_decisions(node, source, &mut complexity);
     complexity
 }
 
-fn count_decisions(node: &tree_sitter::Node, source: &str, lang: Language, complexity: &mut u32) {
+fn count_decisions(node: &tree_sitter::Node, source: &str, complexity: &mut u32) {
     let kind = node.kind();
 
     match kind {
@@ -144,7 +144,7 @@ fn count_decisions(node: &tree_sitter::Node, source: &str, lang: Language, compl
     // Recurse into children
     for i in 0..node.child_count() {
         if let Some(child) = node.child(i as u32) {
-            count_decisions(&child, source, lang, complexity);
+            count_decisions(&child, source, complexity);
         }
     }
 }
@@ -2974,7 +2974,7 @@ mod tests {
         let tree = parse(source, Language::Rust).unwrap();
         let root = tree.root_node();
         let func = root.child(0).unwrap();
-        assert_eq!(cyclomatic_complexity(&func, source, Language::Rust), 1);
+        assert_eq!(cyclomatic_complexity(&func, source), 1);
     }
 
     #[test]
@@ -2982,7 +2982,7 @@ mod tests {
         let source = "fn check(x: bool) { if x { return; } }";
         let tree = parse(source, Language::Rust).unwrap();
         let func = tree.root_node().child(0).unwrap();
-        assert_eq!(cyclomatic_complexity(&func, source, Language::Rust), 2);
+        assert_eq!(cyclomatic_complexity(&func, source), 2);
     }
 
     #[test]
@@ -2991,7 +2991,7 @@ mod tests {
         let tree = parse(source, Language::Rust).unwrap();
         let func = tree.root_node().child(0).unwrap();
         // if adds 1 path, else doesn't add (it's the other branch of existing decision)
-        assert_eq!(cyclomatic_complexity(&func, source, Language::Rust), 2);
+        assert_eq!(cyclomatic_complexity(&func, source), 2);
     }
 
     #[test]
@@ -2999,7 +2999,7 @@ mod tests {
         let source = "fn nested(a: bool, b: bool) { if a { if b { return; } } }";
         let tree = parse(source, Language::Rust).unwrap();
         let func = tree.root_node().child(0).unwrap();
-        assert_eq!(cyclomatic_complexity(&func, source, Language::Rust), 3);
+        assert_eq!(cyclomatic_complexity(&func, source), 3);
     }
 
     #[test]
@@ -3008,7 +3008,7 @@ mod tests {
         let tree = parse(source, Language::Rust).unwrap();
         let func = tree.root_node().child(0).unwrap();
         // 4 match arms = base(1) + 4 arms = 5
-        assert_eq!(cyclomatic_complexity(&func, source, Language::Rust), 5);
+        assert_eq!(cyclomatic_complexity(&func, source), 5);
     }
 
     #[test]
@@ -3016,7 +3016,7 @@ mod tests {
         let source = "fn loopy(items: &[i32]) { for x in items { println!(\"{}\", x); } }";
         let tree = parse(source, Language::Rust).unwrap();
         let func = tree.root_node().child(0).unwrap();
-        assert_eq!(cyclomatic_complexity(&func, source, Language::Rust), 2);
+        assert_eq!(cyclomatic_complexity(&func, source), 2);
     }
 
     #[test]
@@ -3024,7 +3024,7 @@ mod tests {
         let source = "fn loopy() { while true { break; } }";
         let tree = parse(source, Language::Rust).unwrap();
         let func = tree.root_node().child(0).unwrap();
-        assert_eq!(cyclomatic_complexity(&func, source, Language::Rust), 2);
+        assert_eq!(cyclomatic_complexity(&func, source), 2);
     }
 
     #[test]
@@ -3033,7 +3033,7 @@ mod tests {
         let tree = parse(source, Language::Rust).unwrap();
         let func = tree.root_node().child(0).unwrap();
         // if=1, &&=1, ||=1, base=1 => 4
-        assert_eq!(cyclomatic_complexity(&func, source, Language::Rust), 4);
+        assert_eq!(cyclomatic_complexity(&func, source), 4);
     }
 
     // -- Python --
@@ -3043,7 +3043,7 @@ mod tests {
         let source = "def simple():\n    return 42\n";
         let tree = parse(source, Language::Python).unwrap();
         let func = tree.root_node().child(0).unwrap();
-        assert_eq!(cyclomatic_complexity(&func, source, Language::Python), 1);
+        assert_eq!(cyclomatic_complexity(&func, source), 1);
     }
 
     #[test]
@@ -3052,7 +3052,7 @@ mod tests {
         let tree = parse(source, Language::Python).unwrap();
         let func = tree.root_node().child(0).unwrap();
         // if + elif = 3
-        assert_eq!(cyclomatic_complexity(&func, source, Language::Python), 3);
+        assert_eq!(cyclomatic_complexity(&func, source), 3);
     }
 
     // -- TypeScript --
@@ -3063,7 +3063,7 @@ mod tests {
         let tree = parse(source, Language::TypeScript).unwrap();
         let func = tree.root_node().child(0).unwrap();
         assert_eq!(
-            cyclomatic_complexity(&func, source, Language::TypeScript),
+            cyclomatic_complexity(&func, source),
             1
         );
     }
@@ -3074,7 +3074,7 @@ mod tests {
         let tree = parse(source, Language::TypeScript).unwrap();
         let func = tree.root_node().child(0).unwrap();
         assert_eq!(
-            cyclomatic_complexity(&func, source, Language::TypeScript),
+            cyclomatic_complexity(&func, source),
             2
         );
     }

--- a/src/analysis.rs
+++ b/src/analysis.rs
@@ -193,17 +193,15 @@ fn is_in_test_context(node: &tree_sitter::Node, source: &str) -> bool {
     let mut current = node.parent();
     while let Some(parent) = current {
         // Check for #[cfg(test)] on mod items
-        if parent.kind() == "mod_item" {
-            if has_attribute(&parent, source, "cfg(test)") {
+        if parent.kind() == "mod_item"
+            && has_attribute(&parent, source, "cfg(test)") {
                 return true;
             }
-        }
         // Check for #[test] on function items
-        if parent.kind() == "function_item" {
-            if has_attribute(&parent, source, "test") {
+        if parent.kind() == "function_item"
+            && has_attribute(&parent, source, "test") {
                 return true;
             }
-        }
         current = parent.parent();
     }
     false
@@ -254,10 +252,10 @@ fn scan_insecure_rust(node: &tree_sitter::Node, source: &str, findings: &mut Vec
 
     // .unwrap() calls — tree-sitter-rust: call_expression with function=field_expression
     // Skip unwrap in test code (#[cfg(test)] modules, #[test] functions)
-    if node.kind() == "call_expression" && !is_in_test_context(node, source) {
-        if let Some(func) = node.child_by_field_name("function") {
-            if func.kind() == "field_expression" {
-                if let Some(field) = func.child_by_field_name("field") {
+    if node.kind() == "call_expression" && !is_in_test_context(node, source)
+        && let Some(func) = node.child_by_field_name("function")
+            && func.kind() == "field_expression"
+                && let Some(field) = func.child_by_field_name("field") {
                     let field_name = &source[field.byte_range()];
                     if field_name == "unwrap" {
                         findings.push(Finding {
@@ -282,9 +280,6 @@ fn scan_insecure_rust(node: &tree_sitter::Node, source: &str, findings: &mut Vec
                         });
                     }
                 }
-            }
-        }
-    }
 }
 
 fn scan_insecure_python(node: &tree_sitter::Node, source: &str, findings: &mut Vec<Finding>) {
@@ -374,8 +369,8 @@ fn scan_insecure_python(node: &tree_sitter::Node, source: &str, findings: &mut V
         // SQL injection: .execute() with f-string or .format() argument
         if let Some(func) = node.child_by_field_name("function") {
             let func_text = &source[func.byte_range()];
-            if func_text.ends_with(".execute") || func_text.ends_with(".executemany") {
-                if let Some(args) = node.child_by_field_name("arguments") {
+            if (func_text.ends_with(".execute") || func_text.ends_with(".executemany"))
+                && let Some(args) = node.child_by_field_name("arguments") {
                     // Check first argument for f-string or .format()
                     if let Some(first_arg) = args.named_child(0) {
                         let arg_kind = first_arg.kind();
@@ -427,14 +422,13 @@ fn scan_insecure_python(node: &tree_sitter::Node, source: &str, findings: &mut V
                         }
                     }
                 }
-            }
         }
 
         // open() without explicit encoding
         if let Some(func) = node.child_by_field_name("function") {
             let func_name = &source[func.byte_range()];
-            if func_name == "open" {
-                if let Some(args) = node.child_by_field_name("arguments") {
+            if func_name == "open"
+                && let Some(args) = node.child_by_field_name("arguments") {
                     let args_text = &source[args.byte_range()];
                     let binary_modes = [
                         "'rb'", "\"rb\"", "'wb'", "\"wb\"", "'ab'", "\"ab\"", "'xb'", "\"xb\"",
@@ -468,7 +462,6 @@ fn scan_insecure_python(node: &tree_sitter::Node, source: &str, findings: &mut V
                         });
                     }
                 }
-            }
         }
     }
 
@@ -501,8 +494,8 @@ fn scan_insecure_python(node: &tree_sitter::Node, source: &str, findings: &mut V
             None => true, // bare `except:`
             Some(t) => t == "Exception" || t == "BaseException",
         };
-        if is_catch_all {
-            if let Some(body) = body_node {
+        if is_catch_all
+            && let Some(body) = body_node {
                 let body_has_only_pass = body.named_child_count() == 1
                     && body.named_child(0).map(|c| c.kind()) == Some("pass_statement");
                 if body_has_only_pass {
@@ -528,12 +521,11 @@ fn scan_insecure_python(node: &tree_sitter::Node, source: &str, findings: &mut V
                     });
                 }
             }
-        }
     }
 
     // Hardcoded secrets: SECRET_KEY = "...", PASSWORD = "...", API_KEY = "..."
-    if node.kind() == "assignment" {
-        if let Some(left) = node.child_by_field_name("left") {
+    if node.kind() == "assignment"
+        && let Some(left) = node.child_by_field_name("left") {
             let var_name = source[left.byte_range()].to_uppercase();
             let secret_names = [
                 "SECRET_KEY",
@@ -546,8 +538,8 @@ fn scan_insecure_python(node: &tree_sitter::Node, source: &str, findings: &mut V
                 "TOKEN",
                 "PRIVATE_KEY",
             ];
-            if secret_names.iter().any(|s| var_name.contains(s)) {
-                if let Some(right) = node.child_by_field_name("right") {
+            if secret_names.iter().any(|s| var_name.contains(s))
+                && let Some(right) = node.child_by_field_name("right") {
                     let right_kind = right.kind();
                     let right_text = &source[right.byte_range()];
                     // Only flag string literals that look like real secrets:
@@ -602,9 +594,7 @@ fn scan_insecure_python(node: &tree_sitter::Node, source: &str, findings: &mut V
                         });
                     }
                 }
-            }
         }
-    }
 
     // Mutating collection while iterating
     if node.kind() == "for_statement" {
@@ -614,8 +604,8 @@ fn scan_insecure_python(node: &tree_sitter::Node, source: &str, findings: &mut V
             // Only match when iterating directly over an identifier (not list(items) or other call)
             if right.kind() == "identifier" {
                 let iterable_name = &source[right.byte_range()];
-                if let Some(body) = node.child_by_field_name("body") {
-                    if has_mutating_call(&body, source, iterable_name) {
+                if let Some(body) = node.child_by_field_name("body")
+                    && has_mutating_call(&body, source, iterable_name) {
                         findings.push(Finding {
                             id: crate::finding::new_finding_ulid(),
                             title: format!("Mutating `{}` while iterating over it", iterable_name),
@@ -637,7 +627,6 @@ fn scan_insecure_python(node: &tree_sitter::Node, source: &str, findings: &mut V
                     grounding_status: None,
                         });
                     }
-                }
             }
         }
     }
@@ -648,23 +637,19 @@ fn scan_insecure_python(node: &tree_sitter::Node, source: &str, findings: &mut V
         // Tree structure: except_clause > as_pattern > as_pattern_target > identifier
         let mut exc_var: Option<&str> = None;
         for i in 0..node.child_count() {
-            if let Some(child) = node.child(i as u32) {
-                if child.kind() == "as_pattern" {
+            if let Some(child) = node.child(i as u32)
+                && child.kind() == "as_pattern" {
                     // Look for as_pattern_target child which contains the identifier
                     for j in 0..child.child_count() {
-                        if let Some(target) = child.child(j as u32) {
-                            if target.kind() == "as_pattern_target" {
-                                if let Some(ident) = target.child(0) {
-                                    if ident.kind() == "identifier" {
+                        if let Some(target) = child.child(j as u32)
+                            && target.kind() == "as_pattern_target"
+                                && let Some(ident) = target.child(0)
+                                    && ident.kind() == "identifier" {
                                         exc_var = Some(&source[ident.byte_range()]);
                                     }
-                                }
-                            }
-                        }
                     }
                     break;
                 }
-            }
         }
         if let Some(var_name) = exc_var {
             // Look for return statements that expose the exception
@@ -702,8 +687,8 @@ fn scan_insecure_python(node: &tree_sitter::Node, source: &str, findings: &mut V
         // In tree-sitter-python, async functions have "async" as a preceding sibling or
         // the node text starts with "async"
         let func_text = &source[node.byte_range()];
-        if func_text.starts_with("async ") {
-            if has_result_call(node, source) {
+        if func_text.starts_with("async ")
+            && has_result_call(node, source) {
                 findings.push(Finding {
                     id: crate::finding::new_finding_ulid(),
                     title: "Blocking `.result()` call in async function".into(),
@@ -725,12 +710,11 @@ fn scan_insecure_python(node: &tree_sitter::Node, source: &str, findings: &mut V
                     grounding_status: None,
                 });
             }
-        }
     }
 
     // Mutable default arguments: def foo(x=[], y={})
-    if node.kind() == "default_parameter" {
-        if let Some(value) = node.child_by_field_name("value") {
+    if node.kind() == "default_parameter"
+        && let Some(value) = node.child_by_field_name("value") {
             let val_kind = value.kind();
             if val_kind == "list" || val_kind == "dictionary" || val_kind == "set" {
                 let param_name = node
@@ -759,36 +743,29 @@ fn scan_insecure_python(node: &tree_sitter::Node, source: &str, findings: &mut V
                 });
             }
         }
-    }
 }
 
 /// Check if a node tree contains a mutating method call on the given identifier.
 fn has_mutating_call(node: &tree_sitter::Node, source: &str, target: &str) -> bool {
     let mutating_methods = ["append", "remove", "pop", "insert", "extend", "clear"];
 
-    if node.kind() == "call" {
-        if let Some(func) = node.child_by_field_name("function") {
-            if func.kind() == "attribute" {
-                if let Some(obj) = func.child_by_field_name("object") {
-                    if obj.kind() == "identifier" && &source[obj.byte_range()] == target {
-                        if let Some(attr) = func.child_by_field_name("attribute") {
+    if node.kind() == "call"
+        && let Some(func) = node.child_by_field_name("function")
+            && func.kind() == "attribute"
+                && let Some(obj) = func.child_by_field_name("object")
+                    && obj.kind() == "identifier" && &source[obj.byte_range()] == target
+                        && let Some(attr) = func.child_by_field_name("attribute") {
                             let method = &source[attr.byte_range()];
                             if mutating_methods.contains(&method) {
                                 return true;
                             }
                         }
-                    }
-                }
-            }
-        }
-    }
 
     for i in 0..node.child_count() {
-        if let Some(child) = node.child(i as u32) {
-            if has_mutating_call(&child, source, target) {
+        if let Some(child) = node.child(i as u32)
+            && has_mutating_call(&child, source, target) {
                 return true;
             }
-        }
     }
     false
 }
@@ -810,35 +787,29 @@ fn has_exception_in_return(node: &tree_sitter::Node, source: &str, var_name: &st
     }
 
     for i in 0..node.child_count() {
-        if let Some(child) = node.child(i as u32) {
-            if has_exception_in_return(&child, source, var_name) {
+        if let Some(child) = node.child(i as u32)
+            && has_exception_in_return(&child, source, var_name) {
                 return true;
             }
-        }
     }
     false
 }
 
 /// Check if a function body contains a .result() call.
 fn has_result_call(node: &tree_sitter::Node, source: &str) -> bool {
-    if node.kind() == "call" {
-        if let Some(func) = node.child_by_field_name("function") {
-            if func.kind() == "attribute" {
-                if let Some(attr) = func.child_by_field_name("attribute") {
-                    if &source[attr.byte_range()] == "result" {
+    if node.kind() == "call"
+        && let Some(func) = node.child_by_field_name("function")
+            && func.kind() == "attribute"
+                && let Some(attr) = func.child_by_field_name("attribute")
+                    && &source[attr.byte_range()] == "result" {
                         return true;
                     }
-                }
-            }
-        }
-    }
 
     for i in 0..node.child_count() {
-        if let Some(child) = node.child(i as u32) {
-            if has_result_call(&child, source) {
+        if let Some(child) = node.child(i as u32)
+            && has_result_call(&child, source) {
                 return true;
             }
-        }
     }
     false
 }
@@ -908,8 +879,8 @@ fn yaml_value_has_safe_tag(value_node: &tree_sitter::Node, source: &str) -> bool
             }
             // Recurse one more level (flow_node may contain tag)
             for j in 0..child.child_count() {
-                if let Some(gc) = child.child(j as u32) {
-                    if gc.kind() == "tag" {
+                if let Some(gc) = child.child(j as u32)
+                    && gc.kind() == "tag" {
                         let tag_text = &source[gc.byte_range()];
                         if tag_text.starts_with("!secret")
                             || tag_text.starts_with("!include")
@@ -918,7 +889,6 @@ fn yaml_value_has_safe_tag(value_node: &tree_sitter::Node, source: &str) -> bool
                             return true;
                         }
                     }
-                }
             }
         }
     }
@@ -955,12 +925,11 @@ fn is_in_automation_context(node: &tree_sitter::Node, source: &str) -> bool {
             candidate = c.parent();
             continue;
         }
-        if c.kind() == "block_mapping_pair" {
-            if let Some(key) = c.child_by_field_name("key") {
+        if c.kind() == "block_mapping_pair"
+            && let Some(key) = c.child_by_field_name("key") {
                 let key_text = source[key.byte_range()].trim();
                 return key_text == "automation" || key_text == "automation!";
             }
-        }
         break;
     }
     false
@@ -970,13 +939,11 @@ fn is_in_automation_context(node: &tree_sitter::Node, source: &str) -> bool {
 fn collect_mapping_keys<'a>(node: &tree_sitter::Node, source: &'a str) -> Vec<&'a str> {
     let mut keys = Vec::new();
     for i in 0..node.child_count() {
-        if let Some(child) = node.child(i as u32) {
-            if child.kind() == "block_mapping_pair" {
-                if let Some(key) = child.child_by_field_name("key") {
+        if let Some(child) = node.child(i as u32)
+            && child.kind() == "block_mapping_pair"
+                && let Some(key) = child.child_by_field_name("key") {
                     keys.push(source[key.byte_range()].trim());
                 }
-            }
-        }
     }
     keys
 }
@@ -990,20 +957,18 @@ fn yaml_value_is_empty(pair_node: &tree_sitter::Node, source: &str) -> bool {
         }
         // Check if value has a block_sequence child with items
         for i in 0..value.child_count() {
-            if let Some(child) = value.child(i as u32) {
-                if child.kind() == "block_sequence" {
+            if let Some(child) = value.child(i as u32)
+                && child.kind() == "block_sequence" {
                     let mut has_items = false;
                     for j in 0..child.child_count() {
-                        if let Some(item) = child.child(j as u32) {
-                            if item.kind() == "block_sequence_item" {
+                        if let Some(item) = child.child(j as u32)
+                            && item.kind() == "block_sequence_item" {
                                 has_items = true;
                                 break;
                             }
-                        }
                     }
                     return !has_items;
                 }
-            }
         }
         false
     } else {
@@ -1056,18 +1021,14 @@ fn find_value_mapping<'a>(
     key_name: &str,
 ) -> Option<tree_sitter::Node<'a>> {
     for i in 0..mapping_node.child_count() {
-        if let Some(child) = mapping_node.child(i as u32) {
-            if child.kind() == "block_mapping_pair" {
-                if let Some(key) = child.child_by_field_name("key") {
-                    if source[key.byte_range()].trim() == key_name {
-                        if let Some(value) = child.child_by_field_name("value") {
+        if let Some(child) = mapping_node.child(i as u32)
+            && child.kind() == "block_mapping_pair"
+                && let Some(key) = child.child_by_field_name("key")
+                    && source[key.byte_range()].trim() == key_name
+                        && let Some(value) = child.child_by_field_name("value") {
                             // Walk through block_node wrappers to find block_mapping
                             return find_block_mapping_in(&value);
                         }
-                    }
-                }
-            }
-        }
     }
     None
 }
@@ -1082,11 +1043,10 @@ fn find_block_mapping_in<'a>(node: &tree_sitter::Node<'a>) -> Option<tree_sitter
             if child.kind() == "block_mapping" {
                 return Some(child);
             }
-            if child.kind() == "block_node" {
-                if let Some(found) = find_block_mapping_in(&child) {
+            if child.kind() == "block_node"
+                && let Some(found) = find_block_mapping_in(&child) {
                     return Some(found);
                 }
-            }
         }
     }
     None
@@ -1100,9 +1060,9 @@ fn scan_insecure_yaml(node: &tree_sitter::Node, source: &str, findings: &mut Vec
     if node.kind() == "block_mapping" {
         let mut seen_keys: Vec<(&str, u32)> = Vec::new();
         for i in 0..node.child_count() {
-            if let Some(child) = node.child(i as u32) {
-                if child.kind() == "block_mapping_pair" {
-                    if let Some(key) = child.child_by_field_name("key") {
+            if let Some(child) = node.child(i as u32)
+                && child.kind() == "block_mapping_pair"
+                    && let Some(key) = child.child_by_field_name("key") {
                         let key_text = source[key.byte_range()].trim();
                         let key_line = key.start_position().row as u32 + 1;
                         if let Some((_, first_line)) =
@@ -1135,8 +1095,6 @@ fn scan_insecure_yaml(node: &tree_sitter::Node, source: &str, findings: &mut Vec
                             seen_keys.push((key_text, key_line));
                         }
                     }
-                }
-            }
         }
 
         // --- Tier 2: Automation-level checks ---
@@ -1230,9 +1188,9 @@ fn scan_insecure_yaml(node: &tree_sitter::Node, source: &str, findings: &mut Vec
 
             // 6. Empty triggers or actions
             for i in 0..node.child_count() {
-                if let Some(child) = node.child(i as u32) {
-                    if child.kind() == "block_mapping_pair" {
-                        if let Some(key) = child.child_by_field_name("key") {
+                if let Some(child) = node.child(i as u32)
+                    && child.kind() == "block_mapping_pair"
+                        && let Some(key) = child.child_by_field_name("key") {
                             let key_text = source[key.byte_range()].trim();
                             if (key_text == "triggers" || key_text == "actions")
                                 && yaml_value_is_empty(&child, source)
@@ -1262,8 +1220,6 @@ fn scan_insecure_yaml(node: &tree_sitter::Node, source: &str, findings: &mut Vec
                                 });
                             }
                         }
-                    }
-                }
             }
         }
 
@@ -1342,12 +1298,12 @@ fn scan_insecure_yaml(node: &tree_sitter::Node, source: &str, findings: &mut Vec
             // --- Tier 5b: Docker Compose checks ---
             // Detect docker-compose files by presence of top-level `services:` key.
             // Skip if `apiVersion` is present (excludes Kubernetes, CloudFormation, etc.).
-            if keys.contains(&"services") && !keys.contains(&"apiVersion") {
-                if let Some(services_mapping) = find_value_mapping(node, source, "services") {
+            if keys.contains(&"services") && !keys.contains(&"apiVersion")
+                && let Some(services_mapping) = find_value_mapping(node, source, "services") {
                     // Iterate over each service defined under `services:`
                     for i in 0..services_mapping.child_count() {
-                        if let Some(child) = services_mapping.child(i as u32) {
-                            if child.kind() == "block_mapping_pair" {
+                        if let Some(child) = services_mapping.child(i as u32)
+                            && child.kind() == "block_mapping_pair" {
                                 let svc_line = child.start_position().row as u32 + 1;
                                 let svc_end = child.end_position().row as u32 + 1;
                                 let svc_name = if let Some(key) = child.child_by_field_name("key") {
@@ -1427,24 +1383,21 @@ fn scan_insecure_yaml(node: &tree_sitter::Node, source: &str, findings: &mut Vec
                                     }
                                 }
                             }
-                        }
                     }
                 }
-            }
         }
     }
 
     // --- Tier 1: Hardcoded secrets (on block_mapping_pair nodes) ---
-    if node.kind() == "block_mapping_pair" {
-        if let Some(key) = node.child_by_field_name("key") {
+    if node.kind() == "block_mapping_pair"
+        && let Some(key) = node.child_by_field_name("key") {
             let key_text = source[key.byte_range()].trim().to_lowercase();
 
             if YAML_SECRET_KEY_PATTERNS
                 .iter()
                 .any(|p| key_text.contains(p))
-            {
-                if let Some(value) = node.child_by_field_name("value") {
-                    if !yaml_value_has_safe_tag(&value, source) {
+                && let Some(value) = node.child_by_field_name("value")
+                    && !yaml_value_has_safe_tag(&value, source) {
                         let val_text = source[value.byte_range()].trim();
                         if !val_text.is_empty() {
                             findings.push(Finding {
@@ -1477,21 +1430,19 @@ fn scan_insecure_yaml(node: &tree_sitter::Node, source: &str, findings: &mut Vec
                             });
                         }
                     }
-                }
-            }
 
             // --- Tier 3: entity_id without domain ---
-            if key_text == "entity_id" {
-                if let Some(value) = node.child_by_field_name("value") {
+            if key_text == "entity_id"
+                && let Some(value) = node.child_by_field_name("value") {
                     let val_text = source[value.byte_range()].trim();
                     let mut is_list = false;
                     for i in 0..value.child_count() {
-                        if let Some(child) = value.child(i as u32) {
-                            if child.kind() == "block_sequence" {
+                        if let Some(child) = value.child(i as u32)
+                            && child.kind() == "block_sequence" {
                                 is_list = true;
                                 for j in 0..child.child_count() {
-                                    if let Some(item) = child.child(j as u32) {
-                                        if item.kind() == "block_sequence_item" {
+                                    if let Some(item) = child.child(j as u32)
+                                        && item.kind() == "block_sequence_item" {
                                             let item_text = source[item.byte_range()]
                                                 .trim()
                                                 .trim_start_matches("- ")
@@ -1522,11 +1473,9 @@ fn scan_insecure_yaml(node: &tree_sitter::Node, source: &str, findings: &mut Vec
                                                 });
                                             }
                                         }
-                                    }
                                 }
                                 break;
                             }
-                        }
                     }
                     if !is_list && !val_text.is_empty() && !val_text.contains('.') {
                         findings.push(Finding {
@@ -1554,11 +1503,10 @@ fn scan_insecure_yaml(node: &tree_sitter::Node, source: &str, findings: &mut Vec
                         });
                     }
                 }
-            }
 
             // --- Tier 3: service without domain ---
-            if key_text == "service" {
-                if let Some(value) = node.child_by_field_name("value") {
+            if key_text == "service"
+                && let Some(value) = node.child_by_field_name("value") {
                     let val_text = source[value.byte_range()].trim();
                     if !val_text.is_empty() && !val_text.contains('.') {
                         findings.push(Finding {
@@ -1586,11 +1534,10 @@ fn scan_insecure_yaml(node: &tree_sitter::Node, source: &str, findings: &mut Vec
                         });
                     }
                 }
-            }
 
             // --- Tier 4: Exposed 0.0.0.0 binding ---
-            if key_text == "host" || key_text == "server_host" || key_text == "server" {
-                if let Some(value) = node.child_by_field_name("value") {
+            if (key_text == "host" || key_text == "server_host" || key_text == "server")
+                && let Some(value) = node.child_by_field_name("value") {
                     let val_text = source[value.byte_range()].trim();
                     if val_text.contains("0.0.0.0") {
                         findings.push(Finding {
@@ -1615,13 +1562,12 @@ fn scan_insecure_yaml(node: &tree_sitter::Node, source: &str, findings: &mut Vec
                         });
                     }
                 }
-            }
 
             // --- Tier 4: URL with embedded credentials ---
             if let Some(value) = node.child_by_field_name("value") {
                 let val_text = source[value.byte_range()].trim();
-                if !val_text.starts_with("!secret") && !val_text.starts_with("!include") {
-                    if val_text.contains("://") && yaml_url_has_credentials(val_text) {
+                if !val_text.starts_with("!secret") && !val_text.starts_with("!include")
+                    && val_text.contains("://") && yaml_url_has_credentials(val_text) {
                         findings.push(Finding {
                             id: crate::finding::new_finding_ulid(),
                             title: "URL contains embedded credentials".into(),
@@ -1643,10 +1589,8 @@ fn scan_insecure_yaml(node: &tree_sitter::Node, source: &str, findings: &mut Vec
                     grounding_status: None,
                         });
                     }
-                }
             }
         }
-    }
 
     // --- Tier 6: Jinja2 template patterns (on scalar values) ---
     if node.kind() == "plain_scalar"
@@ -1750,8 +1694,8 @@ fn scan_insecure_typescript(node: &tree_sitter::Node, source: &str, findings: &m
     let end_line = node.end_position().row as u32 + 1;
 
     // eval(), document.write(), console.log/debug calls
-    if node.kind() == "call_expression" {
-        if let Some(func) = node.child_by_field_name("function") {
+    if node.kind() == "call_expression"
+        && let Some(func) = node.child_by_field_name("function") {
             let func_name = &source[func.byte_range()];
             if func_name == "eval" {
                 findings.push(Finding {
@@ -1826,11 +1770,10 @@ fn scan_insecure_typescript(node: &tree_sitter::Node, source: &str, findings: &m
                 });
             }
         }
-    }
 
     // Hardcoded secrets in variable declarations
-    if node.kind() == "variable_declarator" {
-        if let Some(name_node) = node.child_by_field_name("name") {
+    if node.kind() == "variable_declarator"
+        && let Some(name_node) = node.child_by_field_name("name") {
             let var_name = source[name_node.byte_range()].to_uppercase();
             let secret_names = [
                 "SECRET_KEY",
@@ -1843,8 +1786,8 @@ fn scan_insecure_typescript(node: &tree_sitter::Node, source: &str, findings: &m
                 "TOKEN",
                 "PRIVATE_KEY",
             ];
-            if secret_names.iter().any(|s| var_name.contains(s)) {
-                if let Some(value) = node.child_by_field_name("value") {
+            if secret_names.iter().any(|s| var_name.contains(s))
+                && let Some(value) = node.child_by_field_name("value") {
                     let val_kind = value.kind();
                     let val_text = &source[value.byte_range()];
                     // Only flag string literals that look like real secrets
@@ -1880,13 +1823,11 @@ fn scan_insecure_typescript(node: &tree_sitter::Node, source: &str, findings: &m
                         }
                     }
                 }
-            }
         }
-    }
 
     // innerHTML / outerHTML XSS
-    if node.kind() == "assignment_expression" {
-        if let Some(left) = node.child_by_field_name("left") {
+    if node.kind() == "assignment_expression"
+        && let Some(left) = node.child_by_field_name("left") {
             let left_text = &source[left.byte_range()];
             if left_text.ends_with(".innerHTML") || left_text.ends_with(".outerHTML") {
                 let prop = if left_text.ends_with(".innerHTML") {
@@ -1916,7 +1857,6 @@ fn scan_insecure_typescript(node: &tree_sitter::Node, source: &str, findings: &m
                 });
             }
         }
-    }
 
     // `any` type annotation
     if node.kind() == "type_annotation" {
@@ -1947,8 +1887,8 @@ fn scan_insecure_typescript(node: &tree_sitter::Node, source: &str, findings: &m
     }
 
     // Empty catch blocks that silently swallow errors
-    if node.kind() == "catch_clause" {
-        if let Some(body) = node.child_by_field_name("body") {
+    if node.kind() == "catch_clause"
+        && let Some(body) = node.child_by_field_name("body") {
             let has_statements = (0..body.named_child_count()).any(|i| {
                 body.named_child(i as u32)
                     .map(|c| c.kind() != "comment" && c.kind() != "empty_statement")
@@ -1979,11 +1919,10 @@ fn scan_insecure_typescript(node: &tree_sitter::Node, source: &str, findings: &m
                 });
             }
         }
-    }
 
     // Sync Node.js APIs inside async functions
-    if node.kind() == "call_expression" {
-        if let Some(func) = node.child_by_field_name("function") {
+    if node.kind() == "call_expression"
+        && let Some(func) = node.child_by_field_name("function") {
             let func_name = &source[func.byte_range()];
             let sync_apis = [
                 "readFileSync",
@@ -1999,8 +1938,8 @@ fn scan_insecure_typescript(node: &tree_sitter::Node, source: &str, findings: &m
                 "accessSync",
             ];
             for api in &sync_apis {
-                if func_name.ends_with(api) {
-                    if is_in_async_function(node, source) {
+                if func_name.ends_with(api)
+                    && is_in_async_function(node, source) {
                         findings.push(Finding {
                             id: crate::finding::new_finding_ulid(),
                             title: format!("`{}` blocks the event loop in async function", api),
@@ -2026,18 +1965,16 @@ fn scan_insecure_typescript(node: &tree_sitter::Node, source: &str, findings: &m
                         });
                         break;
                     }
-                }
             }
         }
-    }
 
     // Tautological .length >= 0 (always true for arrays/strings)
-    if node.kind() == "binary_expression" {
-        if let Some(op) = node.child_by_field_name("operator") {
+    if node.kind() == "binary_expression"
+        && let Some(op) = node.child_by_field_name("operator") {
             let op_text = &source[op.byte_range()];
-            if op_text == ">=" {
-                if let Some(left) = node.child_by_field_name("left") {
-                    if let Some(right) = node.child_by_field_name("right") {
+            if op_text == ">="
+                && let Some(left) = node.child_by_field_name("left")
+                    && let Some(right) = node.child_by_field_name("right") {
                         let right_text = &source[right.byte_range()];
                         let is_length_access = left.kind() == "member_expression"
                             && left
@@ -2067,10 +2004,7 @@ fn scan_insecure_typescript(node: &tree_sitter::Node, source: &str, findings: &m
                             });
                         }
                     }
-                }
-            }
         }
-    }
 
     // Non-null assertion operator (!)
     if node.kind() == "non_null_expression" {
@@ -2103,8 +2037,8 @@ fn scan_insecure_bash(node: &tree_sitter::Node, source: &str, findings: &mut Vec
     let end_line = node.end_position().row as u32 + 1;
 
     // B11: Missing shebang (root program node only)
-    if kind == "program" {
-        if !source.starts_with("#!") {
+    if kind == "program"
+        && !source.starts_with("#!") {
             findings.push(Finding {
                 id: crate::finding::new_finding_ulid(),
                 title: "Script has no shebang line".into(),
@@ -2126,22 +2060,20 @@ fn scan_insecure_bash(node: &tree_sitter::Node, source: &str, findings: &mut Vec
                     grounding_status: None,
             });
         }
-    }
 
     // B4: Missing set -e (root program node only)
     if kind == "program" {
         let mut found_set_e = false;
         let limit = node.child_count().min(10);
         for i in 0..limit {
-            if let Some(child) = node.child(i as u32) {
-                if child.kind() == "command" {
+            if let Some(child) = node.child(i as u32)
+                && child.kind() == "command" {
                     let text = &source[child.byte_range()];
                     if text.contains("set") && (text.contains("-e") || text.contains("errexit")) {
                         found_set_e = true;
                         break;
                     }
                 }
-            }
         }
         if !found_set_e {
             findings.push(Finding {
@@ -2169,8 +2101,8 @@ fn scan_insecure_bash(node: &tree_sitter::Node, source: &str, findings: &mut Vec
     }
 
     // B2: eval usage
-    if kind == "command" {
-        if let Some(name_node) = node.child_by_field_name("name") {
+    if kind == "command"
+        && let Some(name_node) = node.child_by_field_name("name") {
             let name = &source[name_node.byte_range()];
             if name == "eval" {
                 findings.push(Finding {
@@ -2230,15 +2162,14 @@ fn scan_insecure_bash(node: &tree_sitter::Node, source: &str, findings: &mut Vec
                 }
             }
         }
-    }
 
     // B3: curl|bash piping
     if kind == "pipeline" {
         let mut saw_curl = false;
         for i in 0..node.child_count() {
-            if let Some(child) = node.child(i as u32) {
-                if child.kind() == "command" {
-                    if let Some(name_node) = child.child_by_field_name("name") {
+            if let Some(child) = node.child(i as u32)
+                && child.kind() == "command"
+                    && let Some(name_node) = child.child_by_field_name("name") {
                         let name = &source[name_node.byte_range()];
                         if name == "curl" || name == "wget" {
                             saw_curl = true;
@@ -2270,14 +2201,12 @@ fn scan_insecure_bash(node: &tree_sitter::Node, source: &str, findings: &mut Vec
                             break;
                         }
                     }
-                }
-            }
         }
     }
 
     // B5: Hardcoded secrets
-    if kind == "variable_assignment" {
-        if let Some(name_node) = node.child_by_field_name("name") {
+    if kind == "variable_assignment"
+        && let Some(name_node) = node.child_by_field_name("name") {
             let var_name = &source[name_node.byte_range()];
             let upper = var_name.to_uppercase();
             let is_secret_name = upper.contains("PASSWORD")
@@ -2286,8 +2215,8 @@ fn scan_insecure_bash(node: &tree_sitter::Node, source: &str, findings: &mut Vec
                 || upper.contains("TOKEN")
                 || upper.contains("APIKEY")
                 || upper.contains("PRIVATE_KEY");
-            if is_secret_name {
-                if let Some(value_node) = node.child_by_field_name("value") {
+            if is_secret_name
+                && let Some(value_node) = node.child_by_field_name("value") {
                     let vkind = value_node.kind();
                     // Skip command substitutions and expansions
                     if vkind != "command_substitution"
@@ -2320,9 +2249,7 @@ fn scan_insecure_bash(node: &tree_sitter::Node, source: &str, findings: &mut Vec
                         }
                     }
                 }
-            }
         }
-    }
 }
 
 fn scan_insecure_dockerfile(node: &tree_sitter::Node, source: &str, findings: &mut Vec<Finding>) {
@@ -2461,38 +2388,34 @@ const TF_SECRET_PATTERNS: &[&str] = &[
 fn tf_expr_is_variable_ref(attr_node: &tree_sitter::Node) -> bool {
     // attribute children: identifier, =, expression
     // expression child(0) is variable_expr for `var.xxx`
-    if let Some(expr) = attr_node.child(2) {
-        if expr.kind() == "expression" {
-            if let Some(first) = expr.child(0) {
+    if let Some(expr) = attr_node.child(2)
+        && expr.kind() == "expression"
+            && let Some(first) = expr.child(0) {
                 return first.kind() == "variable_expr";
             }
-        }
-    }
     false
 }
 
 /// Extract the string content of a Terraform attribute's expression value.
 /// Returns the inner text (without quotes) if the value is a string literal.
 fn tf_expr_string_inner<'a>(attr_node: &tree_sitter::Node, source: &'a str) -> Option<&'a str> {
-    if let Some(expr) = attr_node.child(2) {
-        if expr.kind() == "expression" {
+    if let Some(expr) = attr_node.child(2)
+        && expr.kind() == "expression" {
             let text = source[expr.byte_range()].trim();
             if text.starts_with('"') && text.ends_with('"') && text.len() >= 2 {
                 return Some(&text[1..text.len() - 1]);
             }
         }
-    }
     None
 }
 
 /// Extract the numeric value from a Terraform attribute's expression.
 fn tf_expr_numeric(attr_node: &tree_sitter::Node, source: &str) -> Option<u16> {
-    if let Some(expr) = attr_node.child(2) {
-        if expr.kind() == "expression" {
+    if let Some(expr) = attr_node.child(2)
+        && expr.kind() == "expression" {
             let text = source[expr.byte_range()].trim();
             return text.parse::<u16>().ok();
         }
-    }
     None
 }
 
@@ -2503,15 +2426,15 @@ fn scan_insecure_terraform(node: &tree_sitter::Node, source: &str, findings: &mu
 
     // T1: Hardcoded secrets in attributes
     // AST: attribute > identifier, =, expression > literal_value > string_lit
-    if kind == "attribute" {
-        if let Some(name_node) = node.child(0) {
-            if name_node.kind() == "identifier" {
+    if kind == "attribute"
+        && let Some(name_node) = node.child(0)
+            && name_node.kind() == "identifier" {
                 let attr_name = source[name_node.byte_range()].to_uppercase();
                 if TF_SECRET_PATTERNS.iter().any(|p| attr_name.contains(p)) {
                     // Only flag if value is a non-empty string literal (not a variable ref)
-                    if !tf_expr_is_variable_ref(node) {
-                        if let Some(inner) = tf_expr_string_inner(node, source) {
-                            if !inner.is_empty()
+                    if !tf_expr_is_variable_ref(node)
+                        && let Some(inner) = tf_expr_string_inner(node, source)
+                            && !inner.is_empty()
                                 && !inner.starts_with("${var.")
                                 && !inner.starts_with("${")
                             {
@@ -2536,24 +2459,20 @@ fn scan_insecure_terraform(node: &tree_sitter::Node, source: &str, findings: &mu
                     grounding_status: None,
                                 });
                             }
-                        }
-                    }
                 }
             }
-        }
-    }
 
     // T2: Wildcard IAM actions in object_elem (jsonencode-style HCL objects)
     // AST: object_elem > expression(variable_expr "Action"), =, expression(literal_value "\"*\"")
     if kind == "object_elem" {
         // Check if the key expression is "Action" (case-insensitive)
-        if let Some(key_expr) = node.child(0) {
-            if key_expr.kind() == "expression" {
+        if let Some(key_expr) = node.child(0)
+            && key_expr.kind() == "expression" {
                 let key_text = source[key_expr.byte_range()].trim();
                 if key_text.eq_ignore_ascii_case("Action") {
                     // Check if value expression is "*"
-                    if let Some(val_expr) = node.child(2) {
-                        if val_expr.kind() == "expression" {
+                    if let Some(val_expr) = node.child(2)
+                        && val_expr.kind() == "expression" {
                             let val_text = source[val_expr.byte_range()].trim();
                             let inner = val_text.trim_matches('"');
                             if inner == "*" {
@@ -2579,30 +2498,28 @@ fn scan_insecure_terraform(node: &tree_sitter::Node, source: &str, findings: &mu
                                 });
                             }
                         }
-                    }
                 }
             }
-        }
     }
 
     // T3: Open security groups on sensitive ports
     // AST: block > identifier("ingress"), block_start, body > attribute(from_port), attribute(cidr_blocks), block_end
-    if kind == "block" {
-        if let Some(first_child) = node.child(0) {
-            if first_child.kind() == "identifier" && &source[first_child.byte_range()] == "ingress"
+    if kind == "block"
+        && let Some(first_child) = node.child(0)
+            && first_child.kind() == "identifier" && &source[first_child.byte_range()] == "ingress"
             {
                 let mut has_open_cidr = false;
                 let mut port_is_sensitive = true;
                 let mut found_port = false;
 
                 for i in 0..node.child_count() {
-                    if let Some(child) = node.child(i as u32) {
-                        if child.kind() == "body" {
+                    if let Some(child) = node.child(i as u32)
+                        && child.kind() == "body" {
                             for j in 0..child.child_count() {
-                                if let Some(attr) = child.child(j as u32) {
-                                    if attr.kind() == "attribute" {
-                                        if let Some(attr_name) = attr.child(0) {
-                                            if attr_name.kind() == "identifier" {
+                                if let Some(attr) = child.child(j as u32)
+                                    && attr.kind() == "attribute"
+                                        && let Some(attr_name) = attr.child(0)
+                                            && attr_name.kind() == "identifier" {
                                                 let name = &source[attr_name.byte_range()];
                                                 if name == "cidr_blocks" {
                                                     let attr_text = &source[attr.byte_range()];
@@ -2612,8 +2529,8 @@ fn scan_insecure_terraform(node: &tree_sitter::Node, source: &str, findings: &mu
                                                         has_open_cidr = true;
                                                     }
                                                 }
-                                                if name == "from_port" {
-                                                    if let Some(port) =
+                                                if name == "from_port"
+                                                    && let Some(port) =
                                                         tf_expr_numeric(&attr, source)
                                                     {
                                                         found_port = true;
@@ -2621,14 +2538,9 @@ fn scan_insecure_terraform(node: &tree_sitter::Node, source: &str, findings: &mu
                                                             port_is_sensitive = false;
                                                         }
                                                     }
-                                                }
                                             }
-                                        }
-                                    }
-                                }
                             }
                         }
-                    }
                 }
 
                 if has_open_cidr && port_is_sensitive && found_port {
@@ -2654,8 +2566,6 @@ fn scan_insecure_terraform(node: &tree_sitter::Node, source: &str, findings: &mu
                     });
                 }
             }
-        }
-    }
 }
 
 fn analyze_terraform_structure(tree: &tree_sitter::Tree, source: &str) -> Vec<Finding> {
@@ -2703,24 +2613,20 @@ fn analyze_terraform_structure(tree: &tree_sitter::Tree, source: &str) -> Vec<Fi
                         let Some(attr_or_block) = tbody.child(j as u32) else {
                             continue;
                         };
-                        if attr_or_block.kind() == "attribute" {
-                            if let Some(id) = attr_or_block.child(0) {
-                                if id.kind() == "identifier"
+                        if attr_or_block.kind() == "attribute"
+                            && let Some(id) = attr_or_block.child(0)
+                                && id.kind() == "identifier"
                                     && &source[id.byte_range()] == "required_version"
                                 {
                                     has_required_version = true;
                                 }
-                            }
-                        }
 
                         // S2: Check required_providers block
-                        if attr_or_block.kind() == "block" {
-                            if hcl_block_type(attr_or_block, source) == Some("required_providers") {
-                                if let Some(rp_body) = hcl_block_body(attr_or_block) {
+                        if attr_or_block.kind() == "block"
+                            && hcl_block_type(attr_or_block, source) == Some("required_providers")
+                                && let Some(rp_body) = hcl_block_body(attr_or_block) {
                                     check_required_providers(rp_body, source, &mut findings);
                                 }
-                            }
-                        }
                     }
                 }
             }
@@ -2758,11 +2664,10 @@ fn analyze_terraform_structure(tree: &tree_sitter::Tree, source: &str) -> Vec<Fi
 /// Get the first child identifier text from an HCL block node.
 fn hcl_block_type<'a>(block: tree_sitter::Node, source: &'a str) -> Option<&'a str> {
     for i in 0..block.child_count() {
-        if let Some(c) = block.child(i as u32) {
-            if c.kind() == "identifier" {
+        if let Some(c) = block.child(i as u32)
+            && c.kind() == "identifier" {
                 return Some(&source[c.byte_range()]);
             }
-        }
     }
     None
 }
@@ -2770,11 +2675,10 @@ fn hcl_block_type<'a>(block: tree_sitter::Node, source: &'a str) -> Option<&'a s
 /// Get the body child node from an HCL block.
 fn hcl_block_body(block: tree_sitter::Node) -> Option<tree_sitter::Node> {
     for i in 0..block.child_count() {
-        if let Some(c) = block.child(i as u32) {
-            if c.kind() == "body" {
+        if let Some(c) = block.child(i as u32)
+            && c.kind() == "body" {
                 return Some(c);
             }
-        }
     }
     None
 }
@@ -2885,11 +2789,10 @@ fn extract_identifier_from_expr<'a>(node: tree_sitter::Node, source: &'a str) ->
         return Some(&source[node.byte_range()]);
     }
     for i in 0..node.child_count() {
-        if let Some(child) = node.child(i as u32) {
-            if let Some(result) = extract_identifier_from_expr(child, source) {
+        if let Some(child) = node.child(i as u32)
+            && let Some(result) = extract_identifier_from_expr(child, source) {
                 return Some(result);
             }
-        }
     }
     None
 }

--- a/src/analytics.rs
+++ b/src/analytics.rs
@@ -370,11 +370,9 @@ pub fn format_channel_attribution(summary: &TierSummary) -> String {
         let s = &summary.unknown;
         writeln!(
             out,
-            "  {label:<10}  {total:>6}  {dim}(legacy rows, no provenance field){reset}",
+            "  {label:<10}  {total:>6}  (legacy rows, no provenance field)",
             label = "Unknown",
             total = s.total(),
-            dim = "",
-            reset = "",
         )
         .unwrap();
     }
@@ -438,14 +436,13 @@ pub fn compute_external_overlap(
                 ..Default::default()
             });
         row.findings += 1;
-        if let Some(fid) = &e.finding_id {
-            if let Some(qv) = quorum_verdicts.get(fid) {
+        if let Some(fid) = &e.finding_id
+            && let Some(qv) = quorum_verdicts.get(fid) {
                 row.overlap += 1;
                 if verdict_eq(qv, &e.verdict) {
                     row.agree += 1;
                 }
             }
-        }
     }
     let mut agents: Vec<AgentOverlap> = per_agent.into_values().collect();
     agents.sort_by(|a, b| {

--- a/src/analytics.rs
+++ b/src/analytics.rs
@@ -611,6 +611,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(deprecated)]
     fn tier_stats_format_shows_external_and_top_agents_stable() {
         use crate::feedback::Provenance;
         let fb = vec![
@@ -658,6 +659,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(deprecated)]
     fn format_tier_report_handles_zero_external_entries() {
         use crate::feedback::Provenance;
         let fb = vec![entry_with(Provenance::Human, Verdict::Tp)];
@@ -712,16 +714,20 @@ mod tests {
 
     #[test]
     fn stats_precision_calculation() {
-        let mut s = SourceStats::default();
-        s.tp = 8;
-        s.fp = 2;
+        let s = SourceStats {
+            tp: 8,
+            fp: 2,
+            ..Default::default()
+        };
         assert!((s.precision() - 0.8).abs() < f64::EPSILON);
     }
 
     #[test]
     fn stats_precision_all_fp() {
-        let mut s = SourceStats::default();
-        s.fp = 5;
+        let s = SourceStats {
+            fp: 5,
+            ..Default::default()
+        };
         assert!((s.precision() - 0.0).abs() < f64::EPSILON);
     }
 
@@ -733,10 +739,12 @@ mod tests {
 
     #[test]
     fn stats_partial_counts_as_relevant() {
-        let mut s = SourceStats::default();
-        s.tp = 3;
-        s.partial = 2;
-        s.fp = 5;
+        let s = SourceStats {
+            tp: 3,
+            partial: 2,
+            fp: 5,
+            ..Default::default()
+        };
         // precision = (3+2) / (3+2+5) = 0.5
         assert!((s.precision() - 0.5).abs() < f64::EPSILON);
     }

--- a/src/analytics.rs
+++ b/src/analytics.rs
@@ -109,7 +109,7 @@ pub fn format_stats_report(stats: &HashMap<String, SourceStats>) -> String {
     lines.push("-".repeat(65));
 
     let mut sources: Vec<_> = stats.iter().collect();
-    sources.sort_by(|a, b| b.1.total().cmp(&a.1.total()));
+    sources.sort_by_key(|item| std::cmp::Reverse(item.1.total()));
 
     for (source, s) in &sources {
         lines.push(format!(

--- a/src/calibrate.rs
+++ b/src/calibrate.rs
@@ -193,6 +193,7 @@ pub fn join_feedback_and_traces(
 /// - `disable_fuzzy`: when `true`, skips tiers 2-4 (normalized exact, fuzzy
 ///   same-file, normalized title-only). Only tier 1 (raw exact) and the raw
 ///   title-only fallback are used.
+#[allow(clippy::type_complexity)]
 pub fn join_feedback_and_traces_with_options(
     feedback: &[serde_json::Value],
     traces: &[serde_json::Value],

--- a/src/calibrate.rs
+++ b/src/calibrate.rs
@@ -344,27 +344,24 @@ pub fn join_feedback_and_traces_with_options(
         let norm = normalize_title(&title);
 
         // Tier 1: raw exact (title, file_path)
-        if let Some(weights) = raw_map.get(&(title.clone(), fp.clone())) {
-            if push_sample(&mut samples, weights, is_positive) {
+        if let Some(weights) = raw_map.get(&(title.clone(), fp.clone()))
+            && push_sample(&mut samples, weights, is_positive) {
                 stats.exact_raw += 1;
                 continue;
             }
-        }
 
         // Tier 2: normalized exact (norm_title, file_path) -- skipped when fuzzy disabled
-        if !disable_fuzzy && !norm.is_empty() {
-            if let Some(weights) = norm_map.get(&(norm.clone(), fp.clone())) {
-                if push_sample(&mut samples, weights, is_positive) {
+        if !disable_fuzzy && !norm.is_empty()
+            && let Some(weights) = norm_map.get(&(norm.clone(), fp.clone()))
+                && push_sample(&mut samples, weights, is_positive) {
                     stats.exact_normalized += 1;
                     continue;
                 }
-            }
-        }
 
         // Tier 3: fuzzy same-file -- skipped when fuzzy disabled
         let mut fuzzy_below_threshold = false;
-        if !disable_fuzzy && !norm.is_empty() && !fp.is_empty() {
-            if let Some(candidates) = file_traces.get(&fp) {
+        if !disable_fuzzy && !norm.is_empty() && !fp.is_empty()
+            && let Some(candidates) = file_traces.get(&fp) {
                 let mut best_score = 0.0_f64;
                 let mut second_best = 0.0_f64;
                 let mut best_weights: Option<&(f64, f64)> = None;
@@ -383,12 +380,11 @@ pub fn join_feedback_and_traces_with_options(
                 if best_score >= FUZZY_THRESHOLD {
                     let margin = best_score - second_best;
                     if margin >= FUZZY_AMBIGUITY_MARGIN {
-                        if let Some(weights) = best_weights {
-                            if push_sample(&mut samples, weights, is_positive) {
+                        if let Some(weights) = best_weights
+                            && push_sample(&mut samples, weights, is_positive) {
                                 stats.fuzzy_same_file += 1;
                                 continue;
                             }
-                        }
                     } else {
                         stats.ambiguous_skipped += 1;
                         continue;
@@ -397,23 +393,19 @@ pub fn join_feedback_and_traces_with_options(
                     fuzzy_below_threshold = true;
                 }
             }
-        }
 
         // Title-only fallback (raw first, then normalized -- normalized skipped when fuzzy disabled)
-        if let Some(weights) = raw_title_only.get(&title) {
-            if push_sample(&mut samples, weights, is_positive) {
+        if let Some(weights) = raw_title_only.get(&title)
+            && push_sample(&mut samples, weights, is_positive) {
                 stats.raw_title_only += 1;
                 continue;
             }
-        }
-        if !disable_fuzzy && !norm.is_empty() {
-            if let Some(weights) = norm_title_only.get(&norm) {
-                if push_sample(&mut samples, weights, is_positive) {
+        if !disable_fuzzy && !norm.is_empty()
+            && let Some(weights) = norm_title_only.get(&norm)
+                && push_sample(&mut samples, weights, is_positive) {
                     stats.normalized_title_only += 1;
                     continue;
                 }
-            }
-        }
 
         if fuzzy_below_threshold {
             stats.below_threshold += 1;
@@ -581,29 +573,26 @@ pub fn backfill_file_paths(
         }
 
         // Tier 1: exact title match
-        if let Some(files) = exact_map.get(&title) {
-            if files.len() == 1 {
+        if let Some(files) = exact_map.get(&title)
+            && files.len() == 1 {
                 let fp = files.iter().next().unwrap().clone();
                 trace["file_path"] = serde_json::Value::String(fp);
                 stats.feedback_exact += 1;
                 stats.total_backfilled += 1;
                 continue;
             }
-        }
 
         // Tier 2: normalized title match
         let norm = normalize_title(&title);
-        if !norm.is_empty() {
-            if let Some(files) = norm_map.get(&norm) {
-                if files.len() == 1 {
+        if !norm.is_empty()
+            && let Some(files) = norm_map.get(&norm)
+                && files.len() == 1 {
                     let fp = files.iter().next().unwrap().clone();
                     trace["file_path"] = serde_json::Value::String(fp);
                     stats.feedback_normalized += 1;
                     stats.total_backfilled += 1;
                     continue;
                 }
-            }
-        }
 
         // Tier 3: precedent inference
         if let Some(precs) = trace.get("matched_precedents").and_then(|v| v.as_array()) {

--- a/src/calibrator.rs
+++ b/src/calibrator.rs
@@ -3097,9 +3097,11 @@ mod tests {
             .category("security".into())
             .severity(crate::finding::Severity::High)
             .build();
-        let mut config = CalibratorConfig::default();
         // Lower threshold for this test so the sub-1.0 Jaccard similarity clears the gate.
-        config.embedding_similarity_threshold = 0.3;
+        let config = CalibratorConfig {
+            embedding_similarity_threshold: 0.3,
+            ..Default::default()
+        };
         let result = calibrate_with_index(vec![finding], &mut index, &config, "");
         let trace = &result.traces[0];
         let prec = trace
@@ -3873,8 +3875,10 @@ mod tests {
             .category(Category::Security)
             .severity(Severity::High)
             .build();
-        let mut config = CalibratorConfig::default();
-        config.suppress_threshold = Some(0.05);
+        let config = CalibratorConfig {
+            suppress_threshold: Some(0.05),
+            ..Default::default()
+        };
         let decision = calibrate_core_decision(
             &mut finding,
             &config,
@@ -3903,8 +3907,10 @@ mod tests {
             .category(Category::Security)
             .severity(Severity::Medium)
             .build();
-        let mut config = CalibratorConfig::default();
-        config.boost_threshold = Some(0.90);
+        let config = CalibratorConfig {
+            boost_threshold: Some(0.90),
+            ..Default::default()
+        };
         let decision = calibrate_core_decision(
             &mut finding,
             &config,
@@ -3957,8 +3963,10 @@ mod tests {
             .category(Category::Security)
             .severity(Severity::High)
             .build();
-        let mut config = CalibratorConfig::default();
-        config.force_threshold = Some(0.05);
+        let config = CalibratorConfig {
+            force_threshold: Some(0.05),
+            ..Default::default()
+        };
         let decision = calibrate_core_decision(
             &mut finding,
             &config,
@@ -3986,8 +3994,10 @@ mod tests {
             .category(Category::Security)
             .severity(Severity::Medium)
             .build();
-        let mut config = CalibratorConfig::default();
-        config.suppress_threshold = Some(0.5);
+        let config = CalibratorConfig {
+            suppress_threshold: Some(0.5),
+            ..Default::default()
+        };
         // tp=0.5, fp=0.5 -> score = 0.5
         let decision = calibrate_core_decision(
             &mut finding,
@@ -4011,8 +4021,10 @@ mod tests {
             .category(Category::Security)
             .severity(Severity::Medium)
             .build();
-        let mut config2 = CalibratorConfig::default();
-        config2.boost_threshold = Some(0.5);
+        let config2 = CalibratorConfig {
+            boost_threshold: Some(0.5),
+            ..Default::default()
+        };
         let decision2 = calibrate_core_decision(
             &mut finding2,
             &config2,
@@ -4040,9 +4052,11 @@ mod tests {
             .category(Category::Security)
             .severity(Severity::Medium)
             .build();
-        let mut config = CalibratorConfig::default();
-        config.suppress_threshold = Some(0.4);
-        config.boost_threshold = Some(0.6);
+        let config = CalibratorConfig {
+            suppress_threshold: Some(0.4),
+            boost_threshold: Some(0.6),
+            ..Default::default()
+        };
         let decision = calibrate_core_decision(
             &mut finding,
             &config,
@@ -4086,8 +4100,10 @@ mod tests {
             run_id: Some("01JTEST_CAL".into()),
             ..Default::default()
         };
-        let mut config = CalibratorConfig::default();
-        config.trace_provenance = Some(prov.clone());
+        let config = CalibratorConfig {
+            trace_provenance: Some(prov.clone()),
+            ..Default::default()
+        };
         // Empty feedback: all traces take the NoMatch path.
         let result = calibrate(findings, &[], &config, "test.rs");
         assert_eq!(result.traces.len(), 2, "one trace per finding");
@@ -4120,8 +4136,10 @@ mod tests {
             commit_sha: Some("deadbeef".into()),
             ..Default::default()
         };
-        let mut config = CalibratorConfig::default();
-        config.trace_provenance = Some(prov.clone());
+        let config = CalibratorConfig {
+            trace_provenance: Some(prov.clone()),
+            ..Default::default()
+        };
         let result = calibrate_with_index(findings, &mut index, &config, "buf.c");
         assert_eq!(result.traces.len(), 1, "one trace per finding");
         assert_eq!(
@@ -4148,8 +4166,10 @@ mod tests {
             run_id: Some("01JTEST_DECISION".into()),
             ..Default::default()
         };
-        let mut config = CalibratorConfig::default();
-        config.trace_provenance = Some(prov.clone());
+        let config = CalibratorConfig {
+            trace_provenance: Some(prov.clone()),
+            ..Default::default()
+        };
         let result = calibrate(findings, &feedback, &config, "src/db.rs");
         assert_eq!(result.traces.len(), 1);
         assert_eq!(

--- a/src/calibrator.rs
+++ b/src/calibrator.rs
@@ -2200,7 +2200,7 @@ mod tests {
         let config = CalibratorConfig::default();
         let result1 = calibrate(
             findings.clone(),
-            &vec![human_fp.clone(), auto_fp.clone()],
+            &[human_fp.clone(), auto_fp.clone()],
             &config,
             "",
         );
@@ -2209,7 +2209,7 @@ mod tests {
         // 2 auto only: 0.5 + 0.5 = 1.0 < 1.5 threshold -> NOT suppress
         let result2 = calibrate(
             findings.clone(),
-            &vec![auto_fp.clone(), auto_fp],
+            &[auto_fp.clone(), auto_fp],
             &config,
             "",
         );
@@ -2258,14 +2258,14 @@ mod tests {
         // 2 recent human FPs: 1.0 + 1.0 = 2.0 >= 1.5 -> suppress
         let result1 = calibrate(
             findings.clone(),
-            &vec![recent_fp.clone(), recent_fp],
+            &[recent_fp.clone(), recent_fp],
             &config,
             "",
         );
         assert_eq!(result1.suppressed, 1);
 
         // 2 old FPs: exp(-90/60) ~= 0.22 each, total ~0.44 < 1.5 -> NOT suppress
-        let result2 = calibrate(findings.clone(), &vec![old_fp.clone(), old_fp], &config, "");
+        let result2 = calibrate(findings.clone(), &[old_fp.clone(), old_fp], &config, "");
         assert!(result2.suppressed <= 1);
     }
 
@@ -2292,7 +2292,7 @@ mod tests {
         };
 
         let config = CalibratorConfig::default();
-        let result = calibrate(findings, &vec![tp], &config, "");
+        let result = calibrate(findings, &[tp], &config, "");
         assert_eq!(result.findings.len(), 1);
         assert_eq!(
             result.findings[0].calibrator_action,
@@ -2347,7 +2347,7 @@ mod tests {
         };
 
         let config = CalibratorConfig::default();
-        let result = calibrate(findings, &vec![postfix_tp], &config, "");
+        let result = calibrate(findings, &[postfix_tp], &config, "");
         assert_eq!(
             result.findings[0].calibrator_action,
             Some(CalibratorAction::Confirmed)
@@ -2576,7 +2576,7 @@ mod tests {
         };
 
         let config = CalibratorConfig::default();
-        let result = calibrate(findings, &vec![postfix_fp], &config, "");
+        let result = calibrate(findings, &[postfix_fp], &config, "");
         assert_eq!(
             result.suppressed, 1,
             "Single PostFix FP should suppress (weight 1.5 >= threshold)"
@@ -3028,7 +3028,7 @@ mod tests {
         eprintln!("action: {:?}", trace.action);
         eprintln!(
             "output severity: {:?} (input High)\n",
-            result.findings.get(0).map(|f| f.severity.clone())
+            result.findings.first().map(|f| f.severity.clone())
         );
 
         // Core assertion: JWT finding must not be suppressed (output or disputed).

--- a/src/category.rs
+++ b/src/category.rs
@@ -77,8 +77,7 @@ impl From<String> for Category {
         match s
             .to_lowercase()
             .trim()
-            .replace(' ', "-")
-            .replace('_', "-")
+            .replace([' ', '_'], "-")
             .as_str()
         {
             "security" | "safety" => Category::Security,

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -471,7 +471,7 @@ pub struct ReviewOpts {
 }
 
 /// CLI surface for `--fp-kind` (#123 Layer 1). Variants map onto
-/// `feedback::FpKind` via `FeedbackOpts::into_fp_kind`. Only meaningful
+/// `feedback::FpKind` via `FeedbackOpts::to_fp_kind`. Only meaningful
 /// when `--verdict fp`; ignored (with `tracing::warn`) on other verdicts.
 #[derive(Clone, Debug, PartialEq, Eq, clap::ValueEnum)]
 pub enum FpKindArg {
@@ -551,7 +551,7 @@ pub struct FeedbackOpts {
     // `--fp-kind` is meaningful only when `--verdict fp`. On other verdicts
     // it's silently dropped with a `tracing::warn` (composability with
     // shell pipelines). Cross-field validation (compensating-control needs
-    // a reference) lives in `into_fp_kind`, NOT in clap, because clap can't
+    // a reference) lives in `to_fp_kind`, NOT in clap, because clap can't
     // see cross-arg requirements at parse time.
     /// Discriminate FP verdict by reason: hallucination | trust-model |
     /// compensating-control | pattern-overgeneralization | out-of-scope.
@@ -585,7 +585,7 @@ impl FeedbackOpts {
     /// - `--fp-kind compensating-control` without `--fp-reference` → Err.
     /// - `--fp-kind out-of-scope` without `--fp-tracked-in` → Ok(Some(..))
     ///   with `tracing::warn` (orphaned deferral discouraged but legal).
-    pub fn into_fp_kind(&self) -> anyhow::Result<Option<crate::feedback::FpKind>> {
+    pub fn to_fp_kind(&self) -> anyhow::Result<Option<crate::feedback::FpKind>> {
         use crate::feedback::FpKind;
 
         // Drop fp_kind silently when verdict != fp. Caller logs the warn
@@ -740,14 +740,14 @@ mod tests {
             "r",
         ])
         .expect("parse");
-        let kind = opts.into_fp_kind().expect("into_fp_kind");
+        let kind = opts.to_fp_kind().expect("to_fp_kind");
         assert_eq!(kind, Some(crate::feedback::FpKind::TrustModelAssumption));
     }
 
     #[test]
-    fn cli_fp_kind_compensating_control_requires_reference_in_into_fp_kind() {
+    fn cli_fp_kind_compensating_control_requires_reference_in_to_fp_kind() {
         // PINNED: clap parses successfully because cross-field validation
-        // can't happen at parse time. The error surfaces in into_fp_kind().
+        // can't happen at parse time. The error surfaces in to_fp_kind().
         // If a future refactor moves validation to clap, this test fails at
         // parse_args() — that's the signal to update the test, not to silently
         // rely on a different error path.
@@ -763,8 +763,8 @@ mod tests {
             "--reason",
             "r",
         ])
-        .expect("clap parses; cross-field validation lives in into_fp_kind");
-        let result = opts.into_fp_kind();
+        .expect("clap parses; cross-field validation lives in to_fp_kind");
+        let result = opts.to_fp_kind();
         assert!(
             result.is_err(),
             "compensating-control without --fp-reference must error"
@@ -794,7 +794,7 @@ mod tests {
             "r",
         ])
         .expect("parse");
-        let kind = opts.into_fp_kind().expect("into_fp_kind").unwrap();
+        let kind = opts.to_fp_kind().expect("to_fp_kind").unwrap();
         match kind {
             crate::feedback::FpKind::CompensatingControl { reference } => {
                 assert_eq!(reference, "PR #99 line 42");
@@ -823,7 +823,7 @@ mod tests {
     #[test]
     fn cli_fp_kind_on_tp_verdict_silently_dropped() {
         // Composability: a shell pipeline can pipe `--verdict tp --fp-kind X`
-        // without the CLI failing. into_fp_kind returns Ok(None); the call
+        // without the CLI failing. to_fp_kind returns Ok(None); the call
         // site is responsible for emitting a tracing::warn. Test the dropped-
         // kind contract here.
         let opts = parse_args(&[
@@ -839,7 +839,7 @@ mod tests {
             "r",
         ])
         .expect("parse");
-        let kind = opts.into_fp_kind().expect("must not fail on tp+kind");
+        let kind = opts.to_fp_kind().expect("must not fail on tp+kind");
         assert_eq!(kind, None, "fp_kind must be dropped when verdict != fp");
     }
 
@@ -860,7 +860,7 @@ mod tests {
             "r",
         ])
         .expect("parse");
-        let kind = opts.into_fp_kind().expect("into_fp_kind").unwrap();
+        let kind = opts.to_fp_kind().expect("to_fp_kind").unwrap();
         match kind {
             crate::feedback::FpKind::PatternOvergeneralization { discriminator_hint } => {
                 assert_eq!(
@@ -887,7 +887,7 @@ mod tests {
             "r",
         ])
         .expect("parse");
-        let kind = opts.into_fp_kind().expect("into_fp_kind").unwrap();
+        let kind = opts.to_fp_kind().expect("to_fp_kind").unwrap();
         assert!(matches!(
             kind,
             crate::feedback::FpKind::OutOfScope { tracked_in: None }
@@ -911,7 +911,7 @@ mod tests {
             "r",
         ])
         .expect("parse");
-        let kind = opts.into_fp_kind().expect("into_fp_kind").unwrap();
+        let kind = opts.to_fp_kind().expect("to_fp_kind").unwrap();
         match kind {
             crate::feedback::FpKind::OutOfScope { tracked_in } => {
                 assert_eq!(tracked_in.as_deref(), Some("#456"));
@@ -933,7 +933,7 @@ mod tests {
             "r",
         ])
         .expect("parse");
-        let kind = opts.into_fp_kind().expect("into_fp_kind");
+        let kind = opts.to_fp_kind().expect("to_fp_kind");
         assert_eq!(kind, None, "no --fp-kind flag = no kind");
     }
 

--- a/src/context/bootstrap.rs
+++ b/src/context/bootstrap.rs
@@ -9,8 +9,8 @@
 //! The retriever closure opens the SQLite db read-only on every call and
 //! owns a fresh `HashEmbedder` / `SystemClock`. This keeps it `Send + Sync
 //! + 'static` without threading a shared connection through the pipeline;
-//! review workloads query once per file so the per-call open is negligible
-//! relative to the LLM round-trip.
+//!   review workloads query once per file so the per-call open is negligible
+//!   relative to the LLM round-trip.
 //!
 //! NOTE: the current wiring picks the first registered source that has an
 //! index on disk. Cross-source fanout (merging hits across multiple dbs) is

--- a/src/context/cli.rs
+++ b/src/context/cli.rs
@@ -1736,7 +1736,7 @@ fn check_state_json<D: ContextDeps>(deps: &D, name: &str) -> CheckResult {
             name: "per_source_state_json_valid",
             scope: Some(name.to_string()),
             status: CheckStatus::Fail { fixable: true },
-            detail: format!("empty state.json"),
+            detail: "empty state.json".to_string(),
         },
         Err(e) => CheckResult {
             name: "per_source_state_json_valid",

--- a/src/context/cli.rs
+++ b/src/context/cli.rs
@@ -41,7 +41,7 @@ use crate::context::index::traits::{Clock, Embedder, SystemClock};
 /// fallback at runtime.
 pub enum ProdEmbedder {
     #[cfg(feature = "embeddings")]
-    Fast(FastEmbedEmbedder),
+    Fast(Box<FastEmbedEmbedder>),
     Hash(HashEmbedder),
 }
 
@@ -193,7 +193,7 @@ pub(crate) fn new_prod_embedder() -> ProdEmbedder {
     #[cfg(feature = "embeddings")]
     {
         match FastEmbedEmbedder::new() {
-            Ok(e) => ProdEmbedder::Fast(e),
+            Ok(e) => ProdEmbedder::Fast(Box::new(e)),
             Err(e) => {
                 tracing::warn!(
                     error = %e,
@@ -231,7 +231,7 @@ pub(crate) fn new_prod_embedder_strict() -> anyhow::Result<ProdEmbedder> {
                  HashEmbedder fallback — retry once the model is available"
             )
         })?;
-        Ok(ProdEmbedder::Fast(e))
+        Ok(ProdEmbedder::Fast(Box::new(e)))
     }
     #[cfg(not(feature = "embeddings"))]
     {

--- a/src/context/extract/astgrep_py.rs
+++ b/src/context/extract/astgrep_py.rs
@@ -97,7 +97,7 @@ pub fn extract_python(
             let sig_start_line = (node.start_pos().line() as u32) + 1;
             let end_line = (node.end_pos().line() as u32) + 1;
 
-            let docstring = extract_docstring(src, &node);
+            let docstring = extract_docstring(src, node);
 
             let content = match &docstring {
                 Some(d) if !d.is_empty() => d.clone(),
@@ -426,13 +426,11 @@ fn item_signature(item_text: &str) -> String {
             i += 2;
             continue;
         }
-        if b == b' ' {
-            if let Some(&next) = bytes.get(i + 1) {
-                if matches!(next, b')' | b']' | b'}' | b',') {
+        if b == b' '
+            && let Some(&next) = bytes.get(i + 1)
+                && matches!(next, b')' | b']' | b'}' | b',') {
                     tidied.pop();
                 }
-            }
-        }
         i += 1;
     }
     tidied

--- a/src/context/extract/astgrep_ts.rs
+++ b/src/context/extract/astgrep_ts.rs
@@ -178,6 +178,7 @@ struct ExtractedSymbol {
 /// - type_alias_declaration: truncate at the first `;` only; `{` is legal on
 ///   the RHS (object type) and must be preserved.
 /// - any other kind: fall back to the first `{` or `;`.
+///
 /// Runs of whitespace collapse to a single space.
 fn item_signature(item_text: &str, kind: &str) -> String {
     let end = match kind {

--- a/src/context/extract/dispatch.rs
+++ b/src/context/extract/dispatch.rs
@@ -446,13 +446,11 @@ fn first_match<'a>(patterns: &'a [(String, Pattern)], rel: &str) -> Option<&'a s
         }
         // Also try matching without a leading `**/` prefix so that
         // `**/docs/**` matches `docs/adr/001.md` at the root.
-        if pat.as_str().starts_with("**/") {
-            if let Ok(inner) = Pattern::new(&pat.as_str()[3..]) {
-                if inner.matches(rel) {
+        if pat.as_str().starts_with("**/")
+            && let Ok(inner) = Pattern::new(&pat.as_str()[3..])
+                && inner.matches(rel) {
                     return Some(raw);
                 }
-            }
-        }
     }
     None
 }

--- a/src/context/extract/dispatch_tests.rs
+++ b/src/context/extract/dispatch_tests.rs
@@ -101,16 +101,16 @@ fn extracts_mini_terraform_source() {
         .collect();
 
     assert!(
-        qn.iter().any(|n| *n == "aws_vpc.this"),
+        qn.contains(&"aws_vpc.this"),
         "expected resource aws_vpc.this, got {qn:?}"
     );
     assert!(
-        qn.iter().any(|n| *n == "vpc_id"),
+        qn.contains(&"vpc_id"),
         "expected output vpc_id, got {qn:?}"
     );
-    assert!(qn.iter().any(|n| *n == "name"), "expected variable name");
+    assert!(qn.contains(&"name"), "expected variable name");
     assert!(
-        qn.iter().any(|n| *n == "cidr_block"),
+        qn.contains(&"cidr_block"),
         "expected variable cidr_block"
     );
     assert!(

--- a/src/context/index/builder.rs
+++ b/src/context/index/builder.rs
@@ -266,12 +266,11 @@ impl<'a, C: Clock, E: Embedder> IndexBuilder<'a, C, E> {
     }
 
     fn open_with_vec(db_path: &Path) -> rusqlite::Result<Connection> {
-        if let Some(parent) = db_path.parent() {
-            if !parent.as_os_str().is_empty() {
+        if let Some(parent) = db_path.parent()
+            && !parent.as_os_str().is_empty() {
                 std::fs::create_dir_all(parent)
                     .map_err(|e| rusqlite::Error::ToSqlConversionFailure(Box::new(e)))?;
             }
-        }
         ensure_vec_loaded();
         let conn = Connection::open(db_path)?;
         conn.pragma_update(None, "journal_mode", "WAL")?;

--- a/src/context/index/state.rs
+++ b/src/context/index/state.rs
@@ -82,14 +82,13 @@ impl IndexState {
 
     /// Write the state atomically (write to temp file, rename).
     pub fn save(&self, path: &Path) -> Result<(), StateError> {
-        if let Some(parent) = path.parent() {
-            if !parent.as_os_str().is_empty() {
+        if let Some(parent) = path.parent()
+            && !parent.as_os_str().is_empty() {
                 std::fs::create_dir_all(parent).map_err(|source| StateError::Io {
                     path: parent.to_path_buf(),
                     source,
                 })?;
             }
-        }
         let json = serde_json::to_string_pretty(self)?;
         let tmp = {
             let mut t = path.as_os_str().to_os_string();

--- a/src/context/inject/injector.rs
+++ b/src/context/inject/injector.rs
@@ -371,7 +371,7 @@ fn score_distribution(hits: &[ScoredChunk]) -> Option<ScoreDist> {
     };
     let p10 = scores[pct_idx(0.10)];
     // Proper median: average the two middle values for even n.
-    let median = if n % 2 == 0 {
+    let median = if n.is_multiple_of(2) {
         (scores[n / 2 - 1] + scores[n / 2]) / 2.0
     } else {
         scores[n / 2]

--- a/src/context/phase5_integration_tests.rs
+++ b/src/context/phase5_integration_tests.rs
@@ -9,7 +9,7 @@ use super::config::{ContextConfig, SourceEntry, SourceKind, SourceLocation};
 use super::extract::dispatch::{ExtractConfig, extract_source};
 use super::index::builder::IndexBuilder;
 use super::index::traits::{FixedClock, HashEmbedder};
-use super::inject::plan::{InjectionPlan, plan_injection};
+use super::inject::plan::plan_injection;
 use super::inject::render::render_context_block;
 use super::inject::stale::NoStaleness;
 use super::retrieve::{

--- a/src/context/retrieve/identifiers.rs
+++ b/src/context/retrieve/identifiers.rs
@@ -79,7 +79,7 @@ fn is_path_noise(s: &str) -> bool {
 /// Keeps tokens with len >= 3 that aren't path noise.
 fn split_token(token: &str, out: &mut Vec<String>) {
     // First split on _ and -
-    for piece in token.split(|c: char| c == '_' || c == '-') {
+    for piece in token.split(['_', '-']) {
         if piece.is_empty() {
             continue;
         }
@@ -89,12 +89,11 @@ fn split_token(token: &str, out: &mut Vec<String>) {
         for (i, ch) in chars.iter().enumerate() {
             if i > 0 && ch.is_ascii_uppercase() {
                 let prev = chars[i - 1];
-                if prev.is_ascii_lowercase() || prev.is_ascii_digit() {
-                    if !current.is_empty() {
+                if (prev.is_ascii_lowercase() || prev.is_ascii_digit())
+                    && !current.is_empty() {
                         push_if_valid(&current, out);
                         current.clear();
                     }
-                }
             }
             current.push(*ch);
         }
@@ -114,7 +113,7 @@ fn push_if_valid(tok: &str, out: &mut Vec<String>) {
 /// the filename's extension, splitting on `_`/`-`/camelCase, filtering noise.
 fn path_segments(path: &str) -> Vec<String> {
     let mut out = Vec::new();
-    let parts: Vec<&str> = path.split(|c: char| c == '/' || c == '\\').collect();
+    let parts: Vec<&str> = path.split(['/', '\\']).collect();
     let last_idx = parts.len().saturating_sub(1);
     for (i, part) in parts.iter().enumerate() {
         if part.is_empty() {

--- a/src/context/retrieve/vector_tests.rs
+++ b/src/context/retrieve/vector_tests.rs
@@ -239,10 +239,7 @@ fn mismatched_dim_returns_error_or_empty() {
     let q = vec![0.1f32; 128];
     let result = vec_search(&conn, &q, &Filters::default(), 3);
 
-    match result {
-        Ok(hits) => assert!(hits.is_empty()),
-        Err(_) => {}
-    }
+    if let Ok(hits) = result { assert!(hits.is_empty()) }
 }
 
 #[test]

--- a/src/context_enrichment.rs
+++ b/src/context_enrichment.rs
@@ -1,6 +1,5 @@
 /// Context7 integration: fetch framework-specific docs for LLM review enrichment.
 /// Detected frameworks are mapped to library queries, docs fetched, and injected into prompts.
-
 /// A document fetched from Context7 for a specific library/framework.
 #[derive(Debug, Clone)]
 pub struct ContextDoc {

--- a/src/context_enrichment.rs
+++ b/src/context_enrichment.rs
@@ -209,11 +209,10 @@ pub fn enrich_for_review(
     let mut import_matched: Vec<&crate::dep_manifest::Dependency> = Vec::new();
     for imp in imports {
         for name in normalize_import_to_dep_names(imp) {
-            if let Some(dep) = deps.iter().find(|d| d.name == name) {
-                if !import_matched.iter().any(|d| d.name == dep.name) {
+            if let Some(dep) = deps.iter().find(|d| d.name == name)
+                && !import_matched.iter().any(|d| d.name == dep.name) {
                     import_matched.push(dep);
                 }
-            }
         }
     }
 
@@ -458,13 +457,11 @@ impl<'a> CachedContextFetcher<'a> {
 impl<'a> ContextFetcher for CachedContextFetcher<'a> {
     fn resolve_library(&self, name: &str) -> Option<String> {
         let now = (self.now)();
-        if let Ok(mut cache) = self.resolve_cache.lock() {
-            if let Some(entry) = cache.get(name) {
-                if now.duration_since(entry.cached_at) < self.resolve_ttl {
+        if let Ok(mut cache) = self.resolve_cache.lock()
+            && let Some(entry) = cache.get(name)
+                && now.duration_since(entry.cached_at) < self.resolve_ttl {
                     return entry.result.clone();
                 }
-            }
-        }
         let result = self.inner.resolve_library(name);
         if let Ok(mut cache) = self.resolve_cache.lock() {
             // LruCache::put auto-evicts the LRU entry at capacity — preserves
@@ -484,11 +481,10 @@ impl<'a> ContextFetcher for CachedContextFetcher<'a> {
     fn query_docs(&self, library_id: &str, query: &str, max_tokens: usize) -> Option<String> {
         let key = (library_id.to_string(), query.to_string(), max_tokens);
 
-        if let Ok(mut cache) = self.query_cache.lock() {
-            if let Some(cached) = cache.get(&key) {
+        if let Ok(mut cache) = self.query_cache.lock()
+            && let Some(cached) = cache.get(&key) {
                 return cached.clone();
             }
-        }
 
         let result = self.inner.query_docs(library_id, query, max_tokens);
 
@@ -632,11 +628,10 @@ impl ContextFetcher for Context7HttpFetcher {
 
         // Context7 API may return plain text/markdown or JSON
         if let Ok(json) = serde_json::from_str::<serde_json::Value>(&body_text) {
-            if let Some(content) = json["content"].as_str() {
-                if !content.is_empty() {
+            if let Some(content) = json["content"].as_str()
+                && !content.is_empty() {
                     return Some(content.to_string());
                 }
-            }
             if let Some(snippets) = json["snippets"].as_array() {
                 let combined: String = snippets
                     .iter()

--- a/src/dep_manifest.rs
+++ b/src/dep_manifest.rs
@@ -104,7 +104,7 @@ fn strip_python_dep_spec(raw: &str) -> Option<String> {
     // whitespace): `name @ url`, `name[extra] @ url`, and the no-space
     // `name@url` / `name[extra]@url` forms all yield the bare name.
     let name_end = no_extras
-        .find(|c: char| matches!(c, '<' | '>' | '=' | '!' | '~' | ' ' | ';' | '@'))
+        .find(['<', '>', '=', '!', '~', ' ', ';', '@'])
         .unwrap_or(no_extras.len());
     let name = no_extras[..name_end].trim();
     if name.is_empty() {

--- a/src/domain.rs
+++ b/src/domain.rs
@@ -391,7 +391,6 @@ mod tests {
     }
 
     #[test]
-    #[test]
     fn detect_ha_from_subdirectory_layout() {
         // Real HA repos use configuration/ subdirectory
         let dir = tempfile::tempdir().unwrap();

--- a/src/domain.rs
+++ b/src/domain.rs
@@ -36,8 +36,8 @@ pub fn detect_domain(project_dir: &Path) -> DomainInfo {
     }
 
     // Framework detection from package.json — exact key matching
-    if let Ok(content) = std::fs::read_to_string(project_dir.join("package.json")) {
-        if let Ok(pkg) = serde_json::from_str::<serde_json::Value>(&content) {
+    if let Ok(content) = std::fs::read_to_string(project_dir.join("package.json"))
+        && let Ok(pkg) = serde_json::from_str::<serde_json::Value>(&content) {
             let deps = collect_dep_keys(&pkg);
             if deps.contains("next") {
                 frameworks.insert("nextjs".into());
@@ -55,7 +55,6 @@ pub fn detect_domain(project_dir: &Path) -> DomainInfo {
                 frameworks.insert("fastify".into());
             }
         }
-    }
 
     // Framework detection from pyproject.toml
     if let Ok(content) = std::fs::read_to_string(project_dir.join("pyproject.toml")) {
@@ -72,13 +71,11 @@ pub fn detect_domain(project_dir: &Path) -> DomainInfo {
     }
 
     // Django detection from manage.py
-    if project_dir.join("manage.py").exists() {
-        if let Ok(content) = std::fs::read_to_string(project_dir.join("manage.py")) {
-            if content.contains("django") {
+    if project_dir.join("manage.py").exists()
+        && let Ok(content) = std::fs::read_to_string(project_dir.join("manage.py"))
+            && content.contains("django") {
                 frameworks.insert("django".into());
             }
-        }
-    }
 
     // Terraform detection
     if project_dir.join(".terraform.lock.hcl").exists()
@@ -114,12 +111,11 @@ pub fn detect_domain(project_dir: &Path) -> DomainInfo {
             project_dir.join("configuration.yaml"),
             project_dir.join("configuration/configuration.yaml"),
         ] {
-            if let Ok(content) = std::fs::read_to_string(config_path) {
-                if has_yaml_top_level_key(&content, "homeassistant") {
+            if let Ok(content) = std::fs::read_to_string(config_path)
+                && has_yaml_top_level_key(&content, "homeassistant") {
                     frameworks.insert("home-assistant".into());
                     break;
                 }
-            }
         }
     }
 
@@ -152,33 +148,28 @@ pub fn detect_domain(project_dir: &Path) -> DomainInfo {
         if let Ok(entries) = std::fs::read_dir(project_dir.join("esphome")) {
             for entry in entries.flatten() {
                 let path = entry.path();
-                if path.extension().and_then(|e| e.to_str()) == Some("yaml") {
-                    if let Ok(content) = std::fs::read_to_string(&path) {
-                        if content.starts_with("esphome:") || content.contains("\nesphome:") {
+                if path.extension().and_then(|e| e.to_str()) == Some("yaml")
+                    && let Ok(content) = std::fs::read_to_string(&path)
+                        && (content.starts_with("esphome:") || content.contains("\nesphome:")) {
                             frameworks.insert("esphome".into());
                             break;
                         }
-                    }
-                }
             }
         }
     }
     // Also check root-level YAML files (flat layout)
-    if !frameworks.contains("esphome") {
-        if let Ok(entries) = std::fs::read_dir(project_dir) {
+    if !frameworks.contains("esphome")
+        && let Ok(entries) = std::fs::read_dir(project_dir) {
             for entry in entries.flatten() {
                 let path = entry.path();
-                if path.extension().and_then(|e| e.to_str()) == Some("yaml") {
-                    if let Ok(content) = std::fs::read_to_string(&path) {
-                        if content.starts_with("esphome:") || content.contains("\nesphome:") {
+                if path.extension().and_then(|e| e.to_str()) == Some("yaml")
+                    && let Ok(content) = std::fs::read_to_string(&path)
+                        && (content.starts_with("esphome:") || content.contains("\nesphome:")) {
                             frameworks.insert("esphome".into());
                             break;
                         }
-                    }
-                }
             }
         }
-    }
 
     let mut langs: Vec<String> = languages.into_iter().collect();
     let mut fws: Vec<String> = frameworks.into_iter().collect();

--- a/src/embeddings.rs
+++ b/src/embeddings.rs
@@ -30,7 +30,7 @@ impl LocalEmbedder {
     }
 
     pub fn embed_batch(&mut self, texts: &[String]) -> anyhow::Result<Vec<Vec<f32>>> {
-        Ok(self.model.embed(texts.to_vec(), None)?)
+        self.model.embed(texts, None)
     }
 }
 

--- a/src/feedback.rs
+++ b/src/feedback.rs
@@ -26,6 +26,7 @@ pub enum Verdict {
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
+#[derive(Default)]
 pub enum Provenance {
     Human,
     PostFix,               // verdict recorded after applying a fix (strongest signal)
@@ -46,14 +47,10 @@ pub enum Provenance {
         #[serde(default)]
         confidence: Option<f32>,
     },
+    #[default]
     Unknown,
 }
 
-impl Default for Provenance {
-    fn default() -> Self {
-        Provenance::Unknown
-    }
-}
 
 /// Discriminates `Verdict::Fp` entries by reason. Calibrator applies
 /// different decay/scope rules per kind. `Option<FpKind> = None` ↔
@@ -1369,7 +1366,7 @@ mod tests {
         // `confidence: None` may serialize as `null` OR be absent (if serde is
         // later configured with skip_serializing_if). Both are valid wire forms.
         assert!(
-            inner.get("confidence").map_or(true, |c| c.is_null()),
+            inner.get("confidence").is_none_or(|c| c.is_null()),
             "confidence must be null or absent, got {:?}",
             inner.get("confidence")
         );
@@ -2184,8 +2181,7 @@ mod tests {
                         // Padding inside `reason` keeps the JSON valid;
                         // distinct chars per thread make truncation
                         // detectable in failure messages.
-                        let pad: String = std::iter::repeat(if tid == 0 { 'A' } else { 'B' })
-                            .take(PAD_BYTES)
+                        let pad: String = std::iter::repeat_n(if tid == 0 { 'A' } else { 'B' }, PAD_BYTES)
                             .collect();
                         e.reason = format!("t{tid}-i{i}-{pad}");
                         store.record(&e).unwrap();

--- a/src/finding.rs
+++ b/src/finding.rs
@@ -137,6 +137,12 @@ pub struct FindingBuilder {
     inner: Finding,
 }
 
+impl Default for FindingBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl FindingBuilder {
     pub fn new() -> Self {
         Self {

--- a/src/hydration.rs
+++ b/src/hydration.rs
@@ -1,5 +1,9 @@
 use crate::parser::Language;
 
+/// Per-file changed line ranges extracted from a unified diff.
+/// Each entry maps a file path to a list of `(start_line, end_line)` ranges.
+pub type DiffRanges = Vec<(String, Vec<(u32, u32)>)>;
+
 /// Context gathered from AST for lines within a changed region.
 #[derive(Debug, Clone, Default)]
 pub struct HydrationContext {
@@ -178,6 +182,7 @@ fn import_kinds(lang: Language) -> Vec<&'static str> {
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 fn collect_definitions(
     node: &tree_sitter::Node,
     source: &str,
@@ -397,6 +402,7 @@ fn extract_imported_names(import_text: &str) -> Vec<String> {
     names
 }
 
+#[allow(clippy::too_many_arguments)]
 fn collect_calls_in_range(
     node: &tree_sitter::Node,
     source: &str,
@@ -460,6 +466,7 @@ fn collect_calls_in_range(
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 fn collect_type_refs_in_range(
     node: &tree_sitter::Node,
     source: &str,
@@ -597,19 +604,19 @@ fn collect_import_refs_in_range(
 
 /// Parse a unified diff to extract changed line ranges per file.
 /// Returns Vec<(file_path, Vec<(start_line, end_line)>)>
-pub fn parse_unified_diff(diff: &str) -> Vec<(String, Vec<(u32, u32)>)> {
+pub fn parse_unified_diff(diff: &str) -> DiffRanges {
     let mut results = Vec::new();
     let mut current_file: Option<String> = None;
     let mut current_ranges: Vec<(u32, u32)> = Vec::new();
 
     for line in diff.lines() {
-        if line.starts_with("+++ b/") {
+        if let Some(path) = line.strip_prefix("+++ b/") {
             // Save previous file
             if let Some(file) = current_file.take()
                 && !current_ranges.is_empty() {
                     results.push((file, std::mem::take(&mut current_ranges)));
                 }
-            current_file = Some(line[6..].to_string());
+            current_file = Some(path.to_string());
         } else if line.starts_with("@@ ") {
             // Parse @@ -old,count +new,count @@ format
             if let Some(plus_part) = line.split('+').nth(1) {

--- a/src/hydration.rs
+++ b/src/hydration.rs
@@ -192,23 +192,21 @@ fn collect_definitions(
     let line1 = node.start_position().row as u32 + 1;
     let line2 = node.end_position().row as u32 + 1;
 
-    if func_kinds.contains(&kind) {
-        if let Some(name_node) = node.child_by_field_name("name") {
+    if func_kinds.contains(&kind)
+        && let Some(name_node) = node.child_by_field_name("name") {
             let name = source[name_node.byte_range()].to_string();
             // Extract first line as signature
             let text = &source[node.byte_range()];
             let sig = text.lines().next().unwrap_or(text).to_string();
             funcs.push((name, sig, line1, line2));
         }
-    }
 
-    if type_kinds.contains(&kind) {
-        if let Some(name_node) = node.child_by_field_name("name") {
+    if type_kinds.contains(&kind)
+        && let Some(name_node) = node.child_by_field_name("name") {
             let name = source[name_node.byte_range()].to_string();
             let text = source[node.byte_range()].to_string();
             types.push((name, text));
         }
-    }
 
     if import_kinds_list.contains(&kind) {
         let text = source[node.byte_range()].to_string();
@@ -244,8 +242,8 @@ fn extract_imported_names(import_text: &str) -> Vec<String> {
 
     if text.starts_with("use ") {
         // Rust: handle grouped `use std::collections::{HashMap, BTreeSet}` first.
-        if let (Some(open), Some(close)) = (text.find('{'), text.rfind('}')) {
-            if open < close {
+        if let (Some(open), Some(close)) = (text.find('{'), text.rfind('}'))
+            && open < close {
                 let inner = &text[open + 1..close];
                 for part in inner.split(',') {
                     let part = part.trim();
@@ -275,7 +273,6 @@ fn extract_imported_names(import_text: &str) -> Vec<String> {
                 }
                 return names;
             }
-        }
         // Rust: last segment after ::, handle `as` aliases
         if let Some(last) = text.rsplit("::").next() {
             let name = last.trim().trim_end_matches(';');
@@ -390,7 +387,7 @@ fn extract_imported_names(import_text: &str) -> Vec<String> {
             let name = if let Some(after_as) = part.split(" as ").nth(1) {
                 after_as.trim()
             } else {
-                part.split('.').last().unwrap_or(part).trim()
+                part.split('.').next_back().unwrap_or(part).trim()
             };
             if !name.is_empty() {
                 names.push(name.to_string());
@@ -608,11 +605,10 @@ pub fn parse_unified_diff(diff: &str) -> Vec<(String, Vec<(u32, u32)>)> {
     for line in diff.lines() {
         if line.starts_with("+++ b/") {
             // Save previous file
-            if let Some(file) = current_file.take() {
-                if !current_ranges.is_empty() {
+            if let Some(file) = current_file.take()
+                && !current_ranges.is_empty() {
                     results.push((file, std::mem::take(&mut current_ranges)));
                 }
-            }
             current_file = Some(line[6..].to_string());
         } else if line.starts_with("@@ ") {
             // Parse @@ -old,count +new,count @@ format
@@ -621,8 +617,8 @@ pub fn parse_unified_diff(diff: &str) -> Vec<(String, Vec<(u32, u32)>)> {
                     .split(|c: char| !c.is_ascii_digit())
                     .filter(|s| !s.is_empty())
                     .collect();
-                if let Some(start_str) = nums.first() {
-                    if let Ok(s) = start_str.parse::<u32>() {
+                if let Some(start_str) = nums.first()
+                    && let Ok(s) = start_str.parse::<u32>() {
                         // Count is optional in unified diff format (defaults to 1).
                         // "@@ -10 +10 @@" means a single-line change at line 10.
                         let count = nums.get(1).and_then(|c| c.parse::<u32>().ok()).unwrap_or(1);
@@ -633,16 +629,14 @@ pub fn parse_unified_diff(diff: &str) -> Vec<(String, Vec<(u32, u32)>)> {
                             current_ranges.push((s, s + count - 1));
                         }
                     }
-                }
             }
         }
     }
     // Save last file
-    if let Some(file) = current_file {
-        if !current_ranges.is_empty() {
+    if let Some(file) = current_file
+        && !current_ranges.is_empty() {
             results.push((file, current_ranges));
         }
-    }
 
     results
 }
@@ -656,8 +650,8 @@ fn find_callers_of(
     all_funcs: &[(String, String, u32, u32)],
     callers: &mut Vec<String>,
 ) {
-    if call_kinds.contains(&node.kind()) {
-        if let Some(func_node) = node.child_by_field_name("function") {
+    if call_kinds.contains(&node.kind())
+        && let Some(func_node) = node.child_by_field_name("function") {
             let func_text = &source[func_node.byte_range()];
             let call_name = func_text
                 .rsplit('.')
@@ -672,15 +666,13 @@ fn find_callers_of(
                 // Find which function this call is inside
                 let call_line = node.start_position().row as u32 + 1;
                 for (fname, _, fstart, fend) in all_funcs {
-                    if fname != target_name && call_line >= *fstart && call_line <= *fend {
-                        if !callers.contains(fname) {
+                    if fname != target_name && call_line >= *fstart && call_line <= *fend
+                        && !callers.contains(fname) {
                             callers.push(fname.clone());
                         }
-                    }
                 }
             }
         }
-    }
 
     for i in 0..node.child_count() {
         if let Some(child) = node.child(i as u32) {

--- a/src/linter.rs
+++ b/src/linter.rs
@@ -64,7 +64,7 @@ pub fn detect_unconfigured_linters(project_dir: &Path, files: &[&Path]) -> Vec<L
     let count_by = |matches: fn(&str) -> bool| -> usize {
         files
             .iter()
-            .filter(|p| ext_of(p).as_deref().map_or(false, matches))
+            .filter(|p| ext_of(p).as_deref().is_some_and(matches))
             .count()
     };
 
@@ -136,11 +136,10 @@ pub fn detect_linters(project_dir: &Path) -> Vec<LinterKind> {
     // Ruff: pyproject.toml with [tool.ruff] or ruff.toml
     if project_dir.join("ruff.toml").exists() {
         linters.push(LinterKind::Ruff);
-    } else if let Ok(content) = std::fs::read_to_string(project_dir.join("pyproject.toml")) {
-        if content.contains("[tool.ruff]") {
+    } else if let Ok(content) = std::fs::read_to_string(project_dir.join("pyproject.toml"))
+        && content.contains("[tool.ruff]") {
             linters.push(LinterKind::Ruff);
         }
-    }
 
     // Clippy: Cargo.toml present
     if project_dir.join("Cargo.toml").exists() {

--- a/src/llm_client.rs
+++ b/src/llm_client.rs
@@ -42,8 +42,8 @@ pub fn parse_chat_response(json: &serde_json::Value) -> anyhow::Result<LlmTurnRe
         .and_then(|f| f.as_str())
         .unwrap_or("stop");
 
-    if let Some(tool_calls) = message.get("tool_calls").and_then(|tc| tc.as_array()) {
-        if !tool_calls.is_empty() {
+    if let Some(tool_calls) = message.get("tool_calls").and_then(|tc| tc.as_array())
+        && !tool_calls.is_empty() {
             // Error on any malformed entry rather than silently dropping it
             // via filter_map. A partial tool_calls vec leaves orphaned
             // assistant calls without matching tool responses, which most
@@ -80,7 +80,6 @@ pub fn parse_chat_response(json: &serde_json::Value) -> anyhow::Result<LlmTurnRe
             }
             return Ok(LlmTurnResult::ToolCalls(calls));
         }
-    }
 
     if finish_reason == "length" {
         anyhow::bail!("Response truncated (finish_reason=length)");
@@ -747,7 +746,7 @@ impl OpenAiClient {
     }
 
     fn needs_responses_api(model: &str) -> bool {
-        RESPONSES_API_MODELS.iter().any(|m| *m == model)
+        RESPONSES_API_MODELS.contains(&model)
     }
 
     async fn call_model(
@@ -995,17 +994,15 @@ impl OpenAiClient {
 
         let mut texts = Vec::new();
         for item in output {
-            if item["type"].as_str() == Some("message") {
-                if let Some(content) = item["content"].as_array() {
+            if item["type"].as_str() == Some("message")
+                && let Some(content) = item["content"].as_array() {
                     for block in content {
-                        if block["type"].as_str() == Some("output_text") {
-                            if let Some(text) = block["text"].as_str() {
+                        if block["type"].as_str() == Some("output_text")
+                            && let Some(text) = block["text"].as_str() {
                                 texts.push(text.to_string());
                             }
-                        }
                     }
                 }
-            }
         }
 
         if texts.is_empty() {
@@ -2391,7 +2388,7 @@ mod tests {
     #[test]
     fn jitter_unit_returns_value_in_zero_one() {
         let u = jitter_unit();
-        assert!(u >= 0.0 && u < 1.0, "got {u}");
+        assert!((0.0..1.0).contains(&u), "got {u}");
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -63,11 +63,10 @@ use pipeline::{LlmReviewer, PipelineConfig};
 /// override so integration tests can be hermetic. Falls back to
 /// `$HOME/.quorum`. Returns None if neither can be resolved.
 fn quorum_dir() -> Option<std::path::PathBuf> {
-    if let Ok(override_path) = std::env::var("QUORUM_HOME") {
-        if !override_path.is_empty() {
+    if let Ok(override_path) = std::env::var("QUORUM_HOME")
+        && !override_path.is_empty() {
             return Some(std::path::PathBuf::from(override_path));
         }
-    }
     std::env::var("HOME")
         .ok()
         .map(|h| std::path::PathBuf::from(h).join(".quorum"))
@@ -601,11 +600,10 @@ fn unicode_ok() -> bool {
     if std::env::var_os("NO_UNICODE").is_some() {
         return false;
     }
-    if let Some(term) = std::env::var_os("TERM") {
-        if term == "dumb" {
+    if let Some(term) = std::env::var_os("TERM")
+        && term == "dumb" {
             return false;
         }
-    }
     if let Ok(lang) = std::env::var("LANG") {
         return lang.to_uppercase().contains("UTF-8") || lang.to_uppercase().contains("UTF8");
     }
@@ -1078,8 +1076,8 @@ async fn run_review(opts: cli::ReviewOpts) -> i32 {
             progress.start_file(&file_display);
 
             // Deep review: agent loop with tool calling
-            if opts.deep {
-                if let Some(client) = llm_client.as_deref() {
+            if opts.deep
+                && let Some(client) = llm_client.as_deref() {
                     let project_root = deep_tool_root(file_path);
                     let tool_reg = tools::ToolRegistry::new(&project_root);
                     let agent_cfg = agent::AgentConfig::default();
@@ -1139,7 +1137,6 @@ async fn run_review(opts: cli::ReviewOpts) -> i32 {
                         }
                     }
                 }
-            }
 
             // Run pipeline: full (AST + LLM) for supported languages, LLM-only for others
             let review_result = if let Some(l) = lang {
@@ -1237,8 +1234,8 @@ async fn run_review(opts: cli::ReviewOpts) -> i32 {
                 let file_display = file_path.to_string_lossy().to_string();
 
                 // Deep review path
-                if deep {
-                    if let Some(ref client) = llm_client {
+                if deep
+                    && let Some(ref client) = llm_client {
                         let project_root = deep_tool_root(&file_path);
                         let tool_reg = tools::ToolRegistry::new(&project_root);
                         let agent_cfg = agent::AgentConfig::default();
@@ -1280,7 +1277,6 @@ async fn run_review(opts: cli::ReviewOpts) -> i32 {
                             }
                         }
                     }
-                }
 
                 // Standard review path
                 let llm_reviewer: Option<&dyn pipeline::LlmReviewer> =
@@ -1358,34 +1354,32 @@ async fn run_review(opts: cli::ReviewOpts) -> i32 {
         }
 
         // Output in file order (sequential -- no interleaving)
-        for result_opt in indexed_results.into_iter() {
-            if let Some((result, suppressed_findings)) = result_opt {
-                if !suppressed_findings.is_empty() {
-                    eprintln!(
-                        "Suppressed {} finding(s) in {}",
-                        suppressed_findings.len(),
-                        result.file_path
-                    );
-                }
-                if opts.show_suppressed {
-                    for (f, rule) in &suppressed_findings {
-                        eprint!("{}", suppress::format_suppressed_finding(f, rule));
-                    }
-                }
-                if use_compact {
-                    println!(
-                        "{}",
-                        output::format_compact_review(&result.file_path, &result.findings)
-                    );
-                } else if !use_json {
-                    print!(
-                        "{}",
-                        output::format_review(&result.file_path, &result.findings, &style)
-                    );
-                }
-                all_findings.extend(result.findings.clone());
-                file_results.push(result);
+        for (result, suppressed_findings) in indexed_results.into_iter().flatten() {
+            if !suppressed_findings.is_empty() {
+                eprintln!(
+                    "Suppressed {} finding(s) in {}",
+                    suppressed_findings.len(),
+                    result.file_path
+                );
             }
+            if opts.show_suppressed {
+                for (f, rule) in &suppressed_findings {
+                    eprint!("{}", suppress::format_suppressed_finding(f, rule));
+                }
+            }
+            if use_compact {
+                println!(
+                    "{}",
+                    output::format_compact_review(&result.file_path, &result.findings)
+                );
+            } else if !use_json {
+                print!(
+                    "{}",
+                    output::format_review(&result.file_path, &result.findings, &style)
+                );
+            }
+            all_findings.extend(result.findings.clone());
+            file_results.push(result);
         }
 
         if opts.parallel > 1 && file_results.len() > 1 {

--- a/src/main.rs
+++ b/src/main.rs
@@ -913,8 +913,10 @@ async fn run_review(opts: cli::ReviewOpts) -> i32 {
     };
 
     // Build calibrator config, loading data-driven thresholds if available.
-    let mut calibrator_config = calibrator::CalibratorConfig::default();
-    calibrator_config.trace_provenance = Some(trace_provenance);
+    let mut calibrator_config = calibrator::CalibratorConfig {
+        trace_provenance: Some(trace_provenance),
+        ..Default::default()
+    };
     let thresholds_path = qhome.join("calibrator_thresholds.toml");
     if let Some(tc) =
         quorum::threshold_config::ThresholdConfig::load_from(&thresholds_path.to_string_lossy())
@@ -1940,7 +1942,7 @@ fn run_feedback(opts: cli::FeedbackOpts) -> i32 {
         // a kind was specified that requires associated data (e.g.
         // compensating-control needs --fp-reference). Returns None silently
         // when verdict != fp; warn the user so the dropped flag is visible.
-        let fp_kind = match opts.into_fp_kind() {
+        let fp_kind = match opts.to_fp_kind() {
             Ok(k) => {
                 if opts.fp_kind.is_some() && k.is_none() {
                     tracing::warn!(
@@ -2217,9 +2219,11 @@ mod threshold_loading_tests {
         assert!(tc.is_some(), "TOML should load successfully");
         let tc = tc.unwrap();
 
-        let mut calibrator_config = calibrator::CalibratorConfig::default();
-        calibrator_config.suppress_threshold = tc.suppress.map(|p| p.threshold);
-        calibrator_config.boost_threshold = tc.boost.map(|p| p.threshold);
+        let calibrator_config = calibrator::CalibratorConfig {
+            suppress_threshold: tc.suppress.map(|p| p.threshold),
+            boost_threshold: tc.boost.map(|p| p.threshold),
+            ..Default::default()
+        };
 
         assert!(
             (calibrator_config.suppress_threshold.unwrap() - 0.30).abs() < 1e-9,

--- a/src/mcp/handler.rs
+++ b/src/mcp/handler.rs
@@ -489,7 +489,7 @@ impl ServerHandler for QuorumHandler {
             _ => return Err(CallToolError::unknown_tool(params.name)),
         };
 
-        result.map_err(|e| CallToolError::from_message(e))
+        result.map_err(CallToolError::from_message)
     }
 }
 

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -391,11 +391,10 @@ pub fn unicode_ok_default() -> bool {
     if std::env::var_os("NO_UNICODE").is_some() {
         return false;
     }
-    if let Some(term) = std::env::var_os("TERM") {
-        if term == "dumb" {
+    if let Some(term) = std::env::var_os("TERM")
+        && term == "dumb" {
             return false;
         }
-    }
     if let Ok(lang) = std::env::var("LANG") {
         return lang.to_uppercase().contains("UTF-8") || lang.to_uppercase().contains("UTF8");
     }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -29,11 +29,10 @@ impl Language {
 
     pub fn from_path(path: &Path) -> Option<Self> {
         // Check filename first for extensionless files (Dockerfile, Dockerfile.prod, etc.)
-        if let Some(name) = path.file_name().and_then(|n| n.to_str()) {
-            if name.to_lowercase().starts_with("dockerfile") {
+        if let Some(name) = path.file_name().and_then(|n| n.to_str())
+            && name.to_lowercase().starts_with("dockerfile") {
                 return Some(Language::Dockerfile);
             }
-        }
         path.extension()
             .and_then(|ext| ext.to_str())
             .and_then(Self::from_extension)
@@ -105,8 +104,8 @@ pub fn extract_functions(
             let node = cursor.node();
 
             // Standard named functions/methods
-            if kinds.contains(&node.kind()) {
-                if let Some(name_node) = node.child_by_field_name("name") {
+            if kinds.contains(&node.kind())
+                && let Some(name_node) = node.child_by_field_name("name") {
                     let name = &source[name_node.byte_range()];
                     functions.push(FunctionInfo {
                         name: name.to_string(),
@@ -114,14 +113,13 @@ pub fn extract_functions(
                         line_end: node.end_position().row as u32 + 1,
                     });
                 }
-            }
 
             // Arrow functions: const name = (...) => { ... }
             // Tree shape: lexical_declaration > variable_declarator[name, value=arrow_function]
-            if is_ts && node.kind() == "arrow_function" {
-                if let Some(parent) = node.parent() {
-                    if parent.kind() == "variable_declarator" {
-                        if let Some(name_node) = parent.child_by_field_name("name") {
+            if is_ts && node.kind() == "arrow_function"
+                && let Some(parent) = node.parent()
+                    && parent.kind() == "variable_declarator"
+                        && let Some(name_node) = parent.child_by_field_name("name") {
                             let name = &source[name_node.byte_range()];
                             functions.push(FunctionInfo {
                                 name: name.to_string(),
@@ -129,9 +127,6 @@ pub fn extract_functions(
                                 line_end: node.end_position().row as u32 + 1,
                             });
                         }
-                    }
-                }
-            }
         }
 
         // Iterative tree walk: down, right, or up

--- a/src/patterns.rs
+++ b/src/patterns.rs
@@ -1,6 +1,5 @@
 /// Canonical pattern vocabulary for normalizing findings.
 /// Maps diverse finding titles/descriptions to standard pattern names.
-
 /// Known patterns with keywords that identify them.
 const PATTERN_RULES: &[(&str, &[&str])] = &[
     (

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -131,7 +131,7 @@ pub struct PipelineConfig {
     pub calibrate: bool,
     pub feedback_store: Option<std::path::PathBuf>,
     /// Per-file changed line ranges from a unified diff (overrides full-file hydration)
-    pub diff_ranges: Option<Vec<(String, Vec<(u32, u32)>)>>,
+    pub diff_ranges: Option<hydration::DiffRanges>,
     /// Maximum number of lines to send to the LLM for review
     pub max_review_lines: usize,
     /// Framework overrides from CLI --framework flags
@@ -592,7 +592,7 @@ pub async fn review_file(
                     Some(
                         docs.iter()
                             .map(|d| {
-                                crate::context_enrichment::format_context_section(&[d.clone()])
+                                crate::context_enrichment::format_context_section(std::slice::from_ref(d))
                             })
                             .collect(),
                     )
@@ -1060,7 +1060,7 @@ pub async fn review_file_llm_only(
                     Some(
                         docs.iter()
                             .map(|d| {
-                                crate::context_enrichment::format_context_section(&[d.clone()])
+                                crate::context_enrichment::format_context_section(std::slice::from_ref(d))
                             })
                             .collect(),
                     )

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -1018,8 +1018,8 @@ pub async fn review_file_llm_only(
     // No local AST analysis — unsupported language
 
     // LLM review (if configured)
-    if let Some(reviewer) = llm {
-        if !pipeline_config.models.is_empty() {
+    if let Some(reviewer) = llm
+        && !pipeline_config.models.is_empty() {
             let redacted_code = redact::redact_secrets(source);
             let (review_code, truncation_notice) =
                 truncate_for_review(&redacted_code, pipeline_config.max_review_lines);
@@ -1134,7 +1134,6 @@ pub async fn review_file_llm_only(
                 }
             }
         }
-    }
 
     let merged = merge::merge_findings(all_sources, pipeline_config.similarity_threshold);
 

--- a/src/prompt_sanitize.rs
+++ b/src/prompt_sanitize.rs
@@ -61,7 +61,7 @@ pub fn defang_sandbox_tags(s: &str) -> String {
                 }
                 if k < bytes.len() && bytes[k] == b'>' {
                     let lower_name = name.to_ascii_lowercase();
-                    if SANDBOX_TAGS.iter().any(|t| *t == lower_name.as_str()) {
+                    if SANDBOX_TAGS.contains(&lower_name.as_str()) {
                         out.push_str("</\u{200B}");
                         out.push_str(name);
                         out.push('>');

--- a/src/review.rs
+++ b/src/review.rs
@@ -170,8 +170,8 @@ use crate::prompt_sanitize::{defang_sandbox_tags, pick_fence_for, sanitize_fence
 pub fn build_review_prompt(req: &ReviewRequest) -> String {
     let mut prompt = String::new();
 
-    if let Some(docs) = &req.framework_docs {
-        if !docs.is_empty() {
+    if let Some(docs) = &req.framework_docs
+        && !docs.is_empty() {
             prompt.push_str("<framework_docs>\n");
             for doc in docs {
                 prompt.push_str(&defang_sandbox_tags(doc));
@@ -179,7 +179,6 @@ pub fn build_review_prompt(req: &ReviewRequest) -> String {
             }
             prompt.push_str("</framework_docs>\n\n");
         }
-    }
 
     if let Some(ctx) = &req.hydration_context {
         let any_section = !ctx.callee_signatures.is_empty()
@@ -232,15 +231,14 @@ pub fn build_review_prompt(req: &ReviewRequest) -> String {
         }
     }
 
-    if let Some(precedents) = &req.feedback_precedents {
-        if !precedents.is_empty() {
+    if let Some(precedents) = &req.feedback_precedents
+        && !precedents.is_empty() {
             prompt.push_str("<historical_findings>\n");
             for p in precedents {
                 prompt.push_str(&format!("- {}\n", defang_sandbox_tags(p)));
             }
             prompt.push_str("</historical_findings>\n\n");
         }
-    }
 
     if let Some(ref notice) = req.truncation_notice {
         prompt.push_str(&format!(
@@ -346,25 +344,23 @@ pub fn parse_llm_response(json_str: &str, model_name: &str) -> anyhow::Result<Ve
     // that strategy 1 couldn't deserialize because of invalid JSON
     // escapes). Fall through to the sanitize-then-envelope retry
     // instead of returning an empty result.
-    if let Ok(findings) = try_parse_findings(&cleaned) {
-        if !findings.is_empty() || !payload_is_object {
+    if let Ok(findings) = try_parse_findings(&cleaned)
+        && (!findings.is_empty() || !payload_is_object) {
             return Ok(findings
                 .into_iter()
                 .map(|f| f.into_finding(model_name))
                 .collect());
         }
-    }
 
     // Strategy 3: sanitize invalid JSON escapes (LLMs emit \d, \s, etc.)
     let sanitized = sanitize_json_escapes(&cleaned);
-    if let Ok(findings) = try_parse_findings(&sanitized) {
-        if !findings.is_empty() || !payload_is_object {
+    if let Ok(findings) = try_parse_findings(&sanitized)
+        && (!findings.is_empty() || !payload_is_object) {
             return Ok(findings
                 .into_iter()
                 .map(|f| f.into_finding(model_name))
                 .collect());
         }
-    }
 
     // Strategy 4: same sanitize-then-envelope pass on the full payload.
     let sanitized_payload = sanitize_json_escapes(trimmed_payload.trim());
@@ -527,11 +523,10 @@ fn extract_json_array(text: &str) -> String {
             // would push depth negative, then the real `[` later in the response
             // would not satisfy `depth == 0`, and the array would be missed.
             depth -= 1;
-            if depth == 0 {
-                if let Some(s) = start {
+            if depth == 0
+                && let Some(s) = start {
                     return text[s..=i].to_string();
                 }
-            }
         }
     }
 

--- a/src/review_log.rs
+++ b/src/review_log.rs
@@ -313,13 +313,12 @@ impl ReviewLog {
     /// Append one record as a JSON line. Creates the file (and parent dir) if missing.
     pub fn record(&self, entry: &ReviewRecord) -> anyhow::Result<()> {
         use std::io::Write;
-        if let Some(parent) = self.path.parent() {
-            if !parent.as_os_str().is_empty() {
+        if let Some(parent) = self.path.parent()
+            && !parent.as_os_str().is_empty() {
                 std::fs::create_dir_all(parent).with_context(|| {
                     format!("Failed to create review log dir: {}", parent.display())
                 })?;
             }
-        }
         let mut file = std::fs::OpenOptions::new()
             .create(true)
             .append(true)
@@ -363,11 +362,10 @@ impl Iterator for ReviewLogIter {
 /// compact-mode sniffing in telemetry.rs. Priority order matters: more specific
 /// signals beat generic `AGENT`.
 pub fn detect_invoked_from(caller_override: Option<&str>) -> String {
-    if let Some(name) = caller_override {
-        if !name.is_empty() {
+    if let Some(name) = caller_override
+        && !name.is_empty() {
             return name.to_string();
         }
-    }
     if std::env::var_os("CLAUDE_CODE").is_some() {
         return "claude_code".to_string();
     }
@@ -377,13 +375,11 @@ pub fn detect_invoked_from(caller_override: Option<&str>) -> String {
     if std::env::var_os("GEMINI_CLI").is_some() {
         return "gemini_cli".to_string();
     }
-    if let Some(v) = std::env::var_os("AGENT") {
-        if let Some(s) = v.to_str() {
-            if !s.is_empty() {
+    if let Some(v) = std::env::var_os("AGENT")
+        && let Some(s) = v.to_str()
+            && !s.is_empty() {
                 return s.to_string();
             }
-        }
-    }
     use std::io::IsTerminal;
     if std::io::stdout().is_terminal() {
         "tty".to_string()
@@ -684,7 +680,7 @@ mod tests {
             let mut f = std::fs::File::create(&path).unwrap();
             writeln!(f, "{}", serde_json::to_string(&sample_record()).unwrap()).unwrap();
             writeln!(f, "{{ this is not json").unwrap();
-            writeln!(f, "").unwrap();
+            writeln!(f).unwrap();
             writeln!(f, "{}", serde_json::to_string(&sample_record()).unwrap()).unwrap();
         }
         let log = ReviewLog::new(path);

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -66,7 +66,7 @@ pub struct StatsReport {
 /// Take top-N slices by review volume. Ties resolved by insertion order
 /// (which reflects first-seen-in-log); stable enough for a highlight.
 fn take_top(mut slices: Vec<DimensionSlice>, n: usize) -> Vec<DimensionSlice> {
-    slices.sort_by(|a, b| b.n_reviews.cmp(&a.n_reviews));
+    slices.sort_by_key(|s| std::cmp::Reverse(s.n_reviews));
     slices.truncate(n);
     slices
 }

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -937,7 +937,7 @@ pub fn format_json(report: &StatsReport) -> anyhow::Result<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::path::PathBuf;
+    
     use tempfile::TempDir;
 
     fn make_review_log(

--- a/src/test_support.rs
+++ b/src/test_support.rs
@@ -94,17 +94,4 @@ pub mod fakes {
         }
     }
 
-    #[cfg(test)]
-    mod tests {
-        use super::*;
-
-        #[test]
-        fn fake_reviewer_empty_sequence_does_not_panic() {
-            let reviewer = FakeReviewer::sequence(vec![]);
-            // Calling review on empty sequence should not panic
-            let result = reviewer.review("prompt", "model", "system");
-            // Should either return an error or a sensible default, not panic
-            assert!(result.is_err() || result.is_ok());
-        }
-    }
 }

--- a/src/test_support.rs
+++ b/src/test_support.rs
@@ -78,20 +78,6 @@ pub mod fakes {
         }
     }
 
-    #[cfg(test)]
-    mod tests {
-        use super::*;
-
-        #[test]
-        fn fake_reviewer_empty_sequence_does_not_panic() {
-            let reviewer = FakeReviewer::sequence(vec![]);
-            // Calling review on empty sequence should not panic
-            let result = reviewer.review("prompt", "model", "system");
-            // Should either return an error or a sensible default, not panic
-            assert!(result.is_err() || result.is_ok());
-        }
-    }
-
     impl crate::agent::AgentReviewer for FakeAgentReviewer {
         fn chat_turn(
             &self,
@@ -105,6 +91,20 @@ pub mod fakes {
             } else {
                 Ok(crate::llm_client::LlmTurnResult::FinalContent("[]".into()))
             }
+        }
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+
+        #[test]
+        fn fake_reviewer_empty_sequence_does_not_panic() {
+            let reviewer = FakeReviewer::sequence(vec![]);
+            // Calling review on empty sequence should not panic
+            let result = reviewer.review("prompt", "model", "system");
+            // Should either return an error or a sensible default, not panic
+            assert!(result.is_err() || result.is_ok());
         }
     }
 }

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -230,8 +230,8 @@ impl ToolRegistry {
             if path.is_dir() {
                 self.grep_recursive(&path, pattern, glob, acc)?;
             } else if path.is_file() {
-                if let Some(g) = glob {
-                    if g != "*" {
+                if let Some(g) = glob
+                    && g != "*" {
                         let ext_match = g.trim_start_matches("*.");
                         if let Some(ext) = path.extension() {
                             if ext.to_string_lossy() != ext_match {
@@ -241,7 +241,6 @@ impl ToolRegistry {
                             continue;
                         }
                     }
-                }
                 if let Ok(content) = std::fs::read_to_string(&path) {
                     let rel = path.strip_prefix(&self.root).unwrap_or(&path);
                     for (i, line) in content.lines().enumerate() {
@@ -323,8 +322,8 @@ impl ToolRegistry {
                 self.list_recursive(&path, glob, acc)?;
             } else {
                 let rel = path.strip_prefix(&self.root).unwrap_or(&path);
-                if let Some(g) = glob {
-                    if g != "*" {
+                if let Some(g) = glob
+                    && g != "*" {
                         let ext = g.trim_start_matches("*.");
                         if let Some(file_ext) = path.extension() {
                             if file_ext.to_string_lossy() != ext {
@@ -334,7 +333,6 @@ impl ToolRegistry {
                             continue;
                         }
                     }
-                }
                 acc.push(rel.display().to_string());
             }
         }

--- a/tests/calibrate_backfill.rs
+++ b/tests/calibrate_backfill.rs
@@ -1,4 +1,3 @@
-use std::io::Write;
 
 /// Integration test for `quorum calibrate --backfill-paths --dry-run`.
 #[test]


### PR DESCRIPTION
## Summary

- Applied `cargo clippy --fix` for 146 mechanical lint fixes (collapsible_if: 129, useless_vec: 7, field_reassign_with_default auto-fixes, and 9 single-instance lints)
- Manually fixed 20 remaining lints: removed unused `lang` parameter from complexity analysis, renamed `into_fp_kind` to `to_fp_kind` (wrong_self_convention), extracted `DiffRanges` type alias, boxed `FastEmbedEmbedder` for large_enum_variant, converted 10 test configs to struct-update syntax
- Removed `continue-on-error: true` from CI clippy job — clippy is now a blocking gate

## Verification

- `cargo clippy --workspace --all-targets --locked -- -D warnings`: zero errors
- `cargo test --bin quorum`: 1273 passed, 0 failed
- `cargo build --release`: success

## Test plan

- [x] All 1273 existing tests pass (no new tests needed — all changes are semantics-preserving)
- [x] Clippy reports zero warnings on stable
- [x] Release build compiles
- [x] No `#[allow(clippy::...)]` without reasonable justification

Closes #214
Closes #182

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-chunk injection threshold tracking and escalation (Calibrator)
  * QUORUM_HOME environment variable support for custom state directory

* **Bug Fixes**
  * Improved diff parsing and import extraction for change-aware analysis
  * Better handling for non-unicode terminals

* **Refactor**
  * Many internal control‑flow and formatting cleanups with no behavioral changes

* **Behavior Change**
  * Provenance now defaults to Unknown (affects default provenance values)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->