### PR TITLE
feat: cross-model ensemble agreement as confidence signal (#248)

### DIFF
--- a/src/analysis.rs
+++ b/src/analysis.rs
@@ -67,6 +67,7 @@ pub fn analyze_complexity(
                     cited_lines: None,
                     grounding_status: None,
                     grounding_confidence: None,
+                model_agreement: None,
                 });
             }
         }
@@ -249,6 +250,7 @@ fn scan_insecure_rust(node: &tree_sitter::Node, source: &str, findings: &mut Vec
             cited_lines: None,
                     grounding_status: None,
                     grounding_confidence: None,
+        model_agreement: None,
         });
     }
 
@@ -284,6 +286,7 @@ fn scan_insecure_rust(node: &tree_sitter::Node, source: &str, findings: &mut Vec
                 cited_lines: None,
                 grounding_status: None,
                 grounding_confidence: None,
+                model_agreement: None,
             });
         }
     }
@@ -322,6 +325,7 @@ fn scan_insecure_python(node: &tree_sitter::Node, source: &str, findings: &mut V
                     cited_lines: None,
                     grounding_status: None,
                     grounding_confidence: None,
+                    model_agreement: None,
                 });
             }
         }
@@ -351,6 +355,7 @@ fn scan_insecure_python(node: &tree_sitter::Node, source: &str, findings: &mut V
                     cited_lines: None,
                     grounding_status: None,
                     grounding_confidence: None,
+                model_agreement: None,
                 });
             }
             if args_text.contains("host=\"0.0.0.0\"") || args_text.contains("host='0.0.0.0'") {
@@ -375,6 +380,7 @@ fn scan_insecure_python(node: &tree_sitter::Node, source: &str, findings: &mut V
                     cited_lines: None,
                     grounding_status: None,
                     grounding_confidence: None,
+                model_agreement: None,
                 });
             }
         }
@@ -413,6 +419,7 @@ fn scan_insecure_python(node: &tree_sitter::Node, source: &str, findings: &mut V
                                 cited_lines: None,
                     grounding_status: None,
                     grounding_confidence: None,
+                            model_agreement: None,
                             });
                     } else if arg_text.contains(".format(") {
                         findings.push(Finding {
@@ -436,6 +443,7 @@ fn scan_insecure_python(node: &tree_sitter::Node, source: &str, findings: &mut V
                                 cited_lines: None,
                     grounding_status: None,
                     grounding_confidence: None,
+                            model_agreement: None,
                             });
                     }
                 }
@@ -479,6 +487,7 @@ fn scan_insecure_python(node: &tree_sitter::Node, source: &str, findings: &mut V
                             cited_lines: None,
                     grounding_status: None,
                     grounding_confidence: None,
+                        model_agreement: None,
                         });
                 }
             }
@@ -539,6 +548,7 @@ fn scan_insecure_python(node: &tree_sitter::Node, source: &str, findings: &mut V
                         cited_lines: None,
                     grounding_status: None,
                     grounding_confidence: None,
+                    model_agreement: None,
                     });
             }
         }
@@ -615,6 +625,7 @@ fn scan_insecure_python(node: &tree_sitter::Node, source: &str, findings: &mut V
                             cited_lines: None,
                     grounding_status: None,
                     grounding_confidence: None,
+                        model_agreement: None,
                         });
             }
         }
@@ -652,6 +663,7 @@ fn scan_insecure_python(node: &tree_sitter::Node, source: &str, findings: &mut V
                             cited_lines: None,
                     grounding_status: None,
                     grounding_confidence: None,
+                        model_agreement: None,
                         });
                 }
             }
@@ -707,6 +719,7 @@ fn scan_insecure_python(node: &tree_sitter::Node, source: &str, findings: &mut V
                     cited_lines: None,
                     grounding_status: None,
                     grounding_confidence: None,
+                model_agreement: None,
                 });
             }
         }
@@ -740,6 +753,7 @@ fn scan_insecure_python(node: &tree_sitter::Node, source: &str, findings: &mut V
                     cited_lines: None,
                     grounding_status: None,
                     grounding_confidence: None,
+                model_agreement: None,
                 });
         }
     }
@@ -775,6 +789,7 @@ fn scan_insecure_python(node: &tree_sitter::Node, source: &str, findings: &mut V
                     cited_lines: None,
                     grounding_status: None,
                     grounding_confidence: None,
+                model_agreement: None,
                 });
         }
     }
@@ -1139,6 +1154,7 @@ fn scan_insecure_yaml(node: &tree_sitter::Node, source: &str, findings: &mut Vec
                                 cited_lines: None,
                     grounding_status: None,
                     grounding_confidence: None,
+                            model_agreement: None,
                             });
                 } else {
                     seen_keys.push((key_text, key_line));
@@ -1176,6 +1192,7 @@ fn scan_insecure_yaml(node: &tree_sitter::Node, source: &str, findings: &mut Vec
                     cited_lines: None,
                     grounding_status: None,
                     grounding_confidence: None,
+                    model_agreement: None,
                 });
             }
 
@@ -1202,6 +1219,7 @@ fn scan_insecure_yaml(node: &tree_sitter::Node, source: &str, findings: &mut Vec
                     cited_lines: None,
                     grounding_status: None,
                     grounding_confidence: None,
+                    model_agreement: None,
                 });
             }
 
@@ -1237,6 +1255,7 @@ fn scan_insecure_yaml(node: &tree_sitter::Node, source: &str, findings: &mut Vec
                         cited_lines: None,
                     grounding_status: None,
                     grounding_confidence: None,
+                    model_agreement: None,
                     });
                 }
             }
@@ -1275,6 +1294,7 @@ fn scan_insecure_yaml(node: &tree_sitter::Node, source: &str, findings: &mut Vec
                                     cited_lines: None,
                     grounding_status: None,
                     grounding_confidence: None,
+                                model_agreement: None,
                                 });
                     }
                 }
@@ -1317,6 +1337,7 @@ fn scan_insecure_yaml(node: &tree_sitter::Node, source: &str, findings: &mut Vec
                             cited_lines: None,
                     grounding_status: None,
                     grounding_confidence: None,
+                        model_agreement: None,
                         });
                     }
                 }
@@ -1352,6 +1373,7 @@ fn scan_insecure_yaml(node: &tree_sitter::Node, source: &str, findings: &mut Vec
                             cited_lines: None,
                     grounding_status: None,
                     grounding_confidence: None,
+                        model_agreement: None,
                         });
                     }
                 }
@@ -1421,6 +1443,7 @@ fn scan_insecure_yaml(node: &tree_sitter::Node, source: &str, findings: &mut Vec
                                             cited_lines: None,
                     grounding_status: None,
                     grounding_confidence: None,
+                                        model_agreement: None,
                                         });
                             }
 
@@ -1447,6 +1470,7 @@ fn scan_insecure_yaml(node: &tree_sitter::Node, source: &str, findings: &mut Vec
                                             cited_lines: None,
                     grounding_status: None,
                     grounding_confidence: None,
+                                        model_agreement: None,
                                         });
                             }
                         }
@@ -1492,6 +1516,7 @@ fn scan_insecure_yaml(node: &tree_sitter::Node, source: &str, findings: &mut Vec
                     cited_lines: None,
                     grounding_status: None,
                     grounding_confidence: None,
+                    model_agreement: None,
                 });
             }
         }
@@ -1540,6 +1565,7 @@ fn scan_insecure_yaml(node: &tree_sitter::Node, source: &str, findings: &mut Vec
                                     cited_lines: None,
                                     grounding_status: None,
                                     grounding_confidence: None,
+                                    model_agreement: None,
                                 });
                             }
                         }
@@ -1572,6 +1598,7 @@ fn scan_insecure_yaml(node: &tree_sitter::Node, source: &str, findings: &mut Vec
                     cited_lines: None,
                     grounding_status: None,
                     grounding_confidence: None,
+                    model_agreement: None,
                 });
             }
         }
@@ -1606,6 +1633,7 @@ fn scan_insecure_yaml(node: &tree_sitter::Node, source: &str, findings: &mut Vec
                     cited_lines: None,
                     grounding_status: None,
                     grounding_confidence: None,
+                    model_agreement: None,
                 });
             }
         }
@@ -1637,6 +1665,7 @@ fn scan_insecure_yaml(node: &tree_sitter::Node, source: &str, findings: &mut Vec
                             cited_lines: None,
                     grounding_status: None,
                     grounding_confidence: None,
+                        model_agreement: None,
                         });
             }
         }
@@ -1670,6 +1699,7 @@ fn scan_insecure_yaml(node: &tree_sitter::Node, source: &str, findings: &mut Vec
                             cited_lines: None,
                     grounding_status: None,
                     grounding_confidence: None,
+                        model_agreement: None,
                         });
             }
         }
@@ -1710,6 +1740,7 @@ fn scan_insecure_yaml(node: &tree_sitter::Node, source: &str, findings: &mut Vec
                         cited_lines: None,
                     grounding_status: None,
                     grounding_confidence: None,
+                    model_agreement: None,
                     });
                 }
             }
@@ -1770,6 +1801,7 @@ fn scan_insecure_yaml(node: &tree_sitter::Node, source: &str, findings: &mut Vec
                     cited_lines: None,
                     grounding_status: None,
                     grounding_confidence: None,
+                    model_agreement: None,
                 });
             }
         }
@@ -1808,6 +1840,7 @@ fn scan_insecure_typescript(node: &tree_sitter::Node, source: &str, findings: &m
                 cited_lines: None,
                 grounding_status: None,
                 grounding_confidence: None,
+                model_agreement: None,
             });
         }
 
@@ -1834,6 +1867,7 @@ fn scan_insecure_typescript(node: &tree_sitter::Node, source: &str, findings: &m
                     cited_lines: None,
                     grounding_status: None,
                     grounding_confidence: None,
+                model_agreement: None,
                 });
         }
 
@@ -1860,6 +1894,7 @@ fn scan_insecure_typescript(node: &tree_sitter::Node, source: &str, findings: &m
                     cited_lines: None,
                     grounding_status: None,
                     grounding_confidence: None,
+                model_agreement: None,
                 });
         }
     }
@@ -1915,6 +1950,7 @@ fn scan_insecure_typescript(node: &tree_sitter::Node, source: &str, findings: &m
                                 cited_lines: None,
                     grounding_status: None,
                     grounding_confidence: None,
+                            model_agreement: None,
                             });
                 }
             }
@@ -1953,6 +1989,7 @@ fn scan_insecure_typescript(node: &tree_sitter::Node, source: &str, findings: &m
                     cited_lines: None,
                     grounding_status: None,
                     grounding_confidence: None,
+                model_agreement: None,
                 });
         }
     }
@@ -1983,6 +2020,7 @@ fn scan_insecure_typescript(node: &tree_sitter::Node, source: &str, findings: &m
                 cited_lines: None,
                 grounding_status: None,
                 grounding_confidence: None,
+                model_agreement: None,
             });
         }
     }
@@ -2020,6 +2058,7 @@ fn scan_insecure_typescript(node: &tree_sitter::Node, source: &str, findings: &m
                 cited_lines: None,
                 grounding_status: None,
                 grounding_confidence: None,
+                model_agreement: None,
             });
         }
     }
@@ -2068,6 +2107,7 @@ fn scan_insecure_typescript(node: &tree_sitter::Node, source: &str, findings: &m
                             cited_lines: None,
                     grounding_status: None,
                     grounding_confidence: None,
+                        model_agreement: None,
                         });
                 break;
             }
@@ -2111,6 +2151,7 @@ fn scan_insecure_typescript(node: &tree_sitter::Node, source: &str, findings: &m
                                 cited_lines: None,
                     grounding_status: None,
                     grounding_confidence: None,
+                            model_agreement: None,
                             });
             }
         }
@@ -2139,6 +2180,7 @@ fn scan_insecure_typescript(node: &tree_sitter::Node, source: &str, findings: &m
             cited_lines: None,
                     grounding_status: None,
                     grounding_confidence: None,
+        model_agreement: None,
         });
     }
 }
@@ -2171,6 +2213,7 @@ fn scan_insecure_bash(node: &tree_sitter::Node, source: &str, findings: &mut Vec
                 cited_lines: None,
                     grounding_status: None,
                 grounding_confidence: None,
+            model_agreement: None,
             });
     }
 
@@ -2212,6 +2255,7 @@ fn scan_insecure_bash(node: &tree_sitter::Node, source: &str, findings: &mut Vec
                 cited_lines: None,
                 grounding_status: None,
                 grounding_confidence: None,
+                model_agreement: None,
             });
         }
     }
@@ -2244,6 +2288,7 @@ fn scan_insecure_bash(node: &tree_sitter::Node, source: &str, findings: &mut Vec
                 cited_lines: None,
                 grounding_status: None,
                 grounding_confidence: None,
+                model_agreement: None,
             });
         }
 
@@ -2275,6 +2320,7 @@ fn scan_insecure_bash(node: &tree_sitter::Node, source: &str, findings: &mut Vec
                             cited_lines: None,
                             grounding_status: None,
                             grounding_confidence: None,
+                            model_agreement: None,
                         });
                         break;
                     }
@@ -2316,6 +2362,7 @@ fn scan_insecure_bash(node: &tree_sitter::Node, source: &str, findings: &mut Vec
                         cited_lines: None,
                         grounding_status: None,
                         grounding_confidence: None,
+                        model_agreement: None,
                     });
                     break;
                 }
@@ -2366,6 +2413,7 @@ fn scan_insecure_bash(node: &tree_sitter::Node, source: &str, findings: &mut Vec
                                 cited_lines: None,
                     grounding_status: None,
                     grounding_confidence: None,
+                            model_agreement: None,
                             });
                 }
             }
@@ -2402,6 +2450,7 @@ fn scan_insecure_dockerfile(node: &tree_sitter::Node, source: &str, findings: &m
                     cited_lines: None,
                     grounding_status: None,
                     grounding_confidence: None,
+                model_agreement: None,
                 });
             }
         }
@@ -2449,6 +2498,7 @@ fn scan_insecure_dockerfile(node: &tree_sitter::Node, source: &str, findings: &m
                                 cited_lines: None,
                     grounding_status: None,
                     grounding_confidence: None,
+                            model_agreement: None,
                             });
                             break;
                         }
@@ -2485,6 +2535,7 @@ fn scan_insecure_dockerfile(node: &tree_sitter::Node, source: &str, findings: &m
                     cited_lines: None,
                     grounding_status: None,
                     grounding_confidence: None,
+                model_agreement: None,
                 });
             }
         }
@@ -2590,6 +2641,7 @@ fn scan_insecure_terraform(node: &tree_sitter::Node, source: &str, findings: &mu
                                     cited_lines: None,
                     grounding_status: None,
                     grounding_confidence: None,
+                                model_agreement: None,
                                 });
             }
         }
@@ -2632,6 +2684,7 @@ fn scan_insecure_terraform(node: &tree_sitter::Node, source: &str, findings: &mu
                                     cited_lines: None,
                     grounding_status: None,
                     grounding_confidence: None,
+                                model_agreement: None,
                                 });
                     }
                 }
@@ -2702,6 +2755,7 @@ fn scan_insecure_terraform(node: &tree_sitter::Node, source: &str, findings: &mu
                         cited_lines: None,
                     grounding_status: None,
                     grounding_confidence: None,
+                    model_agreement: None,
                     });
         }
     }
@@ -2797,6 +2851,7 @@ fn analyze_terraform_structure(tree: &tree_sitter::Tree, source: &str) -> Vec<Fi
             cited_lines: None,
                     grounding_status: None,
                     grounding_confidence: None,
+        model_agreement: None,
         });
     }
 
@@ -2893,6 +2948,7 @@ fn check_required_providers(rp_body: tree_sitter::Node, source: &str, findings: 
                 cited_lines: None,
                 grounding_status: None,
                 grounding_confidence: None,
+                model_agreement: None,
             });
         }
     }
@@ -2994,6 +3050,7 @@ fn analyze_dockerfile_structure(tree: &tree_sitter::Tree, source: &str) -> Vec<F
                             cited_lines: None,
                     grounding_status: None,
                     grounding_confidence: None,
+                        model_agreement: None,
                         });
                     }
                 }
@@ -3030,6 +3087,7 @@ fn analyze_dockerfile_structure(tree: &tree_sitter::Tree, source: &str) -> Vec<F
             cited_lines: None,
             grounding_status: None,
             grounding_confidence: None,
+            model_agreement: None,
         });
     }
 
@@ -3056,6 +3114,7 @@ fn analyze_dockerfile_structure(tree: &tree_sitter::Tree, source: &str) -> Vec<F
             cited_lines: None,
                     grounding_status: None,
                     grounding_confidence: None,
+        model_agreement: None,
         });
     }
 
@@ -3085,6 +3144,7 @@ fn analyze_dockerfile_structure(tree: &tree_sitter::Tree, source: &str) -> Vec<F
             cited_lines: None,
             grounding_status: None,
             grounding_confidence: None,
+            model_agreement: None,
         });
     }
     if entrypoint_count > 1 {
@@ -3112,6 +3172,7 @@ fn analyze_dockerfile_structure(tree: &tree_sitter::Tree, source: &str) -> Vec<F
             cited_lines: None,
             grounding_status: None,
             grounding_confidence: None,
+            model_agreement: None,
         });
     }
 

--- a/src/ast_grep.rs
+++ b/src/ast_grep.rs
@@ -295,6 +295,7 @@ pub fn scan_file(source: &str, ext: &str, rules: &[RuleConfig<SupportLang>]) -> 
                     cited_lines: None,
                     grounding_status: None,
                     grounding_confidence: None,
+                    model_agreement: None,
                 });
             }
         }

--- a/src/finding.rs
+++ b/src/finding.rs
@@ -110,6 +110,8 @@ pub struct Finding {
     pub grounding_status: Option<GroundingStatus>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub grounding_confidence: Option<f32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub model_agreement: Option<f32>,
 }
 
 impl Finding {
@@ -130,7 +132,11 @@ impl Finding {
             Some(CalibratorAction::Added) => 0.7,
             None => 1.0,
         };
-        self.confidence = Some((base * cal_factor).clamp(0.0, 1.0));
+        let agreement_factor = match self.model_agreement {
+            Some(a) => 0.85 + 0.30 * a,
+            None => 1.0,
+        };
+        self.confidence = Some((base * cal_factor * agreement_factor).clamp(0.0, 1.0));
     }
 
     pub fn severity_label(&self) -> &'static str {
@@ -187,6 +193,7 @@ impl FindingBuilder {
                 cited_lines: None,
                 grounding_status: None,
                 grounding_confidence: None,
+                model_agreement: None,
             },
         }
     }
@@ -289,6 +296,11 @@ impl FindingBuilder {
         self
     }
 
+    pub fn model_agreement(mut self, a: f32) -> Self {
+        self.inner.model_agreement = Some(a);
+        self
+    }
+
     pub fn precedent(mut self, p: &str) -> Self {
         self.inner.similar_precedent.push(p.into());
         self
@@ -378,6 +390,7 @@ mod tests {
             cited_lines: None,
             grounding_status: None,
             grounding_confidence: None,
+            model_agreement: None,
         };
         let json = serde_json::to_value(&f).unwrap();
         assert_eq!(json["title"], "Unvalidated input");
@@ -414,6 +427,7 @@ mod tests {
             cited_lines: None,
             grounding_status: None,
             grounding_confidence: None,
+            model_agreement: None,
         };
         let json_str = serde_json::to_string(&original).unwrap();
         let deserialized: Finding = serde_json::from_str(&json_str).unwrap();
@@ -443,6 +457,7 @@ mod tests {
             cited_lines: None,
             grounding_status: None,
             grounding_confidence: None,
+            model_agreement: None,
         };
         let json = serde_json::to_value(&f).unwrap();
         assert!(json["calibrator_action"].is_null());
@@ -474,6 +489,7 @@ mod tests {
             cited_lines: None,
             grounding_status: None,
             grounding_confidence: None,
+            model_agreement: None,
         };
         assert!(f.is_valid());
     }
@@ -501,6 +517,7 @@ mod tests {
             cited_lines: None,
             grounding_status: None,
             grounding_confidence: None,
+            model_agreement: None,
         };
         assert!(f.is_valid());
     }
@@ -528,6 +545,7 @@ mod tests {
             cited_lines: None,
             grounding_status: None,
             grounding_confidence: None,
+            model_agreement: None,
         };
         assert!(!f.is_valid());
     }
@@ -555,6 +573,7 @@ mod tests {
             cited_lines: None,
             grounding_status: None,
             grounding_confidence: None,
+            model_agreement: None,
         };
         assert!(!f.is_valid());
     }
@@ -810,5 +829,52 @@ mod tests {
             .build();
         f.compute_confidence();
         assert_eq!(f.confidence, Some(1.0));
+    }
+
+    #[test]
+    fn confidence_full_agreement_boosts() {
+        let mut f = FindingBuilder::new()
+            .source(Source::Llm("gpt-5.4".into()))
+            .model_agreement(1.0)
+            .build();
+        f.grounding_confidence = Some(0.5);
+        f.compute_confidence();
+        // 0.5 * 1.0 * (0.85 + 0.30) = 0.575
+        assert!((f.confidence.unwrap() - 0.575).abs() < 0.01);
+    }
+
+    #[test]
+    fn confidence_half_agreement_neutral() {
+        let mut f = FindingBuilder::new()
+            .source(Source::Llm("gpt-5.4".into()))
+            .model_agreement(0.5)
+            .build();
+        f.grounding_confidence = Some(0.5);
+        f.compute_confidence();
+        // 0.5 * 1.0 * (0.85 + 0.15) = 0.5
+        assert!((f.confidence.unwrap() - 0.5).abs() < 0.01);
+    }
+
+    #[test]
+    fn confidence_no_agreement_info_unchanged() {
+        let mut f = FindingBuilder::new()
+            .source(Source::Llm("gpt-5.4".into()))
+            .build();
+        f.grounding_confidence = Some(0.5);
+        f.compute_confidence();
+        assert_eq!(f.confidence, Some(0.5));
+    }
+
+    #[test]
+    fn confidence_low_agreement_penalizes() {
+        let mut f = FindingBuilder::new()
+            .source(Source::Llm("gpt-5.4".into()))
+            .model_agreement(0.33)
+            .build();
+        f.grounding_confidence = Some(1.0);
+        f.compute_confidence();
+        // 1.0 * 1.0 * (0.85 + 0.099) = 0.949
+        assert!(f.confidence.unwrap() < 1.0);
+        assert!(f.confidence.unwrap() > 0.9);
     }
 }

--- a/src/finding.rs
+++ b/src/finding.rs
@@ -132,9 +132,12 @@ impl Finding {
             Some(CalibratorAction::Added) => 0.7,
             None => 1.0,
         };
-        let agreement_factor = match self.model_agreement {
-            Some(a) => 0.85 + 0.30 * a,
-            None => 1.0,
+        let agreement_factor = match (&self.source, self.model_agreement) {
+            (Source::Llm(_), Some(a)) if a.is_finite() => {
+                let a = a.clamp(0.0, 1.0);
+                0.85 + 0.30 * a
+            }
+            _ => 1.0,
         };
         self.confidence = Some((base * cal_factor * agreement_factor).clamp(0.0, 1.0));
     }

--- a/src/linter.rs
+++ b/src/linter.rs
@@ -294,6 +294,7 @@ pub fn normalize_ruff_output(json_output: &str) -> anyhow::Result<Vec<Finding>> 
             cited_lines: None,
             grounding_status: None,
             grounding_confidence: None,
+            model_agreement: None,
         });
     }
 
@@ -356,6 +357,7 @@ pub fn normalize_clippy_output(json_output: &str) -> anyhow::Result<Vec<Finding>
             cited_lines: None,
             grounding_status: None,
             grounding_confidence: None,
+            model_agreement: None,
         });
     }
 
@@ -406,6 +408,7 @@ pub fn normalize_eslint_output(json_output: &str) -> anyhow::Result<Vec<Finding>
                 cited_lines: None,
                 grounding_status: None,
                 grounding_confidence: None,
+                model_agreement: None,
             });
         }
     }
@@ -470,6 +473,7 @@ pub fn normalize_yamllint_output(output: &str) -> anyhow::Result<Vec<Finding>> {
             cited_lines: None,
             grounding_status: None,
             grounding_confidence: None,
+            model_agreement: None,
         });
     }
     Ok(findings)
@@ -517,6 +521,7 @@ pub fn normalize_shellcheck_output(json_output: &str) -> anyhow::Result<Vec<Find
                 cited_lines: None,
                 grounding_status: None,
                 grounding_confidence: None,
+                model_agreement: None,
             });
         }
     }
@@ -581,6 +586,7 @@ pub fn normalize_hadolint_output(output: &str) -> anyhow::Result<Vec<Finding>> {
             cited_lines: None,
             grounding_status: None,
             grounding_confidence: None,
+            model_agreement: None,
         });
     }
     Ok(findings)
@@ -629,6 +635,7 @@ pub fn normalize_tflint_output(json_output: &str) -> anyhow::Result<Vec<Finding>
                 cited_lines: None,
                 grounding_status: None,
                 grounding_confidence: None,
+                model_agreement: None,
             });
         }
     }

--- a/src/merge.rs
+++ b/src/merge.rs
@@ -57,9 +57,9 @@ pub fn merge_findings(
 
     if num_models > 1 {
         for (idx, finding) in merged.iter_mut().enumerate() {
-            if matches!(finding.source, Source::Llm(_)) {
-                let agreeing = llm_model_names[idx].len() as f32;
-                finding.model_agreement = Some(agreeing / num_models as f32);
+            let agreeing = llm_model_names[idx].len();
+            if agreeing > 0 {
+                finding.model_agreement = Some(agreeing as f32 / num_models as f32);
             }
         }
     }

--- a/src/merge.rs
+++ b/src/merge.rs
@@ -1,6 +1,10 @@
-use crate::finding::Finding;
+use crate::finding::{Finding, Source};
 
-pub fn merge_findings(groups: Vec<Vec<Finding>>, similarity_threshold: f64) -> Vec<Finding> {
+pub fn merge_findings(
+    groups: Vec<Vec<Finding>>,
+    similarity_threshold: f64,
+    num_models: usize,
+) -> Vec<Finding> {
     let all: Vec<Finding> = groups.into_iter().flatten().collect();
     if all.is_empty() {
         return vec![];
@@ -8,6 +12,7 @@ pub fn merge_findings(groups: Vec<Vec<Finding>>, similarity_threshold: f64) -> V
 
     let mut merged: Vec<Finding> = Vec::new();
     let mut occurrence_count: Vec<usize> = Vec::new();
+    let mut llm_model_names: Vec<std::collections::HashSet<String>> = Vec::new();
 
     for finding in all {
         let mut found_match = false;
@@ -23,24 +28,39 @@ pub fn merge_findings(groups: Vec<Vec<Finding>>, similarity_threshold: f64) -> V
                         existing.evidence.push(e.clone());
                     }
                 }
+                if let Source::Llm(ref model) = finding.source {
+                    llm_model_names[idx].insert(model.clone());
+                }
                 occurrence_count[idx] += 1;
                 found_match = true;
                 break;
             }
         }
         if !found_match {
+            let mut models = std::collections::HashSet::new();
+            if let Source::Llm(ref model) = finding.source {
+                models.insert(model.clone());
+            }
+            llm_model_names.push(models);
             merged.push(finding);
             occurrence_count.push(1);
         }
     }
 
-    // Annotate findings that absorbed duplicates so downstream output can
-    // show "N occurrences" instead of N separate entries.
     for (idx, count) in occurrence_count.iter().enumerate() {
         if *count > 1 {
             merged[idx]
                 .evidence
                 .push(format!("{} occurrences merged", count));
+        }
+    }
+
+    if num_models > 1 {
+        for (idx, finding) in merged.iter_mut().enumerate() {
+            if matches!(finding.source, Source::Llm(_)) {
+                let agreeing = llm_model_names[idx].len() as f32;
+                finding.model_agreement = Some(agreeing / num_models as f32);
+            }
         }
     }
 
@@ -137,7 +157,7 @@ mod tests {
             .lines(42, 50)
             .source(Source::Llm("claude".into()))
             .build();
-        let result = merge_findings(vec![vec![f1], vec![f2]], 0.8);
+        let result = merge_findings(vec![vec![f1], vec![f2]], 0.8, 2);
         assert_eq!(result.len(), 1);
     }
 
@@ -153,7 +173,7 @@ mod tests {
             .category("style".into())
             .lines(1, 1)
             .build();
-        let result = merge_findings(vec![vec![f1], vec![f2]], 0.8);
+        let result = merge_findings(vec![vec![f1], vec![f2]], 0.8, 1);
         assert_eq!(result.len(), 2);
     }
 
@@ -169,14 +189,14 @@ mod tests {
             .severity(Severity::Critical)
             .lines(42, 50)
             .build();
-        let result = merge_findings(vec![vec![f1], vec![f2]], 0.8);
+        let result = merge_findings(vec![vec![f1], vec![f2]], 0.8, 1);
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].severity, Severity::Critical);
     }
 
     #[test]
     fn merge_empty_input() {
-        let result = merge_findings(vec![], 0.8);
+        let result = merge_findings(vec![], 0.8, 1);
         assert!(result.is_empty());
     }
 
@@ -184,7 +204,7 @@ mod tests {
     fn merge_single_source_passthrough() {
         let f1 = FindingBuilder::new().title("Bug 1").lines(10, 20).build();
         let f2 = FindingBuilder::new().title("Bug 2").lines(30, 40).build();
-        let result = merge_findings(vec![vec![f1, f2]], 0.8);
+        let result = merge_findings(vec![vec![f1, f2]], 0.8, 1);
         assert_eq!(result.len(), 2);
     }
 
@@ -200,7 +220,7 @@ mod tests {
             .category("security".into())
             .lines(45, 55)
             .build();
-        let result = merge_findings(vec![vec![f1], vec![f2]], 0.8);
+        let result = merge_findings(vec![vec![f1], vec![f2]], 0.8, 1);
         assert_eq!(result.len(), 1);
     }
 
@@ -221,7 +241,7 @@ mod tests {
             .category("error-handling".into())
             .lines(150, 150)
             .build();
-        let result = merge_findings(vec![vec![f1], vec![f2], vec![f3]], 0.8);
+        let result = merge_findings(vec![vec![f1], vec![f2], vec![f3]], 0.8, 1);
         assert_eq!(
             result.len(),
             1,
@@ -249,7 +269,7 @@ mod tests {
             .category("security".into())
             .lines(100, 100)
             .build();
-        let result = merge_findings(vec![vec![f1], vec![f2]], 0.8);
+        let result = merge_findings(vec![vec![f1], vec![f2]], 0.8, 1);
         assert_eq!(result.len(), 2);
     }
 
@@ -270,7 +290,7 @@ mod tests {
             .severity(Severity::Medium)
             .lines(20, 30)
             .build();
-        let result = merge_findings(vec![vec![f1, f2, f3]], 0.8);
+        let result = merge_findings(vec![vec![f1, f2, f3]], 0.8, 1);
         assert_eq!(result[0].severity, Severity::Critical);
         assert_eq!(result[1].severity, Severity::Medium);
         assert_eq!(result[2].severity, Severity::Info);
@@ -288,8 +308,8 @@ mod tests {
             .lines(10, 20)
             .severity(Severity::Medium)
             .build();
-        let first = merge_findings(vec![vec![f1.clone(), f2.clone()]], 0.8);
-        let second = merge_findings(vec![first], 0.8);
+        let first = merge_findings(vec![vec![f1.clone(), f2.clone()]], 0.8, 1);
+        let second = merge_findings(vec![first], 0.8, 1);
         assert_eq!(second.len(), 1);
     }
 
@@ -305,7 +325,7 @@ mod tests {
             .lines(42, 50)
             .evidence("pattern match")
             .build();
-        let result = merge_findings(vec![vec![f1], vec![f2]], 0.8);
+        let result = merge_findings(vec![vec![f1], vec![f2]], 0.8, 1);
         assert_eq!(result.len(), 1);
         assert!(result[0].evidence.len() >= 2);
     }
@@ -333,5 +353,66 @@ mod tests {
             .lines(200, 200)
             .build();
         assert!(similarity(&f1, &f2) < 0.3);
+    }
+
+    // -- model agreement --
+
+    #[test]
+    fn ensemble_full_agreement_sets_model_agreement() {
+        let f1 = FindingBuilder::new()
+            .title("SQL injection")
+            .category("security".into())
+            .lines(42, 50)
+            .source(Source::Llm("gpt-5.4".into()))
+            .build();
+        let f2 = FindingBuilder::new()
+            .title("SQL injection")
+            .category("security".into())
+            .lines(42, 50)
+            .source(Source::Llm("claude".into()))
+            .build();
+        let result = merge_findings(vec![vec![f1], vec![f2]], 0.8, 2);
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].model_agreement, Some(1.0));
+    }
+
+    #[test]
+    fn ensemble_partial_agreement() {
+        let f1 = FindingBuilder::new()
+            .title("SQL injection")
+            .category("security".into())
+            .lines(42, 50)
+            .source(Source::Llm("gpt-5.4".into()))
+            .build();
+        let f2 = FindingBuilder::new()
+            .title("Unused import")
+            .category("style".into())
+            .lines(1, 1)
+            .source(Source::Llm("claude".into()))
+            .build();
+        let result = merge_findings(vec![vec![f1], vec![f2]], 0.8, 2);
+        assert_eq!(result.len(), 2);
+        assert_eq!(result[0].model_agreement, Some(0.5));
+        assert_eq!(result[1].model_agreement, Some(0.5));
+    }
+
+    #[test]
+    fn single_model_no_agreement_field() {
+        let f1 = FindingBuilder::new()
+            .title("SQL injection")
+            .source(Source::Llm("gpt-5.4".into()))
+            .build();
+        let result = merge_findings(vec![vec![f1]], 0.8, 1);
+        assert_eq!(result[0].model_agreement, None);
+    }
+
+    #[test]
+    fn ast_findings_no_agreement_in_ensemble() {
+        let f1 = FindingBuilder::new()
+            .title("Unwrap without context")
+            .source(Source::LocalAst)
+            .build();
+        let result = merge_findings(vec![vec![f1]], 0.8, 2);
+        assert_eq!(result[0].model_agreement, None);
     }
 }

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -752,7 +752,11 @@ pub async fn review_file(
     let merge_t0 = std::time::Instant::now();
     let merged = {
         let _span = tracing::info_span!("phase.merge", file = %file_str).entered();
-        let result = merge::merge_findings(all_sources, pipeline_config.similarity_threshold);
+        let result = merge::merge_findings(
+            all_sources,
+            pipeline_config.similarity_threshold,
+            pipeline_config.models.len(),
+        );
         tracing::info!(
             phase = "merge",
             duration_ms = merge_t0.elapsed().as_millis() as u64,
@@ -1169,7 +1173,11 @@ pub async fn review_file_llm_only(
         }
     }
 
-    let merged = merge::merge_findings(all_sources, pipeline_config.similarity_threshold);
+    let merged = merge::merge_findings(
+        all_sources,
+        pipeline_config.similarity_threshold,
+        pipeline_config.models.len(),
+    );
 
     // Grounding: verify LLM-cited symbols exist in source (skipped for prose reviews)
     let merged = if pipeline_config.mode.is_prose() {

--- a/src/review.rs
+++ b/src/review.rs
@@ -155,6 +155,7 @@ impl LlmFinding {
             cited_lines: None,
             grounding_status: None,
             grounding_confidence: None,
+            model_agreement: None,
         }
     }
 }

--- a/tests/finding_schema_test.rs
+++ b/tests/finding_schema_test.rs
@@ -24,6 +24,7 @@ fn finding_with_new_fields_roundtrips() {
         cited_lines: Some((10, 12)),
         grounding_status: None,
         grounding_confidence: None,
+        model_agreement: None,
     };
 
     let json = serde_json::to_string(&finding).unwrap();
@@ -77,6 +78,7 @@ fn new_fields_omitted_from_json_when_none() {
         cited_lines: None,
         grounding_status: None,
         grounding_confidence: None,
+        model_agreement: None,
     };
 
     let json = serde_json::to_string(&finding).unwrap();
@@ -84,6 +86,7 @@ fn new_fields_omitted_from_json_when_none() {
     assert!(!json.contains("confidence"));
     assert!(!json.contains("cited_lines"));
     assert!(!json.contains("grounding_confidence"));
+    assert!(!json.contains("model_agreement"));
 }
 
 #[test]
@@ -109,6 +112,7 @@ fn category_serializes_as_kebab_case_in_finding() {
         cited_lines: None,
         grounding_status: None,
         grounding_confidence: None,
+        model_agreement: None,
     };
 
     let json = serde_json::to_string(&finding).unwrap();

--- a/tests/lib_integration_smoke.rs
+++ b/tests/lib_integration_smoke.rs
@@ -40,6 +40,7 @@ fn lib_exports_are_reachable_from_integration_tests() {
         cited_lines: None,
         grounding_status: None,
         grounding_confidence: None,
+        model_agreement: None,
     };
 
     // calibrate(...) must be callable with no precedents — exercises the


### PR DESCRIPTION
## Summary

- Adds `model_agreement: Option<f32>` to `Finding` — ratio of LLM models that agreed on a finding during `--ensemble` reviews
- `merge_findings` now tracks which distinct LLM model names contributed to each merged finding and computes the agreement ratio when `num_models > 1`
- `compute_confidence()` incorporates model agreement as a multiplicative factor: `0.85 + 0.30 * agreement` (full agreement = 1.15x boost, half = neutral, single-model-only = 0.85x mild penalty)
- Single-model reviews are unaffected (`model_agreement` stays `None`, factor is 1.0)

Closes #248

## Test plan

- [x] 4 new merge tests: full agreement, partial agreement, single model no field, AST findings excluded
- [x] 4 new confidence tests: full agreement boost, half agreement neutral, no agreement info unchanged, low agreement penalty
- [x] All 1276 bin + 772 lib tests pass
- [x] Schema test verifies `model_agreement` omitted from JSON when None
- [x] Clippy clean, fmt clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added model agreement tracking to enhance confidence scoring for findings. When multiple AI models identify the same issue, confidence scores are now adjusted to reflect consensus, improving the reliability of vulnerability assessments.

* **Tests**
  * Updated test coverage to validate model agreement calculations under various consensus scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->