### PR TITLE
fix(grounding): normalize backticked identifiers (#269, #262)

### DIFF
--- a/src/grounding.rs
+++ b/src/grounding.rs
@@ -70,16 +70,14 @@ fn looks_like_symbol(s: &str) -> bool {
     if s.contains(char::is_whitespace) {
         return false;
     }
-    let has_alpha_start = s.split([':', '.', '#', '@'])
-        .any(|seg| {
-            seg.starts_with(|c: char| c == '_' || c.is_alphabetic())
-        });
+    let has_alpha_start = s
+        .split([':', '.', '#', '@'])
+        .any(|seg| seg.starts_with(|c: char| c == '_' || c.is_alphabetic()));
     if !has_alpha_start {
         return false;
     }
-    s.chars().all(|c| {
-        c.is_alphanumeric() || matches!(c, '_' | ':' | '.' | '!' | '?' | '#' | '@' | '\'')
-    })
+    s.chars()
+        .all(|c| c.is_alphanumeric() || matches!(c, '_' | ':' | '.' | '!' | '?' | '#' | '@' | '\''))
 }
 
 /// Extract backtick-delimited identifiers from text, filtering stopwords
@@ -93,7 +91,9 @@ pub fn extract_identifiers(text: &str) -> Vec<&str> {
             // Strip generic parameters first: truncate at first '<' if '>' exists.
             // Must run before arg stripping so `Option<(u32, u32)>` strips to
             // `Option`, not `Option<` (which would happen if `(` were found first).
-            if id.contains('>') && let Some(pos) = id.find('<') {
+            if id.contains('>')
+                && let Some(pos) = id.find('<')
+            {
                 id = id[..pos].trim_end();
             }
 
@@ -105,10 +105,7 @@ pub fn extract_identifiers(text: &str) -> Vec<&str> {
             // Post-strip cleanup: trailing :: and .
             id = id.trim_end_matches([':', '.']);
 
-            if id.len() >= MIN_IDENTIFIER_LEN
-                && !STOPWORDS.contains(id)
-                && looks_like_symbol(id)
-            {
+            if id.len() >= MIN_IDENTIFIER_LEN && !STOPWORDS.contains(id) && looks_like_symbol(id) {
                 Some(id)
             } else {
                 None
@@ -411,7 +408,9 @@ mod tests {
 
     #[test]
     fn looks_like_symbol_accepts_multibyte_unicode() {
-        assert!(looks_like_symbol("\u{65e5}\u{672c}\u{8a9e}\u{30c6}\u{30b9}\u{30c8}"));
+        assert!(looks_like_symbol(
+            "\u{65e5}\u{672c}\u{8a9e}\u{30c6}\u{30b9}\u{30c8}"
+        ));
     }
 
     #[test]
@@ -455,7 +454,10 @@ mod tests {
     #[test]
     fn strips_nested_call_arguments() {
         let ids = extract_identifiers("Calling `foo(bar(baz))` is wrong");
-        assert!(ids.is_empty(), "foo is only 3 chars, below MIN_IDENTIFIER_LEN");
+        assert!(
+            ids.is_empty(),
+            "foo is only 3 chars, below MIN_IDENTIFIER_LEN"
+        );
     }
 
     #[test]
@@ -521,7 +523,10 @@ mod tests {
     #[test]
     fn unbalanced_generic_passes_through() {
         let ids = extract_identifiers("The `foo_bar<T` type is odd");
-        assert!(ids.is_empty(), "no closing > so < not stripped, but < is not in allowed chars");
+        assert!(
+            ids.is_empty(),
+            "no closing > so < not stripped, but < is not in allowed chars"
+        );
     }
 
     #[test]

--- a/src/grounding.rs
+++ b/src/grounding.rs
@@ -89,13 +89,15 @@ pub fn extract_identifiers(text: &str) -> Vec<&str> {
         .filter_map(|cap| {
             let mut id = cap.get(1).unwrap().as_str().trim();
 
-            // Strip call arguments: truncate at first '('
-            if let Some(pos) = id.find('(') {
+            // Strip generic parameters first: truncate at first '<' if '>' exists.
+            // Must run before arg stripping so `Option<(u32, u32)>` strips to
+            // `Option`, not `Option<` (which would happen if `(` were found first).
+            if id.contains('>') && let Some(pos) = id.find('<') {
                 id = id[..pos].trim_end();
             }
 
-            // Strip generic parameters: truncate at first '<' if '>' exists
-            if id.contains('>') && let Some(pos) = id.find('<') {
+            // Strip call arguments: truncate at first '('
+            if let Some(pos) = id.find('(') {
                 id = id[..pos].trim_end();
             }
 
@@ -519,6 +521,18 @@ mod tests {
     fn multi_segment_generic_filtered_by_length() {
         let ids = extract_identifiers("Type `Foo<A>::Bar<B>` is complex");
         assert!(ids.is_empty(), "Foo is only 3 chars after stripping");
+    }
+
+    #[test]
+    fn generic_with_tuple_inside_not_dropped() {
+        let ids = extract_identifiers("The `Decoder<(u32, u32)>` type wraps a pair");
+        assert_eq!(ids, vec!["Decoder"]);
+    }
+
+    #[test]
+    fn generic_with_fn_syntax_inside_not_dropped() {
+        let ids = extract_identifiers("Use `Callback<fn(i32)>` for handlers");
+        assert_eq!(ids, vec!["Callback"]);
     }
 
     // --- verify_grounding / apply_grounding tests (Task 3) ---

--- a/src/grounding.rs
+++ b/src/grounding.rs
@@ -27,7 +27,6 @@ static STOPWORDS: LazyLock<HashSet<&'static str>> = LazyLock::new(|| {
         "is_empty",
         "map",
         "filter",
-        "collect",
         "Result",
         "Option",
         "String",
@@ -63,6 +62,25 @@ static STOPWORDS: LazyLock<HashSet<&'static str>> = LazyLock::new(|| {
 
 const MIN_IDENTIFIER_LEN: usize = 4;
 
+fn looks_like_symbol(s: &str) -> bool {
+    if s.is_empty() {
+        return false;
+    }
+    if s.contains(char::is_whitespace) {
+        return false;
+    }
+    let has_alpha_start = s.split([':', '.', '#', '@'])
+        .any(|seg| {
+            seg.starts_with(|c: char| c == '_' || c.is_alphabetic())
+        });
+    if !has_alpha_start {
+        return false;
+    }
+    s.chars().all(|c| {
+        c.is_alphanumeric() || matches!(c, '_' | ':' | '.' | '!' | '?' | '#' | '@' | '\'')
+    })
+}
+
 /// Extract backtick-delimited identifiers from text, filtering stopwords
 /// and short tokens.
 pub fn extract_identifiers(text: &str) -> Vec<&str> {
@@ -70,10 +88,24 @@ pub fn extract_identifiers(text: &str) -> Vec<&str> {
         .captures_iter(text)
         .filter_map(|cap| {
             let mut id = cap.get(1).unwrap().as_str().trim();
-            if id.ends_with("()") {
-                id = &id[..id.len() - 2];
+
+            // Strip call arguments: truncate at first '('
+            if let Some(pos) = id.find('(') {
+                id = id[..pos].trim_end();
             }
-            if id.len() >= MIN_IDENTIFIER_LEN && !STOPWORDS.contains(id) {
+
+            // Strip generic parameters: truncate at first '<' if '>' exists
+            if id.contains('>') && let Some(pos) = id.find('<') {
+                id = id[..pos].trim_end();
+            }
+
+            // Post-strip cleanup: trailing :: and .
+            id = id.trim_end_matches([':', '.']);
+
+            if id.len() >= MIN_IDENTIFIER_LEN
+                && !STOPWORDS.contains(id)
+                && looks_like_symbol(id)
+            {
                 Some(id)
             } else {
                 None
@@ -345,6 +377,148 @@ mod tests {
             "`some_func` and `\u{65e5}\u{672c}\u{8a9e}\u{30c6}\u{30b9}\u{30c8}` both present",
         );
         assert_eq!(ids.len(), 2);
+    }
+
+    // --- looks_like_symbol ---
+
+    #[test]
+    fn looks_like_symbol_accepts_simple_identifier() {
+        assert!(looks_like_symbol("parse_config"));
+    }
+
+    #[test]
+    fn looks_like_symbol_accepts_qualified_path() {
+        assert!(looks_like_symbol("std::io::Error"));
+    }
+
+    #[test]
+    fn looks_like_symbol_accepts_dotted_access() {
+        assert!(looks_like_symbol("self.process"));
+    }
+
+    #[test]
+    fn looks_like_symbol_accepts_rust_macro() {
+        assert!(looks_like_symbol("macro_rules!"));
+    }
+
+    #[test]
+    fn looks_like_symbol_accepts_decorator() {
+        assert!(looks_like_symbol("@app.route"));
+    }
+
+    #[test]
+    fn looks_like_symbol_accepts_multibyte_unicode() {
+        assert!(looks_like_symbol("\u{65e5}\u{672c}\u{8a9e}\u{30c6}\u{30b9}\u{30c8}"));
+    }
+
+    #[test]
+    fn looks_like_symbol_rejects_prose_with_space() {
+        assert!(!looks_like_symbol("missing check"));
+    }
+
+    #[test]
+    fn looks_like_symbol_rejects_number_phrase() {
+        assert!(!looks_like_symbol("line 42"));
+    }
+
+    #[test]
+    fn looks_like_symbol_rejects_operator() {
+        assert!(!looks_like_symbol("->"));
+    }
+
+    #[test]
+    fn looks_like_symbol_rejects_string_literal() {
+        assert!(!looks_like_symbol("\"hello\""));
+    }
+
+    #[test]
+    fn looks_like_symbol_rejects_pure_digits() {
+        assert!(!looks_like_symbol("1234"));
+    }
+
+    #[test]
+    fn looks_like_symbol_rejects_empty() {
+        assert!(!looks_like_symbol(""));
+    }
+
+    // --- extract_identifiers normalization (#269, #262) ---
+
+    #[test]
+    fn strips_call_arguments_from_identifier() {
+        let ids = extract_identifiers("The `parse_diff(input)` function panics");
+        assert_eq!(ids, vec!["parse_diff"]);
+    }
+
+    #[test]
+    fn strips_nested_call_arguments() {
+        let ids = extract_identifiers("Calling `foo(bar(baz))` is wrong");
+        assert!(ids.is_empty(), "foo is only 3 chars, below MIN_IDENTIFIER_LEN");
+    }
+
+    #[test]
+    fn strips_generic_parameters() {
+        let ids = extract_identifiers("The `HashMap<String, Vec<u8>>` type");
+        assert_eq!(ids, vec!["HashMap"]);
+    }
+
+    #[test]
+    fn strips_turbofish_and_trailing_colons() {
+        let ids = extract_identifiers("Use `collect::<Vec<_>>()` here");
+        assert_eq!(ids, vec!["collect"]);
+    }
+
+    #[test]
+    fn strips_method_call_preserves_receiver() {
+        let ids = extract_identifiers("The `iter.collect::<Vec<_>>()` call");
+        assert_eq!(ids, vec!["iter.collect"]);
+    }
+
+    #[test]
+    fn rejects_prose_in_backticks() {
+        let ids = extract_identifiers("The `missing check` causes issues");
+        assert!(ids.is_empty());
+    }
+
+    #[test]
+    fn rejects_line_reference_in_backticks() {
+        let ids = extract_identifiers("At `line 42` the code fails");
+        assert!(ids.is_empty());
+    }
+
+    #[test]
+    fn rejects_operator_in_backticks() {
+        let ids = extract_identifiers("The `->` return type");
+        assert!(ids.is_empty());
+    }
+
+    #[test]
+    fn rejects_string_literal_in_backticks() {
+        let ids = extract_identifiers("Returns `\"hello\"` always");
+        assert!(ids.is_empty());
+    }
+
+    #[test]
+    fn strips_args_with_spaces_around_paren() {
+        let ids = extract_identifiers("Call `process_data ( x, y )` safely");
+        assert_eq!(ids, vec!["process_data"]);
+    }
+
+    #[test]
+    fn vec_new_parens_stripped() {
+        let ids = extract_identifiers("Creates `Vec::new()` each time");
+        assert_eq!(ids, vec!["Vec::new"]);
+    }
+
+    #[test]
+    fn unbalanced_generic_passes_through() {
+        let ids = extract_identifiers("The `foo_bar<T` type is odd");
+        assert!(ids.is_empty(), "no closing > so < not stripped, but < is not in allowed chars");
+    }
+
+    #[test]
+    fn multi_segment_generic_filtered_by_length() {
+        let ids = extract_identifiers("Type `Foo<A>::Bar<B>` is complex");
+        assert!(ids.is_empty(), "Foo is only 3 chars after stripping");
     }
 
     // --- verify_grounding / apply_grounding tests (Task 3) ---

--- a/src/grounding.rs
+++ b/src/grounding.rs
@@ -102,7 +102,8 @@ pub fn extract_identifiers(text: &str) -> Vec<&str> {
                 id = id[..pos].trim_end();
             }
 
-            // Post-strip cleanup: trailing :: and .
+            // Post-strip cleanup: leading/trailing :: and .
+            id = id.trim_start_matches([':', '.']);
             id = id.trim_end_matches([':', '.']);
 
             if id.len() >= MIN_IDENTIFIER_LEN && !STOPWORDS.contains(id) && looks_like_symbol(id) {
@@ -476,6 +477,12 @@ mod tests {
     fn turbofish_stopword_still_rejected() {
         let ids = extract_identifiers("Use `collect::<Vec<_>>()` here");
         assert!(ids.is_empty());
+    }
+
+    #[test]
+    fn strips_leading_separator() {
+        let ids = extract_identifiers("The `::some_func` call");
+        assert_eq!(ids, vec!["some_func"]);
     }
 
     #[test]

--- a/src/grounding.rs
+++ b/src/grounding.rs
@@ -27,6 +27,7 @@ static STOPWORDS: LazyLock<HashSet<&'static str>> = LazyLock::new(|| {
         "is_empty",
         "map",
         "filter",
+        "collect",
         "Result",
         "Option",
         "String",
@@ -465,8 +466,14 @@ mod tests {
 
     #[test]
     fn strips_turbofish_and_trailing_colons() {
+        let ids = extract_identifiers("Use `transform::<Vec<_>>()` here");
+        assert_eq!(ids, vec!["transform"]);
+    }
+
+    #[test]
+    fn turbofish_stopword_still_rejected() {
         let ids = extract_identifiers("Use `collect::<Vec<_>>()` here");
-        assert_eq!(ids, vec!["collect"]);
+        assert!(ids.is_empty());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Adds `looks_like_symbol` validator that rejects whitespace, non-alpha content, and disallowed characters from backtick captures
- Adds normalization pipeline to `extract_identifiers`: strip generic type params (`<`/`>`), strip call arguments (`(`), clean trailing `::` and `.`
- Fixes ordering: generics stripped before args to handle tuple/fn syntax inside type params (e.g. `Decoder<(u32, u32)>`)
- Restores `collect` to STOPWORDS (caught by independent code review)
- 29 new tests covering happy path, edge cases, rejections, and regression guards

## Quorum verdicts recorded
- **TP** (post_fix): generic/tuple ordering bug — `Option<(u32, u32)>` truncated at `(` before generics could strip
- **FP** (pattern-overgeneralization): prose words suggestion — intentionally accepted by `looks_like_symbol` design

## Test plan
- [x] All 2106 tests pass (`cargo test --bin quorum` + `cargo test --lib`)
- [x] `cargo clippy -- -D warnings` clean
- [x] Quorum self-review: no in-branch findings remaining
- [x] Independent code review pass completed

Closes #269, closes #262

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced identifier extraction to properly handle Rust generics and function calls with improved validation.

* **Tests**
  * Expanded test coverage for identifier validation edge cases.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jsnyder/quorum/pull/285)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->