### PR TITLE
feat: replace grounding severity demotion with confidence signal

### DIFF
--- a/src/analysis.rs
+++ b/src/analysis.rs
@@ -65,6 +65,7 @@ pub fn analyze_complexity(
                     confidence: None,
                     cited_lines: None,
                     grounding_status: None,
+                    grounding_confidence: None,
                 });
             }
         }
@@ -245,6 +246,7 @@ fn scan_insecure_rust(node: &tree_sitter::Node, source: &str, findings: &mut Vec
             confidence: None,
             cited_lines: None,
                     grounding_status: None,
+                    grounding_confidence: None,
         });
     }
 
@@ -278,6 +280,7 @@ fn scan_insecure_rust(node: &tree_sitter::Node, source: &str, findings: &mut Vec
                 confidence: None,
                 cited_lines: None,
                 grounding_status: None,
+                grounding_confidence: None,
             });
         }
     }
@@ -314,6 +317,7 @@ fn scan_insecure_python(node: &tree_sitter::Node, source: &str, findings: &mut V
                     confidence: None,
                     cited_lines: None,
                     grounding_status: None,
+                    grounding_confidence: None,
                 });
             }
         }
@@ -341,6 +345,7 @@ fn scan_insecure_python(node: &tree_sitter::Node, source: &str, findings: &mut V
                     confidence: None,
                     cited_lines: None,
                     grounding_status: None,
+                    grounding_confidence: None,
                 });
             }
             if args_text.contains("host=\"0.0.0.0\"") || args_text.contains("host='0.0.0.0'") {
@@ -363,6 +368,7 @@ fn scan_insecure_python(node: &tree_sitter::Node, source: &str, findings: &mut V
                     confidence: None,
                     cited_lines: None,
                     grounding_status: None,
+                    grounding_confidence: None,
                 });
             }
         }
@@ -399,6 +405,7 @@ fn scan_insecure_python(node: &tree_sitter::Node, source: &str, findings: &mut V
                                 confidence: None,
                                 cited_lines: None,
                     grounding_status: None,
+                    grounding_confidence: None,
                             });
                     } else if arg_text.contains(".format(") {
                         findings.push(Finding {
@@ -420,6 +427,7 @@ fn scan_insecure_python(node: &tree_sitter::Node, source: &str, findings: &mut V
                                 confidence: None,
                                 cited_lines: None,
                     grounding_status: None,
+                    grounding_confidence: None,
                             });
                     }
                 }
@@ -461,6 +469,7 @@ fn scan_insecure_python(node: &tree_sitter::Node, source: &str, findings: &mut V
                             confidence: None,
                             cited_lines: None,
                     grounding_status: None,
+                    grounding_confidence: None,
                         });
                 }
             }
@@ -519,6 +528,7 @@ fn scan_insecure_python(node: &tree_sitter::Node, source: &str, findings: &mut V
                         confidence: None,
                         cited_lines: None,
                     grounding_status: None,
+                    grounding_confidence: None,
                     });
             }
         }
@@ -593,6 +603,7 @@ fn scan_insecure_python(node: &tree_sitter::Node, source: &str, findings: &mut V
                             confidence: None,
                             cited_lines: None,
                     grounding_status: None,
+                    grounding_confidence: None,
                         });
             }
         }
@@ -628,6 +639,7 @@ fn scan_insecure_python(node: &tree_sitter::Node, source: &str, findings: &mut V
                             confidence: None,
                             cited_lines: None,
                     grounding_status: None,
+                    grounding_confidence: None,
                         });
                 }
             }
@@ -681,6 +693,7 @@ fn scan_insecure_python(node: &tree_sitter::Node, source: &str, findings: &mut V
                     confidence: None,
                     cited_lines: None,
                     grounding_status: None,
+                    grounding_confidence: None,
                 });
             }
         }
@@ -712,6 +725,7 @@ fn scan_insecure_python(node: &tree_sitter::Node, source: &str, findings: &mut V
                     confidence: None,
                     cited_lines: None,
                     grounding_status: None,
+                    grounding_confidence: None,
                 });
         }
     }
@@ -745,6 +759,7 @@ fn scan_insecure_python(node: &tree_sitter::Node, source: &str, findings: &mut V
                     confidence: None,
                     cited_lines: None,
                     grounding_status: None,
+                    grounding_confidence: None,
                 });
         }
     }
@@ -1107,6 +1122,7 @@ fn scan_insecure_yaml(node: &tree_sitter::Node, source: &str, findings: &mut Vec
                                 confidence: None,
                                 cited_lines: None,
                     grounding_status: None,
+                    grounding_confidence: None,
                             });
                 } else {
                     seen_keys.push((key_text, key_line));
@@ -1142,6 +1158,7 @@ fn scan_insecure_yaml(node: &tree_sitter::Node, source: &str, findings: &mut Vec
                     confidence: None,
                     cited_lines: None,
                     grounding_status: None,
+                    grounding_confidence: None,
                 });
             }
 
@@ -1166,6 +1183,7 @@ fn scan_insecure_yaml(node: &tree_sitter::Node, source: &str, findings: &mut Vec
                     confidence: None,
                     cited_lines: None,
                     grounding_status: None,
+                    grounding_confidence: None,
                 });
             }
 
@@ -1199,6 +1217,7 @@ fn scan_insecure_yaml(node: &tree_sitter::Node, source: &str, findings: &mut Vec
                         confidence: None,
                         cited_lines: None,
                     grounding_status: None,
+                    grounding_confidence: None,
                     });
                 }
             }
@@ -1235,6 +1254,7 @@ fn scan_insecure_yaml(node: &tree_sitter::Node, source: &str, findings: &mut Vec
                                     confidence: None,
                                     cited_lines: None,
                     grounding_status: None,
+                    grounding_confidence: None,
                                 });
                     }
                 }
@@ -1275,6 +1295,7 @@ fn scan_insecure_yaml(node: &tree_sitter::Node, source: &str, findings: &mut Vec
                             confidence: None,
                             cited_lines: None,
                     grounding_status: None,
+                    grounding_confidence: None,
                         });
                     }
                 }
@@ -1308,6 +1329,7 @@ fn scan_insecure_yaml(node: &tree_sitter::Node, source: &str, findings: &mut Vec
                             confidence: None,
                             cited_lines: None,
                     grounding_status: None,
+                    grounding_confidence: None,
                         });
                     }
                 }
@@ -1375,6 +1397,7 @@ fn scan_insecure_yaml(node: &tree_sitter::Node, source: &str, findings: &mut Vec
                                             confidence: None,
                                             cited_lines: None,
                     grounding_status: None,
+                    grounding_confidence: None,
                                         });
                             }
 
@@ -1399,6 +1422,7 @@ fn scan_insecure_yaml(node: &tree_sitter::Node, source: &str, findings: &mut Vec
                                             confidence: None,
                                             cited_lines: None,
                     grounding_status: None,
+                    grounding_confidence: None,
                                         });
                             }
                         }
@@ -1442,6 +1466,7 @@ fn scan_insecure_yaml(node: &tree_sitter::Node, source: &str, findings: &mut Vec
                     confidence: None,
                     cited_lines: None,
                     grounding_status: None,
+                    grounding_confidence: None,
                 });
             }
         }
@@ -1488,6 +1513,7 @@ fn scan_insecure_yaml(node: &tree_sitter::Node, source: &str, findings: &mut Vec
                                     confidence: None,
                                     cited_lines: None,
                                     grounding_status: None,
+                                    grounding_confidence: None,
                                 });
                             }
                         }
@@ -1518,6 +1544,7 @@ fn scan_insecure_yaml(node: &tree_sitter::Node, source: &str, findings: &mut Vec
                     confidence: None,
                     cited_lines: None,
                     grounding_status: None,
+                    grounding_confidence: None,
                 });
             }
         }
@@ -1550,6 +1577,7 @@ fn scan_insecure_yaml(node: &tree_sitter::Node, source: &str, findings: &mut Vec
                     confidence: None,
                     cited_lines: None,
                     grounding_status: None,
+                    grounding_confidence: None,
                 });
             }
         }
@@ -1579,6 +1607,7 @@ fn scan_insecure_yaml(node: &tree_sitter::Node, source: &str, findings: &mut Vec
                             confidence: None,
                             cited_lines: None,
                     grounding_status: None,
+                    grounding_confidence: None,
                         });
             }
         }
@@ -1610,6 +1639,7 @@ fn scan_insecure_yaml(node: &tree_sitter::Node, source: &str, findings: &mut Vec
                             confidence: None,
                             cited_lines: None,
                     grounding_status: None,
+                    grounding_confidence: None,
                         });
             }
         }
@@ -1648,6 +1678,7 @@ fn scan_insecure_yaml(node: &tree_sitter::Node, source: &str, findings: &mut Vec
                         confidence: None,
                         cited_lines: None,
                     grounding_status: None,
+                    grounding_confidence: None,
                     });
                 }
             }
@@ -1706,6 +1737,7 @@ fn scan_insecure_yaml(node: &tree_sitter::Node, source: &str, findings: &mut Vec
                     confidence: None,
                     cited_lines: None,
                     grounding_status: None,
+                    grounding_confidence: None,
                 });
             }
         }
@@ -1742,6 +1774,7 @@ fn scan_insecure_typescript(node: &tree_sitter::Node, source: &str, findings: &m
                 confidence: None,
                 cited_lines: None,
                 grounding_status: None,
+                grounding_confidence: None,
             });
         }
 
@@ -1766,6 +1799,7 @@ fn scan_insecure_typescript(node: &tree_sitter::Node, source: &str, findings: &m
                     confidence: None,
                     cited_lines: None,
                     grounding_status: None,
+                    grounding_confidence: None,
                 });
         }
 
@@ -1790,6 +1824,7 @@ fn scan_insecure_typescript(node: &tree_sitter::Node, source: &str, findings: &m
                     confidence: None,
                     cited_lines: None,
                     grounding_status: None,
+                    grounding_confidence: None,
                 });
         }
     }
@@ -1843,6 +1878,7 @@ fn scan_insecure_typescript(node: &tree_sitter::Node, source: &str, findings: &m
                                 confidence: None,
                                 cited_lines: None,
                     grounding_status: None,
+                    grounding_confidence: None,
                             });
                 }
             }
@@ -1879,6 +1915,7 @@ fn scan_insecure_typescript(node: &tree_sitter::Node, source: &str, findings: &m
                     confidence: None,
                     cited_lines: None,
                     grounding_status: None,
+                    grounding_confidence: None,
                 });
         }
     }
@@ -1907,6 +1944,7 @@ fn scan_insecure_typescript(node: &tree_sitter::Node, source: &str, findings: &m
                 confidence: None,
                 cited_lines: None,
                 grounding_status: None,
+                grounding_confidence: None,
             });
         }
     }
@@ -1942,6 +1980,7 @@ fn scan_insecure_typescript(node: &tree_sitter::Node, source: &str, findings: &m
                 confidence: None,
                 cited_lines: None,
                 grounding_status: None,
+                grounding_confidence: None,
             });
         }
     }
@@ -1988,6 +2027,7 @@ fn scan_insecure_typescript(node: &tree_sitter::Node, source: &str, findings: &m
                             confidence: None,
                             cited_lines: None,
                     grounding_status: None,
+                    grounding_confidence: None,
                         });
                 break;
             }
@@ -2029,6 +2069,7 @@ fn scan_insecure_typescript(node: &tree_sitter::Node, source: &str, findings: &m
                                 confidence: None,
                                 cited_lines: None,
                     grounding_status: None,
+                    grounding_confidence: None,
                             });
             }
         }
@@ -2055,6 +2096,7 @@ fn scan_insecure_typescript(node: &tree_sitter::Node, source: &str, findings: &m
             confidence: None,
             cited_lines: None,
                     grounding_status: None,
+                    grounding_confidence: None,
         });
     }
 }
@@ -2085,6 +2127,7 @@ fn scan_insecure_bash(node: &tree_sitter::Node, source: &str, findings: &mut Vec
                 confidence: None,
                 cited_lines: None,
                     grounding_status: None,
+                grounding_confidence: None,
             });
     }
 
@@ -2124,6 +2167,7 @@ fn scan_insecure_bash(node: &tree_sitter::Node, source: &str, findings: &mut Vec
                 confidence: None,
                 cited_lines: None,
                 grounding_status: None,
+                grounding_confidence: None,
             });
         }
     }
@@ -2154,6 +2198,7 @@ fn scan_insecure_bash(node: &tree_sitter::Node, source: &str, findings: &mut Vec
                 confidence: None,
                 cited_lines: None,
                 grounding_status: None,
+                grounding_confidence: None,
             });
         }
 
@@ -2183,6 +2228,7 @@ fn scan_insecure_bash(node: &tree_sitter::Node, source: &str, findings: &mut Vec
                             confidence: None,
                             cited_lines: None,
                             grounding_status: None,
+                            grounding_confidence: None,
                         });
                         break;
                     }
@@ -2222,6 +2268,7 @@ fn scan_insecure_bash(node: &tree_sitter::Node, source: &str, findings: &mut Vec
                         confidence: None,
                         cited_lines: None,
                         grounding_status: None,
+                        grounding_confidence: None,
                     });
                     break;
                 }
@@ -2270,6 +2317,7 @@ fn scan_insecure_bash(node: &tree_sitter::Node, source: &str, findings: &mut Vec
                                 confidence: None,
                                 cited_lines: None,
                     grounding_status: None,
+                    grounding_confidence: None,
                             });
                 }
             }
@@ -2304,6 +2352,7 @@ fn scan_insecure_dockerfile(node: &tree_sitter::Node, source: &str, findings: &m
                     confidence: None,
                     cited_lines: None,
                     grounding_status: None,
+                    grounding_confidence: None,
                 });
             }
         }
@@ -2349,6 +2398,7 @@ fn scan_insecure_dockerfile(node: &tree_sitter::Node, source: &str, findings: &m
                                 confidence: None,
                                 cited_lines: None,
                     grounding_status: None,
+                    grounding_confidence: None,
                             });
                             break;
                         }
@@ -2383,6 +2433,7 @@ fn scan_insecure_dockerfile(node: &tree_sitter::Node, source: &str, findings: &m
                     confidence: None,
                     cited_lines: None,
                     grounding_status: None,
+                    grounding_confidence: None,
                 });
             }
         }
@@ -2486,6 +2537,7 @@ fn scan_insecure_terraform(node: &tree_sitter::Node, source: &str, findings: &mu
                                     confidence: None,
                                     cited_lines: None,
                     grounding_status: None,
+                    grounding_confidence: None,
                                 });
             }
         }
@@ -2526,6 +2578,7 @@ fn scan_insecure_terraform(node: &tree_sitter::Node, source: &str, findings: &mu
                                     confidence: None,
                                     cited_lines: None,
                     grounding_status: None,
+                    grounding_confidence: None,
                                 });
                     }
                 }
@@ -2594,6 +2647,7 @@ fn scan_insecure_terraform(node: &tree_sitter::Node, source: &str, findings: &mu
                         confidence: None,
                         cited_lines: None,
                     grounding_status: None,
+                    grounding_confidence: None,
                     });
         }
     }
@@ -2687,6 +2741,7 @@ fn analyze_terraform_structure(tree: &tree_sitter::Tree, source: &str) -> Vec<Fi
             confidence: None,
             cited_lines: None,
                     grounding_status: None,
+                    grounding_confidence: None,
         });
     }
 
@@ -2781,6 +2836,7 @@ fn check_required_providers(rp_body: tree_sitter::Node, source: &str, findings: 
                 confidence: None,
                 cited_lines: None,
                 grounding_status: None,
+                grounding_confidence: None,
             });
         }
     }
@@ -2880,6 +2936,7 @@ fn analyze_dockerfile_structure(tree: &tree_sitter::Tree, source: &str) -> Vec<F
                             confidence: None,
                             cited_lines: None,
                     grounding_status: None,
+                    grounding_confidence: None,
                         });
                     }
                 }
@@ -2914,6 +2971,7 @@ fn analyze_dockerfile_structure(tree: &tree_sitter::Tree, source: &str) -> Vec<F
             confidence: None,
             cited_lines: None,
             grounding_status: None,
+            grounding_confidence: None,
         });
     }
 
@@ -2938,6 +2996,7 @@ fn analyze_dockerfile_structure(tree: &tree_sitter::Tree, source: &str) -> Vec<F
             confidence: None,
             cited_lines: None,
                     grounding_status: None,
+                    grounding_confidence: None,
         });
     }
 
@@ -2965,6 +3024,7 @@ fn analyze_dockerfile_structure(tree: &tree_sitter::Tree, source: &str) -> Vec<F
             confidence: None,
             cited_lines: None,
             grounding_status: None,
+            grounding_confidence: None,
         });
     }
     if entrypoint_count > 1 {
@@ -2990,6 +3050,7 @@ fn analyze_dockerfile_structure(tree: &tree_sitter::Tree, source: &str) -> Vec<F
             confidence: None,
             cited_lines: None,
             grounding_status: None,
+            grounding_confidence: None,
         });
     }
 

--- a/src/ast_grep.rs
+++ b/src/ast_grep.rs
@@ -293,6 +293,7 @@ pub fn scan_file(source: &str, ext: &str, rules: &[RuleConfig<SupportLang>]) -> 
                     confidence: None,
                     cited_lines: None,
                     grounding_status: None,
+                    grounding_confidence: None,
                 });
             }
         }

--- a/src/finding.rs
+++ b/src/finding.rs
@@ -106,6 +106,8 @@ pub struct Finding {
     pub cited_lines: Option<(u32, u32)>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub grounding_status: Option<GroundingStatus>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub grounding_confidence: Option<f32>,
 }
 
 impl Finding {
@@ -165,6 +167,7 @@ impl FindingBuilder {
                 confidence: None,
                 cited_lines: None,
                 grounding_status: None,
+                grounding_confidence: None,
             },
         }
     }
@@ -257,6 +260,11 @@ impl FindingBuilder {
         self
     }
 
+    pub fn grounding_confidence(mut self, c: f32) -> Self {
+        self.inner.grounding_confidence = Some(c);
+        self
+    }
+
     pub fn precedent(mut self, p: &str) -> Self {
         self.inner.similar_precedent.push(p.into());
         self
@@ -344,6 +352,7 @@ mod tests {
             confidence: None,
             cited_lines: None,
             grounding_status: None,
+            grounding_confidence: None,
         };
         let json = serde_json::to_value(&f).unwrap();
         assert_eq!(json["title"], "Unvalidated input");
@@ -378,6 +387,7 @@ mod tests {
             confidence: None,
             cited_lines: None,
             grounding_status: None,
+            grounding_confidence: None,
         };
         let json_str = serde_json::to_string(&original).unwrap();
         let deserialized: Finding = serde_json::from_str(&json_str).unwrap();
@@ -405,6 +415,7 @@ mod tests {
             confidence: None,
             cited_lines: None,
             grounding_status: None,
+            grounding_confidence: None,
         };
         let json = serde_json::to_value(&f).unwrap();
         assert!(json["calibrator_action"].is_null());
@@ -434,6 +445,7 @@ mod tests {
             confidence: None,
             cited_lines: None,
             grounding_status: None,
+            grounding_confidence: None,
         };
         assert!(f.is_valid());
     }
@@ -459,6 +471,7 @@ mod tests {
             confidence: None,
             cited_lines: None,
             grounding_status: None,
+            grounding_confidence: None,
         };
         assert!(f.is_valid());
     }
@@ -484,6 +497,7 @@ mod tests {
             confidence: None,
             cited_lines: None,
             grounding_status: None,
+            grounding_confidence: None,
         };
         assert!(!f.is_valid());
     }
@@ -509,6 +523,7 @@ mod tests {
             confidence: None,
             cited_lines: None,
             grounding_status: None,
+            grounding_confidence: None,
         };
         assert!(!f.is_valid());
     }

--- a/src/grounding.rs
+++ b/src/grounding.rs
@@ -1,4 +1,4 @@
-use crate::finding::{Finding, GroundingStatus, Severity, Source};
+use crate::finding::{Finding, GroundingStatus, Source};
 use regex::Regex;
 use std::collections::HashSet;
 use std::sync::LazyLock;
@@ -93,18 +93,7 @@ pub fn extract_identifiers_from_finding_text<'a>(
 #[derive(Debug)]
 pub struct GroundingResult {
     pub status: GroundingStatus,
-    pub severity_change: Option<Severity>,
-}
-
-/// Step severity down one level. Returns `None` for `Info` (cannot demote further).
-fn demote_severity(s: &Severity) -> Option<Severity> {
-    match s {
-        Severity::Critical => Some(Severity::High),
-        Severity::High => Some(Severity::Medium),
-        Severity::Medium => Some(Severity::Low),
-        Severity::Low => Some(Severity::Info),
-        Severity::Info => None,
-    }
+    pub confidence: Option<f32>,
 }
 
 fn is_word_char(c: char) -> bool {
@@ -148,13 +137,12 @@ fn verify_grounding_with_lines(finding: &Finding, source_lines: &[&str]) -> Grou
     if !matches!(finding.source, Source::Llm(_)) {
         return GroundingResult {
             status: GroundingStatus::NotChecked,
-            severity_change: None,
+            confidence: None,
         };
     }
 
     let line_count = source_lines.len() as u32;
 
-    // Check line range validity (1-indexed, ordered).
     if finding.line_start == 0
         || finding.line_end == 0
         || finding.line_start > finding.line_end
@@ -163,36 +151,33 @@ fn verify_grounding_with_lines(finding: &Finding, source_lines: &[&str]) -> Grou
     {
         return GroundingResult {
             status: GroundingStatus::LineOutOfRange,
-            severity_change: demote_severity(&finding.severity),
+            confidence: Some(0.1),
         };
     }
 
-    // Extract identifiers from title (fallback to description).
     let identifiers = extract_identifiers_from_finding_text(&finding.title, &finding.description);
     if identifiers.is_empty() {
         return GroundingResult {
             status: GroundingStatus::NotChecked,
-            severity_change: None,
+            confidence: None,
         };
     }
 
-    // Build the +/- 2 line window (1-indexed to 0-indexed).
-    let start = (finding.line_start as usize).saturating_sub(3); // -1 for 0-index, -2 for window
+    let start = (finding.line_start as usize).saturating_sub(3);
     let end = ((finding.line_end as usize) + 2).min(source_lines.len());
     let window: String = source_lines[start..end].join("\n");
 
-    // Check all identifiers exist with context-aware boundary matching.
     let all_found = identifiers.iter().all(|id| contains_symbol(&window, id));
 
     if all_found {
         GroundingResult {
             status: GroundingStatus::Verified,
-            severity_change: None,
+            confidence: Some(1.0),
         }
     } else {
         GroundingResult {
             status: GroundingStatus::SymbolNotFound,
-            severity_change: demote_severity(&finding.severity),
+            confidence: Some(0.3),
         }
     }
 }
@@ -220,9 +205,9 @@ pub fn count_grounding_outcomes(findings: &[Finding]) -> GroundingCounters {
     c
 }
 
-/// Apply grounding verification to a batch of findings, mutating severity
-/// in place for ungrounded LLM findings. When `disabled` is true, returns
-/// findings unchanged.
+/// Apply grounding verification to a batch of findings, setting
+/// `grounding_status` and `grounding_confidence` on each LLM finding.
+/// When `disabled` is true, returns findings unchanged.
 pub fn apply_grounding(mut findings: Vec<Finding>, source: &str, disabled: bool) -> Vec<Finding> {
     if disabled {
         return findings;
@@ -234,9 +219,7 @@ pub fn apply_grounding(mut findings: Vec<Finding>, source: &str, disabled: bool)
         }
         let result = verify_grounding_with_lines(finding, &source_lines);
         finding.grounding_status = Some(result.status);
-        if let Some(new_severity) = result.severity_change {
-            finding.severity = new_severity;
-        }
+        finding.grounding_confidence = result.confidence;
     }
     findings
 }
@@ -343,7 +326,7 @@ mod tests {
             .build();
         let result = verify_grounding(&f, sample_source());
         assert_eq!(result.status, GroundingStatus::Verified);
-        assert_eq!(result.severity_change, None);
+        assert_eq!(result.confidence, Some(1.0));
     }
 
     #[test]
@@ -356,7 +339,7 @@ mod tests {
             .build();
         let result = verify_grounding(&f, sample_source());
         assert_eq!(result.status, GroundingStatus::SymbolNotFound);
-        assert_eq!(result.severity_change, Some(Severity::Medium));
+        assert_eq!(result.confidence, Some(0.3));
     }
 
     #[test]
@@ -369,7 +352,7 @@ mod tests {
             .build();
         let result = verify_grounding(&f, sample_source());
         assert_eq!(result.status, GroundingStatus::LineOutOfRange);
-        assert_eq!(result.severity_change, Some(Severity::Medium));
+        assert_eq!(result.confidence, Some(0.1));
     }
 
     #[test]
@@ -382,7 +365,7 @@ mod tests {
             .build();
         let result = verify_grounding(&f, sample_source());
         assert_eq!(result.status, GroundingStatus::NotChecked);
-        assert_eq!(result.severity_change, None);
+        assert_eq!(result.confidence, None);
     }
 
     #[test]
@@ -396,44 +379,33 @@ mod tests {
             .build();
         let result = verify_grounding(&f, sample_source());
         assert_eq!(result.status, GroundingStatus::NotChecked);
-        assert_eq!(result.severity_change, None);
+        assert_eq!(result.confidence, None);
     }
 
     #[test]
-    fn grounding_demotion_steps_down_one_level() {
-        for (input, expected) in [
-            (Severity::Critical, Severity::High),
-            (Severity::High, Severity::Medium),
-            (Severity::Medium, Severity::Low),
-            (Severity::Low, Severity::Info),
+    fn grounding_confidence_consistent_across_severities() {
+        for severity in [
+            Severity::Critical,
+            Severity::High,
+            Severity::Medium,
+            Severity::Low,
+            Severity::Info,
         ] {
             let f = FindingBuilder::new()
                 .title("Function `nonexistent_func` has a bug")
                 .source(Source::Llm("gpt-5.4".into()))
                 .lines(3, 9)
-                .severity(input.clone())
+                .severity(severity.clone())
                 .build();
             let result = verify_grounding(&f, sample_source());
+            assert_eq!(result.status, GroundingStatus::SymbolNotFound);
             assert_eq!(
-                result.severity_change,
-                Some(expected),
-                "failed for {:?}",
-                input
+                result.confidence,
+                Some(0.3),
+                "confidence should be 0.3 for SymbolNotFound regardless of severity {:?}",
+                severity
             );
         }
-    }
-
-    #[test]
-    fn grounding_info_cannot_demote_further() {
-        let f = FindingBuilder::new()
-            .title("Function `nonexistent_func` has a bug")
-            .source(Source::Llm("gpt-5.4".into()))
-            .lines(3, 9)
-            .severity(Severity::Info)
-            .build();
-        let result = verify_grounding(&f, sample_source());
-        assert_eq!(result.status, GroundingStatus::SymbolNotFound);
-        assert_eq!(result.severity_change, None);
     }
 
     #[test]
@@ -475,7 +447,7 @@ mod tests {
             .build();
         let result = verify_grounding(&f, sample_source());
         assert_eq!(result.status, GroundingStatus::SymbolNotFound);
-        assert_eq!(result.severity_change, Some(Severity::Medium));
+        assert_eq!(result.confidence, Some(0.3));
     }
 
     #[test]
@@ -490,7 +462,7 @@ mod tests {
             .build();
         let result = verify_grounding(&f, sample_source());
         assert_eq!(result.status, GroundingStatus::Verified);
-        assert_eq!(result.severity_change, None);
+        assert_eq!(result.confidence, Some(1.0));
     }
 
     #[test]
@@ -505,7 +477,7 @@ mod tests {
             .build();
         let result = verify_grounding(&f, source);
         assert_eq!(result.status, GroundingStatus::Verified);
-        assert_eq!(result.severity_change, None);
+        assert_eq!(result.confidence, Some(1.0));
     }
 
     #[test]
@@ -518,7 +490,7 @@ mod tests {
             .build();
         let result = verify_grounding(&f, sample_source());
         assert_eq!(result.status, GroundingStatus::SymbolNotFound);
-        assert_eq!(result.severity_change, Some(Severity::Medium));
+        assert_eq!(result.confidence, Some(0.3));
     }
 
     #[test]
@@ -531,13 +503,13 @@ mod tests {
             .build();
         let result = verify_grounding(&f, sample_source());
         assert_eq!(result.status, GroundingStatus::NotChecked);
-        assert_eq!(result.severity_change, None);
+        assert_eq!(result.confidence, None);
     }
 
     // --- apply_grounding tests ---
 
     #[test]
-    fn apply_grounding_pass_sets_status_and_demotes() {
+    fn apply_grounding_sets_status_and_confidence() {
         let source = "fn parse_unified_diff() {}\nfn other() {}\n";
         let findings = vec![
             FindingBuilder::new()
@@ -561,13 +533,16 @@ mod tests {
         ];
         let result = apply_grounding(findings, source, false);
         assert_eq!(result[0].grounding_status, Some(GroundingStatus::Verified));
+        assert_eq!(result[0].grounding_confidence, Some(1.0));
         assert_eq!(result[0].severity, Severity::High);
         assert_eq!(
             result[1].grounding_status,
             Some(GroundingStatus::SymbolNotFound)
         );
-        assert_eq!(result[1].severity, Severity::Medium); // demoted
+        assert_eq!(result[1].grounding_confidence, Some(0.3));
+        assert_eq!(result[1].severity, Severity::High); // severity unchanged
         assert!(result[2].grounding_status.is_none()); // LocalAst untouched
+        assert!(result[2].grounding_confidence.is_none());
         assert_eq!(result[2].severity, Severity::Medium);
     }
 
@@ -663,7 +638,7 @@ mod tests {
             .build();
         let result = verify_grounding(&f, sample_source());
         assert_eq!(result.status, GroundingStatus::LineOutOfRange);
-        assert_eq!(result.severity_change, Some(Severity::Medium));
+        assert_eq!(result.confidence, Some(0.1));
     }
 
     #[test]
@@ -676,7 +651,7 @@ mod tests {
             .build();
         let result = verify_grounding(&f, sample_source());
         assert_eq!(result.status, GroundingStatus::LineOutOfRange);
-        assert_eq!(result.severity_change, Some(Severity::Medium));
+        assert_eq!(result.confidence, Some(0.1));
     }
 
     #[test]
@@ -696,8 +671,8 @@ mod tests {
             "title has no backticked IDs; description fallback should not cause SymbolNotFound"
         );
         assert!(
-            result.severity_change.is_none(),
-            "severity should not change"
+            result.confidence.is_none(),
+            "confidence should be None for NotChecked"
         );
     }
 }

--- a/src/linter.rs
+++ b/src/linter.rs
@@ -292,6 +292,7 @@ pub fn normalize_ruff_output(json_output: &str) -> anyhow::Result<Vec<Finding>> 
             confidence: None,
             cited_lines: None,
             grounding_status: None,
+            grounding_confidence: None,
         });
     }
 
@@ -352,6 +353,7 @@ pub fn normalize_clippy_output(json_output: &str) -> anyhow::Result<Vec<Finding>
             confidence: None,
             cited_lines: None,
             grounding_status: None,
+            grounding_confidence: None,
         });
     }
 
@@ -400,6 +402,7 @@ pub fn normalize_eslint_output(json_output: &str) -> anyhow::Result<Vec<Finding>
                 confidence: None,
                 cited_lines: None,
                 grounding_status: None,
+                grounding_confidence: None,
             });
         }
     }
@@ -462,6 +465,7 @@ pub fn normalize_yamllint_output(output: &str) -> anyhow::Result<Vec<Finding>> {
             confidence: None,
             cited_lines: None,
             grounding_status: None,
+            grounding_confidence: None,
         });
     }
     Ok(findings)
@@ -507,6 +511,7 @@ pub fn normalize_shellcheck_output(json_output: &str) -> anyhow::Result<Vec<Find
                 confidence: None,
                 cited_lines: None,
                 grounding_status: None,
+                grounding_confidence: None,
             });
         }
     }
@@ -569,6 +574,7 @@ pub fn normalize_hadolint_output(output: &str) -> anyhow::Result<Vec<Finding>> {
             confidence: None,
             cited_lines: None,
             grounding_status: None,
+            grounding_confidence: None,
         });
     }
     Ok(findings)
@@ -615,6 +621,7 @@ pub fn normalize_tflint_output(json_output: &str) -> anyhow::Result<Vec<Finding>
                 confidence: None,
                 cited_lines: None,
                 grounding_status: None,
+                grounding_confidence: None,
             });
         }
     }

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -124,18 +124,15 @@ pub fn format_finding(f: &Finding, style: &Style) -> String {
         ));
     }
 
-    if let Some(ref status) = f.grounding_status {
-        use crate::finding::GroundingStatus;
-        if matches!(
-            status,
-            GroundingStatus::SymbolNotFound | GroundingStatus::LineOutOfRange
-        ) {
-            output.push_str(&format!(
-                "    {dim}[ungrounded] cited symbol not verified in source{reset}\n",
-                dim = style.dim,
-                reset = style.reset,
-            ));
-        }
+    if let Some(gc) = f.grounding_confidence
+        && gc < 1.0
+    {
+        output.push_str(&format!(
+            "    {dim}[grounding: {gc:.1}] cited symbol not verified in source{reset}\n",
+            dim = style.dim,
+            gc = gc,
+            reset = style.reset,
+        ));
     }
 
     output
@@ -883,30 +880,32 @@ mod tests {
     use crate::finding::GroundingStatus;
 
     #[test]
-    fn format_finding_shows_ungrounded_tag() {
+    fn format_finding_shows_grounding_confidence_for_symbol_not_found() {
         let f = FindingBuilder::new()
             .title("Function `nonexistent` has bug")
             .severity(Severity::Medium)
             .grounding_status(GroundingStatus::SymbolNotFound)
+            .grounding_confidence(0.3)
             .build();
         let output = format_finding(&f, &Style::plain());
         assert!(
-            output.contains("[ungrounded]"),
-            "Expected [ungrounded] in output: {output}"
+            output.contains("[grounding: 0.3]"),
+            "Expected [grounding: 0.3] in output: {output}"
         );
     }
 
     #[test]
-    fn format_finding_shows_ungrounded_for_line_out_of_range() {
+    fn format_finding_shows_grounding_confidence_for_line_out_of_range() {
         let f = FindingBuilder::new()
             .title("Function `foo_bar` has bug")
             .severity(Severity::Medium)
             .grounding_status(GroundingStatus::LineOutOfRange)
+            .grounding_confidence(0.1)
             .build();
         let output = format_finding(&f, &Style::plain());
         assert!(
-            output.contains("[ungrounded]"),
-            "Expected [ungrounded] in output: {output}"
+            output.contains("[grounding: 0.1]"),
+            "Expected [grounding: 0.1] in output: {output}"
         );
     }
 
@@ -916,11 +915,12 @@ mod tests {
             .title("Function `real_func` has bug")
             .severity(Severity::Medium)
             .grounding_status(GroundingStatus::Verified)
+            .grounding_confidence(1.0)
             .build();
         let output = format_finding(&f, &Style::plain());
         assert!(
-            !output.contains("[ungrounded]"),
-            "Verified should NOT show [ungrounded]: {output}"
+            !output.contains("[grounding:"),
+            "Verified (1.0) should NOT show grounding tag: {output}"
         );
     }
 
@@ -933,8 +933,8 @@ mod tests {
             .build();
         let output = format_finding(&f, &Style::plain());
         assert!(
-            !output.contains("[ungrounded]"),
-            "NotChecked should NOT show [ungrounded]: {output}"
+            !output.contains("[grounding:"),
+            "NotChecked should NOT show grounding tag: {output}"
         );
     }
 
@@ -946,16 +946,17 @@ mod tests {
             .build();
         let output = format_finding(&f, &Style::plain());
         assert!(
-            !output.contains("[ungrounded]"),
-            "None grounding should NOT show [ungrounded]: {output}"
+            !output.contains("[grounding:"),
+            "None grounding should NOT show grounding tag: {output}"
         );
     }
 
     #[test]
-    fn grounding_status_in_json_output() {
+    fn grounding_confidence_in_json_output() {
         let f = FindingBuilder::new()
             .title("Function `nonexistent` has bug")
             .grounding_status(GroundingStatus::SymbolNotFound)
+            .grounding_confidence(0.3)
             .build();
         let json = serde_json::to_string(&f).unwrap();
         assert!(
@@ -965,6 +966,10 @@ mod tests {
         assert!(
             json.contains("symbol-not-found"),
             "JSON should contain kebab-case status: {json}"
+        );
+        assert!(
+            json.contains("grounding_confidence"),
+            "JSON should contain grounding_confidence: {json}"
         );
     }
 

--- a/src/review.rs
+++ b/src/review.rs
@@ -153,6 +153,7 @@ impl LlmFinding {
             confidence: self.confidence.map(|c| c.clamp(0.0, 1.0)),
             cited_lines: None,
             grounding_status: None,
+            grounding_confidence: None,
         }
     }
 }

--- a/tests/finding_schema_test.rs
+++ b/tests/finding_schema_test.rs
@@ -81,6 +81,7 @@ fn new_fields_omitted_from_json_when_none() {
     assert!(!json.contains("reasoning"));
     assert!(!json.contains("confidence"));
     assert!(!json.contains("cited_lines"));
+    assert!(!json.contains("grounding_confidence"));
 }
 
 #[test]

--- a/tests/finding_schema_test.rs
+++ b/tests/finding_schema_test.rs
@@ -22,6 +22,7 @@ fn finding_with_new_fields_roundtrips() {
         confidence: Some(0.92),
         cited_lines: Some((10, 12)),
         grounding_status: None,
+        grounding_confidence: None,
     };
 
     let json = serde_json::to_string(&finding).unwrap();
@@ -73,6 +74,7 @@ fn new_fields_omitted_from_json_when_none() {
         confidence: None,
         cited_lines: None,
         grounding_status: None,
+        grounding_confidence: None,
     };
 
     let json = serde_json::to_string(&finding).unwrap();
@@ -102,6 +104,7 @@ fn category_serializes_as_kebab_case_in_finding() {
         confidence: None,
         cited_lines: None,
         grounding_status: None,
+        grounding_confidence: None,
     };
 
     let json = serde_json::to_string(&finding).unwrap();

--- a/tests/lib_integration_smoke.rs
+++ b/tests/lib_integration_smoke.rs
@@ -38,6 +38,7 @@ fn lib_exports_are_reachable_from_integration_tests() {
         confidence: None,
         cited_lines: None,
         grounding_status: None,
+        grounding_confidence: None,
     };
 
     // calibrate(...) must be callable with no precedents — exercises the


### PR DESCRIPTION
## Summary

Closes #250.

- Grounding verification no longer mutates `finding.severity` — the `demote_severity()` function and `severity_change` field are removed entirely
- Instead, `GroundingResult` carries a `confidence: Option<f32>` signal: Verified=1.0, SymbolNotFound=0.3, LineOutOfRange=0.1, NotChecked=None
- `apply_grounding()` sets `finding.grounding_confidence` (new field on `Finding`) instead of mutating `finding.severity`
- Human output shows `[grounding: 0.3]` instead of `[ungrounded]`, surfacing the actual confidence value
- JSON output includes `grounding_confidence` when present (serde skip_serializing_if None)

This decouples the grounding signal from the severity axis, making it composable for downstream consumers (#248, #251).

## Test plan

- [x] All 1276 unit tests pass
- [x] All 753 lib tests pass
- [x] All integration tests pass (except pre-existing env issue in parallel_review)
- [x] Clippy clean (zero warnings)
- [x] `cargo fmt --check` clean
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added confidence scoring for grounded findings
  * Added optional focus areas directive in review requests

* **Changes**
  * Updated grounding output format to display `[grounding: {confidence}]` instead of `[ungrounded]` tags
  * Removed automatic severity demotion for findings based on grounding status; severity now remains independent of grounding verification

<!-- end of auto-generated comment: release notes by coderabbit.ai -->