### PR TITLE
style: apply rustfmt to clippy-introduced if-let chains

### DIFF
--- a/examples/compare_calibration.rs
+++ b/examples/compare_calibration.rs
@@ -22,9 +22,10 @@ fn load_entries(path: &std::path::Path) -> anyhow::Result<Vec<Entry>> {
             continue;
         }
         if let Ok(e) = serde_json::from_str::<Entry>(line)
-            && !e.finding_title.is_empty() {
-                out.push(e);
-            }
+            && !e.finding_title.is_empty()
+        {
+            out.push(e);
+        }
     }
     Ok(out)
 }

--- a/examples/compare_retrieval.rs
+++ b/examples/compare_retrieval.rs
@@ -24,9 +24,10 @@ fn load_entries(path: &std::path::Path) -> anyhow::Result<Vec<Entry>> {
             continue;
         }
         if let Ok(e) = serde_json::from_str::<Entry>(line)
-            && !e.finding_title.is_empty() {
-                out.push(e);
-            }
+            && !e.finding_title.is_empty()
+        {
+            out.push(e);
+        }
     }
     Ok(out)
 }

--- a/src/analysis.rs
+++ b/src/analysis.rs
@@ -193,15 +193,13 @@ fn is_in_test_context(node: &tree_sitter::Node, source: &str) -> bool {
     let mut current = node.parent();
     while let Some(parent) = current {
         // Check for #[cfg(test)] on mod items
-        if parent.kind() == "mod_item"
-            && has_attribute(&parent, source, "cfg(test)") {
-                return true;
-            }
+        if parent.kind() == "mod_item" && has_attribute(&parent, source, "cfg(test)") {
+            return true;
+        }
         // Check for #[test] on function items
-        if parent.kind() == "function_item"
-            && has_attribute(&parent, source, "test") {
-                return true;
-            }
+        if parent.kind() == "function_item" && has_attribute(&parent, source, "test") {
+            return true;
+        }
         current = parent.parent();
     }
     false
@@ -252,34 +250,37 @@ fn scan_insecure_rust(node: &tree_sitter::Node, source: &str, findings: &mut Vec
 
     // .unwrap() calls — tree-sitter-rust: call_expression with function=field_expression
     // Skip unwrap in test code (#[cfg(test)] modules, #[test] functions)
-    if node.kind() == "call_expression" && !is_in_test_context(node, source)
+    if node.kind() == "call_expression"
+        && !is_in_test_context(node, source)
         && let Some(func) = node.child_by_field_name("function")
-            && func.kind() == "field_expression"
-                && let Some(field) = func.child_by_field_name("field") {
-                    let field_name = &source[field.byte_range()];
-                    if field_name == "unwrap" {
-                        findings.push(Finding {
-                            id: crate::finding::new_finding_ulid(),
-                            title: "Use of `.unwrap()` may panic at runtime".into(),
-                            description: "Consider using `.expect()` with a message or proper error handling.".into(),
-                            severity: Severity::Low,
-                            category: "security".into(),
-                            source: Source::LocalAst,
-                            line_start: node.start_position().row as u32 + 1,
-                            line_end: node.end_position().row as u32 + 1,
-                            evidence: vec![],
-                            calibrator_action: None,
-                            similar_precedent: vec![],
-                            canonical_pattern: None,
-                            suggested_fix: None,
-                            based_on_excerpt: None,
-                            reasoning: None,
-                            confidence: None,
-                            cited_lines: None,
-                    grounding_status: None,
-                        });
-                    }
-                }
+        && func.kind() == "field_expression"
+        && let Some(field) = func.child_by_field_name("field")
+    {
+        let field_name = &source[field.byte_range()];
+        if field_name == "unwrap" {
+            findings.push(Finding {
+                id: crate::finding::new_finding_ulid(),
+                title: "Use of `.unwrap()` may panic at runtime".into(),
+                description: "Consider using `.expect()` with a message or proper error handling."
+                    .into(),
+                severity: Severity::Low,
+                category: "security".into(),
+                source: Source::LocalAst,
+                line_start: node.start_position().row as u32 + 1,
+                line_end: node.end_position().row as u32 + 1,
+                evidence: vec![],
+                calibrator_action: None,
+                similar_precedent: vec![],
+                canonical_pattern: None,
+                suggested_fix: None,
+                based_on_excerpt: None,
+                reasoning: None,
+                confidence: None,
+                cited_lines: None,
+                grounding_status: None,
+            });
+        }
+    }
 }
 
 fn scan_insecure_python(node: &tree_sitter::Node, source: &str, findings: &mut Vec<Finding>) {
@@ -370,15 +371,16 @@ fn scan_insecure_python(node: &tree_sitter::Node, source: &str, findings: &mut V
         if let Some(func) = node.child_by_field_name("function") {
             let func_text = &source[func.byte_range()];
             if (func_text.ends_with(".execute") || func_text.ends_with(".executemany"))
-                && let Some(args) = node.child_by_field_name("arguments") {
-                    // Check first argument for f-string or .format()
-                    if let Some(first_arg) = args.named_child(0) {
-                        let arg_kind = first_arg.kind();
-                        let arg_text = &source[first_arg.byte_range()];
-                        if arg_kind == "string"
-                            && (arg_text.starts_with("f\"") || arg_text.starts_with("f'"))
-                        {
-                            findings.push(Finding {
+                && let Some(args) = node.child_by_field_name("arguments")
+            {
+                // Check first argument for f-string or .format()
+                if let Some(first_arg) = args.named_child(0) {
+                    let arg_kind = first_arg.kind();
+                    let arg_text = &source[first_arg.byte_range()];
+                    if arg_kind == "string"
+                        && (arg_text.starts_with("f\"") || arg_text.starts_with("f'"))
+                    {
+                        findings.push(Finding {
                                 id: crate::finding::new_finding_ulid(),
                                 title: "Potential SQL injection via f-string in execute()".into(),
                                 description: "String interpolation in SQL queries allows injection. Use parameterized queries instead.".into(),
@@ -398,8 +400,8 @@ fn scan_insecure_python(node: &tree_sitter::Node, source: &str, findings: &mut V
                                 cited_lines: None,
                     grounding_status: None,
                             });
-                        } else if arg_text.contains(".format(") {
-                            findings.push(Finding {
+                    } else if arg_text.contains(".format(") {
+                        findings.push(Finding {
                                 id: crate::finding::new_finding_ulid(),
                                 title: "Potential SQL injection via .format() in execute()".into(),
                                 description: "String formatting in SQL queries allows injection. Use parameterized queries instead.".into(),
@@ -419,28 +421,28 @@ fn scan_insecure_python(node: &tree_sitter::Node, source: &str, findings: &mut V
                                 cited_lines: None,
                     grounding_status: None,
                             });
-                        }
                     }
                 }
+            }
         }
 
         // open() without explicit encoding
         if let Some(func) = node.child_by_field_name("function") {
             let func_name = &source[func.byte_range()];
             if func_name == "open"
-                && let Some(args) = node.child_by_field_name("arguments") {
-                    let args_text = &source[args.byte_range()];
-                    let binary_modes = [
-                        "'rb'", "\"rb\"", "'wb'", "\"wb\"", "'ab'", "\"ab\"", "'xb'", "\"xb\"",
-                        "'r+b'", "\"r+b\"", "'w+b'", "\"w+b\"", "'a+b'", "\"a+b\"", "'x+b'",
-                        "\"x+b\"", "'rb+'", "\"rb+\"", "'wb+'", "\"wb+\"", "'ab+'", "\"ab+\"",
-                        "'xb+'", "\"xb+\"",
-                    ];
-                    let is_binary = binary_modes.iter().any(|m| args_text.contains(m));
-                    let has_encoding =
-                        args_text.contains("encoding=") || args_text.contains("encoding =");
-                    if !is_binary && !has_encoding {
-                        findings.push(Finding {
+                && let Some(args) = node.child_by_field_name("arguments")
+            {
+                let args_text = &source[args.byte_range()];
+                let binary_modes = [
+                    "'rb'", "\"rb\"", "'wb'", "\"wb\"", "'ab'", "\"ab\"", "'xb'", "\"xb\"",
+                    "'r+b'", "\"r+b\"", "'w+b'", "\"w+b\"", "'a+b'", "\"a+b\"", "'x+b'", "\"x+b\"",
+                    "'rb+'", "\"rb+\"", "'wb+'", "\"wb+\"", "'ab+'", "\"ab+\"", "'xb+'", "\"xb+\"",
+                ];
+                let is_binary = binary_modes.iter().any(|m| args_text.contains(m));
+                let has_encoding =
+                    args_text.contains("encoding=") || args_text.contains("encoding =");
+                if !is_binary && !has_encoding {
+                    findings.push(Finding {
                             id: crate::finding::new_finding_ulid(),
                             title: "`open()` without explicit `encoding` parameter".into(),
                             description: "Without `encoding=`, open() uses the system default which varies by platform. Specify `encoding='utf-8'` for portable behavior.".into(),
@@ -460,8 +462,8 @@ fn scan_insecure_python(node: &tree_sitter::Node, source: &str, findings: &mut V
                             cited_lines: None,
                     grounding_status: None,
                         });
-                    }
                 }
+            }
         }
     }
 
@@ -494,12 +496,11 @@ fn scan_insecure_python(node: &tree_sitter::Node, source: &str, findings: &mut V
             None => true, // bare `except:`
             Some(t) => t == "Exception" || t == "BaseException",
         };
-        if is_catch_all
-            && let Some(body) = body_node {
-                let body_has_only_pass = body.named_child_count() == 1
-                    && body.named_child(0).map(|c| c.kind()) == Some("pass_statement");
-                if body_has_only_pass {
-                    findings.push(Finding {
+        if is_catch_all && let Some(body) = body_node {
+            let body_has_only_pass = body.named_child_count() == 1
+                && body.named_child(0).map(|c| c.kind()) == Some("pass_statement");
+            if body_has_only_pass {
+                findings.push(Finding {
                         id: crate::finding::new_finding_ulid(),
                         title: "Catch-all `except: pass` silently swallows errors".into(),
                         description: "Catching all exceptions with `pass` hides bugs. Log the error or catch a specific exception type.".into(),
@@ -519,60 +520,61 @@ fn scan_insecure_python(node: &tree_sitter::Node, source: &str, findings: &mut V
                         cited_lines: None,
                     grounding_status: None,
                     });
-                }
             }
+        }
     }
 
     // Hardcoded secrets: SECRET_KEY = "...", PASSWORD = "...", API_KEY = "..."
     if node.kind() == "assignment"
-        && let Some(left) = node.child_by_field_name("left") {
-            let var_name = source[left.byte_range()].to_uppercase();
-            let secret_names = [
-                "SECRET_KEY",
-                "SECRET",
-                "PASSWORD",
-                "PASSWD",
-                "API_KEY",
-                "APIKEY",
-                "AUTH_TOKEN",
-                "TOKEN",
-                "PRIVATE_KEY",
-            ];
-            if secret_names.iter().any(|s| var_name.contains(s))
-                && let Some(right) = node.child_by_field_name("right") {
-                    let right_kind = right.kind();
-                    let right_text = &source[right.byte_range()];
-                    // Only flag string literals that look like real secrets:
-                    // - Not empty, not None, not env lookups
-                    // - Longer than a typical key name (> 10 chars inside quotes)
-                    // - Contains mixed case, numbers, or special chars (not just lowercase words)
-                    // Guard: only slice into string content if it's actually a quoted string
-                    let inner_len = if right_text.len() > 2 {
-                        right_text.len() - 2
-                    } else {
-                        0
-                    };
-                    let inner = if right_text.len() > 2 {
-                        &right_text[1..right_text.len() - 1]
-                    } else {
-                        ""
-                    };
-                    let has_upper = inner.chars().any(|c| c.is_ascii_uppercase());
-                    let has_digit = inner.chars().any(|c| c.is_ascii_digit());
-                    let has_special = inner.chars().any(|c| matches!(c, '-' | '/' | '+' | '='));
-                    // Real secrets have mixed character classes (upper+lower, digits, special chars)
-                    // Plain lowercase_words or dotted.names are key names, not secrets
-                    let looks_like_secret =
-                        (has_upper || has_digit || has_special) && inner_len > 8;
-                    if (right_kind == "string" || right_kind == "concatenated_string")
-                        && inner_len > 3
-                        && looks_like_secret
-                        && !right_text.contains("os.environ")
-                        && !right_text.contains("getenv")
-                        && !inner.starts_with("http://")
-                        && !inner.starts_with("https://")
-                    {
-                        findings.push(Finding {
+        && let Some(left) = node.child_by_field_name("left")
+    {
+        let var_name = source[left.byte_range()].to_uppercase();
+        let secret_names = [
+            "SECRET_KEY",
+            "SECRET",
+            "PASSWORD",
+            "PASSWD",
+            "API_KEY",
+            "APIKEY",
+            "AUTH_TOKEN",
+            "TOKEN",
+            "PRIVATE_KEY",
+        ];
+        if secret_names.iter().any(|s| var_name.contains(s))
+            && let Some(right) = node.child_by_field_name("right")
+        {
+            let right_kind = right.kind();
+            let right_text = &source[right.byte_range()];
+            // Only flag string literals that look like real secrets:
+            // - Not empty, not None, not env lookups
+            // - Longer than a typical key name (> 10 chars inside quotes)
+            // - Contains mixed case, numbers, or special chars (not just lowercase words)
+            // Guard: only slice into string content if it's actually a quoted string
+            let inner_len = if right_text.len() > 2 {
+                right_text.len() - 2
+            } else {
+                0
+            };
+            let inner = if right_text.len() > 2 {
+                &right_text[1..right_text.len() - 1]
+            } else {
+                ""
+            };
+            let has_upper = inner.chars().any(|c| c.is_ascii_uppercase());
+            let has_digit = inner.chars().any(|c| c.is_ascii_digit());
+            let has_special = inner.chars().any(|c| matches!(c, '-' | '/' | '+' | '='));
+            // Real secrets have mixed character classes (upper+lower, digits, special chars)
+            // Plain lowercase_words or dotted.names are key names, not secrets
+            let looks_like_secret = (has_upper || has_digit || has_special) && inner_len > 8;
+            if (right_kind == "string" || right_kind == "concatenated_string")
+                && inner_len > 3
+                && looks_like_secret
+                && !right_text.contains("os.environ")
+                && !right_text.contains("getenv")
+                && !inner.starts_with("http://")
+                && !inner.starts_with("https://")
+            {
+                findings.push(Finding {
                             id: crate::finding::new_finding_ulid(),
                             title: format!("Hardcoded secret in `{}`", &source[left.byte_range()]),
                             description: "Secrets should be loaded from environment variables or a secrets manager, not hardcoded in source.".into(),
@@ -592,9 +594,9 @@ fn scan_insecure_python(node: &tree_sitter::Node, source: &str, findings: &mut V
                             cited_lines: None,
                     grounding_status: None,
                         });
-                    }
-                }
+            }
         }
+    }
 
     // Mutating collection while iterating
     if node.kind() == "for_statement" {
@@ -605,8 +607,9 @@ fn scan_insecure_python(node: &tree_sitter::Node, source: &str, findings: &mut V
             if right.kind() == "identifier" {
                 let iterable_name = &source[right.byte_range()];
                 if let Some(body) = node.child_by_field_name("body")
-                    && has_mutating_call(&body, source, iterable_name) {
-                        findings.push(Finding {
+                    && has_mutating_call(&body, source, iterable_name)
+                {
+                    findings.push(Finding {
                             id: crate::finding::new_finding_ulid(),
                             title: format!("Mutating `{}` while iterating over it", iterable_name),
                             description: "Modifying a collection while iterating over it leads to skipped elements or RuntimeError. Iterate over a copy instead.".into(),
@@ -626,7 +629,7 @@ fn scan_insecure_python(node: &tree_sitter::Node, source: &str, findings: &mut V
                             cited_lines: None,
                     grounding_status: None,
                         });
-                    }
+                }
             }
         }
     }
@@ -638,18 +641,20 @@ fn scan_insecure_python(node: &tree_sitter::Node, source: &str, findings: &mut V
         let mut exc_var: Option<&str> = None;
         for i in 0..node.child_count() {
             if let Some(child) = node.child(i as u32)
-                && child.kind() == "as_pattern" {
-                    // Look for as_pattern_target child which contains the identifier
-                    for j in 0..child.child_count() {
-                        if let Some(target) = child.child(j as u32)
-                            && target.kind() == "as_pattern_target"
-                                && let Some(ident) = target.child(0)
-                                    && ident.kind() == "identifier" {
-                                        exc_var = Some(&source[ident.byte_range()]);
-                                    }
+                && child.kind() == "as_pattern"
+            {
+                // Look for as_pattern_target child which contains the identifier
+                for j in 0..child.child_count() {
+                    if let Some(target) = child.child(j as u32)
+                        && target.kind() == "as_pattern_target"
+                        && let Some(ident) = target.child(0)
+                        && ident.kind() == "identifier"
+                    {
+                        exc_var = Some(&source[ident.byte_range()]);
                     }
-                    break;
                 }
+                break;
+            }
         }
         if let Some(var_name) = exc_var {
             // Look for return statements that expose the exception
@@ -687,9 +692,8 @@ fn scan_insecure_python(node: &tree_sitter::Node, source: &str, findings: &mut V
         // In tree-sitter-python, async functions have "async" as a preceding sibling or
         // the node text starts with "async"
         let func_text = &source[node.byte_range()];
-        if func_text.starts_with("async ")
-            && has_result_call(node, source) {
-                findings.push(Finding {
+        if func_text.starts_with("async ") && has_result_call(node, source) {
+            findings.push(Finding {
                     id: crate::finding::new_finding_ulid(),
                     title: "Blocking `.result()` call in async function".into(),
                     description: "Calling `.result()` on a future inside an async function blocks the event loop. Use `await` or run in an executor.".into(),
@@ -709,19 +713,20 @@ fn scan_insecure_python(node: &tree_sitter::Node, source: &str, findings: &mut V
                     cited_lines: None,
                     grounding_status: None,
                 });
-            }
+        }
     }
 
     // Mutable default arguments: def foo(x=[], y={})
     if node.kind() == "default_parameter"
-        && let Some(value) = node.child_by_field_name("value") {
-            let val_kind = value.kind();
-            if val_kind == "list" || val_kind == "dictionary" || val_kind == "set" {
-                let param_name = node
-                    .child_by_field_name("name")
-                    .map(|n| &source[n.byte_range()])
-                    .unwrap_or("parameter");
-                findings.push(Finding {
+        && let Some(value) = node.child_by_field_name("value")
+    {
+        let val_kind = value.kind();
+        if val_kind == "list" || val_kind == "dictionary" || val_kind == "set" {
+            let param_name = node
+                .child_by_field_name("name")
+                .map(|n| &source[n.byte_range()])
+                .unwrap_or("parameter");
+            findings.push(Finding {
                     id: crate::finding::new_finding_ulid(),
                     title: format!("Mutable default argument `{}`", param_name),
                     description: "Mutable default arguments are shared across calls and cause subtle bugs. Use None and initialize inside the function.".into(),
@@ -741,8 +746,8 @@ fn scan_insecure_python(node: &tree_sitter::Node, source: &str, findings: &mut V
                     cited_lines: None,
                     grounding_status: None,
                 });
-            }
         }
+    }
 }
 
 /// Check if a node tree contains a mutating method call on the given identifier.
@@ -751,21 +756,24 @@ fn has_mutating_call(node: &tree_sitter::Node, source: &str, target: &str) -> bo
 
     if node.kind() == "call"
         && let Some(func) = node.child_by_field_name("function")
-            && func.kind() == "attribute"
-                && let Some(obj) = func.child_by_field_name("object")
-                    && obj.kind() == "identifier" && &source[obj.byte_range()] == target
-                        && let Some(attr) = func.child_by_field_name("attribute") {
-                            let method = &source[attr.byte_range()];
-                            if mutating_methods.contains(&method) {
-                                return true;
-                            }
-                        }
+        && func.kind() == "attribute"
+        && let Some(obj) = func.child_by_field_name("object")
+        && obj.kind() == "identifier"
+        && &source[obj.byte_range()] == target
+        && let Some(attr) = func.child_by_field_name("attribute")
+    {
+        let method = &source[attr.byte_range()];
+        if mutating_methods.contains(&method) {
+            return true;
+        }
+    }
 
     for i in 0..node.child_count() {
         if let Some(child) = node.child(i as u32)
-            && has_mutating_call(&child, source, target) {
-                return true;
-            }
+            && has_mutating_call(&child, source, target)
+        {
+            return true;
+        }
     }
     false
 }
@@ -788,9 +796,10 @@ fn has_exception_in_return(node: &tree_sitter::Node, source: &str, var_name: &st
 
     for i in 0..node.child_count() {
         if let Some(child) = node.child(i as u32)
-            && has_exception_in_return(&child, source, var_name) {
-                return true;
-            }
+            && has_exception_in_return(&child, source, var_name)
+        {
+            return true;
+        }
     }
     false
 }
@@ -799,17 +808,19 @@ fn has_exception_in_return(node: &tree_sitter::Node, source: &str, var_name: &st
 fn has_result_call(node: &tree_sitter::Node, source: &str) -> bool {
     if node.kind() == "call"
         && let Some(func) = node.child_by_field_name("function")
-            && func.kind() == "attribute"
-                && let Some(attr) = func.child_by_field_name("attribute")
-                    && &source[attr.byte_range()] == "result" {
-                        return true;
-                    }
+        && func.kind() == "attribute"
+        && let Some(attr) = func.child_by_field_name("attribute")
+        && &source[attr.byte_range()] == "result"
+    {
+        return true;
+    }
 
     for i in 0..node.child_count() {
         if let Some(child) = node.child(i as u32)
-            && has_result_call(&child, source) {
-                return true;
-            }
+            && has_result_call(&child, source)
+        {
+            return true;
+        }
     }
     false
 }
@@ -880,15 +891,16 @@ fn yaml_value_has_safe_tag(value_node: &tree_sitter::Node, source: &str) -> bool
             // Recurse one more level (flow_node may contain tag)
             for j in 0..child.child_count() {
                 if let Some(gc) = child.child(j as u32)
-                    && gc.kind() == "tag" {
-                        let tag_text = &source[gc.byte_range()];
-                        if tag_text.starts_with("!secret")
-                            || tag_text.starts_with("!include")
-                            || tag_text.starts_with("!env_var")
-                        {
-                            return true;
-                        }
+                    && gc.kind() == "tag"
+                {
+                    let tag_text = &source[gc.byte_range()];
+                    if tag_text.starts_with("!secret")
+                        || tag_text.starts_with("!include")
+                        || tag_text.starts_with("!env_var")
+                    {
+                        return true;
                     }
+                }
             }
         }
     }
@@ -926,10 +938,11 @@ fn is_in_automation_context(node: &tree_sitter::Node, source: &str) -> bool {
             continue;
         }
         if c.kind() == "block_mapping_pair"
-            && let Some(key) = c.child_by_field_name("key") {
-                let key_text = source[key.byte_range()].trim();
-                return key_text == "automation" || key_text == "automation!";
-            }
+            && let Some(key) = c.child_by_field_name("key")
+        {
+            let key_text = source[key.byte_range()].trim();
+            return key_text == "automation" || key_text == "automation!";
+        }
         break;
     }
     false
@@ -941,9 +954,10 @@ fn collect_mapping_keys<'a>(node: &tree_sitter::Node, source: &'a str) -> Vec<&'
     for i in 0..node.child_count() {
         if let Some(child) = node.child(i as u32)
             && child.kind() == "block_mapping_pair"
-                && let Some(key) = child.child_by_field_name("key") {
-                    keys.push(source[key.byte_range()].trim());
-                }
+            && let Some(key) = child.child_by_field_name("key")
+        {
+            keys.push(source[key.byte_range()].trim());
+        }
     }
     keys
 }
@@ -958,17 +972,19 @@ fn yaml_value_is_empty(pair_node: &tree_sitter::Node, source: &str) -> bool {
         // Check if value has a block_sequence child with items
         for i in 0..value.child_count() {
             if let Some(child) = value.child(i as u32)
-                && child.kind() == "block_sequence" {
-                    let mut has_items = false;
-                    for j in 0..child.child_count() {
-                        if let Some(item) = child.child(j as u32)
-                            && item.kind() == "block_sequence_item" {
-                                has_items = true;
-                                break;
-                            }
+                && child.kind() == "block_sequence"
+            {
+                let mut has_items = false;
+                for j in 0..child.child_count() {
+                    if let Some(item) = child.child(j as u32)
+                        && item.kind() == "block_sequence_item"
+                    {
+                        has_items = true;
+                        break;
                     }
-                    return !has_items;
                 }
+                return !has_items;
+            }
         }
         false
     } else {
@@ -1023,12 +1039,13 @@ fn find_value_mapping<'a>(
     for i in 0..mapping_node.child_count() {
         if let Some(child) = mapping_node.child(i as u32)
             && child.kind() == "block_mapping_pair"
-                && let Some(key) = child.child_by_field_name("key")
-                    && source[key.byte_range()].trim() == key_name
-                        && let Some(value) = child.child_by_field_name("value") {
-                            // Walk through block_node wrappers to find block_mapping
-                            return find_block_mapping_in(&value);
-                        }
+            && let Some(key) = child.child_by_field_name("key")
+            && source[key.byte_range()].trim() == key_name
+            && let Some(value) = child.child_by_field_name("value")
+        {
+            // Walk through block_node wrappers to find block_mapping
+            return find_block_mapping_in(&value);
+        }
     }
     None
 }
@@ -1044,9 +1061,10 @@ fn find_block_mapping_in<'a>(node: &tree_sitter::Node<'a>) -> Option<tree_sitter
                 return Some(child);
             }
             if child.kind() == "block_node"
-                && let Some(found) = find_block_mapping_in(&child) {
-                    return Some(found);
-                }
+                && let Some(found) = find_block_mapping_in(&child)
+            {
+                return Some(found);
+            }
         }
     }
     None
@@ -1062,13 +1080,12 @@ fn scan_insecure_yaml(node: &tree_sitter::Node, source: &str, findings: &mut Vec
         for i in 0..node.child_count() {
             if let Some(child) = node.child(i as u32)
                 && child.kind() == "block_mapping_pair"
-                    && let Some(key) = child.child_by_field_name("key") {
-                        let key_text = source[key.byte_range()].trim();
-                        let key_line = key.start_position().row as u32 + 1;
-                        if let Some((_, first_line)) =
-                            seen_keys.iter().find(|(k, _)| *k == key_text)
-                        {
-                            findings.push(Finding {
+                && let Some(key) = child.child_by_field_name("key")
+            {
+                let key_text = source[key.byte_range()].trim();
+                let key_line = key.start_position().row as u32 + 1;
+                if let Some((_, first_line)) = seen_keys.iter().find(|(k, _)| *k == key_text) {
+                    findings.push(Finding {
                                 id: crate::finding::new_finding_ulid(),
                                 title: format!("Duplicate key `{}` in mapping", key_text),
                                 description: format!(
@@ -1091,10 +1108,10 @@ fn scan_insecure_yaml(node: &tree_sitter::Node, source: &str, findings: &mut Vec
                                 cited_lines: None,
                     grounding_status: None,
                             });
-                        } else {
-                            seen_keys.push((key_text, key_line));
-                        }
-                    }
+                } else {
+                    seen_keys.push((key_text, key_line));
+                }
+            }
         }
 
         // --- Tier 2: Automation-level checks ---
@@ -1190,12 +1207,13 @@ fn scan_insecure_yaml(node: &tree_sitter::Node, source: &str, findings: &mut Vec
             for i in 0..node.child_count() {
                 if let Some(child) = node.child(i as u32)
                     && child.kind() == "block_mapping_pair"
-                        && let Some(key) = child.child_by_field_name("key") {
-                            let key_text = source[key.byte_range()].trim();
-                            if (key_text == "triggers" || key_text == "actions")
-                                && yaml_value_is_empty(&child, source)
-                            {
-                                findings.push(Finding {
+                    && let Some(key) = child.child_by_field_name("key")
+                {
+                    let key_text = source[key.byte_range()].trim();
+                    if (key_text == "triggers" || key_text == "actions")
+                        && yaml_value_is_empty(&child, source)
+                    {
+                        findings.push(Finding {
                                     id: crate::finding::new_finding_ulid(),
                                     title: format!("Empty `{}:` in automation", key_text),
                                     description: format!(
@@ -1218,8 +1236,8 @@ fn scan_insecure_yaml(node: &tree_sitter::Node, source: &str, findings: &mut Vec
                                     cited_lines: None,
                     grounding_status: None,
                                 });
-                            }
-                        }
+                    }
+                }
             }
         }
 
@@ -1298,45 +1316,47 @@ fn scan_insecure_yaml(node: &tree_sitter::Node, source: &str, findings: &mut Vec
             // --- Tier 5b: Docker Compose checks ---
             // Detect docker-compose files by presence of top-level `services:` key.
             // Skip if `apiVersion` is present (excludes Kubernetes, CloudFormation, etc.).
-            if keys.contains(&"services") && !keys.contains(&"apiVersion")
-                && let Some(services_mapping) = find_value_mapping(node, source, "services") {
-                    // Iterate over each service defined under `services:`
-                    for i in 0..services_mapping.child_count() {
-                        if let Some(child) = services_mapping.child(i as u32)
-                            && child.kind() == "block_mapping_pair" {
-                                let svc_line = child.start_position().row as u32 + 1;
-                                let svc_end = child.end_position().row as u32 + 1;
-                                let svc_name = if let Some(key) = child.child_by_field_name("key") {
-                                    source[key.byte_range()].trim().to_string()
+            if keys.contains(&"services")
+                && !keys.contains(&"apiVersion")
+                && let Some(services_mapping) = find_value_mapping(node, source, "services")
+            {
+                // Iterate over each service defined under `services:`
+                for i in 0..services_mapping.child_count() {
+                    if let Some(child) = services_mapping.child(i as u32)
+                        && child.kind() == "block_mapping_pair"
+                    {
+                        let svc_line = child.start_position().row as u32 + 1;
+                        let svc_end = child.end_position().row as u32 + 1;
+                        let svc_name = if let Some(key) = child.child_by_field_name("key") {
+                            source[key.byte_range()].trim().to_string()
+                        } else {
+                            "unknown".to_string()
+                        };
+
+                        // Get the service's block_mapping (its config keys)
+                        let svc_mapping = if let Some(value) = child.child_by_field_name("value") {
+                            find_block_mapping_in(&value)
+                        } else {
+                            None
+                        };
+
+                        if let Some(ref svc_map) = svc_mapping {
+                            let svc_keys = collect_mapping_keys(svc_map, source);
+
+                            // Pattern: Docker Compose service missing no-new-privileges
+                            let has_no_new_privs = if svc_keys.contains(&"security_opt") {
+                                // Check if security_opt value contains no-new-privileges
+                                if let Some(value) = child.child_by_field_name("value") {
+                                    let svc_text = source[value.byte_range()].to_string();
+                                    svc_text.contains("no-new-privileges")
                                 } else {
-                                    "unknown".to_string()
-                                };
-
-                                // Get the service's block_mapping (its config keys)
-                                let svc_mapping =
-                                    if let Some(value) = child.child_by_field_name("value") {
-                                        find_block_mapping_in(&value)
-                                    } else {
-                                        None
-                                    };
-
-                                if let Some(ref svc_map) = svc_mapping {
-                                    let svc_keys = collect_mapping_keys(svc_map, source);
-
-                                    // Pattern: Docker Compose service missing no-new-privileges
-                                    let has_no_new_privs = if svc_keys.contains(&"security_opt") {
-                                        // Check if security_opt value contains no-new-privileges
-                                        if let Some(value) = child.child_by_field_name("value") {
-                                            let svc_text = source[value.byte_range()].to_string();
-                                            svc_text.contains("no-new-privileges")
-                                        } else {
-                                            false
-                                        }
-                                    } else {
-                                        false
-                                    };
-                                    if !has_no_new_privs {
-                                        findings.push(Finding {
+                                    false
+                                }
+                            } else {
+                                false
+                            };
+                            if !has_no_new_privs {
+                                findings.push(Finding {
                                             id: crate::finding::new_finding_ulid(),
                                             title: format!("Docker Compose service `{}` missing `no-new-privileges` security option", svc_name),
                                             description: "Without `security_opt: [no-new-privileges:true]`, containers can escalate privileges via setuid binaries.".into(),
@@ -1356,11 +1376,11 @@ fn scan_insecure_yaml(node: &tree_sitter::Node, source: &str, findings: &mut Vec
                                             cited_lines: None,
                     grounding_status: None,
                                         });
-                                    }
+                            }
 
-                                    // Pattern: Docker Compose service missing read_only
-                                    if !svc_keys.contains(&"read_only") {
-                                        findings.push(Finding {
+                            // Pattern: Docker Compose service missing read_only
+                            if !svc_keys.contains(&"read_only") {
+                                findings.push(Finding {
                                             id: crate::finding::new_finding_ulid(),
                                             title: format!("Docker Compose service `{}` has writable root filesystem", svc_name),
                                             description: "Without `read_only: true`, the container root filesystem is writable, which allows malicious payload download.".into(),
@@ -1380,167 +1400,167 @@ fn scan_insecure_yaml(node: &tree_sitter::Node, source: &str, findings: &mut Vec
                                             cited_lines: None,
                     grounding_status: None,
                                         });
-                                    }
-                                }
                             }
+                        }
                     }
                 }
+            }
         }
     }
 
     // --- Tier 1: Hardcoded secrets (on block_mapping_pair nodes) ---
     if node.kind() == "block_mapping_pair"
-        && let Some(key) = node.child_by_field_name("key") {
-            let key_text = source[key.byte_range()].trim().to_lowercase();
+        && let Some(key) = node.child_by_field_name("key")
+    {
+        let key_text = source[key.byte_range()].trim().to_lowercase();
 
-            if YAML_SECRET_KEY_PATTERNS
-                .iter()
-                .any(|p| key_text.contains(p))
-                && let Some(value) = node.child_by_field_name("value")
-                    && !yaml_value_has_safe_tag(&value, source) {
-                        let val_text = source[value.byte_range()].trim();
-                        if !val_text.is_empty() {
-                            findings.push(Finding {
-                                id: crate::finding::new_finding_ulid(),
-                                title: format!(
-                                    "Hardcoded secret in `{}`",
-                                    source[key.byte_range()].trim()
-                                ),
-                                description:
-                                    "Secrets should use `!secret` references, not hardcoded values."
-                                        .into(),
-                                severity: Severity::High,
-                                category: "security".into(),
-                                source: Source::LocalAst,
-                                line_start: line,
-                                line_end: end_line,
-                                evidence: vec![format!(
-                                    "{}: [REDACTED]",
-                                    source[key.byte_range()].trim()
-                                )],
-                                calibrator_action: None,
-                                similar_precedent: vec![],
-                                canonical_pattern: None,
-                                suggested_fix: None,
-                                based_on_excerpt: None,
-                                reasoning: None,
-                                confidence: None,
-                                cited_lines: None,
-                                grounding_status: None,
-                            });
+        if YAML_SECRET_KEY_PATTERNS
+            .iter()
+            .any(|p| key_text.contains(p))
+            && let Some(value) = node.child_by_field_name("value")
+            && !yaml_value_has_safe_tag(&value, source)
+        {
+            let val_text = source[value.byte_range()].trim();
+            if !val_text.is_empty() {
+                findings.push(Finding {
+                    id: crate::finding::new_finding_ulid(),
+                    title: format!("Hardcoded secret in `{}`", source[key.byte_range()].trim()),
+                    description: "Secrets should use `!secret` references, not hardcoded values."
+                        .into(),
+                    severity: Severity::High,
+                    category: "security".into(),
+                    source: Source::LocalAst,
+                    line_start: line,
+                    line_end: end_line,
+                    evidence: vec![format!("{}: [REDACTED]", source[key.byte_range()].trim())],
+                    calibrator_action: None,
+                    similar_precedent: vec![],
+                    canonical_pattern: None,
+                    suggested_fix: None,
+                    based_on_excerpt: None,
+                    reasoning: None,
+                    confidence: None,
+                    cited_lines: None,
+                    grounding_status: None,
+                });
+            }
+        }
+
+        // --- Tier 3: entity_id without domain ---
+        if key_text == "entity_id"
+            && let Some(value) = node.child_by_field_name("value")
+        {
+            let val_text = source[value.byte_range()].trim();
+            let mut is_list = false;
+            for i in 0..value.child_count() {
+                if let Some(child) = value.child(i as u32)
+                    && child.kind() == "block_sequence"
+                {
+                    is_list = true;
+                    for j in 0..child.child_count() {
+                        if let Some(item) = child.child(j as u32)
+                            && item.kind() == "block_sequence_item"
+                        {
+                            let item_text = source[item.byte_range()]
+                                .trim()
+                                .trim_start_matches("- ")
+                                .trim();
+                            if !item_text.is_empty() && !item_text.contains('.') {
+                                findings.push(Finding {
+                                    id: crate::finding::new_finding_ulid(),
+                                    title: "entity_id without domain prefix".into(),
+                                    description: format!(
+                                        "`{}` is missing a domain prefix (e.g. `sensor.{}`)",
+                                        item_text, item_text
+                                    ),
+                                    severity: Severity::High,
+                                    category: "bug".into(),
+                                    source: Source::LocalAst,
+                                    line_start: item.start_position().row as u32 + 1,
+                                    line_end: item.end_position().row as u32 + 1,
+                                    evidence: vec![],
+                                    calibrator_action: None,
+                                    similar_precedent: vec![],
+                                    canonical_pattern: None,
+                                    suggested_fix: None,
+                                    based_on_excerpt: None,
+                                    reasoning: None,
+                                    confidence: None,
+                                    cited_lines: None,
+                                    grounding_status: None,
+                                });
+                            }
                         }
                     }
-
-            // --- Tier 3: entity_id without domain ---
-            if key_text == "entity_id"
-                && let Some(value) = node.child_by_field_name("value") {
-                    let val_text = source[value.byte_range()].trim();
-                    let mut is_list = false;
-                    for i in 0..value.child_count() {
-                        if let Some(child) = value.child(i as u32)
-                            && child.kind() == "block_sequence" {
-                                is_list = true;
-                                for j in 0..child.child_count() {
-                                    if let Some(item) = child.child(j as u32)
-                                        && item.kind() == "block_sequence_item" {
-                                            let item_text = source[item.byte_range()]
-                                                .trim()
-                                                .trim_start_matches("- ")
-                                                .trim();
-                                            if !item_text.is_empty() && !item_text.contains('.') {
-                                                findings.push(Finding {
-                                                    id: crate::finding::new_finding_ulid(),
-                                                    title: "entity_id without domain prefix".into(),
-                                                    description: format!(
-                                                        "`{}` is missing a domain prefix (e.g. `sensor.{}`)",
-                                                        item_text, item_text
-                                                    ),
-                                                    severity: Severity::High,
-                                                    category: "bug".into(),
-                                                    source: Source::LocalAst,
-                                                    line_start: item.start_position().row as u32 + 1,
-                                                    line_end: item.end_position().row as u32 + 1,
-                                                    evidence: vec![],
-                                                    calibrator_action: None,
-                                                    similar_precedent: vec![],
-                                                    canonical_pattern: None,
-                                                    suggested_fix: None,
-                                                    based_on_excerpt: None,
-                                                    reasoning: None,
-                                                    confidence: None,
-                                                    cited_lines: None,
+                    break;
+                }
+            }
+            if !is_list && !val_text.is_empty() && !val_text.contains('.') {
+                findings.push(Finding {
+                    id: crate::finding::new_finding_ulid(),
+                    title: "entity_id without domain prefix".into(),
+                    description: format!(
+                        "`{}` is missing a domain prefix (e.g. `sensor.{}`)",
+                        val_text, val_text
+                    ),
+                    severity: Severity::High,
+                    category: "bug".into(),
+                    source: Source::LocalAst,
+                    line_start: line,
+                    line_end: end_line,
+                    evidence: vec![],
+                    calibrator_action: None,
+                    similar_precedent: vec![],
+                    canonical_pattern: None,
+                    suggested_fix: None,
+                    based_on_excerpt: None,
+                    reasoning: None,
+                    confidence: None,
+                    cited_lines: None,
                     grounding_status: None,
-                                                });
-                                            }
-                                        }
-                                }
-                                break;
-                            }
-                    }
-                    if !is_list && !val_text.is_empty() && !val_text.contains('.') {
-                        findings.push(Finding {
-                            id: crate::finding::new_finding_ulid(),
-                            title: "entity_id without domain prefix".into(),
-                            description: format!(
-                                "`{}` is missing a domain prefix (e.g. `sensor.{}`)",
-                                val_text, val_text
-                            ),
-                            severity: Severity::High,
-                            category: "bug".into(),
-                            source: Source::LocalAst,
-                            line_start: line,
-                            line_end: end_line,
-                            evidence: vec![],
-                            calibrator_action: None,
-                            similar_precedent: vec![],
-                            canonical_pattern: None,
-                            suggested_fix: None,
-                            based_on_excerpt: None,
-                            reasoning: None,
-                            confidence: None,
-                            cited_lines: None,
-                            grounding_status: None,
-                        });
-                    }
-                }
+                });
+            }
+        }
 
-            // --- Tier 3: service without domain ---
-            if key_text == "service"
-                && let Some(value) = node.child_by_field_name("value") {
-                    let val_text = source[value.byte_range()].trim();
-                    if !val_text.is_empty() && !val_text.contains('.') {
-                        findings.push(Finding {
-                            id: crate::finding::new_finding_ulid(),
-                            title: "service without domain prefix".into(),
-                            description: format!(
-                                "`{}` is missing a domain prefix (e.g. `light.{}`)",
-                                val_text, val_text
-                            ),
-                            severity: Severity::Medium,
-                            category: "bug".into(),
-                            source: Source::LocalAst,
-                            line_start: line,
-                            line_end: end_line,
-                            evidence: vec![],
-                            calibrator_action: None,
-                            similar_precedent: vec![],
-                            canonical_pattern: None,
-                            suggested_fix: None,
-                            based_on_excerpt: None,
-                            reasoning: None,
-                            confidence: None,
-                            cited_lines: None,
-                            grounding_status: None,
-                        });
-                    }
-                }
+        // --- Tier 3: service without domain ---
+        if key_text == "service"
+            && let Some(value) = node.child_by_field_name("value")
+        {
+            let val_text = source[value.byte_range()].trim();
+            if !val_text.is_empty() && !val_text.contains('.') {
+                findings.push(Finding {
+                    id: crate::finding::new_finding_ulid(),
+                    title: "service without domain prefix".into(),
+                    description: format!(
+                        "`{}` is missing a domain prefix (e.g. `light.{}`)",
+                        val_text, val_text
+                    ),
+                    severity: Severity::Medium,
+                    category: "bug".into(),
+                    source: Source::LocalAst,
+                    line_start: line,
+                    line_end: end_line,
+                    evidence: vec![],
+                    calibrator_action: None,
+                    similar_precedent: vec![],
+                    canonical_pattern: None,
+                    suggested_fix: None,
+                    based_on_excerpt: None,
+                    reasoning: None,
+                    confidence: None,
+                    cited_lines: None,
+                    grounding_status: None,
+                });
+            }
+        }
 
-            // --- Tier 4: Exposed 0.0.0.0 binding ---
-            if (key_text == "host" || key_text == "server_host" || key_text == "server")
-                && let Some(value) = node.child_by_field_name("value") {
-                    let val_text = source[value.byte_range()].trim();
-                    if val_text.contains("0.0.0.0") {
-                        findings.push(Finding {
+        // --- Tier 4: Exposed 0.0.0.0 binding ---
+        if (key_text == "host" || key_text == "server_host" || key_text == "server")
+            && let Some(value) = node.child_by_field_name("value")
+        {
+            let val_text = source[value.byte_range()].trim();
+            if val_text.contains("0.0.0.0") {
+                findings.push(Finding {
                             id: crate::finding::new_finding_ulid(),
                             title: "Server binding to 0.0.0.0 exposes all interfaces".into(),
                             description: "Binding to 0.0.0.0 makes the server accessible from any network interface. Use 127.0.0.1 for local-only access.".into(),
@@ -1560,15 +1580,18 @@ fn scan_insecure_yaml(node: &tree_sitter::Node, source: &str, findings: &mut Vec
                             cited_lines: None,
                     grounding_status: None,
                         });
-                    }
-                }
+            }
+        }
 
-            // --- Tier 4: URL with embedded credentials ---
-            if let Some(value) = node.child_by_field_name("value") {
-                let val_text = source[value.byte_range()].trim();
-                if !val_text.starts_with("!secret") && !val_text.starts_with("!include")
-                    && val_text.contains("://") && yaml_url_has_credentials(val_text) {
-                        findings.push(Finding {
+        // --- Tier 4: URL with embedded credentials ---
+        if let Some(value) = node.child_by_field_name("value") {
+            let val_text = source[value.byte_range()].trim();
+            if !val_text.starts_with("!secret")
+                && !val_text.starts_with("!include")
+                && val_text.contains("://")
+                && yaml_url_has_credentials(val_text)
+            {
+                findings.push(Finding {
                             id: crate::finding::new_finding_ulid(),
                             title: "URL contains embedded credentials".into(),
                             description: "URLs with embedded user:password credentials are a security risk. Use environment variables or secret references.".into(),
@@ -1588,9 +1611,9 @@ fn scan_insecure_yaml(node: &tree_sitter::Node, source: &str, findings: &mut Vec
                             cited_lines: None,
                     grounding_status: None,
                         });
-                    }
             }
         }
+    }
 
     // --- Tier 6: Jinja2 template patterns (on scalar values) ---
     if node.kind() == "plain_scalar"
@@ -1695,36 +1718,36 @@ fn scan_insecure_typescript(node: &tree_sitter::Node, source: &str, findings: &m
 
     // eval(), document.write(), console.log/debug calls
     if node.kind() == "call_expression"
-        && let Some(func) = node.child_by_field_name("function") {
-            let func_name = &source[func.byte_range()];
-            if func_name == "eval" {
-                findings.push(Finding {
-                    id: crate::finding::new_finding_ulid(),
-                    title: "Use of `eval()` is a code injection risk".into(),
-                    description:
-                        "`eval()` executes arbitrary code. Avoid using it with untrusted input."
-                            .into(),
-                    severity: Severity::Critical,
-                    category: "security".into(),
-                    source: Source::LocalAst,
-                    line_start: line,
-                    line_end: end_line,
-                    evidence: vec![],
-                    calibrator_action: None,
-                    similar_precedent: vec![],
-                    canonical_pattern: None,
-                    suggested_fix: None,
-                    based_on_excerpt: None,
-                    reasoning: None,
-                    confidence: None,
-                    cited_lines: None,
-                    grounding_status: None,
-                });
-            }
+        && let Some(func) = node.child_by_field_name("function")
+    {
+        let func_name = &source[func.byte_range()];
+        if func_name == "eval" {
+            findings.push(Finding {
+                id: crate::finding::new_finding_ulid(),
+                title: "Use of `eval()` is a code injection risk".into(),
+                description:
+                    "`eval()` executes arbitrary code. Avoid using it with untrusted input.".into(),
+                severity: Severity::Critical,
+                category: "security".into(),
+                source: Source::LocalAst,
+                line_start: line,
+                line_end: end_line,
+                evidence: vec![],
+                calibrator_action: None,
+                similar_precedent: vec![],
+                canonical_pattern: None,
+                suggested_fix: None,
+                based_on_excerpt: None,
+                reasoning: None,
+                confidence: None,
+                cited_lines: None,
+                grounding_status: None,
+            });
+        }
 
-            // document.write XSS
-            if func_name == "document.write" {
-                findings.push(Finding {
+        // document.write XSS
+        if func_name == "document.write" {
+            findings.push(Finding {
                     id: crate::finding::new_finding_ulid(),
                     title: "Use of `document.write()` is an XSS risk".into(),
                     description: "`document.write()` injects raw HTML into the page. Use DOM APIs or a framework's safe rendering instead.".into(),
@@ -1744,11 +1767,11 @@ fn scan_insecure_typescript(node: &tree_sitter::Node, source: &str, findings: &m
                     cited_lines: None,
                     grounding_status: None,
                 });
-            }
+        }
 
-            // console.log / console.debug debug artifacts
-            if func_name == "console.log" || func_name == "console.debug" {
-                findings.push(Finding {
+        // console.log / console.debug debug artifacts
+        if func_name == "console.log" || func_name == "console.debug" {
+            findings.push(Finding {
                     id: crate::finding::new_finding_ulid(),
                     title: format!("`{}` debug artifact left in code", func_name),
                     description: "Debug logging should be removed or replaced with a proper logging framework before production.".into(),
@@ -1768,39 +1791,40 @@ fn scan_insecure_typescript(node: &tree_sitter::Node, source: &str, findings: &m
                     cited_lines: None,
                     grounding_status: None,
                 });
-            }
         }
+    }
 
     // Hardcoded secrets in variable declarations
     if node.kind() == "variable_declarator"
-        && let Some(name_node) = node.child_by_field_name("name") {
-            let var_name = source[name_node.byte_range()].to_uppercase();
-            let secret_names = [
-                "SECRET_KEY",
-                "SECRET",
-                "PASSWORD",
-                "PASSWD",
-                "API_KEY",
-                "APIKEY",
-                "AUTH_TOKEN",
-                "TOKEN",
-                "PRIVATE_KEY",
-            ];
-            if secret_names.iter().any(|s| var_name.contains(s))
-                && let Some(value) = node.child_by_field_name("value") {
-                    let val_kind = value.kind();
-                    let val_text = &source[value.byte_range()];
-                    // Only flag string literals that look like real secrets
-                    if val_kind == "string" && val_text.len() > 2 {
-                        let inner_len = val_text.len() - 2;
-                        let inner = &val_text[1..val_text.len() - 1];
-                        let has_upper = inner.chars().any(|c| c.is_ascii_uppercase());
-                        let has_digit = inner.chars().any(|c| c.is_ascii_digit());
-                        let has_special = inner.chars().any(|c| matches!(c, '-' | '/' | '+' | '='));
-                        let looks_like_secret =
-                            (has_upper || has_digit || has_special) && inner_len > 8;
-                        if looks_like_secret && !val_text.contains("process.env") {
-                            findings.push(Finding {
+        && let Some(name_node) = node.child_by_field_name("name")
+    {
+        let var_name = source[name_node.byte_range()].to_uppercase();
+        let secret_names = [
+            "SECRET_KEY",
+            "SECRET",
+            "PASSWORD",
+            "PASSWD",
+            "API_KEY",
+            "APIKEY",
+            "AUTH_TOKEN",
+            "TOKEN",
+            "PRIVATE_KEY",
+        ];
+        if secret_names.iter().any(|s| var_name.contains(s))
+            && let Some(value) = node.child_by_field_name("value")
+        {
+            let val_kind = value.kind();
+            let val_text = &source[value.byte_range()];
+            // Only flag string literals that look like real secrets
+            if val_kind == "string" && val_text.len() > 2 {
+                let inner_len = val_text.len() - 2;
+                let inner = &val_text[1..val_text.len() - 1];
+                let has_upper = inner.chars().any(|c| c.is_ascii_uppercase());
+                let has_digit = inner.chars().any(|c| c.is_ascii_digit());
+                let has_special = inner.chars().any(|c| matches!(c, '-' | '/' | '+' | '='));
+                let looks_like_secret = (has_upper || has_digit || has_special) && inner_len > 8;
+                if looks_like_secret && !val_text.contains("process.env") {
+                    findings.push(Finding {
                                 id: crate::finding::new_finding_ulid(),
                                 title: format!("Hardcoded secret in `{}`", &source[name_node.byte_range()]),
                                 description: "Secrets should be loaded from environment variables or a secrets manager, not hardcoded in source.".into(),
@@ -1820,22 +1844,23 @@ fn scan_insecure_typescript(node: &tree_sitter::Node, source: &str, findings: &m
                                 cited_lines: None,
                     grounding_status: None,
                             });
-                        }
-                    }
                 }
+            }
         }
+    }
 
     // innerHTML / outerHTML XSS
     if node.kind() == "assignment_expression"
-        && let Some(left) = node.child_by_field_name("left") {
-            let left_text = &source[left.byte_range()];
-            if left_text.ends_with(".innerHTML") || left_text.ends_with(".outerHTML") {
-                let prop = if left_text.ends_with(".innerHTML") {
-                    "innerHTML"
-                } else {
-                    "outerHTML"
-                };
-                findings.push(Finding {
+        && let Some(left) = node.child_by_field_name("left")
+    {
+        let left_text = &source[left.byte_range()];
+        if left_text.ends_with(".innerHTML") || left_text.ends_with(".outerHTML") {
+            let prop = if left_text.ends_with(".innerHTML") {
+                "innerHTML"
+            } else {
+                "outerHTML"
+            };
+            findings.push(Finding {
                     id: crate::finding::new_finding_ulid(),
                     title: format!("Direct `{}` assignment is an XSS risk", prop),
                     description: format!("Setting `{}` with untrusted data enables XSS. Use `textContent` or a sanitization library.", prop),
@@ -1855,8 +1880,8 @@ fn scan_insecure_typescript(node: &tree_sitter::Node, source: &str, findings: &m
                     cited_lines: None,
                     grounding_status: None,
                 });
-            }
         }
+    }
 
     // `any` type annotation
     if node.kind() == "type_annotation" {
@@ -1888,59 +1913,60 @@ fn scan_insecure_typescript(node: &tree_sitter::Node, source: &str, findings: &m
 
     // Empty catch blocks that silently swallow errors
     if node.kind() == "catch_clause"
-        && let Some(body) = node.child_by_field_name("body") {
-            let has_statements = (0..body.named_child_count()).any(|i| {
-                body.named_child(i as u32)
-                    .map(|c| c.kind() != "comment" && c.kind() != "empty_statement")
-                    .unwrap_or(false)
+        && let Some(body) = node.child_by_field_name("body")
+    {
+        let has_statements = (0..body.named_child_count()).any(|i| {
+            body.named_child(i as u32)
+                .map(|c| c.kind() != "comment" && c.kind() != "empty_statement")
+                .unwrap_or(false)
+        });
+        if !has_statements {
+            findings.push(Finding {
+                id: crate::finding::new_finding_ulid(),
+                title: "Empty `catch` block silently swallows errors".into(),
+                description:
+                    "An empty catch block hides failures. Log the error, handle it, or rethrow."
+                        .into(),
+                severity: Severity::Medium,
+                category: "reliability".into(),
+                source: Source::LocalAst,
+                line_start: line,
+                line_end: end_line,
+                evidence: vec![source[node.byte_range()].chars().take(200).collect()],
+                calibrator_action: None,
+                similar_precedent: vec![],
+                canonical_pattern: None,
+                suggested_fix: None,
+                based_on_excerpt: None,
+                reasoning: None,
+                confidence: None,
+                cited_lines: None,
+                grounding_status: None,
             });
-            if !has_statements {
-                findings.push(Finding {
-                    id: crate::finding::new_finding_ulid(),
-                    title: "Empty `catch` block silently swallows errors".into(),
-                    description:
-                        "An empty catch block hides failures. Log the error, handle it, or rethrow."
-                            .into(),
-                    severity: Severity::Medium,
-                    category: "reliability".into(),
-                    source: Source::LocalAst,
-                    line_start: line,
-                    line_end: end_line,
-                    evidence: vec![source[node.byte_range()].chars().take(200).collect()],
-                    calibrator_action: None,
-                    similar_precedent: vec![],
-                    canonical_pattern: None,
-                    suggested_fix: None,
-                    based_on_excerpt: None,
-                    reasoning: None,
-                    confidence: None,
-                    cited_lines: None,
-                    grounding_status: None,
-                });
-            }
         }
+    }
 
     // Sync Node.js APIs inside async functions
     if node.kind() == "call_expression"
-        && let Some(func) = node.child_by_field_name("function") {
-            let func_name = &source[func.byte_range()];
-            let sync_apis = [
-                "readFileSync",
-                "writeFileSync",
-                "mkdirSync",
-                "existsSync",
-                "readdirSync",
-                "unlinkSync",
-                "appendFileSync",
-                "copyFileSync",
-                "renameSync",
-                "statSync",
-                "accessSync",
-            ];
-            for api in &sync_apis {
-                if func_name.ends_with(api)
-                    && is_in_async_function(node, source) {
-                        findings.push(Finding {
+        && let Some(func) = node.child_by_field_name("function")
+    {
+        let func_name = &source[func.byte_range()];
+        let sync_apis = [
+            "readFileSync",
+            "writeFileSync",
+            "mkdirSync",
+            "existsSync",
+            "readdirSync",
+            "unlinkSync",
+            "appendFileSync",
+            "copyFileSync",
+            "renameSync",
+            "statSync",
+            "accessSync",
+        ];
+        for api in &sync_apis {
+            if func_name.ends_with(api) && is_in_async_function(node, source) {
+                findings.push(Finding {
                             id: crate::finding::new_finding_ulid(),
                             title: format!("`{}` blocks the event loop in async function", api),
                             description: format!(
@@ -1963,26 +1989,28 @@ fn scan_insecure_typescript(node: &tree_sitter::Node, source: &str, findings: &m
                             cited_lines: None,
                     grounding_status: None,
                         });
-                        break;
-                    }
+                break;
             }
         }
+    }
 
     // Tautological .length >= 0 (always true for arrays/strings)
     if node.kind() == "binary_expression"
-        && let Some(op) = node.child_by_field_name("operator") {
-            let op_text = &source[op.byte_range()];
-            if op_text == ">="
-                && let Some(left) = node.child_by_field_name("left")
-                    && let Some(right) = node.child_by_field_name("right") {
-                        let right_text = &source[right.byte_range()];
-                        let is_length_access = left.kind() == "member_expression"
-                            && left
-                                .child_by_field_name("property")
-                                .map(|p| &source[p.byte_range()] == "length")
-                                .unwrap_or(false);
-                        if is_length_access && right_text.trim() == "0" {
-                            findings.push(Finding {
+        && let Some(op) = node.child_by_field_name("operator")
+    {
+        let op_text = &source[op.byte_range()];
+        if op_text == ">="
+            && let Some(left) = node.child_by_field_name("left")
+            && let Some(right) = node.child_by_field_name("right")
+        {
+            let right_text = &source[right.byte_range()];
+            let is_length_access = left.kind() == "member_expression"
+                && left
+                    .child_by_field_name("property")
+                    .map(|p| &source[p.byte_range()] == "length")
+                    .unwrap_or(false);
+            if is_length_access && right_text.trim() == "0" {
+                findings.push(Finding {
                                 id: crate::finding::new_finding_ulid(),
                                 title: "`.length >= 0` is always true".into(),
                                 description: "Array and string `.length` is always >= 0. This condition is tautological. Did you mean `.length > 0`?".into(),
@@ -2002,9 +2030,9 @@ fn scan_insecure_typescript(node: &tree_sitter::Node, source: &str, findings: &m
                                 cited_lines: None,
                     grounding_status: None,
                             });
-                        }
-                    }
+            }
         }
+    }
 
     // Non-null assertion operator (!)
     if node.kind() == "non_null_expression" {
@@ -2037,9 +2065,8 @@ fn scan_insecure_bash(node: &tree_sitter::Node, source: &str, findings: &mut Vec
     let end_line = node.end_position().row as u32 + 1;
 
     // B11: Missing shebang (root program node only)
-    if kind == "program"
-        && !source.starts_with("#!") {
-            findings.push(Finding {
+    if kind == "program" && !source.starts_with("#!") {
+        findings.push(Finding {
                 id: crate::finding::new_finding_ulid(),
                 title: "Script has no shebang line".into(),
                 description: "Add a shebang (e.g. #!/usr/bin/env bash) so the script runs with the intended interpreter.".into(),
@@ -2059,7 +2086,7 @@ fn scan_insecure_bash(node: &tree_sitter::Node, source: &str, findings: &mut Vec
                 cited_lines: None,
                     grounding_status: None,
             });
-        }
+    }
 
     // B4: Missing set -e (root program node only)
     if kind == "program" {
@@ -2067,13 +2094,14 @@ fn scan_insecure_bash(node: &tree_sitter::Node, source: &str, findings: &mut Vec
         let limit = node.child_count().min(10);
         for i in 0..limit {
             if let Some(child) = node.child(i as u32)
-                && child.kind() == "command" {
-                    let text = &source[child.byte_range()];
-                    if text.contains("set") && (text.contains("-e") || text.contains("errexit")) {
-                        found_set_e = true;
-                        break;
-                    }
+                && child.kind() == "command"
+            {
+                let text = &source[child.byte_range()];
+                if text.contains("set") && (text.contains("-e") || text.contains("errexit")) {
+                    found_set_e = true;
+                    break;
                 }
+            }
         }
         if !found_set_e {
             findings.push(Finding {
@@ -2102,66 +2130,66 @@ fn scan_insecure_bash(node: &tree_sitter::Node, source: &str, findings: &mut Vec
 
     // B2: eval usage
     if kind == "command"
-        && let Some(name_node) = node.child_by_field_name("name") {
-            let name = &source[name_node.byte_range()];
-            if name == "eval" {
-                findings.push(Finding {
-                    id: crate::finding::new_finding_ulid(),
-                    title: "Use of `eval` is a code injection risk".into(),
-                    description: "Avoid `eval` -- use arrays, printf, or parameter expansion instead.".into(),
-                    severity: Severity::High,
-                    category: "security".into(),
-                    source: Source::LocalAst,
-                    line_start: line,
-                    line_end: end_line,
-                    evidence: vec![source[node.byte_range()].chars().take(200).collect()],
-                    calibrator_action: None,
-                    similar_precedent: vec![],
-                    canonical_pattern: None,
-                    suggested_fix: None,
-                    based_on_excerpt: None,
-                    reasoning: None,
-                    confidence: None,
-                    cited_lines: None,
-                    grounding_status: None,
-                });
-            }
+        && let Some(name_node) = node.child_by_field_name("name")
+    {
+        let name = &source[name_node.byte_range()];
+        if name == "eval" {
+            findings.push(Finding {
+                id: crate::finding::new_finding_ulid(),
+                title: "Use of `eval` is a code injection risk".into(),
+                description: "Avoid `eval` -- use arrays, printf, or parameter expansion instead."
+                    .into(),
+                severity: Severity::High,
+                category: "security".into(),
+                source: Source::LocalAst,
+                line_start: line,
+                line_end: end_line,
+                evidence: vec![source[node.byte_range()].chars().take(200).collect()],
+                calibrator_action: None,
+                similar_precedent: vec![],
+                canonical_pattern: None,
+                suggested_fix: None,
+                based_on_excerpt: None,
+                reasoning: None,
+                confidence: None,
+                cited_lines: None,
+                grounding_status: None,
+            });
+        }
 
-            // B9: chmod 777
-            if name == "chmod" {
-                for i in 0..node.child_count() {
-                    if let Some(arg) = node.child(i as u32) {
-                        let text = &source[arg.byte_range()];
-                        if text == "777" {
-                            findings.push(Finding {
-                                id: crate::finding::new_finding_ulid(),
-                                title: "`chmod 777` grants world-writable permissions".into(),
-                                description: "Use more restrictive permissions (e.g. 755 or 700)."
-                                    .into(),
-                                severity: Severity::Medium,
-                                category: "security".into(),
-                                source: Source::LocalAst,
-                                line_start: line,
-                                line_end: end_line,
-                                evidence: vec![
-                                    source[node.byte_range()].chars().take(200).collect(),
-                                ],
-                                calibrator_action: None,
-                                similar_precedent: vec![],
-                                canonical_pattern: None,
-                                suggested_fix: None,
-                                based_on_excerpt: None,
-                                reasoning: None,
-                                confidence: None,
-                                cited_lines: None,
-                                grounding_status: None,
-                            });
-                            break;
-                        }
+        // B9: chmod 777
+        if name == "chmod" {
+            for i in 0..node.child_count() {
+                if let Some(arg) = node.child(i as u32) {
+                    let text = &source[arg.byte_range()];
+                    if text == "777" {
+                        findings.push(Finding {
+                            id: crate::finding::new_finding_ulid(),
+                            title: "`chmod 777` grants world-writable permissions".into(),
+                            description: "Use more restrictive permissions (e.g. 755 or 700)."
+                                .into(),
+                            severity: Severity::Medium,
+                            category: "security".into(),
+                            source: Source::LocalAst,
+                            line_start: line,
+                            line_end: end_line,
+                            evidence: vec![source[node.byte_range()].chars().take(200).collect()],
+                            calibrator_action: None,
+                            similar_precedent: vec![],
+                            canonical_pattern: None,
+                            suggested_fix: None,
+                            based_on_excerpt: None,
+                            reasoning: None,
+                            confidence: None,
+                            cited_lines: None,
+                            grounding_status: None,
+                        });
+                        break;
                     }
                 }
             }
         }
+    }
 
     // B3: curl|bash piping
     if kind == "pipeline" {
@@ -2169,64 +2197,61 @@ fn scan_insecure_bash(node: &tree_sitter::Node, source: &str, findings: &mut Vec
         for i in 0..node.child_count() {
             if let Some(child) = node.child(i as u32)
                 && child.kind() == "command"
-                    && let Some(name_node) = child.child_by_field_name("name") {
-                        let name = &source[name_node.byte_range()];
-                        if name == "curl" || name == "wget" {
-                            saw_curl = true;
-                        } else if saw_curl && (name == "bash" || name == "sh" || name == "zsh") {
-                            findings.push(Finding {
-                                id: crate::finding::new_finding_ulid(),
-                                title: "Piping curl/wget to shell executes untrusted remote code"
-                                    .into(),
-                                description: "Download to a file first, inspect it, then execute."
-                                    .into(),
-                                severity: Severity::Critical,
-                                category: "security".into(),
-                                source: Source::LocalAst,
-                                line_start: line,
-                                line_end: end_line,
-                                evidence: vec![
-                                    source[node.byte_range()].chars().take(200).collect(),
-                                ],
-                                calibrator_action: None,
-                                similar_precedent: vec![],
-                                canonical_pattern: None,
-                                suggested_fix: None,
-                                based_on_excerpt: None,
-                                reasoning: None,
-                                confidence: None,
-                                cited_lines: None,
-                                grounding_status: None,
-                            });
-                            break;
-                        }
-                    }
+                && let Some(name_node) = child.child_by_field_name("name")
+            {
+                let name = &source[name_node.byte_range()];
+                if name == "curl" || name == "wget" {
+                    saw_curl = true;
+                } else if saw_curl && (name == "bash" || name == "sh" || name == "zsh") {
+                    findings.push(Finding {
+                        id: crate::finding::new_finding_ulid(),
+                        title: "Piping curl/wget to shell executes untrusted remote code".into(),
+                        description: "Download to a file first, inspect it, then execute.".into(),
+                        severity: Severity::Critical,
+                        category: "security".into(),
+                        source: Source::LocalAst,
+                        line_start: line,
+                        line_end: end_line,
+                        evidence: vec![source[node.byte_range()].chars().take(200).collect()],
+                        calibrator_action: None,
+                        similar_precedent: vec![],
+                        canonical_pattern: None,
+                        suggested_fix: None,
+                        based_on_excerpt: None,
+                        reasoning: None,
+                        confidence: None,
+                        cited_lines: None,
+                        grounding_status: None,
+                    });
+                    break;
+                }
+            }
         }
     }
 
     // B5: Hardcoded secrets
     if kind == "variable_assignment"
-        && let Some(name_node) = node.child_by_field_name("name") {
-            let var_name = &source[name_node.byte_range()];
-            let upper = var_name.to_uppercase();
-            let is_secret_name = upper.contains("PASSWORD")
-                || upper.contains("API_KEY")
-                || upper.contains("SECRET")
-                || upper.contains("TOKEN")
-                || upper.contains("APIKEY")
-                || upper.contains("PRIVATE_KEY");
-            if is_secret_name
-                && let Some(value_node) = node.child_by_field_name("value") {
-                    let vkind = value_node.kind();
-                    // Skip command substitutions and expansions
-                    if vkind != "command_substitution"
-                        && vkind != "simple_expansion"
-                        && vkind != "expansion"
-                    {
-                        let val_text = &source[value_node.byte_range()];
-                        // Skip if value contains $ (env var reference)
-                        if !val_text.contains('$') {
-                            findings.push(Finding {
+        && let Some(name_node) = node.child_by_field_name("name")
+    {
+        let var_name = &source[name_node.byte_range()];
+        let upper = var_name.to_uppercase();
+        let is_secret_name = upper.contains("PASSWORD")
+            || upper.contains("API_KEY")
+            || upper.contains("SECRET")
+            || upper.contains("TOKEN")
+            || upper.contains("APIKEY")
+            || upper.contains("PRIVATE_KEY");
+        if is_secret_name && let Some(value_node) = node.child_by_field_name("value") {
+            let vkind = value_node.kind();
+            // Skip command substitutions and expansions
+            if vkind != "command_substitution"
+                && vkind != "simple_expansion"
+                && vkind != "expansion"
+            {
+                let val_text = &source[value_node.byte_range()];
+                // Skip if value contains $ (env var reference)
+                if !val_text.contains('$') {
+                    findings.push(Finding {
                                 id: crate::finding::new_finding_ulid(),
                                 title: format!("Hardcoded secret in shell variable `{}`", var_name),
                                 description: "Use environment variables or a secrets manager instead of hardcoded values.".into(),
@@ -2246,10 +2271,10 @@ fn scan_insecure_bash(node: &tree_sitter::Node, source: &str, findings: &mut Vec
                                 cited_lines: None,
                     grounding_status: None,
                             });
-                        }
-                    }
                 }
+            }
         }
+    }
 }
 
 fn scan_insecure_dockerfile(node: &tree_sitter::Node, source: &str, findings: &mut Vec<Finding>) {
@@ -2390,9 +2415,10 @@ fn tf_expr_is_variable_ref(attr_node: &tree_sitter::Node) -> bool {
     // expression child(0) is variable_expr for `var.xxx`
     if let Some(expr) = attr_node.child(2)
         && expr.kind() == "expression"
-            && let Some(first) = expr.child(0) {
-                return first.kind() == "variable_expr";
-            }
+        && let Some(first) = expr.child(0)
+    {
+        return first.kind() == "variable_expr";
+    }
     false
 }
 
@@ -2400,22 +2426,24 @@ fn tf_expr_is_variable_ref(attr_node: &tree_sitter::Node) -> bool {
 /// Returns the inner text (without quotes) if the value is a string literal.
 fn tf_expr_string_inner<'a>(attr_node: &tree_sitter::Node, source: &'a str) -> Option<&'a str> {
     if let Some(expr) = attr_node.child(2)
-        && expr.kind() == "expression" {
-            let text = source[expr.byte_range()].trim();
-            if text.starts_with('"') && text.ends_with('"') && text.len() >= 2 {
-                return Some(&text[1..text.len() - 1]);
-            }
+        && expr.kind() == "expression"
+    {
+        let text = source[expr.byte_range()].trim();
+        if text.starts_with('"') && text.ends_with('"') && text.len() >= 2 {
+            return Some(&text[1..text.len() - 1]);
         }
+    }
     None
 }
 
 /// Extract the numeric value from a Terraform attribute's expression.
 fn tf_expr_numeric(attr_node: &tree_sitter::Node, source: &str) -> Option<u16> {
     if let Some(expr) = attr_node.child(2)
-        && expr.kind() == "expression" {
-            let text = source[expr.byte_range()].trim();
-            return text.parse::<u16>().ok();
-        }
+        && expr.kind() == "expression"
+    {
+        let text = source[expr.byte_range()].trim();
+        return text.parse::<u16>().ok();
+    }
     None
 }
 
@@ -2428,17 +2456,18 @@ fn scan_insecure_terraform(node: &tree_sitter::Node, source: &str, findings: &mu
     // AST: attribute > identifier, =, expression > literal_value > string_lit
     if kind == "attribute"
         && let Some(name_node) = node.child(0)
-            && name_node.kind() == "identifier" {
-                let attr_name = source[name_node.byte_range()].to_uppercase();
-                if TF_SECRET_PATTERNS.iter().any(|p| attr_name.contains(p)) {
-                    // Only flag if value is a non-empty string literal (not a variable ref)
-                    if !tf_expr_is_variable_ref(node)
-                        && let Some(inner) = tf_expr_string_inner(node, source)
-                            && !inner.is_empty()
-                                && !inner.starts_with("${var.")
-                                && !inner.starts_with("${")
-                            {
-                                findings.push(Finding {
+        && name_node.kind() == "identifier"
+    {
+        let attr_name = source[name_node.byte_range()].to_uppercase();
+        if TF_SECRET_PATTERNS.iter().any(|p| attr_name.contains(p)) {
+            // Only flag if value is a non-empty string literal (not a variable ref)
+            if !tf_expr_is_variable_ref(node)
+                && let Some(inner) = tf_expr_string_inner(node, source)
+                && !inner.is_empty()
+                && !inner.starts_with("${var.")
+                && !inner.starts_with("${")
+            {
+                findings.push(Finding {
                                     id: crate::finding::new_finding_ulid(),
                                     title: format!("Hardcoded secret in `{}`", &source[name_node.byte_range()]),
                                     description: "Secrets should be loaded from variables or a secrets manager, not hardcoded in Terraform files.".into(),
@@ -2458,25 +2487,27 @@ fn scan_insecure_terraform(node: &tree_sitter::Node, source: &str, findings: &mu
                                     cited_lines: None,
                     grounding_status: None,
                                 });
-                            }
-                }
             }
+        }
+    }
 
     // T2: Wildcard IAM actions in object_elem (jsonencode-style HCL objects)
     // AST: object_elem > expression(variable_expr "Action"), =, expression(literal_value "\"*\"")
     if kind == "object_elem" {
         // Check if the key expression is "Action" (case-insensitive)
         if let Some(key_expr) = node.child(0)
-            && key_expr.kind() == "expression" {
-                let key_text = source[key_expr.byte_range()].trim();
-                if key_text.eq_ignore_ascii_case("Action") {
-                    // Check if value expression is "*"
-                    if let Some(val_expr) = node.child(2)
-                        && val_expr.kind() == "expression" {
-                            let val_text = source[val_expr.byte_range()].trim();
-                            let inner = val_text.trim_matches('"');
-                            if inner == "*" {
-                                findings.push(Finding {
+            && key_expr.kind() == "expression"
+        {
+            let key_text = source[key_expr.byte_range()].trim();
+            if key_text.eq_ignore_ascii_case("Action") {
+                // Check if value expression is "*"
+                if let Some(val_expr) = node.child(2)
+                    && val_expr.kind() == "expression"
+                {
+                    let val_text = source[val_expr.byte_range()].trim();
+                    let inner = val_text.trim_matches('"');
+                    if inner == "*" {
+                        findings.push(Finding {
                                     id: crate::finding::new_finding_ulid(),
                                     title: "Wildcard IAM action grants unrestricted permissions".into(),
                                     description: "Using `Action = \"*\"` grants all permissions. Follow the principle of least privilege.".into(),
@@ -2496,55 +2527,55 @@ fn scan_insecure_terraform(node: &tree_sitter::Node, source: &str, findings: &mu
                                     cited_lines: None,
                     grounding_status: None,
                                 });
-                            }
-                        }
+                    }
                 }
             }
+        }
     }
 
     // T3: Open security groups on sensitive ports
     // AST: block > identifier("ingress"), block_start, body > attribute(from_port), attribute(cidr_blocks), block_end
     if kind == "block"
         && let Some(first_child) = node.child(0)
-            && first_child.kind() == "identifier" && &source[first_child.byte_range()] == "ingress"
-            {
-                let mut has_open_cidr = false;
-                let mut port_is_sensitive = true;
-                let mut found_port = false;
+        && first_child.kind() == "identifier"
+        && &source[first_child.byte_range()] == "ingress"
+    {
+        let mut has_open_cidr = false;
+        let mut port_is_sensitive = true;
+        let mut found_port = false;
 
-                for i in 0..node.child_count() {
-                    if let Some(child) = node.child(i as u32)
-                        && child.kind() == "body" {
-                            for j in 0..child.child_count() {
-                                if let Some(attr) = child.child(j as u32)
-                                    && attr.kind() == "attribute"
-                                        && let Some(attr_name) = attr.child(0)
-                                            && attr_name.kind() == "identifier" {
-                                                let name = &source[attr_name.byte_range()];
-                                                if name == "cidr_blocks" {
-                                                    let attr_text = &source[attr.byte_range()];
-                                                    if attr_text.contains("0.0.0.0/0")
-                                                        || attr_text.contains("::/0")
-                                                    {
-                                                        has_open_cidr = true;
-                                                    }
-                                                }
-                                                if name == "from_port"
-                                                    && let Some(port) =
-                                                        tf_expr_numeric(&attr, source)
-                                                    {
-                                                        found_port = true;
-                                                        if port == 80 || port == 443 {
-                                                            port_is_sensitive = false;
-                                                        }
-                                                    }
-                                            }
+        for i in 0..node.child_count() {
+            if let Some(child) = node.child(i as u32)
+                && child.kind() == "body"
+            {
+                for j in 0..child.child_count() {
+                    if let Some(attr) = child.child(j as u32)
+                        && attr.kind() == "attribute"
+                        && let Some(attr_name) = attr.child(0)
+                        && attr_name.kind() == "identifier"
+                    {
+                        let name = &source[attr_name.byte_range()];
+                        if name == "cidr_blocks" {
+                            let attr_text = &source[attr.byte_range()];
+                            if attr_text.contains("0.0.0.0/0") || attr_text.contains("::/0") {
+                                has_open_cidr = true;
                             }
                         }
+                        if name == "from_port"
+                            && let Some(port) = tf_expr_numeric(&attr, source)
+                        {
+                            found_port = true;
+                            if port == 80 || port == 443 {
+                                port_is_sensitive = false;
+                            }
+                        }
+                    }
                 }
+            }
+        }
 
-                if has_open_cidr && port_is_sensitive && found_port {
-                    findings.push(Finding {
+        if has_open_cidr && port_is_sensitive && found_port {
+            findings.push(Finding {
                         id: crate::finding::new_finding_ulid(),
                         title: "Security group open to 0.0.0.0/0 on sensitive port".into(),
                         description: "Allowing ingress from 0.0.0.0/0 on non-HTTP(S) ports exposes the service to the internet. Restrict to specific CIDR ranges.".into(),
@@ -2564,8 +2595,8 @@ fn scan_insecure_terraform(node: &tree_sitter::Node, source: &str, findings: &mu
                         cited_lines: None,
                     grounding_status: None,
                     });
-                }
-            }
+        }
+    }
 }
 
 fn analyze_terraform_structure(tree: &tree_sitter::Tree, source: &str) -> Vec<Finding> {
@@ -2615,18 +2646,19 @@ fn analyze_terraform_structure(tree: &tree_sitter::Tree, source: &str) -> Vec<Fi
                         };
                         if attr_or_block.kind() == "attribute"
                             && let Some(id) = attr_or_block.child(0)
-                                && id.kind() == "identifier"
-                                    && &source[id.byte_range()] == "required_version"
-                                {
-                                    has_required_version = true;
-                                }
+                            && id.kind() == "identifier"
+                            && &source[id.byte_range()] == "required_version"
+                        {
+                            has_required_version = true;
+                        }
 
                         // S2: Check required_providers block
                         if attr_or_block.kind() == "block"
                             && hcl_block_type(attr_or_block, source) == Some("required_providers")
-                                && let Some(rp_body) = hcl_block_body(attr_or_block) {
-                                    check_required_providers(rp_body, source, &mut findings);
-                                }
+                            && let Some(rp_body) = hcl_block_body(attr_or_block)
+                        {
+                            check_required_providers(rp_body, source, &mut findings);
+                        }
                     }
                 }
             }
@@ -2665,9 +2697,10 @@ fn analyze_terraform_structure(tree: &tree_sitter::Tree, source: &str) -> Vec<Fi
 fn hcl_block_type<'a>(block: tree_sitter::Node, source: &'a str) -> Option<&'a str> {
     for i in 0..block.child_count() {
         if let Some(c) = block.child(i as u32)
-            && c.kind() == "identifier" {
-                return Some(&source[c.byte_range()]);
-            }
+            && c.kind() == "identifier"
+        {
+            return Some(&source[c.byte_range()]);
+        }
     }
     None
 }
@@ -2676,9 +2709,10 @@ fn hcl_block_type<'a>(block: tree_sitter::Node, source: &'a str) -> Option<&'a s
 fn hcl_block_body(block: tree_sitter::Node) -> Option<tree_sitter::Node> {
     for i in 0..block.child_count() {
         if let Some(c) = block.child(i as u32)
-            && c.kind() == "body" {
-                return Some(c);
-            }
+            && c.kind() == "body"
+        {
+            return Some(c);
+        }
     }
     None
 }
@@ -2790,9 +2824,10 @@ fn extract_identifier_from_expr<'a>(node: tree_sitter::Node, source: &'a str) ->
     }
     for i in 0..node.child_count() {
         if let Some(child) = node.child(i as u32)
-            && let Some(result) = extract_identifier_from_expr(child, source) {
-                return Some(result);
-            }
+            && let Some(result) = extract_identifier_from_expr(child, source)
+        {
+            return Some(result);
+        }
     }
     None
 }
@@ -3062,10 +3097,7 @@ mod tests {
         let source = "function simple() { return 42; }";
         let tree = parse(source, Language::TypeScript).unwrap();
         let func = tree.root_node().child(0).unwrap();
-        assert_eq!(
-            cyclomatic_complexity(&func, source),
-            1
-        );
+        assert_eq!(cyclomatic_complexity(&func, source), 1);
     }
 
     #[test]
@@ -3073,10 +3105,7 @@ mod tests {
         let source = "function check(x: boolean) { return x ? 1 : 0; }";
         let tree = parse(source, Language::TypeScript).unwrap();
         let func = tree.root_node().child(0).unwrap();
-        assert_eq!(
-            cyclomatic_complexity(&func, source),
-            2
-        );
+        assert_eq!(cyclomatic_complexity(&func, source), 2);
     }
 
     // -- analyze_complexity integration --

--- a/src/analytics.rs
+++ b/src/analytics.rs
@@ -437,12 +437,13 @@ pub fn compute_external_overlap(
             });
         row.findings += 1;
         if let Some(fid) = &e.finding_id
-            && let Some(qv) = quorum_verdicts.get(fid) {
-                row.overlap += 1;
-                if verdict_eq(qv, &e.verdict) {
-                    row.agree += 1;
-                }
+            && let Some(qv) = quorum_verdicts.get(fid)
+        {
+            row.overlap += 1;
+            if verdict_eq(qv, &e.verdict) {
+                row.agree += 1;
             }
+        }
     }
     let mut agents: Vec<AgentOverlap> = per_agent.into_values().collect();
     agents.sort_by(|a, b| {

--- a/src/calibrate.rs
+++ b/src/calibrate.rs
@@ -346,67 +346,77 @@ pub fn join_feedback_and_traces_with_options(
 
         // Tier 1: raw exact (title, file_path)
         if let Some(weights) = raw_map.get(&(title.clone(), fp.clone()))
-            && push_sample(&mut samples, weights, is_positive) {
-                stats.exact_raw += 1;
-                continue;
-            }
+            && push_sample(&mut samples, weights, is_positive)
+        {
+            stats.exact_raw += 1;
+            continue;
+        }
 
         // Tier 2: normalized exact (norm_title, file_path) -- skipped when fuzzy disabled
-        if !disable_fuzzy && !norm.is_empty()
+        if !disable_fuzzy
+            && !norm.is_empty()
             && let Some(weights) = norm_map.get(&(norm.clone(), fp.clone()))
-                && push_sample(&mut samples, weights, is_positive) {
-                    stats.exact_normalized += 1;
-                    continue;
-                }
+            && push_sample(&mut samples, weights, is_positive)
+        {
+            stats.exact_normalized += 1;
+            continue;
+        }
 
         // Tier 3: fuzzy same-file -- skipped when fuzzy disabled
         let mut fuzzy_below_threshold = false;
-        if !disable_fuzzy && !norm.is_empty() && !fp.is_empty()
-            && let Some(candidates) = file_traces.get(&fp) {
-                let mut best_score = 0.0_f64;
-                let mut second_best = 0.0_f64;
-                let mut best_weights: Option<&(f64, f64)> = None;
+        if !disable_fuzzy
+            && !norm.is_empty()
+            && !fp.is_empty()
+            && let Some(candidates) = file_traces.get(&fp)
+        {
+            let mut best_score = 0.0_f64;
+            let mut second_best = 0.0_f64;
+            let mut best_weights: Option<&(f64, f64)> = None;
 
-                for (cand_norm, weights) in candidates {
-                    let j = token_jaccard(&norm, cand_norm);
-                    if j > best_score {
-                        second_best = best_score;
-                        best_score = j;
-                        best_weights = Some(weights);
-                    } else if j > second_best {
-                        second_best = j;
-                    }
-                }
-
-                if best_score >= FUZZY_THRESHOLD {
-                    let margin = best_score - second_best;
-                    if margin >= FUZZY_AMBIGUITY_MARGIN {
-                        if let Some(weights) = best_weights
-                            && push_sample(&mut samples, weights, is_positive) {
-                                stats.fuzzy_same_file += 1;
-                                continue;
-                            }
-                    } else {
-                        stats.ambiguous_skipped += 1;
-                        continue;
-                    }
-                } else if !candidates.is_empty() {
-                    fuzzy_below_threshold = true;
+            for (cand_norm, weights) in candidates {
+                let j = token_jaccard(&norm, cand_norm);
+                if j > best_score {
+                    second_best = best_score;
+                    best_score = j;
+                    best_weights = Some(weights);
+                } else if j > second_best {
+                    second_best = j;
                 }
             }
+
+            if best_score >= FUZZY_THRESHOLD {
+                let margin = best_score - second_best;
+                if margin >= FUZZY_AMBIGUITY_MARGIN {
+                    if let Some(weights) = best_weights
+                        && push_sample(&mut samples, weights, is_positive)
+                    {
+                        stats.fuzzy_same_file += 1;
+                        continue;
+                    }
+                } else {
+                    stats.ambiguous_skipped += 1;
+                    continue;
+                }
+            } else if !candidates.is_empty() {
+                fuzzy_below_threshold = true;
+            }
+        }
 
         // Title-only fallback (raw first, then normalized -- normalized skipped when fuzzy disabled)
         if let Some(weights) = raw_title_only.get(&title)
-            && push_sample(&mut samples, weights, is_positive) {
-                stats.raw_title_only += 1;
-                continue;
-            }
-        if !disable_fuzzy && !norm.is_empty()
+            && push_sample(&mut samples, weights, is_positive)
+        {
+            stats.raw_title_only += 1;
+            continue;
+        }
+        if !disable_fuzzy
+            && !norm.is_empty()
             && let Some(weights) = norm_title_only.get(&norm)
-                && push_sample(&mut samples, weights, is_positive) {
-                    stats.normalized_title_only += 1;
-                    continue;
-                }
+            && push_sample(&mut samples, weights, is_positive)
+        {
+            stats.normalized_title_only += 1;
+            continue;
+        }
 
         if fuzzy_below_threshold {
             stats.below_threshold += 1;
@@ -575,25 +585,27 @@ pub fn backfill_file_paths(
 
         // Tier 1: exact title match
         if let Some(files) = exact_map.get(&title)
-            && files.len() == 1 {
-                let fp = files.iter().next().unwrap().clone();
-                trace["file_path"] = serde_json::Value::String(fp);
-                stats.feedback_exact += 1;
-                stats.total_backfilled += 1;
-                continue;
-            }
+            && files.len() == 1
+        {
+            let fp = files.iter().next().unwrap().clone();
+            trace["file_path"] = serde_json::Value::String(fp);
+            stats.feedback_exact += 1;
+            stats.total_backfilled += 1;
+            continue;
+        }
 
         // Tier 2: normalized title match
         let norm = normalize_title(&title);
         if !norm.is_empty()
             && let Some(files) = norm_map.get(&norm)
-                && files.len() == 1 {
-                    let fp = files.iter().next().unwrap().clone();
-                    trace["file_path"] = serde_json::Value::String(fp);
-                    stats.feedback_normalized += 1;
-                    stats.total_backfilled += 1;
-                    continue;
-                }
+            && files.len() == 1
+        {
+            let fp = files.iter().next().unwrap().clone();
+            trace["file_path"] = serde_json::Value::String(fp);
+            stats.feedback_normalized += 1;
+            stats.total_backfilled += 1;
+            continue;
+        }
 
         // Tier 3: precedent inference
         if let Some(precs) = trace.get("matched_precedents").and_then(|v| v.as_array()) {

--- a/src/calibrator.rs
+++ b/src/calibrator.rs
@@ -2207,12 +2207,7 @@ mod tests {
         assert_eq!(result1.suppressed, 1, "Human+auto FP should suppress");
 
         // 2 auto only: 0.5 + 0.5 = 1.0 < 1.5 threshold -> NOT suppress
-        let result2 = calibrate(
-            findings.clone(),
-            &[auto_fp.clone(), auto_fp],
-            &config,
-            "",
-        );
+        let result2 = calibrate(findings.clone(), &[auto_fp.clone(), auto_fp], &config, "");
         assert_eq!(
             result2.suppressed, 0,
             "2 auto FPs alone should not suppress (insufficient weight)"

--- a/src/category.rs
+++ b/src/category.rs
@@ -74,12 +74,7 @@ impl PartialEq<&str> for Category {
 
 impl From<String> for Category {
     fn from(s: String) -> Self {
-        match s
-            .to_lowercase()
-            .trim()
-            .replace([' ', '_'], "-")
-            .as_str()
-        {
+        match s.to_lowercase().trim().replace([' ', '_'], "-").as_str() {
             "security" | "safety" => Category::Security,
             "correctness" | "functional-bug" | "bug" => Category::Correctness,
             "logic" | "logic-error" => Category::Logic,

--- a/src/context/extract/astgrep_py.rs
+++ b/src/context/extract/astgrep_py.rs
@@ -428,9 +428,10 @@ fn item_signature(item_text: &str) -> String {
         }
         if b == b' '
             && let Some(&next) = bytes.get(i + 1)
-                && matches!(next, b')' | b']' | b'}' | b',') {
-                    tidied.pop();
-                }
+            && matches!(next, b')' | b']' | b'}' | b',')
+        {
+            tidied.pop();
+        }
         i += 1;
     }
     tidied

--- a/src/context/extract/dispatch.rs
+++ b/src/context/extract/dispatch.rs
@@ -448,9 +448,10 @@ fn first_match<'a>(patterns: &'a [(String, Pattern)], rel: &str) -> Option<&'a s
         // `**/docs/**` matches `docs/adr/001.md` at the root.
         if pat.as_str().starts_with("**/")
             && let Ok(inner) = Pattern::new(&pat.as_str()[3..])
-                && inner.matches(rel) {
-                    return Some(raw);
-                }
+            && inner.matches(rel)
+        {
+            return Some(raw);
+        }
     }
     None
 }

--- a/src/context/extract/dispatch_tests.rs
+++ b/src/context/extract/dispatch_tests.rs
@@ -104,15 +104,9 @@ fn extracts_mini_terraform_source() {
         qn.contains(&"aws_vpc.this"),
         "expected resource aws_vpc.this, got {qn:?}"
     );
-    assert!(
-        qn.contains(&"vpc_id"),
-        "expected output vpc_id, got {qn:?}"
-    );
+    assert!(qn.contains(&"vpc_id"), "expected output vpc_id, got {qn:?}");
     assert!(qn.contains(&"name"), "expected variable name");
-    assert!(
-        qn.contains(&"cidr_block"),
-        "expected variable cidr_block"
-    );
+    assert!(qn.contains(&"cidr_block"), "expected variable cidr_block");
     assert!(
         result
             .chunks

--- a/src/context/index/builder.rs
+++ b/src/context/index/builder.rs
@@ -267,10 +267,11 @@ impl<'a, C: Clock, E: Embedder> IndexBuilder<'a, C, E> {
 
     fn open_with_vec(db_path: &Path) -> rusqlite::Result<Connection> {
         if let Some(parent) = db_path.parent()
-            && !parent.as_os_str().is_empty() {
-                std::fs::create_dir_all(parent)
-                    .map_err(|e| rusqlite::Error::ToSqlConversionFailure(Box::new(e)))?;
-            }
+            && !parent.as_os_str().is_empty()
+        {
+            std::fs::create_dir_all(parent)
+                .map_err(|e| rusqlite::Error::ToSqlConversionFailure(Box::new(e)))?;
+        }
         ensure_vec_loaded();
         let conn = Connection::open(db_path)?;
         conn.pragma_update(None, "journal_mode", "WAL")?;

--- a/src/context/index/state.rs
+++ b/src/context/index/state.rs
@@ -83,12 +83,13 @@ impl IndexState {
     /// Write the state atomically (write to temp file, rename).
     pub fn save(&self, path: &Path) -> Result<(), StateError> {
         if let Some(parent) = path.parent()
-            && !parent.as_os_str().is_empty() {
-                std::fs::create_dir_all(parent).map_err(|source| StateError::Io {
-                    path: parent.to_path_buf(),
-                    source,
-                })?;
-            }
+            && !parent.as_os_str().is_empty()
+        {
+            std::fs::create_dir_all(parent).map_err(|source| StateError::Io {
+                path: parent.to_path_buf(),
+                source,
+            })?;
+        }
         let json = serde_json::to_string_pretty(self)?;
         let tmp = {
             let mut t = path.as_os_str().to_os_string();

--- a/src/context/retrieve/identifiers.rs
+++ b/src/context/retrieve/identifiers.rs
@@ -89,11 +89,10 @@ fn split_token(token: &str, out: &mut Vec<String>) {
         for (i, ch) in chars.iter().enumerate() {
             if i > 0 && ch.is_ascii_uppercase() {
                 let prev = chars[i - 1];
-                if (prev.is_ascii_lowercase() || prev.is_ascii_digit())
-                    && !current.is_empty() {
-                        push_if_valid(&current, out);
-                        current.clear();
-                    }
+                if (prev.is_ascii_lowercase() || prev.is_ascii_digit()) && !current.is_empty() {
+                    push_if_valid(&current, out);
+                    current.clear();
+                }
             }
             current.push(*ch);
         }

--- a/src/context/retrieve/vector_tests.rs
+++ b/src/context/retrieve/vector_tests.rs
@@ -239,7 +239,9 @@ fn mismatched_dim_returns_error_or_empty() {
     let q = vec![0.1f32; 128];
     let result = vec_search(&conn, &q, &Filters::default(), 3);
 
-    if let Ok(hits) = result { assert!(hits.is_empty()) }
+    if let Ok(hits) = result {
+        assert!(hits.is_empty())
+    }
 }
 
 #[test]

--- a/src/context_enrichment.rs
+++ b/src/context_enrichment.rs
@@ -209,9 +209,10 @@ pub fn enrich_for_review(
     for imp in imports {
         for name in normalize_import_to_dep_names(imp) {
             if let Some(dep) = deps.iter().find(|d| d.name == name)
-                && !import_matched.iter().any(|d| d.name == dep.name) {
-                    import_matched.push(dep);
-                }
+                && !import_matched.iter().any(|d| d.name == dep.name)
+            {
+                import_matched.push(dep);
+            }
         }
     }
 
@@ -458,9 +459,10 @@ impl<'a> ContextFetcher for CachedContextFetcher<'a> {
         let now = (self.now)();
         if let Ok(mut cache) = self.resolve_cache.lock()
             && let Some(entry) = cache.get(name)
-                && now.duration_since(entry.cached_at) < self.resolve_ttl {
-                    return entry.result.clone();
-                }
+            && now.duration_since(entry.cached_at) < self.resolve_ttl
+        {
+            return entry.result.clone();
+        }
         let result = self.inner.resolve_library(name);
         if let Ok(mut cache) = self.resolve_cache.lock() {
             // LruCache::put auto-evicts the LRU entry at capacity — preserves
@@ -481,9 +483,10 @@ impl<'a> ContextFetcher for CachedContextFetcher<'a> {
         let key = (library_id.to_string(), query.to_string(), max_tokens);
 
         if let Ok(mut cache) = self.query_cache.lock()
-            && let Some(cached) = cache.get(&key) {
-                return cached.clone();
-            }
+            && let Some(cached) = cache.get(&key)
+        {
+            return cached.clone();
+        }
 
         let result = self.inner.query_docs(library_id, query, max_tokens);
 
@@ -628,9 +631,10 @@ impl ContextFetcher for Context7HttpFetcher {
         // Context7 API may return plain text/markdown or JSON
         if let Ok(json) = serde_json::from_str::<serde_json::Value>(&body_text) {
             if let Some(content) = json["content"].as_str()
-                && !content.is_empty() {
-                    return Some(content.to_string());
-                }
+                && !content.is_empty()
+            {
+                return Some(content.to_string());
+            }
             if let Some(snippets) = json["snippets"].as_array() {
                 let combined: String = snippets
                     .iter()

--- a/src/domain.rs
+++ b/src/domain.rs
@@ -37,24 +37,25 @@ pub fn detect_domain(project_dir: &Path) -> DomainInfo {
 
     // Framework detection from package.json — exact key matching
     if let Ok(content) = std::fs::read_to_string(project_dir.join("package.json"))
-        && let Ok(pkg) = serde_json::from_str::<serde_json::Value>(&content) {
-            let deps = collect_dep_keys(&pkg);
-            if deps.contains("next") {
-                frameworks.insert("nextjs".into());
-            }
-            if deps.contains("react") && !frameworks.contains("nextjs") {
-                frameworks.insert("react".into());
-            }
-            if deps.contains("vue") {
-                frameworks.insert("vue".into());
-            }
-            if deps.contains("express") {
-                frameworks.insert("express".into());
-            }
-            if deps.contains("fastify") {
-                frameworks.insert("fastify".into());
-            }
+        && let Ok(pkg) = serde_json::from_str::<serde_json::Value>(&content)
+    {
+        let deps = collect_dep_keys(&pkg);
+        if deps.contains("next") {
+            frameworks.insert("nextjs".into());
         }
+        if deps.contains("react") && !frameworks.contains("nextjs") {
+            frameworks.insert("react".into());
+        }
+        if deps.contains("vue") {
+            frameworks.insert("vue".into());
+        }
+        if deps.contains("express") {
+            frameworks.insert("express".into());
+        }
+        if deps.contains("fastify") {
+            frameworks.insert("fastify".into());
+        }
+    }
 
     // Framework detection from pyproject.toml
     if let Ok(content) = std::fs::read_to_string(project_dir.join("pyproject.toml")) {
@@ -73,9 +74,10 @@ pub fn detect_domain(project_dir: &Path) -> DomainInfo {
     // Django detection from manage.py
     if project_dir.join("manage.py").exists()
         && let Ok(content) = std::fs::read_to_string(project_dir.join("manage.py"))
-            && content.contains("django") {
-                frameworks.insert("django".into());
-            }
+        && content.contains("django")
+    {
+        frameworks.insert("django".into());
+    }
 
     // Terraform detection
     if project_dir.join(".terraform.lock.hcl").exists()
@@ -112,10 +114,11 @@ pub fn detect_domain(project_dir: &Path) -> DomainInfo {
             project_dir.join("configuration/configuration.yaml"),
         ] {
             if let Ok(content) = std::fs::read_to_string(config_path)
-                && has_yaml_top_level_key(&content, "homeassistant") {
-                    frameworks.insert("home-assistant".into());
-                    break;
-                }
+                && has_yaml_top_level_key(&content, "homeassistant")
+            {
+                frameworks.insert("home-assistant".into());
+                break;
+            }
         }
     }
 
@@ -150,26 +153,29 @@ pub fn detect_domain(project_dir: &Path) -> DomainInfo {
                 let path = entry.path();
                 if path.extension().and_then(|e| e.to_str()) == Some("yaml")
                     && let Ok(content) = std::fs::read_to_string(&path)
-                        && (content.starts_with("esphome:") || content.contains("\nesphome:")) {
-                            frameworks.insert("esphome".into());
-                            break;
-                        }
+                    && (content.starts_with("esphome:") || content.contains("\nesphome:"))
+                {
+                    frameworks.insert("esphome".into());
+                    break;
+                }
             }
         }
     }
     // Also check root-level YAML files (flat layout)
     if !frameworks.contains("esphome")
-        && let Ok(entries) = std::fs::read_dir(project_dir) {
-            for entry in entries.flatten() {
-                let path = entry.path();
-                if path.extension().and_then(|e| e.to_str()) == Some("yaml")
-                    && let Ok(content) = std::fs::read_to_string(&path)
-                        && (content.starts_with("esphome:") || content.contains("\nesphome:")) {
-                            frameworks.insert("esphome".into());
-                            break;
-                        }
+        && let Ok(entries) = std::fs::read_dir(project_dir)
+    {
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.extension().and_then(|e| e.to_str()) == Some("yaml")
+                && let Ok(content) = std::fs::read_to_string(&path)
+                && (content.starts_with("esphome:") || content.contains("\nesphome:"))
+            {
+                frameworks.insert("esphome".into());
+                break;
             }
         }
+    }
 
     let mut langs: Vec<String> = languages.into_iter().collect();
     let mut fws: Vec<String> = frameworks.into_iter().collect();

--- a/src/feedback.rs
+++ b/src/feedback.rs
@@ -51,7 +51,6 @@ pub enum Provenance {
     Unknown,
 }
 
-
 /// Discriminates `Verdict::Fp` entries by reason. Calibrator applies
 /// different decay/scope rules per kind. `Option<FpKind> = None` ↔
 /// Hallucination semantics — preserves behavior on pre-bump entries
@@ -2181,8 +2180,9 @@ mod tests {
                         // Padding inside `reason` keeps the JSON valid;
                         // distinct chars per thread make truncation
                         // detectable in failure messages.
-                        let pad: String = std::iter::repeat_n(if tid == 0 { 'A' } else { 'B' }, PAD_BYTES)
-                            .collect();
+                        let pad: String =
+                            std::iter::repeat_n(if tid == 0 { 'A' } else { 'B' }, PAD_BYTES)
+                                .collect();
                         e.reason = format!("t{tid}-i{i}-{pad}");
                         store.record(&e).unwrap();
                     }

--- a/src/hydration.rs
+++ b/src/hydration.rs
@@ -198,20 +198,22 @@ fn collect_definitions(
     let line2 = node.end_position().row as u32 + 1;
 
     if func_kinds.contains(&kind)
-        && let Some(name_node) = node.child_by_field_name("name") {
-            let name = source[name_node.byte_range()].to_string();
-            // Extract first line as signature
-            let text = &source[node.byte_range()];
-            let sig = text.lines().next().unwrap_or(text).to_string();
-            funcs.push((name, sig, line1, line2));
-        }
+        && let Some(name_node) = node.child_by_field_name("name")
+    {
+        let name = source[name_node.byte_range()].to_string();
+        // Extract first line as signature
+        let text = &source[node.byte_range()];
+        let sig = text.lines().next().unwrap_or(text).to_string();
+        funcs.push((name, sig, line1, line2));
+    }
 
     if type_kinds.contains(&kind)
-        && let Some(name_node) = node.child_by_field_name("name") {
-            let name = source[name_node.byte_range()].to_string();
-            let text = source[node.byte_range()].to_string();
-            types.push((name, text));
-        }
+        && let Some(name_node) = node.child_by_field_name("name")
+    {
+        let name = source[name_node.byte_range()].to_string();
+        let text = source[node.byte_range()].to_string();
+        types.push((name, text));
+    }
 
     if import_kinds_list.contains(&kind) {
         let text = source[node.byte_range()].to_string();
@@ -248,36 +250,37 @@ fn extract_imported_names(import_text: &str) -> Vec<String> {
     if text.starts_with("use ") {
         // Rust: handle grouped `use std::collections::{HashMap, BTreeSet}` first.
         if let (Some(open), Some(close)) = (text.find('{'), text.rfind('}'))
-            && open < close {
-                let inner = &text[open + 1..close];
-                for part in inner.split(',') {
-                    let part = part.trim();
-                    if part.is_empty() || part == "*" {
-                        continue;
-                    }
-                    // Handle `Foo as Bar` aliases inside the group.
-                    let name = if let Some(alias) = part.split(" as ").nth(1) {
-                        alias.trim()
-                    } else {
-                        // Handle nested paths like `io::{self, Read}` — take last segment.
-                        part.rsplit("::").next().unwrap_or(part).trim()
-                    };
-                    if !name.is_empty() && name != "*" && name != "self" {
-                        names.push(name.to_string());
-                    } else if name == "self" {
-                        // `use foo::{self, ...}` brings `foo` into scope; surface the
-                        // parent segment (between "use " and "::{").
-                        let head = &text[..open];
-                        if let Some(parent) = head.rsplit("::").next() {
-                            let parent = parent.trim();
-                            if !parent.is_empty() {
-                                names.push(parent.to_string());
-                            }
+            && open < close
+        {
+            let inner = &text[open + 1..close];
+            for part in inner.split(',') {
+                let part = part.trim();
+                if part.is_empty() || part == "*" {
+                    continue;
+                }
+                // Handle `Foo as Bar` aliases inside the group.
+                let name = if let Some(alias) = part.split(" as ").nth(1) {
+                    alias.trim()
+                } else {
+                    // Handle nested paths like `io::{self, Read}` — take last segment.
+                    part.rsplit("::").next().unwrap_or(part).trim()
+                };
+                if !name.is_empty() && name != "*" && name != "self" {
+                    names.push(name.to_string());
+                } else if name == "self" {
+                    // `use foo::{self, ...}` brings `foo` into scope; surface the
+                    // parent segment (between "use " and "::{").
+                    let head = &text[..open];
+                    if let Some(parent) = head.rsplit("::").next() {
+                        let parent = parent.trim();
+                        if !parent.is_empty() {
+                            names.push(parent.to_string());
                         }
                     }
                 }
-                return names;
             }
+            return names;
+        }
         // Rust: last segment after ::, handle `as` aliases
         if let Some(last) = text.rsplit("::").next() {
             let name = last.trim().trim_end_matches(';');
@@ -613,9 +616,10 @@ pub fn parse_unified_diff(diff: &str) -> DiffRanges {
         if let Some(path) = line.strip_prefix("+++ b/") {
             // Save previous file
             if let Some(file) = current_file.take()
-                && !current_ranges.is_empty() {
-                    results.push((file, std::mem::take(&mut current_ranges)));
-                }
+                && !current_ranges.is_empty()
+            {
+                results.push((file, std::mem::take(&mut current_ranges)));
+            }
             current_file = Some(path.to_string());
         } else if line.starts_with("@@ ") {
             // Parse @@ -old,count +new,count @@ format
@@ -625,25 +629,27 @@ pub fn parse_unified_diff(diff: &str) -> DiffRanges {
                     .filter(|s| !s.is_empty())
                     .collect();
                 if let Some(start_str) = nums.first()
-                    && let Ok(s) = start_str.parse::<u32>() {
-                        // Count is optional in unified diff format (defaults to 1).
-                        // "@@ -10 +10 @@" means a single-line change at line 10.
-                        let count = nums.get(1).and_then(|c| c.parse::<u32>().ok()).unwrap_or(1);
-                        // Pure-deletion hunks (+N,0) have count==0 and contribute no
-                        // changed lines on the new side — skip rather than emit a
-                        // garbage (N, N-1) range from saturating_sub underflow.
-                        if count > 0 {
-                            current_ranges.push((s, s + count - 1));
-                        }
+                    && let Ok(s) = start_str.parse::<u32>()
+                {
+                    // Count is optional in unified diff format (defaults to 1).
+                    // "@@ -10 +10 @@" means a single-line change at line 10.
+                    let count = nums.get(1).and_then(|c| c.parse::<u32>().ok()).unwrap_or(1);
+                    // Pure-deletion hunks (+N,0) have count==0 and contribute no
+                    // changed lines on the new side — skip rather than emit a
+                    // garbage (N, N-1) range from saturating_sub underflow.
+                    if count > 0 {
+                        current_ranges.push((s, s + count - 1));
                     }
+                }
             }
         }
     }
     // Save last file
     if let Some(file) = current_file
-        && !current_ranges.is_empty() {
-            results.push((file, current_ranges));
-        }
+        && !current_ranges.is_empty()
+    {
+        results.push((file, current_ranges));
+    }
 
     results
 }
@@ -658,28 +664,32 @@ fn find_callers_of(
     callers: &mut Vec<String>,
 ) {
     if call_kinds.contains(&node.kind())
-        && let Some(func_node) = node.child_by_field_name("function") {
-            let func_text = &source[func_node.byte_range()];
-            let call_name = func_text
-                .rsplit('.')
-                .next()
-                .unwrap_or(func_text)
-                .rsplit("::")
-                .next()
-                .unwrap_or(func_text)
-                .trim();
+        && let Some(func_node) = node.child_by_field_name("function")
+    {
+        let func_text = &source[func_node.byte_range()];
+        let call_name = func_text
+            .rsplit('.')
+            .next()
+            .unwrap_or(func_text)
+            .rsplit("::")
+            .next()
+            .unwrap_or(func_text)
+            .trim();
 
-            if call_name == target_name {
-                // Find which function this call is inside
-                let call_line = node.start_position().row as u32 + 1;
-                for (fname, _, fstart, fend) in all_funcs {
-                    if fname != target_name && call_line >= *fstart && call_line <= *fend
-                        && !callers.contains(fname) {
-                            callers.push(fname.clone());
-                        }
+        if call_name == target_name {
+            // Find which function this call is inside
+            let call_line = node.start_position().row as u32 + 1;
+            for (fname, _, fstart, fend) in all_funcs {
+                if fname != target_name
+                    && call_line >= *fstart
+                    && call_line <= *fend
+                    && !callers.contains(fname)
+                {
+                    callers.push(fname.clone());
                 }
             }
         }
+    }
 
     for i in 0..node.child_count() {
         if let Some(child) = node.child(i as u32) {

--- a/src/linter.rs
+++ b/src/linter.rs
@@ -137,9 +137,10 @@ pub fn detect_linters(project_dir: &Path) -> Vec<LinterKind> {
     if project_dir.join("ruff.toml").exists() {
         linters.push(LinterKind::Ruff);
     } else if let Ok(content) = std::fs::read_to_string(project_dir.join("pyproject.toml"))
-        && content.contains("[tool.ruff]") {
-            linters.push(LinterKind::Ruff);
-        }
+        && content.contains("[tool.ruff]")
+    {
+        linters.push(LinterKind::Ruff);
+    }
 
     // Clippy: Cargo.toml present
     if project_dir.join("Cargo.toml").exists() {

--- a/src/llm_client.rs
+++ b/src/llm_client.rs
@@ -43,43 +43,44 @@ pub fn parse_chat_response(json: &serde_json::Value) -> anyhow::Result<LlmTurnRe
         .unwrap_or("stop");
 
     if let Some(tool_calls) = message.get("tool_calls").and_then(|tc| tc.as_array())
-        && !tool_calls.is_empty() {
-            // Error on any malformed entry rather than silently dropping it
-            // via filter_map. A partial tool_calls vec leaves orphaned
-            // assistant calls without matching tool responses, which most
-            // chat APIs reject on the next turn — same failure mode as the
-            // agent.rs limit-reached bug, just at the parser layer.
-            let mut calls = Vec::with_capacity(tool_calls.len());
-            for (i, tc) in tool_calls.iter().enumerate() {
-                let id = tc
-                    .get("id")
-                    .and_then(|v| v.as_str())
-                    .ok_or_else(|| anyhow::anyhow!("malformed tool_calls[{i}]: missing `id`"))?
-                    .to_string();
-                let name = tc
-                    .get("function")
-                    .and_then(|f| f.get("name"))
-                    .and_then(|n| n.as_str())
-                    .ok_or_else(|| {
-                        anyhow::anyhow!("malformed tool_calls[{i}]: missing `function.name`")
-                    })?
-                    .to_string();
-                let arguments = tc
-                    .get("function")
-                    .and_then(|f| f.get("arguments"))
-                    .and_then(|a| a.as_str())
-                    .ok_or_else(|| {
-                        anyhow::anyhow!("malformed tool_calls[{i}]: missing `function.arguments`")
-                    })?
-                    .to_string();
-                calls.push(ToolCall {
-                    id,
-                    name,
-                    arguments,
-                });
-            }
-            return Ok(LlmTurnResult::ToolCalls(calls));
+        && !tool_calls.is_empty()
+    {
+        // Error on any malformed entry rather than silently dropping it
+        // via filter_map. A partial tool_calls vec leaves orphaned
+        // assistant calls without matching tool responses, which most
+        // chat APIs reject on the next turn — same failure mode as the
+        // agent.rs limit-reached bug, just at the parser layer.
+        let mut calls = Vec::with_capacity(tool_calls.len());
+        for (i, tc) in tool_calls.iter().enumerate() {
+            let id = tc
+                .get("id")
+                .and_then(|v| v.as_str())
+                .ok_or_else(|| anyhow::anyhow!("malformed tool_calls[{i}]: missing `id`"))?
+                .to_string();
+            let name = tc
+                .get("function")
+                .and_then(|f| f.get("name"))
+                .and_then(|n| n.as_str())
+                .ok_or_else(|| {
+                    anyhow::anyhow!("malformed tool_calls[{i}]: missing `function.name`")
+                })?
+                .to_string();
+            let arguments = tc
+                .get("function")
+                .and_then(|f| f.get("arguments"))
+                .and_then(|a| a.as_str())
+                .ok_or_else(|| {
+                    anyhow::anyhow!("malformed tool_calls[{i}]: missing `function.arguments`")
+                })?
+                .to_string();
+            calls.push(ToolCall {
+                id,
+                name,
+                arguments,
+            });
         }
+        return Ok(LlmTurnResult::ToolCalls(calls));
+    }
 
     if finish_reason == "length" {
         anyhow::bail!("Response truncated (finish_reason=length)");
@@ -995,14 +996,16 @@ impl OpenAiClient {
         let mut texts = Vec::new();
         for item in output {
             if item["type"].as_str() == Some("message")
-                && let Some(content) = item["content"].as_array() {
-                    for block in content {
-                        if block["type"].as_str() == Some("output_text")
-                            && let Some(text) = block["text"].as_str() {
-                                texts.push(text.to_string());
-                            }
+                && let Some(content) = item["content"].as_array()
+            {
+                for block in content {
+                    if block["type"].as_str() == Some("output_text")
+                        && let Some(text) = block["text"].as_str()
+                    {
+                        texts.push(text.to_string());
                     }
                 }
+            }
         }
 
         if texts.is_empty() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -64,9 +64,10 @@ use pipeline::{LlmReviewer, PipelineConfig};
 /// `$HOME/.quorum`. Returns None if neither can be resolved.
 fn quorum_dir() -> Option<std::path::PathBuf> {
     if let Ok(override_path) = std::env::var("QUORUM_HOME")
-        && !override_path.is_empty() {
-            return Some(std::path::PathBuf::from(override_path));
-        }
+        && !override_path.is_empty()
+    {
+        return Some(std::path::PathBuf::from(override_path));
+    }
     std::env::var("HOME")
         .ok()
         .map(|h| std::path::PathBuf::from(h).join(".quorum"))
@@ -601,9 +602,10 @@ fn unicode_ok() -> bool {
         return false;
     }
     if let Some(term) = std::env::var_os("TERM")
-        && term == "dumb" {
-            return false;
-        }
+        && term == "dumb"
+    {
+        return false;
+    }
     if let Ok(lang) = std::env::var("LANG") {
         return lang.to_uppercase().contains("UTF-8") || lang.to_uppercase().contains("UTF8");
     }
@@ -1079,66 +1081,64 @@ async fn run_review(opts: cli::ReviewOpts) -> i32 {
 
             // Deep review: agent loop with tool calling
             if opts.deep
-                && let Some(client) = llm_client.as_deref() {
-                    let project_root = deep_tool_root(file_path);
-                    let tool_reg = tools::ToolRegistry::new(&project_root);
-                    let agent_cfg = agent::AgentConfig::default();
-                    let model = pipeline_cfg
-                        .models
-                        .first()
-                        .map(|s| s.as_str())
-                        .unwrap_or("gpt-5.4");
-                    match agent::agent_loop(
-                        &source,
-                        &file_path.to_string_lossy(),
-                        client as &dyn agent::AgentReviewer,
-                        model,
-                        &tool_reg,
-                        &agent_cfg,
-                    ) {
-                        Ok(findings) => {
-                            // Apply project-level suppressions
-                            let sup_result = suppress::apply_suppressions(
-                                findings,
-                                &suppress_rules,
-                                &file_display,
-                            );
-                            if !sup_result.suppressed.is_empty() {
-                                tracing::debug!(count = sup_result.suppressed.len(), file = %file_display, "project suppressions applied");
-                            }
-                            if opts.show_suppressed {
-                                for (f, rule) in &sup_result.suppressed {
-                                    eprint!("{}", suppress::format_suppressed_finding(f, rule));
-                                }
-                            }
-                            let findings = sup_result.kept;
-                            progress.finish_file(findings.len());
-                            if use_compact {
-                                println!(
-                                    "{}",
-                                    output::format_compact_review(&file_display, &findings)
-                                );
-                            } else if use_json {
-                                // collected below
-                            } else {
-                                print!(
-                                    "{}",
-                                    output::format_review(&file_display, &findings, &style)
-                                );
-                            }
-                            all_findings.extend(findings);
-                            continue;
+                && let Some(client) = llm_client.as_deref()
+            {
+                let project_root = deep_tool_root(file_path);
+                let tool_reg = tools::ToolRegistry::new(&project_root);
+                let agent_cfg = agent::AgentConfig::default();
+                let model = pipeline_cfg
+                    .models
+                    .first()
+                    .map(|s| s.as_str())
+                    .unwrap_or("gpt-5.4");
+                match agent::agent_loop(
+                    &source,
+                    &file_path.to_string_lossy(),
+                    client as &dyn agent::AgentReviewer,
+                    model,
+                    &tool_reg,
+                    &agent_cfg,
+                ) {
+                    Ok(findings) => {
+                        // Apply project-level suppressions
+                        let sup_result =
+                            suppress::apply_suppressions(findings, &suppress_rules, &file_display);
+                        if !sup_result.suppressed.is_empty() {
+                            tracing::debug!(count = sup_result.suppressed.len(), file = %file_display, "project suppressions applied");
                         }
-                        Err(e) => {
-                            progress.clear_line();
-                            eprintln!(
-                                "Warning: Deep review failed for {}: {}. Falling back to standard review.",
-                                file_path.display(),
-                                e
+                        if opts.show_suppressed {
+                            for (f, rule) in &sup_result.suppressed {
+                                eprint!("{}", suppress::format_suppressed_finding(f, rule));
+                            }
+                        }
+                        let findings = sup_result.kept;
+                        progress.finish_file(findings.len());
+                        if use_compact {
+                            println!(
+                                "{}",
+                                output::format_compact_review(&file_display, &findings)
+                            );
+                        } else if use_json {
+                            // collected below
+                        } else {
+                            print!(
+                                "{}",
+                                output::format_review(&file_display, &findings, &style)
                             );
                         }
+                        all_findings.extend(findings);
+                        continue;
+                    }
+                    Err(e) => {
+                        progress.clear_line();
+                        eprintln!(
+                            "Warning: Deep review failed for {}: {}. Falling back to standard review.",
+                            file_path.display(),
+                            e
+                        );
                     }
                 }
+            }
 
             // Run pipeline: full (AST + LLM) for supported languages, LLM-only for others
             let review_result = if let Some(l) = lang {
@@ -1236,49 +1236,48 @@ async fn run_review(opts: cli::ReviewOpts) -> i32 {
                 let file_display = file_path.to_string_lossy().to_string();
 
                 // Deep review path
-                if deep
-                    && let Some(ref client) = llm_client {
-                        let project_root = deep_tool_root(&file_path);
-                        let tool_reg = tools::ToolRegistry::new(&project_root);
-                        let agent_cfg = agent::AgentConfig::default();
-                        let model = pipeline_cfg
-                            .models
-                            .first()
-                            .map(|s| s.as_str())
-                            .unwrap_or("gpt-5.4");
-                        match agent::agent_loop(
-                            &source,
-                            &file_display,
-                            &**client as &dyn agent::AgentReviewer,
-                            model,
-                            &tool_reg,
-                            &agent_cfg,
-                        ) {
-                            Ok(findings) => {
-                                let sup_result = suppress::apply_suppressions(
-                                    findings,
-                                    &suppress_rules,
-                                    &file_display,
-                                );
-                                let result = pipeline::FileReviewResult {
-                                    file_path: file_display,
-                                    findings: sup_result.kept,
-                                    usage: Default::default(),
-                                    suppressed: sup_result.suppressed.len(),
-                                    context_telemetry: None,
-                                    enrichment_metrics: Default::default(),
-                                };
-                                return (idx, Ok((result, sup_result.suppressed)));
-                            }
-                            Err(e) => {
-                                eprintln!(
-                                    "[{}] Warning: Deep review failed: {}. Falling back.",
-                                    file_path.display(),
-                                    e
-                                );
-                            }
+                if deep && let Some(ref client) = llm_client {
+                    let project_root = deep_tool_root(&file_path);
+                    let tool_reg = tools::ToolRegistry::new(&project_root);
+                    let agent_cfg = agent::AgentConfig::default();
+                    let model = pipeline_cfg
+                        .models
+                        .first()
+                        .map(|s| s.as_str())
+                        .unwrap_or("gpt-5.4");
+                    match agent::agent_loop(
+                        &source,
+                        &file_display,
+                        &**client as &dyn agent::AgentReviewer,
+                        model,
+                        &tool_reg,
+                        &agent_cfg,
+                    ) {
+                        Ok(findings) => {
+                            let sup_result = suppress::apply_suppressions(
+                                findings,
+                                &suppress_rules,
+                                &file_display,
+                            );
+                            let result = pipeline::FileReviewResult {
+                                file_path: file_display,
+                                findings: sup_result.kept,
+                                usage: Default::default(),
+                                suppressed: sup_result.suppressed.len(),
+                                context_telemetry: None,
+                                enrichment_metrics: Default::default(),
+                            };
+                            return (idx, Ok((result, sup_result.suppressed)));
+                        }
+                        Err(e) => {
+                            eprintln!(
+                                "[{}] Warning: Deep review failed: {}. Falling back.",
+                                file_path.display(),
+                                e
+                            );
                         }
                     }
+                }
 
                 // Standard review path
                 let llm_reviewer: Option<&dyn pipeline::LlmReviewer> =

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -392,9 +392,10 @@ pub fn unicode_ok_default() -> bool {
         return false;
     }
     if let Some(term) = std::env::var_os("TERM")
-        && term == "dumb" {
-            return false;
-        }
+        && term == "dumb"
+    {
+        return false;
+    }
     if let Ok(lang) = std::env::var("LANG") {
         return lang.to_uppercase().contains("UTF-8") || lang.to_uppercase().contains("UTF8");
     }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -30,9 +30,10 @@ impl Language {
     pub fn from_path(path: &Path) -> Option<Self> {
         // Check filename first for extensionless files (Dockerfile, Dockerfile.prod, etc.)
         if let Some(name) = path.file_name().and_then(|n| n.to_str())
-            && name.to_lowercase().starts_with("dockerfile") {
-                return Some(Language::Dockerfile);
-            }
+            && name.to_lowercase().starts_with("dockerfile")
+        {
+            return Some(Language::Dockerfile);
+        }
         path.extension()
             .and_then(|ext| ext.to_str())
             .and_then(Self::from_extension)
@@ -105,28 +106,31 @@ pub fn extract_functions(
 
             // Standard named functions/methods
             if kinds.contains(&node.kind())
-                && let Some(name_node) = node.child_by_field_name("name") {
-                    let name = &source[name_node.byte_range()];
-                    functions.push(FunctionInfo {
-                        name: name.to_string(),
-                        line_start: node.start_position().row as u32 + 1,
-                        line_end: node.end_position().row as u32 + 1,
-                    });
-                }
+                && let Some(name_node) = node.child_by_field_name("name")
+            {
+                let name = &source[name_node.byte_range()];
+                functions.push(FunctionInfo {
+                    name: name.to_string(),
+                    line_start: node.start_position().row as u32 + 1,
+                    line_end: node.end_position().row as u32 + 1,
+                });
+            }
 
             // Arrow functions: const name = (...) => { ... }
             // Tree shape: lexical_declaration > variable_declarator[name, value=arrow_function]
-            if is_ts && node.kind() == "arrow_function"
+            if is_ts
+                && node.kind() == "arrow_function"
                 && let Some(parent) = node.parent()
-                    && parent.kind() == "variable_declarator"
-                        && let Some(name_node) = parent.child_by_field_name("name") {
-                            let name = &source[name_node.byte_range()];
-                            functions.push(FunctionInfo {
-                                name: name.to_string(),
-                                line_start: parent.start_position().row as u32 + 1,
-                                line_end: node.end_position().row as u32 + 1,
-                            });
-                        }
+                && parent.kind() == "variable_declarator"
+                && let Some(name_node) = parent.child_by_field_name("name")
+            {
+                let name = &source[name_node.byte_range()];
+                functions.push(FunctionInfo {
+                    name: name.to_string(),
+                    line_start: parent.start_position().row as u32 + 1,
+                    line_end: node.end_position().row as u32 + 1,
+                });
+            }
         }
 
         // Iterative tree walk: down, right, or up

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -592,7 +592,9 @@ pub async fn review_file(
                     Some(
                         docs.iter()
                             .map(|d| {
-                                crate::context_enrichment::format_context_section(std::slice::from_ref(d))
+                                crate::context_enrichment::format_context_section(
+                                    std::slice::from_ref(d),
+                                )
                             })
                             .collect(),
                     )
@@ -1019,121 +1021,124 @@ pub async fn review_file_llm_only(
 
     // LLM review (if configured)
     if let Some(reviewer) = llm
-        && !pipeline_config.models.is_empty() {
-            let redacted_code = redact::redact_secrets(source);
-            let (review_code, truncation_notice) =
-                truncate_for_review(&redacted_code, pipeline_config.max_review_lines);
-            let language = lang_name_from_path(file_path);
+        && !pipeline_config.models.is_empty()
+    {
+        let redacted_code = redact::redact_secrets(source);
+        let (review_code, truncation_notice) =
+            truncate_for_review(&redacted_code, pipeline_config.max_review_lines);
+        let language = lang_name_from_path(file_path);
 
-            // Context7 framework docs (metrics aggregate into the function-scoped var)
-            let framework_docs = if let Some(reason) = context7_skip_reason(pipeline_config) {
-                tracing::debug!(reason, "Context7: enrichment skipped");
-                None
-            } else {
-                let project_root = find_project_root(file_path);
-                let mut domain = crate::domain::detect_domain(&project_root);
-                for fw in &pipeline_config.framework_overrides {
-                    if !domain.frameworks.contains(fw) {
-                        domain.frameworks.push(fw.clone());
-                    }
-                }
-                let result = if let Some(shared) = pipeline_config.context7_fetcher.as_ref() {
-                    crate::context_enrichment::enrich_for_review_in_project(
-                        &project_root,
-                        &[],
-                        &domain.frameworks,
-                        shared.as_ref(),
-                    )
-                } else {
-                    let inner = crate::context_enrichment::Context7HttpFetcher::new()?;
-                    let cached = crate::context_enrichment::CachedContextFetcher::new(&inner, 32);
-                    crate::context_enrichment::enrich_for_review_in_project(
-                        &project_root,
-                        &[],
-                        &domain.frameworks,
-                        &cached,
-                    )
-                };
-                let docs = result.docs;
-                enrichment_metrics = result.metrics;
-                if !docs.is_empty() {
-                    Some(
-                        docs.iter()
-                            .map(|d| {
-                                crate::context_enrichment::format_context_section(std::slice::from_ref(d))
-                            })
-                            .collect(),
-                    )
-                } else if domain.frameworks.is_empty() {
-                    None
-                } else {
-                    // skip_context7 unreachable: outer if-let returned None already.
-                    anyhow::bail!(
-                        "Context7: failed to fetch docs for frameworks {:?}. \
-                         This degrades review quality. Fix the Context7 connection or use --skip-context7 to proceed without framework docs.",
-                        domain.frameworks
-                    );
-                }
-            };
-
-            // Query feedback index for few-shot precedents
-            let precedents = if let Some(ref shared) = shared_index {
-                let mut idx = shared.lock().unwrap();
-                query_feedback_precedents(&mut idx, &file_str, &language, &redacted_code)
-            } else if let Some(ref mut idx) = local_index {
-                query_feedback_precedents(idx, &file_str, &language, &redacted_code)
-            } else {
-                Vec::new()
-            };
-
-            let req = ReviewRequest {
-                file_path: file_str.clone(),
-                language,
-                code: review_code,
-                hydration_context: None,
-                framework_docs,
-                feedback_precedents: if precedents.is_empty() {
-                    None
-                } else {
-                    Some(precedents)
-                },
-                context_block: None,
-                truncation_notice: truncation_notice.clone(),
-                focus: pipeline_config.focus.clone(),
-                mode: pipeline_config.mode,
-            };
-
-            let prompt = review::build_review_prompt(&req);
-            let sys_prompt = system_prompt_for_mode(pipeline_config.mode);
-            for model in &pipeline_config.models {
-                let _permit = acquire_llm_permit(&pipeline_config.semaphore).await;
-                match reviewer.review(&prompt, model, sys_prompt) {
-                    Ok(resp) => {
-                        if let Some(u) = &resp.usage {
-                            total_usage.prompt_tokens += u.prompt_tokens;
-                            total_usage.completion_tokens += u.completion_tokens;
-                            total_usage.cached_tokens += u.cached_tokens;
-                        }
-                        match review::parse_llm_response(&resp.content, model) {
-                            Ok(mut findings) => {
-                                if let Some(ref notice) = truncation_notice {
-                                    for f in &mut findings {
-                                        if matches!(f.source, crate::finding::Source::Llm(_)) {
-                                            f.based_on_excerpt = Some(notice.clone());
-                                        }
-                                    }
-                                }
-                                all_sources.push(findings);
-                            }
-                            Err(e) => {
-                                eprintln!("Warning: Failed to parse {} response: {}", model, e)
-                            }
-                        }
-                    }
-                    Err(e) => eprintln!("Warning: {} review failed: {}", model, e),
+        // Context7 framework docs (metrics aggregate into the function-scoped var)
+        let framework_docs = if let Some(reason) = context7_skip_reason(pipeline_config) {
+            tracing::debug!(reason, "Context7: enrichment skipped");
+            None
+        } else {
+            let project_root = find_project_root(file_path);
+            let mut domain = crate::domain::detect_domain(&project_root);
+            for fw in &pipeline_config.framework_overrides {
+                if !domain.frameworks.contains(fw) {
+                    domain.frameworks.push(fw.clone());
                 }
             }
+            let result = if let Some(shared) = pipeline_config.context7_fetcher.as_ref() {
+                crate::context_enrichment::enrich_for_review_in_project(
+                    &project_root,
+                    &[],
+                    &domain.frameworks,
+                    shared.as_ref(),
+                )
+            } else {
+                let inner = crate::context_enrichment::Context7HttpFetcher::new()?;
+                let cached = crate::context_enrichment::CachedContextFetcher::new(&inner, 32);
+                crate::context_enrichment::enrich_for_review_in_project(
+                    &project_root,
+                    &[],
+                    &domain.frameworks,
+                    &cached,
+                )
+            };
+            let docs = result.docs;
+            enrichment_metrics = result.metrics;
+            if !docs.is_empty() {
+                Some(
+                    docs.iter()
+                        .map(|d| {
+                            crate::context_enrichment::format_context_section(std::slice::from_ref(
+                                d,
+                            ))
+                        })
+                        .collect(),
+                )
+            } else if domain.frameworks.is_empty() {
+                None
+            } else {
+                // skip_context7 unreachable: outer if-let returned None already.
+                anyhow::bail!(
+                    "Context7: failed to fetch docs for frameworks {:?}. \
+                         This degrades review quality. Fix the Context7 connection or use --skip-context7 to proceed without framework docs.",
+                    domain.frameworks
+                );
+            }
+        };
+
+        // Query feedback index for few-shot precedents
+        let precedents = if let Some(ref shared) = shared_index {
+            let mut idx = shared.lock().unwrap();
+            query_feedback_precedents(&mut idx, &file_str, &language, &redacted_code)
+        } else if let Some(ref mut idx) = local_index {
+            query_feedback_precedents(idx, &file_str, &language, &redacted_code)
+        } else {
+            Vec::new()
+        };
+
+        let req = ReviewRequest {
+            file_path: file_str.clone(),
+            language,
+            code: review_code,
+            hydration_context: None,
+            framework_docs,
+            feedback_precedents: if precedents.is_empty() {
+                None
+            } else {
+                Some(precedents)
+            },
+            context_block: None,
+            truncation_notice: truncation_notice.clone(),
+            focus: pipeline_config.focus.clone(),
+            mode: pipeline_config.mode,
+        };
+
+        let prompt = review::build_review_prompt(&req);
+        let sys_prompt = system_prompt_for_mode(pipeline_config.mode);
+        for model in &pipeline_config.models {
+            let _permit = acquire_llm_permit(&pipeline_config.semaphore).await;
+            match reviewer.review(&prompt, model, sys_prompt) {
+                Ok(resp) => {
+                    if let Some(u) = &resp.usage {
+                        total_usage.prompt_tokens += u.prompt_tokens;
+                        total_usage.completion_tokens += u.completion_tokens;
+                        total_usage.cached_tokens += u.cached_tokens;
+                    }
+                    match review::parse_llm_response(&resp.content, model) {
+                        Ok(mut findings) => {
+                            if let Some(ref notice) = truncation_notice {
+                                for f in &mut findings {
+                                    if matches!(f.source, crate::finding::Source::Llm(_)) {
+                                        f.based_on_excerpt = Some(notice.clone());
+                                    }
+                                }
+                            }
+                            all_sources.push(findings);
+                        }
+                        Err(e) => {
+                            eprintln!("Warning: Failed to parse {} response: {}", model, e)
+                        }
+                    }
+                }
+                Err(e) => eprintln!("Warning: {} review failed: {}", model, e),
+            }
         }
+    }
 
     let merged = merge::merge_findings(all_sources, pipeline_config.similarity_threshold);
 

--- a/src/review.rs
+++ b/src/review.rs
@@ -171,14 +171,15 @@ pub fn build_review_prompt(req: &ReviewRequest) -> String {
     let mut prompt = String::new();
 
     if let Some(docs) = &req.framework_docs
-        && !docs.is_empty() {
-            prompt.push_str("<framework_docs>\n");
-            for doc in docs {
-                prompt.push_str(&defang_sandbox_tags(doc));
-                prompt.push_str("\n\n");
-            }
-            prompt.push_str("</framework_docs>\n\n");
+        && !docs.is_empty()
+    {
+        prompt.push_str("<framework_docs>\n");
+        for doc in docs {
+            prompt.push_str(&defang_sandbox_tags(doc));
+            prompt.push_str("\n\n");
         }
+        prompt.push_str("</framework_docs>\n\n");
+    }
 
     if let Some(ctx) = &req.hydration_context {
         let any_section = !ctx.callee_signatures.is_empty()
@@ -232,13 +233,14 @@ pub fn build_review_prompt(req: &ReviewRequest) -> String {
     }
 
     if let Some(precedents) = &req.feedback_precedents
-        && !precedents.is_empty() {
-            prompt.push_str("<historical_findings>\n");
-            for p in precedents {
-                prompt.push_str(&format!("- {}\n", defang_sandbox_tags(p)));
-            }
-            prompt.push_str("</historical_findings>\n\n");
+        && !precedents.is_empty()
+    {
+        prompt.push_str("<historical_findings>\n");
+        for p in precedents {
+            prompt.push_str(&format!("- {}\n", defang_sandbox_tags(p)));
         }
+        prompt.push_str("</historical_findings>\n\n");
+    }
 
     if let Some(ref notice) = req.truncation_notice {
         prompt.push_str(&format!(
@@ -345,22 +347,24 @@ pub fn parse_llm_response(json_str: &str, model_name: &str) -> anyhow::Result<Ve
     // escapes). Fall through to the sanitize-then-envelope retry
     // instead of returning an empty result.
     if let Ok(findings) = try_parse_findings(&cleaned)
-        && (!findings.is_empty() || !payload_is_object) {
-            return Ok(findings
-                .into_iter()
-                .map(|f| f.into_finding(model_name))
-                .collect());
-        }
+        && (!findings.is_empty() || !payload_is_object)
+    {
+        return Ok(findings
+            .into_iter()
+            .map(|f| f.into_finding(model_name))
+            .collect());
+    }
 
     // Strategy 3: sanitize invalid JSON escapes (LLMs emit \d, \s, etc.)
     let sanitized = sanitize_json_escapes(&cleaned);
     if let Ok(findings) = try_parse_findings(&sanitized)
-        && (!findings.is_empty() || !payload_is_object) {
-            return Ok(findings
-                .into_iter()
-                .map(|f| f.into_finding(model_name))
-                .collect());
-        }
+        && (!findings.is_empty() || !payload_is_object)
+    {
+        return Ok(findings
+            .into_iter()
+            .map(|f| f.into_finding(model_name))
+            .collect());
+    }
 
     // Strategy 4: same sanitize-then-envelope pass on the full payload.
     let sanitized_payload = sanitize_json_escapes(trimmed_payload.trim());
@@ -524,9 +528,10 @@ fn extract_json_array(text: &str) -> String {
             // would not satisfy `depth == 0`, and the array would be missed.
             depth -= 1;
             if depth == 0
-                && let Some(s) = start {
-                    return text[s..=i].to_string();
-                }
+                && let Some(s) = start
+            {
+                return text[s..=i].to_string();
+            }
         }
     }
 

--- a/src/review_log.rs
+++ b/src/review_log.rs
@@ -314,11 +314,12 @@ impl ReviewLog {
     pub fn record(&self, entry: &ReviewRecord) -> anyhow::Result<()> {
         use std::io::Write;
         if let Some(parent) = self.path.parent()
-            && !parent.as_os_str().is_empty() {
-                std::fs::create_dir_all(parent).with_context(|| {
-                    format!("Failed to create review log dir: {}", parent.display())
-                })?;
-            }
+            && !parent.as_os_str().is_empty()
+        {
+            std::fs::create_dir_all(parent).with_context(|| {
+                format!("Failed to create review log dir: {}", parent.display())
+            })?;
+        }
         let mut file = std::fs::OpenOptions::new()
             .create(true)
             .append(true)
@@ -363,9 +364,10 @@ impl Iterator for ReviewLogIter {
 /// signals beat generic `AGENT`.
 pub fn detect_invoked_from(caller_override: Option<&str>) -> String {
     if let Some(name) = caller_override
-        && !name.is_empty() {
-            return name.to_string();
-        }
+        && !name.is_empty()
+    {
+        return name.to_string();
+    }
     if std::env::var_os("CLAUDE_CODE").is_some() {
         return "claude_code".to_string();
     }
@@ -377,9 +379,10 @@ pub fn detect_invoked_from(caller_override: Option<&str>) -> String {
     }
     if let Some(v) = std::env::var_os("AGENT")
         && let Some(s) = v.to_str()
-            && !s.is_empty() {
-                return s.to_string();
-            }
+        && !s.is_empty()
+    {
+        return s.to_string();
+    }
     use std::io::IsTerminal;
     if std::io::stdout().is_terminal() {
         "tty".to_string()

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -937,7 +937,7 @@ pub fn format_json(report: &StatsReport) -> anyhow::Result<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    
+
     use tempfile::TempDir;
 
     fn make_review_log(

--- a/src/test_support.rs
+++ b/src/test_support.rs
@@ -93,5 +93,4 @@ pub mod fakes {
             }
         }
     }
-
 }

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -231,16 +231,17 @@ impl ToolRegistry {
                 self.grep_recursive(&path, pattern, glob, acc)?;
             } else if path.is_file() {
                 if let Some(g) = glob
-                    && g != "*" {
-                        let ext_match = g.trim_start_matches("*.");
-                        if let Some(ext) = path.extension() {
-                            if ext.to_string_lossy() != ext_match {
-                                continue;
-                            }
-                        } else {
+                    && g != "*"
+                {
+                    let ext_match = g.trim_start_matches("*.");
+                    if let Some(ext) = path.extension() {
+                        if ext.to_string_lossy() != ext_match {
                             continue;
                         }
+                    } else {
+                        continue;
                     }
+                }
                 if let Ok(content) = std::fs::read_to_string(&path) {
                     let rel = path.strip_prefix(&self.root).unwrap_or(&path);
                     for (i, line) in content.lines().enumerate() {
@@ -323,16 +324,17 @@ impl ToolRegistry {
             } else {
                 let rel = path.strip_prefix(&self.root).unwrap_or(&path);
                 if let Some(g) = glob
-                    && g != "*" {
-                        let ext = g.trim_start_matches("*.");
-                        if let Some(file_ext) = path.extension() {
-                            if file_ext.to_string_lossy() != ext {
-                                continue;
-                            }
-                        } else {
+                    && g != "*"
+                {
+                    let ext = g.trim_start_matches("*.");
+                    if let Some(file_ext) = path.extension() {
+                        if file_ext.to_string_lossy() != ext {
                             continue;
                         }
+                    } else {
+                        continue;
                     }
+                }
                 acc.push(rel.display().to_string());
             }
         }

--- a/tests/calibrate_backfill.rs
+++ b/tests/calibrate_backfill.rs
@@ -1,4 +1,3 @@
-
 /// Integration test for `quorum calibrate --backfill-paths --dry-run`.
 #[test]
 fn calibrate_backfill_paths_dry_run() {


### PR DESCRIPTION
## Summary

The clippy cleanup (#240) introduced if-let chain patterns that rustfmt formats differently from hand-written indentation. This applies `cargo fmt` to bring all 30 affected files into compliance.

Pure formatting change — no logic modifications.

## Test plan

- [x] `cargo fmt --check` passes
- [x] `cargo test --bin quorum` — 1276 passed, 1 ignored

🤖 Generated with [Claude Code](https://claude.com/claude-code)