### PR TITLE
fix: hydration-aware grounding and diff fallback warning (#259, #260)

### DIFF
--- a/src/grounding.rs
+++ b/src/grounding.rs
@@ -141,10 +141,14 @@ fn contains_symbol(text: &str, id: &str) -> bool {
 /// the cited range accommodates off-by-one LLM citations.
 pub fn verify_grounding(finding: &Finding, source: &str) -> GroundingResult {
     let source_lines: Vec<&str> = source.lines().collect();
-    verify_grounding_with_lines(finding, &source_lines)
+    verify_grounding_with_lines(finding, &source_lines, "")
 }
 
-fn verify_grounding_with_lines(finding: &Finding, source_lines: &[&str]) -> GroundingResult {
+fn verify_grounding_with_lines(
+    finding: &Finding,
+    source_lines: &[&str],
+    hydration_text: &str,
+) -> GroundingResult {
     if !matches!(finding.source, Source::Llm(_)) {
         return GroundingResult {
             status: GroundingStatus::NotChecked,
@@ -181,8 +185,10 @@ fn verify_grounding_with_lines(finding: &Finding, source_lines: &[&str]) -> Grou
     let end = ((finding.line_end as usize) + 2).min(source_lines.len());
     let window: String = source_lines[start..end].join("\n");
 
-    // Check all identifiers exist with context-aware boundary matching.
-    let all_found = identifiers.iter().all(|id| contains_symbol(&window, id));
+    // Check all identifiers: first in source window, then in hydration context.
+    let all_found = identifiers
+        .iter()
+        .all(|id| contains_symbol(&window, id) || contains_symbol(hydration_text, id));
 
     if all_found {
         GroundingResult {
@@ -223,7 +229,12 @@ pub fn count_grounding_outcomes(findings: &[Finding]) -> GroundingCounters {
 /// Apply grounding verification to a batch of findings, mutating severity
 /// in place for ungrounded LLM findings. When `disabled` is true, returns
 /// findings unchanged.
-pub fn apply_grounding(mut findings: Vec<Finding>, source: &str, disabled: bool) -> Vec<Finding> {
+pub fn apply_grounding(
+    mut findings: Vec<Finding>,
+    source: &str,
+    disabled: bool,
+    hydration_text: &str,
+) -> Vec<Finding> {
     if disabled {
         return findings;
     }
@@ -232,7 +243,7 @@ pub fn apply_grounding(mut findings: Vec<Finding>, source: &str, disabled: bool)
         if !matches!(finding.source, Source::Llm(_)) {
             continue;
         }
-        let result = verify_grounding_with_lines(finding, &source_lines);
+        let result = verify_grounding_with_lines(finding, &source_lines, hydration_text);
         finding.grounding_status = Some(result.status);
         if let Some(new_severity) = result.severity_change {
             finding.severity = new_severity;
@@ -559,7 +570,7 @@ mod tests {
                 .severity(Severity::Medium)
                 .build(),
         ];
-        let result = apply_grounding(findings, source, false);
+        let result = apply_grounding(findings, source, false, "");
         assert_eq!(result[0].grounding_status, Some(GroundingStatus::Verified));
         assert_eq!(result[0].severity, Severity::High);
         assert_eq!(
@@ -604,7 +615,7 @@ mod tests {
                 .severity(Severity::High)
                 .build(),
         ];
-        let result = apply_grounding(findings, source, false);
+        let result = apply_grounding(findings, source, false, "");
         let counters = count_grounding_outcomes(&result);
         assert_eq!(counters.verified, 1);
         assert_eq!(counters.symbol_not_found, 1);
@@ -623,7 +634,7 @@ mod tests {
                 .severity(Severity::High)
                 .build(),
         ];
-        let result = apply_grounding(findings, source, true);
+        let result = apply_grounding(findings, source, true, "");
         assert!(result[0].grounding_status.is_none());
         assert_eq!(result[0].severity, Severity::High);
     }
@@ -646,7 +657,7 @@ mod tests {
                 .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
                 .unwrap_or(false);
             assert!(disabled, "Should be disabled for value: {val}");
-            let result = apply_grounding(findings.clone(), source, disabled);
+            let result = apply_grounding(findings.clone(), source, disabled, "");
             assert!(result[0].grounding_status.is_none());
             assert_eq!(result[0].severity, Severity::High);
         }
@@ -699,5 +710,52 @@ mod tests {
             result.severity_change.is_none(),
             "severity should not change"
         );
+    }
+
+    #[test]
+    fn symbol_in_hydration_text_verifies() {
+        let source = "fn foo() {}\n";
+        let hydration = "fn remote_callee(x: i32) -> bool";
+        let f = FindingBuilder::new()
+            .title("Function `remote_callee` has unchecked return")
+            .source(Source::Llm("gpt-5.4".into()))
+            .lines(1, 1)
+            .severity(Severity::High)
+            .build();
+        let source_lines: Vec<&str> = source.lines().collect();
+        let result = verify_grounding_with_lines(&f, &source_lines, hydration);
+        assert_eq!(result.status, GroundingStatus::Verified);
+        assert!(result.severity_change.is_none());
+    }
+
+    #[test]
+    fn symbol_missing_from_both_source_and_hydration_demotes() {
+        let source = "fn foo() {}\n";
+        let hydration = "fn unrelated_fn(x: i32) -> bool";
+        let f = FindingBuilder::new()
+            .title("Function `remote_callee` has unchecked return")
+            .source(Source::Llm("gpt-5.4".into()))
+            .lines(1, 1)
+            .severity(Severity::High)
+            .build();
+        let source_lines: Vec<&str> = source.lines().collect();
+        let result = verify_grounding_with_lines(&f, &source_lines, hydration);
+        assert_eq!(result.status, GroundingStatus::SymbolNotFound);
+        assert_eq!(result.severity_change, Some(Severity::Medium));
+    }
+
+    #[test]
+    fn apply_grounding_with_hydration_text_verifies() {
+        let source = "fn foo() {}\n";
+        let hydration = "fn remote_callee(x: i32) -> bool";
+        let findings = vec![FindingBuilder::new()
+            .title("Function `remote_callee` has unchecked return")
+            .source(Source::Llm("gpt-5.4".into()))
+            .lines(1, 1)
+            .severity(Severity::High)
+            .build()];
+        let result = apply_grounding(findings, source, false, hydration);
+        assert_eq!(result[0].grounding_status, Some(GroundingStatus::Verified));
+        assert_eq!(result[0].severity, Severity::High);
     }
 }

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -410,6 +410,8 @@ pub async fn review_file(
         None
     };
 
+    let mut hydration_text = String::new();
+
     // Source 1: Local AST analysis (skipped for prose reviews)
     let mut local_findings = Vec::new();
     if !pipeline_config.mode.is_prose() {
@@ -494,6 +496,14 @@ pub async fn review_file(
                         Vec::new()
                     };
                 let hydration_ranges = if changed_lines.is_empty() {
+                    if pipeline_config.diff_ranges.is_some() {
+                        tracing::warn!(
+                            file = %file_str,
+                            "diff-file provided but no ranges matched this file; \
+                             falling back to full-file hydration \
+                             (is the file inside the repository?)"
+                        );
+                    }
                     let total_lines = source.lines().count() as u32;
                     vec![(1, total_lines.max(1))]
                 } else {
@@ -670,6 +680,7 @@ pub async fn review_file(
                 }
             };
 
+            hydration_text = render_hydration_for_grounding(&redacted_ctx);
             let req = ReviewRequest {
                 file_path: file_str.clone(),
                 language: lang_name(lang).to_string(),
@@ -760,7 +771,8 @@ pub async fn review_file(
         let grounding_disabled = std::env::var("QUORUM_DISABLE_AST_GROUNDING")
             .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
             .unwrap_or(false);
-        let grounded = grounding::apply_grounding(merged, source, grounding_disabled);
+        let grounded =
+            grounding::apply_grounding(merged, source, grounding_disabled, &hydration_text);
         let gc = grounding::count_grounding_outcomes(&grounded);
         tracing::info!(
             phase = "grounding",
@@ -831,6 +843,20 @@ pub async fn review_file(
         context_telemetry,
         enrichment_metrics,
     })
+}
+
+fn render_hydration_for_grounding(ctx: &crate::hydration::HydrationContext) -> String {
+    let mut parts: Vec<&str> = Vec::new();
+    for s in &ctx.callee_signatures {
+        parts.push(s);
+    }
+    for s in &ctx.type_definitions {
+        parts.push(s);
+    }
+    for s in &ctx.callers {
+        parts.push(s);
+    }
+    parts.join("\n")
 }
 
 /// Best-effort extraction of an identifier from a hydrated callee signature
@@ -1149,7 +1175,8 @@ pub async fn review_file_llm_only(
         let grounding_disabled = std::env::var("QUORUM_DISABLE_AST_GROUNDING")
             .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
             .unwrap_or(false);
-        let grounded = grounding::apply_grounding(merged, source, grounding_disabled);
+        let grounded =
+            grounding::apply_grounding(merged, source, grounding_disabled, "");
         let gc = grounding::count_grounding_outcomes(&grounded);
         tracing::info!(
             phase = "grounding",

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -480,28 +480,26 @@ pub async fn review_file(
             let redacted_ctx = if pipeline_config.mode.is_prose() {
                 crate::hydration::HydrationContext::default()
             } else {
-                let changed_lines: Vec<(u32, u32)> =
+                let (changed_lines, path_resolved) =
                     if let Some(ref diff_ranges) = pipeline_config.diff_ranges {
-                        // Hoist canonicalization out of the filter loop: review_path and
-                        // repo_root are loop-invariant, only diff_path varies. Without
-                        // this, large diffs paid 2 canonicalize syscalls per range entry.
                         let repo_root = find_project_root(file_path);
                         let resolver = ReviewPathResolver::new(&file_str, &repo_root);
-                        diff_ranges
+                        let lines: Vec<(u32, u32)> = diff_ranges
                             .iter()
                             .filter(|(path, _)| resolver.matches(path))
                             .flat_map(|(_, ranges)| ranges.clone())
-                            .collect()
+                            .collect();
+                        (lines, resolver.resolved())
                     } else {
-                        Vec::new()
+                        (Vec::new(), true)
                     };
                 let hydration_ranges = if changed_lines.is_empty() {
-                    if pipeline_config.diff_ranges.is_some() {
+                    if pipeline_config.diff_ranges.is_some() && !path_resolved {
                         tracing::warn!(
                             file = %file_str,
-                            "diff-file provided but no ranges matched this file; \
-                             falling back to full-file hydration \
-                             (is the file inside the repository?)"
+                            "diff-file provided but file path could not be \
+                             resolved relative to the repository root; \
+                             falling back to full-file hydration"
                         );
                     }
                     let total_lines = source.lines().count() as u32;
@@ -846,17 +844,13 @@ pub async fn review_file(
 }
 
 fn render_hydration_for_grounding(ctx: &crate::hydration::HydrationContext) -> String {
-    let mut parts: Vec<&str> = Vec::new();
-    for s in &ctx.callee_signatures {
-        parts.push(s);
-    }
-    for s in &ctx.type_definitions {
-        parts.push(s);
-    }
-    for s in &ctx.callers {
-        parts.push(s);
-    }
-    parts.join("\n")
+    ctx.callee_signatures
+        .iter()
+        .chain(&ctx.type_definitions)
+        .chain(&ctx.callers)
+        .map(|s| s.as_str())
+        .collect::<Vec<_>>()
+        .join("\n")
 }
 
 /// Best-effort extraction of an identifier from a hydrated callee signature
@@ -910,6 +904,10 @@ impl ReviewPathResolver {
             .ok()
             .map(|p| p.to_path_buf());
         Self { review_rel }
+    }
+
+    pub(crate) fn resolved(&self) -> bool {
+        self.review_rel.is_some()
     }
 
     /// True iff `diff_path` (always repo-relative, as produced by the diff


### PR DESCRIPTION
## Summary

- **#259**: Adds `tracing::warn!` when `--diff-file` is provided but no diff ranges match the reviewed file, surfacing the silent full-file hydration fallback (typically caused by the file being outside a git repo)
- **#260**: The grounder now checks hydration context (callee signatures, type definitions, callers) in addition to source lines when verifying LLM-cited symbols. Prevents false `SymbolNotFound` demotions when the LLM correctly references cross-function identifiers from the hydration XML

## Changes

- `apply_grounding` and `verify_grounding_with_lines` accept `hydration_text: &str`
- New `render_hydration_for_grounding` helper joins hydration context fields for the grounder
- `review_file` renders hydration text before the context is moved into `ReviewRequest`
- `review_file_llm_only` passes empty string (no hydration available for unsupported languages)
- 3 new tests covering hydration-aware grounding verification

## Quorum self-review verdicts

| Finding | Verdict | Notes |
|---------|---------|-------|
| `extract_identifiers` misses calls with args | out_of_scope | Pre-existing, filed #262 |
| `verify_grounding` ignores `hydration_text` | fp | By design — only tests use it |
| complexity 10 in `verify_grounding_with_lines` | wontfix | Borderline, pre-existing |
| Windows path parsing in `query_feedback_precedents` | out_of_scope | Pre-existing, filed #263 |
| TP bias in `query_feedback_precedents` | out_of_scope | Pre-existing, filed #264 |
| complexity 47/34 in review functions | wontfix | Pre-existing |
| silent-error-conversion | fp | Env var fallback pattern |

## Test plan

- [x] `cargo test --bin quorum` — 1276 tests pass
- [x] `cargo clippy` — zero warnings
- [x] Quorum self-review — no in-branch bugs, 3 pre-existing issues filed

Closes #259, closes #260

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Enhanced symbol verification for findings to incorporate additional contextual information, improving accuracy of grounding decisions.
  * Improved fallback behavior when specific code ranges cannot be located during analysis.

* **Tests**
  * Added expanded test coverage for symbol verification with additional context and edge case scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->