### PR TITLE
fix: remove max_tokens cap from LLM review calls

### DIFF
--- a/src/llm_client.rs
+++ b/src/llm_client.rs
@@ -883,8 +883,7 @@ impl OpenAiClient {
                 {"role": "system", "content": system_prompt},
                 {"role": "user", "content": prompt}
             ],
-            "temperature": 0.3,
-            "max_tokens": 16384
+            "temperature": 0.3
         });
         if let Some(effort) = &self.reasoning_effort {
             body["reasoning_effort"] = serde_json::Value::String(effort.clone());
@@ -921,7 +920,7 @@ impl OpenAiClient {
             .unwrap_or("unknown");
         if finish_reason == "length" {
             anyhow::bail!(
-                "Response truncated (finish_reason=length). Model {} may need a higher max_tokens.",
+                "Response truncated (finish_reason=length). Model {} hit its output token limit.",
                 model
             );
         }
@@ -1029,7 +1028,6 @@ impl OpenAiClient {
             "model": model,
             "messages": messages,
             "temperature": 0.3,
-            "max_tokens": 16384,
             "tools": tools
         });
         if let Some(effort) = &self.reasoning_effort {


### PR DESCRIPTION
## Summary

Removes the hardcoded `max_tokens: 16384` from both LLM call sites (single-pass review and agent tool-use loop).

A/B testing during #253 showed that setting `max_tokens` subtly changes model behavior even when output doesn't approach the cap. The model naturally stops after producing the JSON array. The `finish_reason=length` truncation guard remains as a safety net for provider-side limits.

Closes #247

## Test plan

- [x] `cargo test --bin quorum` — 1276 passed, 1 ignored
- [x] `cargo clippy --all-targets` — clean
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)