### PR TITLE
chore: add pre-commit hooks and bump to v0.20.0

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -e
+
+# Only check staged Rust files to keep the hook fast on non-Rust commits.
+rust_staged=$(git diff --cached --name-only --diff-filter=ACMR -- '*.rs')
+if [ -z "$rust_staged" ]; then
+    exit 0
+fi
+
+echo "pre-commit: cargo fmt --check"
+cargo fmt --check 2>&1 || {
+    echo ""
+    echo "Formatting check failed. Run 'cargo fmt' and re-stage."
+    exit 1
+}
+
+echo "pre-commit: cargo clippy"
+cargo clippy --all-targets --quiet -- -D warnings 2>&1 || {
+    echo ""
+    echo "Clippy found warnings. Fix them and re-stage."
+    exit 1
+}
+
+echo "pre-commit: cargo check"
+cargo check --all-targets --quiet 2>&1 || {
+    echo ""
+    echo "Compilation failed."
+    exit 1
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,27 @@
 
 _No unreleased changes._
 
+## [0.20.0] - 2026-05-07
+
+### Review quality
+
+- **Function-by-function LLM prompt (#253).** System prompt reframed from ranked-checklist to function-by-function review instruction. A/B testing showed 100% recall (20/20 planted bugs) vs 93% with the previous prompt. Removed 4 down-classification rules that caused the model to self-censor findings. Severity rubric condensed to concise one-liners.
+
+### Developer experience
+
+- **Pre-commit hooks (.githooks/).** Added `cargo fmt --check`, `cargo clippy`, and `cargo check` as pre-commit hooks. Hooks only fire on commits touching `.rs` files. Setup: `git config core.hooksPath .githooks`.
+
+### Code quality
+
+- **Clippy cleanup (#240).** Fixed all 166 clippy lints across the codebase and made clippy blocking in CI (`-D warnings`).
+- **Formatting sweep (#236, #252).** Applied `rustfmt` across the entire codebase, including if-let chain patterns introduced by the clippy cleanup.
+
+## [0.19.0] - 2026-05-05
+
+### Stats dashboard redesign (#235)
+
+- Redesigned stats dashboard for clarity with improved semigraphics and layout.
+
 ## [0.18.4] - 2026-05-02
 
 Cluster of follow-up fixes from quorum self-reviews after v0.18.2's batch-3, plus a refactor that unblocks integration-testable internal types.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,11 @@
 # Quorum — Rust-native multi-source code review tool
 
+## Setup
+
+```bash
+git config core.hooksPath .githooks    # enable pre-commit hooks (fmt, clippy, check)
+```
+
 ## Commands
 
 ```bash

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2713,7 +2713,7 @@ checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quorum"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quorum"
-version = "0.19.0"
+version = "0.20.0"
 edition = "2024"
 # `str::floor_char_boundary` (used in src/agent.rs and src/tools.rs to
 # truncate UTF-8 safely) stabilized in Rust 1.93. Older constraints —


### PR DESCRIPTION
## Summary

- **Pre-commit hooks** (`.githooks/pre-commit`): `cargo fmt --check`, `cargo clippy --all-targets -D warnings`, `cargo check --all-targets`. Only fires on commits touching `.rs` files — non-Rust commits skip entirely.
- **Version bump** to 0.20.0 with changelog covering all changes since 0.19.0:
  - Function-by-function LLM prompt (#253)
  - Clippy cleanup (#240)
  - Formatting sweeps (#236, #252)
  - Pre-commit hooks (this PR)
- **CLAUDE.md**: setup instructions (`git config core.hooksPath .githooks`)

### Setup

After merge, enable hooks with:
```bash
git config core.hooksPath .githooks
```

## Test plan

- [x] `cargo fmt --check` — clean
- [x] `cargo clippy --all-targets -D warnings` — clean
- [x] `cargo check --all-targets` — clean
- [x] Hook skips non-Rust commits (verified with shell-only commit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)