### PR TITLE
feat: Context7 precision targeting — skip mainstream, tier by popularity

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -464,6 +464,11 @@ pub struct ReviewOpts {
     #[arg(long)]
     pub skip_context7: bool,
 
+    /// Enable live registry lookups (crates.io / npm / PyPI) for popularity-tier
+    /// token-budget assignment. Also enabled by QUORUM_CONTEXT7_LIVE_REGISTRY=1.
+    #[arg(long)]
+    pub live_registry: bool,
+
     /// Max concurrent LLM calls (default: 4, 0 = unlimited, 1 = sequential)
     #[arg(long, default_value = "4")]
     pub parallel: usize,

--- a/src/context_enrichment.rs
+++ b/src/context_enrichment.rs
@@ -7,9 +7,18 @@ pub struct ContextDoc {
     pub content: String,
 }
 
+/// Metadata returned by a successful Context7 library resolve.
+#[derive(Debug, Clone)]
+pub struct ResolveResult {
+    pub library_id: String,
+    pub benchmark_score: Option<f64>,
+    pub snippet_count: Option<u32>,
+    pub reputation: Option<String>,
+}
+
 /// Trait for fetching framework documentation — allows testing with fake implementations.
 pub trait ContextFetcher: Send + Sync {
-    fn resolve_library(&self, name: &str) -> Option<String>;
+    fn resolve_library(&self, name: &str) -> Option<ResolveResult>;
     fn query_docs(&self, library_id: &str, query: &str, max_tokens: usize) -> Option<String>;
 }
 
@@ -280,10 +289,10 @@ fn try_fetch_one(
     // (and a resolve-failure would double-count `context7_resolve_failed`).
     seen.insert(name.into());
     match fetcher.resolve_library(name) {
-        Some(lib_id) => {
+        Some(resolve) => {
             metrics.context7_resolved += 1;
             let enriched = build_code_aware_query(query, imports);
-            if let Some(content) = fetcher.query_docs(&lib_id, &enriched, 5000) {
+            if let Some(content) = fetcher.query_docs(&resolve.library_id, &enriched, 5000) {
                 docs.push(ContextDoc {
                     library: name.into(),
                     content,
@@ -403,7 +412,7 @@ pub fn format_context_section(docs: &[ContextDoc]) -> String {
 
 /// Cache entry for resolve_library results, with TTL gating.
 struct ResolveCacheEntry {
-    result: Option<String>,
+    result: Option<ResolveResult>,
     cached_at: std::time::Instant,
 }
 
@@ -455,7 +464,7 @@ impl<'a> CachedContextFetcher<'a> {
 }
 
 impl<'a> ContextFetcher for CachedContextFetcher<'a> {
-    fn resolve_library(&self, name: &str) -> Option<String> {
+    fn resolve_library(&self, name: &str) -> Option<ResolveResult> {
         let now = (self.now)();
         if let Ok(mut cache) = self.resolve_cache.lock()
             && let Some(entry) = cache.get(name)
@@ -541,7 +550,7 @@ impl Context7HttpFetcher {
 }
 
 impl ContextFetcher for Context7HttpFetcher {
-    fn resolve_library(&self, name: &str) -> Option<String> {
+    fn resolve_library(&self, name: &str) -> Option<ResolveResult> {
         let api_key = self.api_key.as_ref()?;
 
         let resp = match self.block_on(
@@ -571,12 +580,28 @@ impl ContextFetcher for Context7HttpFetcher {
                 return None;
             }
         };
-        json["results"]
-            .as_array()
-            .and_then(|a| a.first())
-            .and_then(|r| r.get("id"))
+        let first = json["results"].as_array()?.first()?;
+        let library_id = first.get("id")?.as_str()?.to_string();
+        let benchmark_score = first
+            .get("benchmarkScore")
+            .or_else(|| first.get("benchmark_score"))
+            .and_then(|v| v.as_f64());
+        let snippet_count = first
+            .get("codeSnippets")
+            .or_else(|| first.get("code_snippets"))
+            .and_then(|v| v.as_u64())
+            .map(|n| n as u32);
+        let reputation = first
+            .get("sourceReputation")
+            .or_else(|| first.get("source_reputation"))
             .and_then(|v| v.as_str())
-            .map(|s| s.to_string())
+            .map(|s| s.to_string());
+        Some(ResolveResult {
+            library_id,
+            benchmark_score,
+            snippet_count,
+            reputation,
+        })
     }
 
     fn query_docs(&self, library_id: &str, query: &str, max_tokens: usize) -> Option<String> {
@@ -659,8 +684,13 @@ mod test_support {
 
     pub struct Spy;
     impl ContextFetcher for Spy {
-        fn resolve_library(&self, name: &str) -> Option<String> {
-            Some(format!("/lib/{name}"))
+        fn resolve_library(&self, name: &str) -> Option<ResolveResult> {
+            Some(ResolveResult {
+                library_id: format!("/lib/{name}"),
+                benchmark_score: Some(80.0),
+                snippet_count: Some(100),
+                reputation: Some("High".into()),
+            })
         }
         fn query_docs(&self, lib: &str, _: &str, _: usize) -> Option<String> {
             Some(format!("docs for {lib}"))
@@ -678,8 +708,13 @@ mod test_support {
         }
     }
     impl ContextFetcher for CapturingSpy {
-        fn resolve_library(&self, name: &str) -> Option<String> {
-            Some(name.into())
+        fn resolve_library(&self, name: &str) -> Option<ResolveResult> {
+            Some(ResolveResult {
+                library_id: name.into(),
+                benchmark_score: Some(80.0),
+                snippet_count: Some(100),
+                reputation: Some("High".into()),
+            })
         }
         fn query_docs(&self, lib: &str, query: &str, _: usize) -> Option<String> {
             self.queries
@@ -1126,7 +1161,7 @@ mod tests {
     fn enrich_for_review_with_empty_inputs_returns_no_docs_and_zero_metrics() {
         struct Spy;
         impl ContextFetcher for Spy {
-            fn resolve_library(&self, _: &str) -> Option<String> {
+            fn resolve_library(&self, _: &str) -> Option<ResolveResult> {
                 None
             }
             fn query_docs(&self, _: &str, _: &str, _: usize) -> Option<String> {
@@ -1268,7 +1303,7 @@ axum = "0.7"
             calls: Mutex<u32>,
         }
         impl ContextFetcher for CountingSpy {
-            fn resolve_library(&self, _: &str) -> Option<String> {
+            fn resolve_library(&self, _: &str) -> Option<ResolveResult> {
                 *self.calls.lock().unwrap() += 1;
                 None
             }
@@ -1297,9 +1332,14 @@ axum = "0.7"
             calls: Mutex<u32>,
         }
         impl ContextFetcher for CountingSpy {
-            fn resolve_library(&self, name: &str) -> Option<String> {
+            fn resolve_library(&self, name: &str) -> Option<ResolveResult> {
                 *self.calls.lock().unwrap() += 1;
-                Some(format!("/lib/{name}"))
+                Some(ResolveResult {
+                    library_id: format!("/lib/{name}"),
+                    benchmark_score: None,
+                    snippet_count: None,
+                    reputation: None,
+                })
             }
             fn query_docs(&self, _: &str, _: &str, _: usize) -> Option<String> {
                 None
@@ -1309,8 +1349,10 @@ axum = "0.7"
             calls: Mutex::new(0),
         };
         let cached = CachedContextFetcher::new(&inner, 16);
-        assert_eq!(cached.resolve_library("react"), Some("/lib/react".into()));
-        assert_eq!(cached.resolve_library("react"), Some("/lib/react".into()));
+        let r1 = cached.resolve_library("react");
+        assert_eq!(r1.as_ref().map(|r| r.library_id.as_str()), Some("/lib/react"));
+        let r2 = cached.resolve_library("react");
+        assert_eq!(r2.as_ref().map(|r| r.library_id.as_str()), Some("/lib/react"));
         assert_eq!(*inner.calls.lock().unwrap(), 1);
     }
 
@@ -1322,7 +1364,7 @@ axum = "0.7"
             calls: Mutex<u32>,
         }
         impl ContextFetcher for CountingSpy {
-            fn resolve_library(&self, _: &str) -> Option<String> {
+            fn resolve_library(&self, _: &str) -> Option<ResolveResult> {
                 *self.calls.lock().unwrap() += 1;
                 None
             }
@@ -1358,8 +1400,13 @@ axum = "0.7"
         use crate::dep_manifest::Dependency;
         struct ResolveOkButQueryFails;
         impl ContextFetcher for ResolveOkButQueryFails {
-            fn resolve_library(&self, name: &str) -> Option<String> {
-                Some(format!("/lib/{name}"))
+            fn resolve_library(&self, name: &str) -> Option<ResolveResult> {
+                Some(ResolveResult {
+                    library_id: format!("/lib/{name}"),
+                    benchmark_score: None,
+                    snippet_count: None,
+                    reputation: None,
+                })
             }
             fn query_docs(&self, _: &str, _: &str, _: usize) -> Option<String> {
                 None
@@ -1387,11 +1434,21 @@ axum = "0.7"
         use crate::dep_manifest::Dependency;
         struct PartialSpy;
         impl ContextFetcher for PartialSpy {
-            fn resolve_library(&self, name: &str) -> Option<String> {
+            fn resolve_library(&self, name: &str) -> Option<ResolveResult> {
                 if name == "good" {
-                    Some("/lib/good".into())
+                    Some(ResolveResult {
+                        library_id: "/lib/good".into(),
+                        benchmark_score: None,
+                        snippet_count: None,
+                        reputation: None,
+                    })
                 } else if name == "query_fails" {
-                    Some("/lib/qf".into())
+                    Some(ResolveResult {
+                        library_id: "/lib/qf".into(),
+                        benchmark_score: None,
+                        snippet_count: None,
+                        reputation: None,
+                    })
                 } else {
                     None
                 }
@@ -1567,8 +1624,13 @@ axum = "0.7"
             calls: Arc<AtomicUsize>,
         }
         impl ContextFetcher for CountingFetcher {
-            fn resolve_library(&self, name: &str) -> Option<String> {
-                Some(format!("/lib/{}", name))
+            fn resolve_library(&self, name: &str) -> Option<ResolveResult> {
+                Some(ResolveResult {
+                    library_id: format!("/lib/{}", name),
+                    benchmark_score: None,
+                    snippet_count: None,
+                    reputation: None,
+                })
             }
             fn query_docs(
                 &self,
@@ -1615,9 +1677,14 @@ axum = "0.7"
             calls: Arc<AtomicUsize>,
         }
         impl ContextFetcher for CountingResolver {
-            fn resolve_library(&self, name: &str) -> Option<String> {
+            fn resolve_library(&self, name: &str) -> Option<ResolveResult> {
                 self.calls.fetch_add(1, Ordering::SeqCst);
-                Some(format!("/lib/{}", name))
+                Some(ResolveResult {
+                    library_id: format!("/lib/{}", name),
+                    benchmark_score: None,
+                    snippet_count: None,
+                    reputation: None,
+                })
             }
             fn query_docs(&self, _: &str, _: &str, _: usize) -> Option<String> {
                 None
@@ -1666,8 +1733,13 @@ axum = "0.7"
             calls: Arc<AtomicUsize>,
         }
         impl ContextFetcher for CountingQuery {
-            fn resolve_library(&self, name: &str) -> Option<String> {
-                Some(name.into())
+            fn resolve_library(&self, name: &str) -> Option<ResolveResult> {
+                Some(ResolveResult {
+                    library_id: name.into(),
+                    benchmark_score: None,
+                    snippet_count: None,
+                    reputation: None,
+                })
             }
             fn query_docs(&self, lib: &str, _: &str, _: usize) -> Option<String> {
                 self.calls.fetch_add(1, Ordering::SeqCst);
@@ -1702,8 +1774,13 @@ axum = "0.7"
     fn cached_fetcher_delegates_resolve() {
         struct StubFetcher;
         impl ContextFetcher for StubFetcher {
-            fn resolve_library(&self, name: &str) -> Option<String> {
-                Some(format!("/resolved/{}", name))
+            fn resolve_library(&self, name: &str) -> Option<ResolveResult> {
+                Some(ResolveResult {
+                    library_id: format!("/resolved/{}", name),
+                    benchmark_score: None,
+                    snippet_count: None,
+                    reputation: None,
+                })
             }
             fn query_docs(&self, _: &str, _: &str, _: usize) -> Option<String> {
                 None
@@ -1713,8 +1790,22 @@ axum = "0.7"
         let inner = StubFetcher;
         let cached = CachedContextFetcher::new(&inner, 16);
         assert_eq!(
-            cached.resolve_library("react"),
+            cached.resolve_library("react").map(|r| r.library_id),
             Some("/resolved/react".into())
         );
+    }
+
+    #[test]
+    fn resolve_result_carries_metadata() {
+        let result = ResolveResult {
+            library_id: "/serde-rs/serde".into(),
+            benchmark_score: Some(83.7),
+            snippet_count: Some(366),
+            reputation: Some("High".into()),
+        };
+        assert_eq!(result.library_id, "/serde-rs/serde");
+        assert_eq!(result.benchmark_score, Some(83.7));
+        assert_eq!(result.snippet_count, Some(366));
+        assert_eq!(result.reputation.as_deref(), Some("High"));
     }
 }

--- a/src/context_enrichment.rs
+++ b/src/context_enrichment.rs
@@ -293,6 +293,11 @@ pub fn enrich_for_review_with_policy(
         }
         seen.insert(dep.name.clone());
 
+        if policy.would_skip_locally(&dep.name, &dep.language, imports) {
+            metrics.context7_skipped_popular += 1;
+            continue;
+        }
+
         let resolve = match fetcher.resolve_library(&dep.name) {
             Some(r) => {
                 metrics.context7_resolved += 1;
@@ -1369,9 +1374,10 @@ axum = "0.7"
             "axum not in imports — must be skipped"
         );
 
-        // Telemetry: both were resolved but then skipped_popular by the policy.
-        // (tokio and serde are mainstream Rust deps)
+        // Telemetry: both were skipped locally (mainstream) before resolve.
         assert_eq!(result.metrics.context7_skipped_popular, 2);
+        // No resolve calls were made for mainstream deps.
+        assert_eq!(result.metrics.context7_resolved, 0);
     }
 
     // Policy-aware enrichment integration tests
@@ -1388,6 +1394,7 @@ axum = "0.7"
         let result = enrich_for_review_with_policy(&deps, &[], &imports, &fetcher, &policy);
         assert!(result.docs.is_empty(), "serde should be skipped");
         assert_eq!(result.metrics.context7_skipped_popular, 1);
+        assert_eq!(result.metrics.context7_resolved, 0, "no resolve for mainstream dep");
     }
 
     #[test]

--- a/src/context_enrichment.rs
+++ b/src/context_enrichment.rs
@@ -337,7 +337,15 @@ pub fn enrich_for_review_with_policy(
             continue;
         }
         if let Some(query) = curated_query_for(fw) {
-            try_fetch_one(fw, &query, imports, fetcher, &mut docs, &mut metrics, &mut seen);
+            try_fetch_one(
+                fw,
+                &query,
+                imports,
+                fetcher,
+                &mut docs,
+                &mut metrics,
+                &mut seen,
+            );
         }
     }
 
@@ -1384,9 +1392,10 @@ axum = "0.7"
 
     #[test]
     fn popular_dep_is_skipped_by_policy() {
-        let deps = vec![
-            crate::dep_manifest::Dependency { name: "serde".into(), language: "rust".into() },
-        ];
+        let deps = vec![crate::dep_manifest::Dependency {
+            name: "serde".into(),
+            language: "rust".into(),
+        }];
         let imports = vec!["Deserialize: use serde::Deserialize;".into()];
         let fetcher = test_support::Spy;
         let policy = crate::enrichment_policy::EnrichmentPolicy::default();
@@ -1394,14 +1403,18 @@ axum = "0.7"
         let result = enrich_for_review_with_policy(&deps, &[], &imports, &fetcher, &policy);
         assert!(result.docs.is_empty(), "serde should be skipped");
         assert_eq!(result.metrics.context7_skipped_popular, 1);
-        assert_eq!(result.metrics.context7_resolved, 0, "no resolve for mainstream dep");
+        assert_eq!(
+            result.metrics.context7_resolved, 0,
+            "no resolve for mainstream dep"
+        );
     }
 
     #[test]
     fn niche_dep_gets_enriched_by_policy() {
-        let deps = vec![
-            crate::dep_manifest::Dependency { name: "fastembed".into(), language: "rust".into() },
-        ];
+        let deps = vec![crate::dep_manifest::Dependency {
+            name: "fastembed".into(),
+            language: "rust".into(),
+        }];
         let imports = vec![
             "TextEmbedding: use fastembed::TextEmbedding;".into(),
             "EmbeddingModel: use fastembed::EmbeddingModel;".into(),
@@ -1486,9 +1499,15 @@ axum = "0.7"
         };
         let cached = CachedContextFetcher::new(&inner, 16);
         let r1 = cached.resolve_library("react");
-        assert_eq!(r1.as_ref().map(|r| r.library_id.as_str()), Some("/lib/react"));
+        assert_eq!(
+            r1.as_ref().map(|r| r.library_id.as_str()),
+            Some("/lib/react")
+        );
         let r2 = cached.resolve_library("react");
-        assert_eq!(r2.as_ref().map(|r| r.library_id.as_str()), Some("/lib/react"));
+        assert_eq!(
+            r2.as_ref().map(|r| r.library_id.as_str()),
+            Some("/lib/react")
+        );
         assert_eq!(*inner.calls.lock().unwrap(), 1);
     }
 

--- a/src/context_enrichment.rs
+++ b/src/context_enrichment.rs
@@ -29,6 +29,8 @@ pub struct EnrichmentMetrics {
     pub context7_resolved: u32,
     pub context7_resolve_failed: u32,
     pub context7_query_failed: u32,
+    pub context7_skipped_popular: u32,
+    pub context7_budget_reduced: u32,
 }
 
 /// Result of enrich_for_review: docs to splice into the prompt + telemetry counters.
@@ -262,16 +264,92 @@ pub fn enrich_for_review(
     EnrichmentResult { docs, metrics }
 }
 
-/// Convenience wrapper: parse the project's manifests, then run enrich_for_review.
+/// Policy-aware enrichment: skips popular deps, tiers budgets, gates on quality.
+pub fn enrich_for_review_with_policy(
+    deps: &[crate::dep_manifest::Dependency],
+    curated_frameworks: &[String],
+    imports: &[String],
+    fetcher: &dyn ContextFetcher,
+    policy: &crate::enrichment_policy::EnrichmentPolicy,
+) -> EnrichmentResult {
+    let mut metrics = EnrichmentMetrics::default();
+    let mut docs: Vec<ContextDoc> = Vec::new();
+    let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
+
+    let mut import_matched: Vec<&crate::dep_manifest::Dependency> = Vec::new();
+    for imp in imports {
+        for name in normalize_import_to_dep_names(imp) {
+            if let Some(dep) = deps.iter().find(|d| d.name == name)
+                && !import_matched.iter().any(|d| d.name == dep.name)
+            {
+                import_matched.push(dep);
+            }
+        }
+    }
+
+    for dep in import_matched.into_iter().take(ENRICH_K) {
+        if seen.contains(&dep.name) {
+            continue;
+        }
+        seen.insert(dep.name.clone());
+
+        let resolve = match fetcher.resolve_library(&dep.name) {
+            Some(r) => {
+                metrics.context7_resolved += 1;
+                r
+            }
+            None => {
+                metrics.context7_resolve_failed += 1;
+                continue;
+            }
+        };
+
+        let budget = policy.token_budget_for(&dep.name, &dep.language, imports, &resolve);
+        if budget == 0 {
+            metrics.context7_skipped_popular += 1;
+            continue;
+        }
+        if budget < 5000 {
+            metrics.context7_budget_reduced += 1;
+        }
+
+        let query = curated_query_for(&dep.name)
+            .unwrap_or_else(|| generic_query_for_language(&dep.language).into());
+        let enriched = build_code_aware_query(&query, imports);
+        if let Some(content) = fetcher.query_docs(&resolve.library_id, &enriched, budget) {
+            docs.push(ContextDoc {
+                library: dep.name.clone(),
+                content,
+            });
+        } else {
+            metrics.context7_query_failed += 1;
+        }
+    }
+
+    // Curated frameworks bypass policy — they're directory-detected (HA/ESPHome)
+    for fw in curated_frameworks {
+        if seen.contains(fw) {
+            continue;
+        }
+        if let Some(query) = curated_query_for(fw) {
+            try_fetch_one(fw, &query, imports, fetcher, &mut docs, &mut metrics, &mut seen);
+        }
+    }
+
+    EnrichmentResult { docs, metrics }
+}
+
+/// Convenience wrapper: parse the project's manifests, then run policy-aware enrichment.
 /// This is the main public entry point used by pipeline.rs.
 pub fn enrich_for_review_in_project(
     project_root: &std::path::Path,
     imports: &[String],
     curated_frameworks: &[String],
     fetcher: &dyn ContextFetcher,
+    policy: &crate::enrichment_policy::EnrichmentPolicy,
 ) -> EnrichmentResult {
     let deps = crate::dep_manifest::parse_dependencies(project_root);
-    enrich_for_review(&deps, curated_frameworks, imports, fetcher)
+    enrich_for_review_with_policy(&deps, curated_frameworks, imports, fetcher, policy)
 }
 
 fn try_fetch_one(
@@ -1280,20 +1358,71 @@ axum = "0.7"
 
         let spy = CapturingSpy::new();
         let imports = vec!["tokio::sync::Mutex".into(), "serde::Serialize".into()];
-        let result = enrich_for_review_in_project(dir.path(), &imports, &[], &spy);
+        let policy = crate::enrichment_policy::EnrichmentPolicy::default();
+        let result = enrich_for_review_in_project(dir.path(), &imports, &[], &spy, &policy);
 
         let libs: Vec<_> = result.docs.iter().map(|d| d.library.clone()).collect();
-        assert!(libs.contains(&"tokio".to_string()));
-        assert!(libs.contains(&"serde".to_string()));
+        // tokio and serde are in the mainstream skip-list, so they will be
+        // skipped by the policy. The test verifies they are not present.
         assert!(
             !libs.contains(&"axum".to_string()),
             "axum not in imports — must be skipped"
         );
 
-        // Telemetry: 2 deps were import-matched and resolved.
-        assert_eq!(result.metrics.context7_resolved, 2);
-        assert_eq!(result.metrics.context7_resolve_failed, 0);
-        assert_eq!(result.metrics.context7_query_failed, 0);
+        // Telemetry: both were resolved but then skipped_popular by the policy.
+        // (tokio and serde are mainstream Rust deps)
+        assert_eq!(result.metrics.context7_skipped_popular, 2);
+    }
+
+    // Policy-aware enrichment integration tests
+
+    #[test]
+    fn popular_dep_is_skipped_by_policy() {
+        let deps = vec![
+            crate::dep_manifest::Dependency { name: "serde".into(), language: "rust".into() },
+        ];
+        let imports = vec!["Deserialize: use serde::Deserialize;".into()];
+        let fetcher = test_support::Spy;
+        let policy = crate::enrichment_policy::EnrichmentPolicy::default();
+
+        let result = enrich_for_review_with_policy(&deps, &[], &imports, &fetcher, &policy);
+        assert!(result.docs.is_empty(), "serde should be skipped");
+        assert_eq!(result.metrics.context7_skipped_popular, 1);
+    }
+
+    #[test]
+    fn niche_dep_gets_enriched_by_policy() {
+        let deps = vec![
+            crate::dep_manifest::Dependency { name: "fastembed".into(), language: "rust".into() },
+        ];
+        let imports = vec![
+            "TextEmbedding: use fastembed::TextEmbedding;".into(),
+            "EmbeddingModel: use fastembed::EmbeddingModel;".into(),
+        ];
+        let fetcher = test_support::Spy;
+        let policy = crate::enrichment_policy::EnrichmentPolicy::default();
+
+        let result = enrich_for_review_with_policy(&deps, &[], &imports, &fetcher, &policy);
+        assert_eq!(result.docs.len(), 1);
+        assert_eq!(result.docs[0].library, "fastembed");
+    }
+
+    #[test]
+    fn curated_frameworks_bypass_policy() {
+        let deps = vec![];
+        let imports = vec![];
+        let fetcher = test_support::Spy;
+        let policy = crate::enrichment_policy::EnrichmentPolicy::default();
+
+        let result = enrich_for_review_with_policy(
+            &deps,
+            &["home-assistant".into()],
+            &imports,
+            &fetcher,
+            &policy,
+        );
+        assert_eq!(result.docs.len(), 1);
+        assert_eq!(result.docs[0].library, "home-assistant");
     }
 
     #[test]

--- a/src/context_enrichment.rs
+++ b/src/context_enrichment.rs
@@ -60,7 +60,7 @@ pub struct EnrichmentResult {
 ///    - JS scoped deep `@nestjs/common/decorators` -> `["@nestjs/common"]`
 ///    - Bare `@foo` -> `["@foo"]`
 ///    - Leading `::std::ptr` -> `["std"]` (skips empty heads)
-pub(crate) fn normalize_import_to_dep_names(imp: &str) -> Vec<String> {
+pub fn normalize_import_to_dep_names(imp: &str) -> Vec<String> {
     // Production hydration form: "{symbol}: {statement}". Detection requires
     // both ": " and a recognized verb (`use`, `from`, `import`) — a clean
     // path like `tokio::sync::Mutex` has no ": " (no space) and falls through.

--- a/src/enrichment_policy.rs
+++ b/src/enrichment_policy.rs
@@ -248,38 +248,44 @@ impl<'a> CachedRegistryClient<'a> {
     }
 }
 
-impl RegistryClient for CachedRegistryClient<'_> {
-    fn monthly_downloads(&self, name: &str, language: &str) -> Option<u64> {
-        let key = (name.to_string(), language.to_string());
-        {
-            let mut cache = self.cache.lock().unwrap();
-            if let Some(entry) = cache.get(&key) {
-                if entry.cached_at.elapsed() < self.ttl {
-                    return entry.downloads;
-                }
+fn cached_lookup(
+    cache: &std::sync::Mutex<lru::LruCache<(String, String), RegistryCacheEntry>>,
+    ttl: std::time::Duration,
+    inner: &dyn RegistryClient,
+    name: &str,
+    language: &str,
+) -> Option<u64> {
+    let key = (name.to_string(), language.to_string());
+    {
+        let mut c = cache.lock().unwrap();
+        if let Some(entry) = c.get(&key) {
+            if entry.cached_at.elapsed() < ttl {
+                return entry.downloads;
             }
         }
-        let downloads = self.inner.monthly_downloads(name, language);
-        {
-            let mut cache = self.cache.lock().unwrap();
-            cache.put(
-                key,
-                RegistryCacheEntry {
-                    downloads,
-                    cached_at: std::time::Instant::now(),
-                },
-            );
-        }
-        downloads
+    }
+    let downloads = inner.monthly_downloads(name, language);
+    {
+        let mut c = cache.lock().unwrap();
+        c.put(
+            key,
+            RegistryCacheEntry {
+                downloads,
+                cached_at: std::time::Instant::now(),
+            },
+        );
+    }
+    downloads
+}
+
+impl RegistryClient for CachedRegistryClient<'_> {
+    fn monthly_downloads(&self, name: &str, language: &str) -> Option<u64> {
+        cached_lookup(&self.cache, self.ttl, self.inner, name, language)
     }
 }
 
-// ── Component 4b: Owned Cached Registry ──────────────────────────────────────
-
 /// Owned variant of `CachedRegistryClient` for pipeline use where the inner
-/// client lives inside an `Arc`. Unlike `CachedRegistryClient<'a>`, this
-/// struct owns its inner client via a `Box<dyn RegistryClient>` so it can
-/// be wrapped in `Arc<dyn RegistryClient>` without lifetime constraints.
+/// client lives inside an `Arc`.
 pub struct OwnedCachedRegistryClient {
     inner: Box<dyn RegistryClient>,
     cache: std::sync::Mutex<lru::LruCache<(String, String), RegistryCacheEntry>>,
@@ -299,27 +305,7 @@ impl OwnedCachedRegistryClient {
 
 impl RegistryClient for OwnedCachedRegistryClient {
     fn monthly_downloads(&self, name: &str, language: &str) -> Option<u64> {
-        let key = (name.to_string(), language.to_string());
-        {
-            let mut cache = self.cache.lock().unwrap();
-            if let Some(entry) = cache.get(&key) {
-                if entry.cached_at.elapsed() < self.ttl {
-                    return entry.downloads;
-                }
-            }
-        }
-        let downloads = self.inner.monthly_downloads(name, language);
-        {
-            let mut cache = self.cache.lock().unwrap();
-            cache.put(
-                key,
-                RegistryCacheEntry {
-                    downloads,
-                    cached_at: std::time::Instant::now(),
-                },
-            );
-        }
-        downloads
+        cached_lookup(&self.cache, self.ttl, self.inner.as_ref(), name, language)
     }
 }
 

--- a/src/enrichment_policy.rs
+++ b/src/enrichment_policy.rs
@@ -112,11 +112,12 @@ pub enum PopularityTier {
 
 impl PopularityTier {
     pub fn from_downloads(monthly: u64, language: &str) -> Self {
+        // All thresholds are monthly downloads (crates.io 90-day is ÷3 in parse_downloads).
         let (very_high, high, medium) = match language {
-            "rust" => (1_000_000, 100_000, 10_000),
+            "rust" => (300_000, 30_000, 3_000),
             "typescript" | "javascript" => (10_000_000, 1_000_000, 100_000),
             "python" => (5_000_000, 500_000, 50_000),
-            _ => (1_000_000, 100_000, 10_000),
+            _ => (300_000, 30_000, 3_000),
         };
         if monthly >= very_high {
             Self::VeryHigh
@@ -180,7 +181,20 @@ impl HttpRegistryClient {
                 "https://api.npmjs.org/downloads/point/last-month/{name}"
             )),
             "python" => {
-                let normalized = name.to_lowercase().replace('-', "_");
+                // PEP 503: collapse runs of `.`, `-`, `_` to a single `-`, lowercase.
+                let mut normalized = String::with_capacity(name.len());
+                let mut prev_sep = false;
+                for c in name.to_lowercase().chars() {
+                    if matches!(c, '.' | '-' | '_') {
+                        if !prev_sep {
+                            normalized.push('-');
+                            prev_sep = true;
+                        }
+                    } else {
+                        normalized.push(c);
+                        prev_sep = false;
+                    }
+                }
                 Some(format!(
                     "https://pypistats.org/api/packages/{normalized}/recent"
                 ))
@@ -189,11 +203,14 @@ impl HttpRegistryClient {
         }
     }
 
+    /// Parse download count from registry JSON. Normalizes to approximate monthly:
+    /// crates.io `recent_downloads` is 90-day, so we divide by 3.
     pub fn parse_downloads(json: &serde_json::Value, language: &str) -> Option<u64> {
         match language {
             "rust" => json["crate"]["recent_downloads"]
                 .as_u64()
-                .or_else(|| json["crate"]["downloads"].as_u64()),
+                .or_else(|| json["crate"]["downloads"].as_u64())
+                .map(|d| d / 3),
             "typescript" | "javascript" => json["downloads"].as_u64(),
             "python" => json["data"]["last_month"].as_u64(),
             _ => None,
@@ -360,6 +377,16 @@ impl Default for EnrichmentPolicy<'_> {
 }
 
 impl EnrichmentPolicy<'_> {
+    /// Cheap local-only check: returns true if this dep would definitely get
+    /// budget=0 without needing a Context7 resolve or registry lookup.
+    pub fn would_skip_locally(&self, dep_name: &str, language: &str, imports: &[String]) -> bool {
+        let usage = usage_relevance(dep_name, imports);
+        if matches!(usage, UsageLevel::None) {
+            return true;
+        }
+        is_mainstream(dep_name, language)
+    }
+
     pub fn token_budget_for(
         &self,
         dep_name: &str,
@@ -435,20 +462,21 @@ mod tests {
     // Popularity tier tests
     #[test]
     fn popularity_tier_from_downloads() {
+        // Thresholds for Rust are monthly: 300k/30k/3k
         assert_eq!(
-            PopularityTier::from_downloads(5_000_000, "rust"),
+            PopularityTier::from_downloads(500_000, "rust"),
             PopularityTier::VeryHigh
         );
         assert_eq!(
-            PopularityTier::from_downloads(500_000, "rust"),
+            PopularityTier::from_downloads(100_000, "rust"),
             PopularityTier::High
         );
         assert_eq!(
-            PopularityTier::from_downloads(50_000, "rust"),
+            PopularityTier::from_downloads(10_000, "rust"),
             PopularityTier::Medium
         );
         assert_eq!(
-            PopularityTier::from_downloads(5_000, "rust"),
+            PopularityTier::from_downloads(1_000, "rust"),
             PopularityTier::Low
         );
         assert_eq!(
@@ -459,13 +487,14 @@ mod tests {
 
     #[test]
     fn npm_thresholds_are_higher_than_crates_io() {
+        // 50k/month is High for Rust but only Low for npm
         assert_eq!(
-            PopularityTier::from_downloads(500_000, "rust"),
+            PopularityTier::from_downloads(50_000, "rust"),
             PopularityTier::High
         );
         assert_eq!(
-            PopularityTier::from_downloads(500_000, "typescript"),
-            PopularityTier::Medium
+            PopularityTier::from_downloads(50_000, "typescript"),
+            PopularityTier::Low
         );
     }
 
@@ -521,6 +550,15 @@ mod tests {
             HttpRegistryClient::registry_url("django", "python"),
             Some("https://pypistats.org/api/packages/django/recent".into())
         );
+        // PEP 503: dashes and underscores normalize to single dash
+        assert_eq!(
+            HttpRegistryClient::registry_url("python-dateutil", "python"),
+            Some("https://pypistats.org/api/packages/python-dateutil/recent".into())
+        );
+        assert_eq!(
+            HttpRegistryClient::registry_url("Flask_SQLAlchemy", "python"),
+            Some("https://pypistats.org/api/packages/flask-sqlalchemy/recent".into())
+        );
     }
 
     #[test]
@@ -530,10 +568,11 @@ mod tests {
 
     #[test]
     fn parse_crates_io_downloads() {
-        let json = serde_json::json!({"crate": {"recent_downloads": 1_234_567u64}});
+        // crates.io recent_downloads is 90-day; parse_downloads normalizes to monthly (÷3)
+        let json = serde_json::json!({"crate": {"recent_downloads": 1_200_000u64}});
         assert_eq!(
             HttpRegistryClient::parse_downloads(&json, "rust"),
-            Some(1_234_567)
+            Some(400_000)
         );
     }
 

--- a/src/enrichment_policy.rs
+++ b/src/enrichment_policy.rs
@@ -274,6 +274,55 @@ impl RegistryClient for CachedRegistryClient<'_> {
     }
 }
 
+// ── Component 4b: Owned Cached Registry ──────────────────────────────────────
+
+/// Owned variant of `CachedRegistryClient` for pipeline use where the inner
+/// client lives inside an `Arc`. Unlike `CachedRegistryClient<'a>`, this
+/// struct owns its inner client via a `Box<dyn RegistryClient>` so it can
+/// be wrapped in `Arc<dyn RegistryClient>` without lifetime constraints.
+pub struct OwnedCachedRegistryClient {
+    inner: Box<dyn RegistryClient>,
+    cache: std::sync::Mutex<lru::LruCache<(String, String), RegistryCacheEntry>>,
+    ttl: std::time::Duration,
+}
+
+impl OwnedCachedRegistryClient {
+    pub fn new(inner: Box<dyn RegistryClient>, max_entries: usize) -> Self {
+        let cap = std::num::NonZeroUsize::new(max_entries.max(1)).unwrap();
+        Self {
+            inner,
+            cache: std::sync::Mutex::new(lru::LruCache::new(cap)),
+            ttl: REGISTRY_CACHE_TTL,
+        }
+    }
+}
+
+impl RegistryClient for OwnedCachedRegistryClient {
+    fn monthly_downloads(&self, name: &str, language: &str) -> Option<u64> {
+        let key = (name.to_string(), language.to_string());
+        {
+            let mut cache = self.cache.lock().unwrap();
+            if let Some(entry) = cache.get(&key) {
+                if entry.cached_at.elapsed() < self.ttl {
+                    return entry.downloads;
+                }
+            }
+        }
+        let downloads = self.inner.monthly_downloads(name, language);
+        {
+            let mut cache = self.cache.lock().unwrap();
+            cache.put(
+                key,
+                RegistryCacheEntry {
+                    downloads,
+                    cached_at: std::time::Instant::now(),
+                },
+            );
+        }
+        downloads
+    }
+}
+
 // ── Component 5: Usage Relevance Gate ────────────────────────────────────────
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -538,6 +587,14 @@ mod tests {
         let second = cached.monthly_downloads("foo", "rust");
         assert_eq!(first, Some(42_000));
         assert_eq!(second, Some(42_000));
+    }
+
+    #[test]
+    fn owned_cached_registry_works() {
+        let inner = Box::new(MockRegistry { downloads: 77_000 });
+        let cached = OwnedCachedRegistryClient::new(inner, 32);
+        assert_eq!(cached.monthly_downloads("foo", "rust"), Some(77_000));
+        assert_eq!(cached.monthly_downloads("foo", "rust"), Some(77_000));
     }
 
     // Usage relevance tests

--- a/src/enrichment_policy.rs
+++ b/src/enrichment_policy.rs
@@ -1,0 +1,622 @@
+/// Precision-targeting logic for Context7 enrichment.
+///
+/// Determines whether a dependency should receive Context7-enriched docs,
+/// and if so, how large a token budget to allocate.
+///
+/// Decision tree:
+///   1. Usage gate: if the dep appears 0 times in file imports → skip.
+///   2. Mainstream skip-list: if the LLM already knows the dep well → skip.
+///   3. Popularity tier (via registry): high-popularity deps get smaller budgets
+///      since the LLM's training data already covers them.
+///   4. Quality gate: Context7 docs with low benchmark score or few snippets
+///      are not worth injecting (would add noise, not signal).
+///   5. Usage multiplier: heavier usage in the file → more budget.
+
+// ── Component 1: Mainstream Skip-List ────────────────────────────────────────
+
+/// Bundled skip-list of libraries the LLM knows well from training data.
+pub fn is_mainstream(dep_name: &str, language: &str) -> bool {
+    let normalized = dep_name.to_lowercase().replace('-', "_");
+    let list: &[&str] = match language {
+        "rust" => &[
+            "serde",
+            "serde_json",
+            "tokio",
+            "anyhow",
+            "thiserror",
+            "clap",
+            "reqwest",
+            "tracing",
+            "tracing_subscriber",
+            "log",
+            "rand",
+            "chrono",
+            "regex",
+            "hyper",
+            "axum",
+            "actix_web",
+            "rocket",
+            "diesel",
+            "futures",
+            "bytes",
+            "syn",
+            "quote",
+            "proc_macro2",
+            "rayon",
+            "crossbeam",
+            "parking_lot",
+            "once_cell",
+            "lazy_static",
+        ],
+        "typescript" | "javascript" => &[
+            "react",
+            "react_dom",
+            "next",
+            "vue",
+            "angular",
+            "express",
+            "lodash",
+            "axios",
+            "zod",
+            "typescript",
+            "webpack",
+            "vite",
+            "eslint",
+            "prettier",
+            "jest",
+            "mocha",
+            "chai",
+            "jquery",
+            "moment",
+            "dayjs",
+            "uuid",
+        ],
+        "python" => &[
+            "django",
+            "flask",
+            "fastapi",
+            "requests",
+            "numpy",
+            "pandas",
+            "pydantic",
+            "sqlalchemy",
+            "pytest",
+            "scipy",
+            "matplotlib",
+            "pillow",
+            "boto3",
+            "celery",
+            "redis",
+            "httpx",
+            "uvicorn",
+            "gunicorn",
+            "click",
+            "typer",
+            "rich",
+        ],
+        _ => return false,
+    };
+    list.contains(&normalized.as_str())
+}
+
+// ── Component 2: Popularity Tiers ────────────────────────────────────────────
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PopularityTier {
+    VeryHigh,
+    High,
+    Medium,
+    Low,
+    Unknown,
+}
+
+impl PopularityTier {
+    pub fn from_downloads(monthly: u64, language: &str) -> Self {
+        let (very_high, high, medium) = match language {
+            "rust" => (1_000_000, 100_000, 10_000),
+            "typescript" | "javascript" => (10_000_000, 1_000_000, 100_000),
+            "python" => (5_000_000, 500_000, 50_000),
+            _ => (1_000_000, 100_000, 10_000),
+        };
+        if monthly >= very_high {
+            Self::VeryHigh
+        } else if monthly >= high {
+            Self::High
+        } else if monthly >= medium {
+            Self::Medium
+        } else {
+            Self::Low
+        }
+    }
+
+    pub fn token_budget(self, benchmark: f64, snippets: u32) -> usize {
+        let quality_ok = benchmark >= 50.0 && snippets >= 5;
+        if !quality_ok {
+            return 0;
+        }
+
+        let quality_multiplier = if benchmark >= 80.0 && snippets >= 50 {
+            1.0
+        } else if benchmark >= 65.0 && snippets >= 20 {
+            0.6
+        } else {
+            0.3
+        };
+
+        let base = match self {
+            Self::VeryHigh => 0,
+            Self::High => 0,
+            Self::Medium => 1500,
+            Self::Low => 3000,
+            Self::Unknown => 1000,
+        };
+        (base as f64 * quality_multiplier) as usize
+    }
+}
+
+// ── Component 3: Registry Client ─────────────────────────────────────────────
+
+pub trait RegistryClient: Send + Sync {
+    fn monthly_downloads(&self, name: &str, language: &str) -> Option<u64>;
+}
+
+pub struct HttpRegistryClient {
+    http: reqwest::Client,
+}
+
+impl HttpRegistryClient {
+    pub fn new() -> anyhow::Result<Self> {
+        let http = reqwest::Client::builder()
+            .timeout(std::time::Duration::from_secs(5))
+            .user_agent("quorum-code-review/1.0")
+            .build()?;
+        Ok(Self { http })
+    }
+
+    pub fn registry_url(name: &str, language: &str) -> Option<String> {
+        match language {
+            "rust" => Some(format!("https://crates.io/api/v1/crates/{name}")),
+            "typescript" | "javascript" => Some(format!(
+                "https://api.npmjs.org/downloads/point/last-month/{name}"
+            )),
+            "python" => {
+                let normalized = name.to_lowercase().replace('-', "_");
+                Some(format!(
+                    "https://pypistats.org/api/packages/{normalized}/recent"
+                ))
+            }
+            _ => None,
+        }
+    }
+
+    pub fn parse_downloads(json: &serde_json::Value, language: &str) -> Option<u64> {
+        match language {
+            "rust" => json["crate"]["recent_downloads"]
+                .as_u64()
+                .or_else(|| json["crate"]["downloads"].as_u64()),
+            "typescript" | "javascript" => json["downloads"].as_u64(),
+            "python" => json["data"]["last_month"].as_u64(),
+            _ => None,
+        }
+    }
+}
+
+impl RegistryClient for HttpRegistryClient {
+    fn monthly_downloads(&self, name: &str, language: &str) -> Option<u64> {
+        let url = Self::registry_url(name, language)?;
+        let resp =
+            crate::llm_client::block_on_async(self.http.get(&url).send()).ok()?;
+        if !resp.status().is_success() {
+            tracing::debug!(
+                name,
+                language,
+                status = %resp.status(),
+                "registry download lookup failed"
+            );
+            return None;
+        }
+        let json: serde_json::Value =
+            crate::llm_client::block_on_async(resp.json()).ok()?;
+        Self::parse_downloads(&json, language)
+    }
+}
+
+// ── Component 4: Cached Registry ─────────────────────────────────────────────
+
+struct RegistryCacheEntry {
+    downloads: Option<u64>,
+    cached_at: std::time::Instant,
+}
+
+const REGISTRY_CACHE_TTL: std::time::Duration =
+    std::time::Duration::from_secs(7 * 24 * 3600);
+
+pub struct CachedRegistryClient<'a> {
+    inner: &'a dyn RegistryClient,
+    cache: std::sync::Mutex<lru::LruCache<(String, String), RegistryCacheEntry>>,
+    ttl: std::time::Duration,
+}
+
+impl<'a> CachedRegistryClient<'a> {
+    pub fn new(inner: &'a dyn RegistryClient, max_entries: usize) -> Self {
+        let cap = std::num::NonZeroUsize::new(max_entries.max(1)).unwrap();
+        Self {
+            inner,
+            cache: std::sync::Mutex::new(lru::LruCache::new(cap)),
+            ttl: REGISTRY_CACHE_TTL,
+        }
+    }
+}
+
+impl RegistryClient for CachedRegistryClient<'_> {
+    fn monthly_downloads(&self, name: &str, language: &str) -> Option<u64> {
+        let key = (name.to_string(), language.to_string());
+        {
+            let mut cache = self.cache.lock().unwrap();
+            if let Some(entry) = cache.get(&key) {
+                if entry.cached_at.elapsed() < self.ttl {
+                    return entry.downloads;
+                }
+            }
+        }
+        let downloads = self.inner.monthly_downloads(name, language);
+        {
+            let mut cache = self.cache.lock().unwrap();
+            cache.put(
+                key,
+                RegistryCacheEntry {
+                    downloads,
+                    cached_at: std::time::Instant::now(),
+                },
+            );
+        }
+        downloads
+    }
+}
+
+// ── Component 5: Usage Relevance Gate ────────────────────────────────────────
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum UsageLevel {
+    None,
+    Low,
+    Meaningful,
+    Heavy,
+}
+
+pub fn usage_relevance(dep_name: &str, imports: &[String]) -> UsageLevel {
+    let count = imports
+        .iter()
+        .filter(|imp| {
+            crate::context_enrichment::normalize_import_to_dep_names(imp)
+                .iter()
+                .any(|n| n == dep_name)
+        })
+        .count();
+    match count {
+        0 => UsageLevel::None,
+        1 => UsageLevel::Low,
+        2..=3 => UsageLevel::Meaningful,
+        _ => UsageLevel::Heavy,
+    }
+}
+
+impl UsageLevel {
+    pub fn budget_multiplier(self) -> f64 {
+        match self {
+            Self::None => 0.0,
+            Self::Low => 0.3,
+            Self::Meaningful => 1.0,
+            Self::Heavy => 1.0,
+        }
+    }
+}
+
+// ── EnrichmentPolicy ─────────────────────────────────────────────────────────
+
+pub struct EnrichmentPolicy<'a> {
+    pub registry: Option<&'a dyn RegistryClient>,
+}
+
+impl Default for EnrichmentPolicy<'_> {
+    fn default() -> Self {
+        Self { registry: None }
+    }
+}
+
+impl EnrichmentPolicy<'_> {
+    pub fn token_budget_for(
+        &self,
+        dep_name: &str,
+        language: &str,
+        imports: &[String],
+        resolve: &crate::context_enrichment::ResolveResult,
+    ) -> usize {
+        let usage = usage_relevance(dep_name, imports);
+        if matches!(usage, UsageLevel::None) {
+            return 0;
+        }
+
+        if is_mainstream(dep_name, language) {
+            return 0;
+        }
+
+        let tier = match &self.registry {
+            Some(reg) => match reg.monthly_downloads(dep_name, language) {
+                Some(count) => PopularityTier::from_downloads(count, language),
+                None => PopularityTier::Unknown,
+            },
+            None => PopularityTier::Unknown,
+        };
+
+        let benchmark = resolve.benchmark_score.unwrap_or(0.0);
+        let snippets = resolve.snippet_count.unwrap_or(0);
+        let base_budget = tier.token_budget(benchmark, snippets);
+
+        (base_budget as f64 * usage.budget_multiplier()) as usize
+    }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Skip-list tests
+    #[test]
+    fn mainstream_rust_deps_are_skipped() {
+        assert!(is_mainstream("serde", "rust"));
+        assert!(is_mainstream("tokio", "rust"));
+        assert!(is_mainstream("anyhow", "rust"));
+    }
+
+    #[test]
+    fn niche_rust_deps_are_not_skipped() {
+        assert!(!is_mainstream("fastembed", "rust"));
+        assert!(!is_mainstream("sqlite_vec", "rust"));
+        assert!(!is_mainstream("tantivy", "rust"));
+    }
+
+    #[test]
+    fn mainstream_js_deps_are_skipped() {
+        assert!(is_mainstream("react", "typescript"));
+        assert!(is_mainstream("express", "javascript"));
+        assert!(is_mainstream("next", "typescript"));
+    }
+
+    #[test]
+    fn mainstream_python_deps_are_skipped() {
+        assert!(is_mainstream("django", "python"));
+        assert!(is_mainstream("fastapi", "python"));
+        assert!(is_mainstream("requests", "python"));
+    }
+
+    #[test]
+    fn unknown_language_is_never_mainstream() {
+        assert!(!is_mainstream("serde", "unknown"));
+    }
+
+    // Popularity tier tests
+    #[test]
+    fn popularity_tier_from_downloads() {
+        assert_eq!(
+            PopularityTier::from_downloads(5_000_000, "rust"),
+            PopularityTier::VeryHigh
+        );
+        assert_eq!(
+            PopularityTier::from_downloads(500_000, "rust"),
+            PopularityTier::High
+        );
+        assert_eq!(
+            PopularityTier::from_downloads(50_000, "rust"),
+            PopularityTier::Medium
+        );
+        assert_eq!(
+            PopularityTier::from_downloads(5_000, "rust"),
+            PopularityTier::Low
+        );
+        assert_eq!(
+            PopularityTier::from_downloads(0, "rust"),
+            PopularityTier::Low
+        );
+    }
+
+    #[test]
+    fn npm_thresholds_are_higher_than_crates_io() {
+        assert_eq!(
+            PopularityTier::from_downloads(500_000, "rust"),
+            PopularityTier::High
+        );
+        assert_eq!(
+            PopularityTier::from_downloads(500_000, "typescript"),
+            PopularityTier::Medium
+        );
+    }
+
+    #[test]
+    fn budget_zero_for_popular_deps() {
+        assert_eq!(PopularityTier::VeryHigh.token_budget(95.0, 5000), 0);
+        assert_eq!(PopularityTier::High.token_budget(90.0, 200), 0);
+    }
+
+    #[test]
+    fn budget_scales_with_quality() {
+        assert_eq!(PopularityTier::Low.token_budget(85.0, 100), 3000);
+        assert_eq!(PopularityTier::Low.token_budget(70.0, 30), 1800);
+        assert_eq!(PopularityTier::Low.token_budget(55.0, 10), 900);
+    }
+
+    #[test]
+    fn budget_zero_for_bad_docs() {
+        assert_eq!(PopularityTier::Low.token_budget(30.0, 200), 0);
+        assert_eq!(PopularityTier::Low.token_budget(80.0, 2), 0);
+    }
+
+    #[test]
+    fn medium_popularity_gets_reduced_budget() {
+        assert_eq!(PopularityTier::Medium.token_budget(85.0, 100), 1500);
+    }
+
+    #[test]
+    fn unknown_tier_budget() {
+        assert_eq!(PopularityTier::Unknown.token_budget(80.0, 100), 1000);
+    }
+
+    // Registry client tests
+    #[test]
+    fn crates_io_url_is_correct() {
+        assert_eq!(
+            HttpRegistryClient::registry_url("serde", "rust"),
+            Some("https://crates.io/api/v1/crates/serde".into())
+        );
+    }
+
+    #[test]
+    fn npm_url_is_correct() {
+        assert_eq!(
+            HttpRegistryClient::registry_url("react", "typescript"),
+            Some("https://api.npmjs.org/downloads/point/last-month/react".into())
+        );
+    }
+
+    #[test]
+    fn pypi_url_is_correct() {
+        assert_eq!(
+            HttpRegistryClient::registry_url("django", "python"),
+            Some("https://pypistats.org/api/packages/django/recent".into())
+        );
+    }
+
+    #[test]
+    fn unknown_language_has_no_url() {
+        assert!(HttpRegistryClient::registry_url("foo", "haskell").is_none());
+    }
+
+    #[test]
+    fn parse_crates_io_downloads() {
+        let json = serde_json::json!({"crate": {"recent_downloads": 1_234_567u64}});
+        assert_eq!(
+            HttpRegistryClient::parse_downloads(&json, "rust"),
+            Some(1_234_567)
+        );
+    }
+
+    #[test]
+    fn parse_npm_downloads() {
+        let json = serde_json::json!({"downloads": 9_876_543u64});
+        assert_eq!(
+            HttpRegistryClient::parse_downloads(&json, "typescript"),
+            Some(9_876_543)
+        );
+    }
+
+    #[test]
+    fn parse_pypi_downloads() {
+        let json = serde_json::json!({"data": {"last_month": 456_789u64}});
+        assert_eq!(
+            HttpRegistryClient::parse_downloads(&json, "python"),
+            Some(456_789)
+        );
+    }
+
+    // Cached registry tests
+    struct MockRegistry {
+        downloads: u64,
+    }
+    impl RegistryClient for MockRegistry {
+        fn monthly_downloads(&self, _: &str, _: &str) -> Option<u64> {
+            Some(self.downloads)
+        }
+    }
+
+    #[test]
+    fn cached_registry_returns_same_result() {
+        let inner = MockRegistry { downloads: 42_000 };
+        let cached = CachedRegistryClient::new(&inner, 32);
+        let first = cached.monthly_downloads("foo", "rust");
+        let second = cached.monthly_downloads("foo", "rust");
+        assert_eq!(first, Some(42_000));
+        assert_eq!(second, Some(42_000));
+    }
+
+    // Usage relevance tests
+    #[test]
+    fn single_import_is_low_usage() {
+        let imports = vec!["Deserialize: use serde::Deserialize;".into()];
+        assert_eq!(usage_relevance("serde", &imports), UsageLevel::Low);
+    }
+
+    #[test]
+    fn multiple_imports_is_meaningful() {
+        let imports = vec![
+            "Deserialize: use serde::Deserialize;".into(),
+            "Serialize: use serde::Serialize;".into(),
+            "Value: use serde_json::Value;".into(),
+        ];
+        assert_eq!(usage_relevance("serde", &imports), UsageLevel::Meaningful);
+    }
+
+    #[test]
+    fn many_imports_is_heavy() {
+        let imports: Vec<String> = (0..5)
+            .map(|i| format!("sym{i}: use tokio::sync::sym{i};"))
+            .collect();
+        assert_eq!(usage_relevance("tokio", &imports), UsageLevel::Heavy);
+    }
+
+    #[test]
+    fn no_matching_imports_is_none() {
+        let imports = vec!["useState: import { useState } from 'react'".into()];
+        assert_eq!(usage_relevance("express", &imports), UsageLevel::None);
+    }
+
+    // EnrichmentPolicy integration tests
+    #[test]
+    fn policy_skips_mainstream_dep() {
+        let policy = EnrichmentPolicy::default();
+        let resolve = crate::context_enrichment::ResolveResult {
+            library_id: "/serde-rs/serde".into(),
+            benchmark_score: Some(83.7),
+            snippet_count: Some(366),
+            reputation: Some("High".into()),
+        };
+        let imports = vec!["Deserialize: use serde::Deserialize;".into()];
+        assert_eq!(
+            policy.token_budget_for("serde", "rust", &imports, &resolve),
+            0
+        );
+    }
+
+    #[test]
+    fn policy_enriches_niche_dep() {
+        let policy = EnrichmentPolicy::default();
+        let resolve = crate::context_enrichment::ResolveResult {
+            library_id: "/qdrant/fastembed".into(),
+            benchmark_score: Some(79.5),
+            snippet_count: Some(317),
+            reputation: Some("High".into()),
+        };
+        let imports = vec![
+            "TextEmbedding: use fastembed::TextEmbedding;".into(),
+            "EmbeddingModel: use fastembed::EmbeddingModel;".into(),
+        ];
+        let budget = policy.token_budget_for("fastembed", "rust", &imports, &resolve);
+        assert!(budget > 0, "niche dep should get a budget, got {budget}");
+    }
+
+    #[test]
+    fn policy_skips_no_usage() {
+        let policy = EnrichmentPolicy::default();
+        let resolve = crate::context_enrichment::ResolveResult {
+            library_id: "/foo/bar".into(),
+            benchmark_score: Some(90.0),
+            snippet_count: Some(500),
+            reputation: Some("High".into()),
+        };
+        assert_eq!(
+            policy.token_budget_for("bar", "rust", &[], &resolve),
+            0
+        );
+    }
+}

--- a/src/enrichment_policy.rs
+++ b/src/enrichment_policy.rs
@@ -1,20 +1,21 @@
-/// Precision-targeting logic for Context7 enrichment.
-///
-/// Determines whether a dependency should receive Context7-enriched docs,
-/// and if so, how large a token budget to allocate.
-///
-/// Decision tree:
-///   1. Usage gate: if the dep appears 0 times in file imports → skip.
-///   2. Mainstream skip-list: if the LLM already knows the dep well → skip.
-///   3. Popularity tier (via registry): high-popularity deps get smaller budgets
-///      since the LLM's training data already covers them.
-///   4. Quality gate: Context7 docs with low benchmark score or few snippets
-///      are not worth injecting (would add noise, not signal).
-///   5. Usage multiplier: heavier usage in the file → more budget.
+//! Precision-targeting logic for Context7 enrichment.
+//!
+//! Determines whether a dependency should receive Context7-enriched docs,
+//! and if so, how large a token budget to allocate.
+//!
+//! Decision tree:
+//!   1. Usage gate: if the dep appears 0 times in file imports → skip.
+//!   2. Mainstream skip-list: if the LLM already knows the dep well → skip.
+//!   3. Popularity tier (via registry): high-popularity deps get smaller budgets
+//!      since the LLM's training data already covers them.
+//!   4. Quality gate: Context7 docs with low benchmark score or few snippets
+//!      are not worth injecting (would add noise, not signal).
+//!   5. Usage multiplier: heavier usage in the file → more budget.
 
 // ── Component 1: Mainstream Skip-List ────────────────────────────────────────
 
-/// Bundled skip-list of libraries the LLM knows well from training data.
+// Bundled skip-list of libraries the LLM knows well from training data.
+/// Returns true if `dep_name` is in the built-in mainstream skip-list for `language`.
 pub fn is_mainstream(dep_name: &str, language: &str) -> bool {
     let normalized = dep_name.to_lowercase().replace('-', "_");
     let list: &[&str] = match language {
@@ -221,8 +222,7 @@ impl HttpRegistryClient {
 impl RegistryClient for HttpRegistryClient {
     fn monthly_downloads(&self, name: &str, language: &str) -> Option<u64> {
         let url = Self::registry_url(name, language)?;
-        let resp =
-            crate::llm_client::block_on_async(self.http.get(&url).send()).ok()?;
+        let resp = crate::llm_client::block_on_async(self.http.get(&url).send()).ok()?;
         if !resp.status().is_success() {
             tracing::debug!(
                 name,
@@ -232,8 +232,7 @@ impl RegistryClient for HttpRegistryClient {
             );
             return None;
         }
-        let json: serde_json::Value =
-            crate::llm_client::block_on_async(resp.json()).ok()?;
+        let json: serde_json::Value = crate::llm_client::block_on_async(resp.json()).ok()?;
         Self::parse_downloads(&json, language)
     }
 }
@@ -245,8 +244,7 @@ struct RegistryCacheEntry {
     cached_at: std::time::Instant,
 }
 
-const REGISTRY_CACHE_TTL: std::time::Duration =
-    std::time::Duration::from_secs(7 * 24 * 3600);
+const REGISTRY_CACHE_TTL: std::time::Duration = std::time::Duration::from_secs(7 * 24 * 3600);
 
 pub struct CachedRegistryClient<'a> {
     inner: &'a dyn RegistryClient,
@@ -275,10 +273,10 @@ fn cached_lookup(
     let key = (name.to_string(), language.to_string());
     {
         let mut c = cache.lock().unwrap();
-        if let Some(entry) = c.get(&key) {
-            if entry.cached_at.elapsed() < ttl {
-                return entry.downloads;
-            }
+        if let Some(entry) = c.get(&key)
+            && entry.cached_at.elapsed() < ttl
+        {
+            return entry.downloads;
         }
     }
     let downloads = inner.monthly_downloads(name, language);
@@ -366,14 +364,9 @@ impl UsageLevel {
 
 // ── EnrichmentPolicy ─────────────────────────────────────────────────────────
 
+#[derive(Default)]
 pub struct EnrichmentPolicy<'a> {
     pub registry: Option<&'a dyn RegistryClient>,
-}
-
-impl Default for EnrichmentPolicy<'_> {
-    fn default() -> Self {
-        Self { registry: None }
-    }
 }
 
 impl EnrichmentPolicy<'_> {
@@ -696,9 +689,6 @@ mod tests {
             snippet_count: Some(500),
             reputation: Some("High".into()),
         };
-        assert_eq!(
-            policy.token_budget_for("bar", "rust", &[], &resolve),
-            0
-        );
+        assert_eq!(policy.token_budget_for("bar", "rust", &[], &resolve), 0);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1494,6 +1494,14 @@ async fn run_review(opts: cli::ReviewOpts) -> i32 {
                 .iter()
                 .map(|r| r.enrichment_metrics.context7_query_failed)
                 .sum(),
+            context7_skipped_popular: file_results
+                .iter()
+                .map(|r| r.enrichment_metrics.context7_skipped_popular)
+                .sum(),
+            context7_budget_reduced: file_results
+                .iter()
+                .map(|r| r.enrichment_metrics.context7_budget_reduced)
+                .sum(),
             // #123 Layer 1 (Task 10): adoption telemetry for the FpKind
             // taxonomy. Computed over the loaded feedback store (same one
             // pipeline_cfg.feedback was built from). None when no FP

--- a/src/main.rs
+++ b/src/main.rs
@@ -999,6 +999,32 @@ async fn run_review(opts: cli::ReviewOpts) -> i32 {
         }
     }
 
+    // Phase 2: live registry lookups for popularity-tier token-budget assignment.
+    // Gated behind --live-registry CLI flag or QUORUM_CONTEXT7_LIVE_REGISTRY=1.
+    let live_registry = opts.live_registry
+        || std::env::var("QUORUM_CONTEXT7_LIVE_REGISTRY")
+            .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+            .unwrap_or(false);
+    let registry_client: Option<
+        std::sync::Arc<dyn crate::enrichment_policy::RegistryClient>,
+    > = if live_registry {
+        match crate::enrichment_policy::HttpRegistryClient::new() {
+            Ok(http) => {
+                let cached = crate::enrichment_policy::OwnedCachedRegistryClient::new(
+                    Box::new(http),
+                    128,
+                );
+                Some(std::sync::Arc::new(cached))
+            }
+            Err(e) => {
+                eprintln!("Warning: failed to initialize registry client: {e}");
+                None
+            }
+        }
+    } else {
+        None
+    };
+
     let pipeline_cfg = PipelineConfig {
         models,
         feedback: feedback_entries,
@@ -1014,6 +1040,7 @@ async fn run_review(opts: cli::ReviewOpts) -> i32 {
         context7_disabled,
         calibrator_config,
         mode: opts.mode,
+        registry_client,
         ..Default::default()
     };
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1005,25 +1005,24 @@ async fn run_review(opts: cli::ReviewOpts) -> i32 {
         || std::env::var("QUORUM_CONTEXT7_LIVE_REGISTRY")
             .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
             .unwrap_or(false);
-    let registry_client: Option<
-        std::sync::Arc<dyn crate::enrichment_policy::RegistryClient>,
-    > = if live_registry && !opts.skip_context7 && !context7_disabled {
-        match crate::enrichment_policy::HttpRegistryClient::new() {
-            Ok(http) => {
-                let cached = crate::enrichment_policy::OwnedCachedRegistryClient::new(
-                    Box::new(http),
-                    128,
-                );
-                Some(std::sync::Arc::new(cached))
+    let registry_client: Option<std::sync::Arc<dyn crate::enrichment_policy::RegistryClient>> =
+        if live_registry && !opts.skip_context7 && !context7_disabled {
+            match crate::enrichment_policy::HttpRegistryClient::new() {
+                Ok(http) => {
+                    let cached = crate::enrichment_policy::OwnedCachedRegistryClient::new(
+                        Box::new(http),
+                        128,
+                    );
+                    Some(std::sync::Arc::new(cached))
+                }
+                Err(e) => {
+                    eprintln!("Warning: failed to initialize registry client: {e}");
+                    None
+                }
             }
-            Err(e) => {
-                eprintln!("Warning: failed to initialize registry client: {e}");
-                None
-            }
-        }
-    } else {
-        None
-    };
+        } else {
+            None
+        };
 
     let pipeline_cfg = PipelineConfig {
         models,

--- a/src/main.rs
+++ b/src/main.rs
@@ -35,6 +35,7 @@ mod context_enrichment;
 mod daemon;
 mod dep_manifest;
 mod dimensions;
+mod enrichment_policy;
 mod formatting;
 mod glyphs;
 mod http_server;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1007,7 +1007,7 @@ async fn run_review(opts: cli::ReviewOpts) -> i32 {
             .unwrap_or(false);
     let registry_client: Option<
         std::sync::Arc<dyn crate::enrichment_policy::RegistryClient>,
-    > = if live_registry {
+    > = if live_registry && !opts.skip_context7 && !context7_disabled {
         match crate::enrichment_policy::HttpRegistryClient::new() {
             Ok(http) => {
                 let cached = crate::enrichment_policy::OwnedCachedRegistryClient::new(

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -176,6 +176,10 @@ pub struct PipelineConfig {
     /// Review mode governing prompt selection, severity rubric, and
     /// AST/linter applicability. Default: `Code`.
     pub mode: crate::review_mode::ReviewMode,
+    /// Optional registry client for Phase 2 popularity-tier lookups.
+    /// When `None` (default / Phase 1), the policy relies on the skip-list
+    /// and quality gate only — no network calls to crates.io / npm / PyPI.
+    pub registry_client: Option<std::sync::Arc<dyn crate::enrichment_policy::RegistryClient>>,
 }
 
 impl Default for PipelineConfig {
@@ -200,6 +204,7 @@ impl Default for PipelineConfig {
             focus: None,
             calibrator_config: CalibratorConfig::default(),
             mode: crate::review_mode::ReviewMode::Code,
+            registry_client: None,
         }
     }
 }
@@ -635,12 +640,16 @@ pub async fn review_file(
                 // cache when no shared one is wired (tests, single-file CLI).
                 let ctx7_t0 = std::time::Instant::now();
                 let _span = tracing::info_span!("phase.context7", file = %file_str).entered();
+                let policy = crate::enrichment_policy::EnrichmentPolicy {
+                    registry: None, // Phase 1: skip-list + quality gate only
+                };
                 let result = if let Some(shared) = pipeline_config.context7_fetcher.as_ref() {
                     crate::context_enrichment::enrich_for_review_in_project(
                         &project_root,
                         &redacted_ctx.import_targets,
                         &domain.frameworks,
                         shared.as_ref(),
+                        &policy,
                     )
                 } else {
                     let inner = crate::context_enrichment::Context7HttpFetcher::new()?;
@@ -650,6 +659,7 @@ pub async fn review_file(
                         &redacted_ctx.import_targets,
                         &domain.frameworks,
                         &cached,
+                        &policy,
                     )
                 };
                 let docs = result.docs;
@@ -1143,12 +1153,16 @@ pub async fn review_file_llm_only(
                     domain.frameworks.push(fw.clone());
                 }
             }
+            let policy = crate::enrichment_policy::EnrichmentPolicy {
+                registry: None, // Phase 1: skip-list + quality gate only
+            };
             let result = if let Some(shared) = pipeline_config.context7_fetcher.as_ref() {
                 crate::context_enrichment::enrich_for_review_in_project(
                     &project_root,
                     &[],
                     &domain.frameworks,
                     shared.as_ref(),
+                    &policy,
                 )
             } else {
                 let inner = crate::context_enrichment::Context7HttpFetcher::new()?;
@@ -1158,6 +1172,7 @@ pub async fn review_file_llm_only(
                     &[],
                     &domain.frameworks,
                     &cached,
+                    &policy,
                 )
             };
             let docs = result.docs;

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -641,7 +641,10 @@ pub async fn review_file(
                 let ctx7_t0 = std::time::Instant::now();
                 let _span = tracing::info_span!("phase.context7", file = %file_str).entered();
                 let policy = crate::enrichment_policy::EnrichmentPolicy {
-                    registry: None, // Phase 1: skip-list + quality gate only
+                    registry: pipeline_config
+                        .registry_client
+                        .as_ref()
+                        .map(|r| r.as_ref() as &dyn crate::enrichment_policy::RegistryClient),
                 };
                 let result = if let Some(shared) = pipeline_config.context7_fetcher.as_ref() {
                     crate::context_enrichment::enrich_for_review_in_project(
@@ -1154,7 +1157,10 @@ pub async fn review_file_llm_only(
                 }
             }
             let policy = crate::enrichment_policy::EnrichmentPolicy {
-                registry: None, // Phase 1: skip-list + quality gate only
+                registry: pipeline_config
+                    .registry_client
+                    .as_ref()
+                    .map(|r| r.as_ref() as &dyn crate::enrichment_policy::RegistryClient),
             };
             let result = if let Some(shared) = pipeline_config.context7_fetcher.as_ref() {
                 crate::context_enrichment::enrich_for_review_in_project(

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -675,6 +675,8 @@ pub async fn review_file(
                     resolved = enrichment_metrics.context7_resolved,
                     resolve_failed = enrichment_metrics.context7_resolve_failed,
                     query_failed = enrichment_metrics.context7_query_failed,
+                    skipped_popular = enrichment_metrics.context7_skipped_popular,
+                    budget_reduced = enrichment_metrics.context7_budget_reduced,
                     "phase complete"
                 );
                 if !docs.is_empty() {

--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -315,6 +315,8 @@ mod tests {
         assert_eq!(entry.context7_resolved, 0);
         assert_eq!(entry.context7_resolve_failed, 0);
         assert_eq!(entry.context7_query_failed, 0);
+        assert_eq!(entry.context7_skipped_popular, 0);
+        assert_eq!(entry.context7_budget_reduced, 0);
     }
 
     #[test]

--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -21,6 +21,10 @@ pub struct TelemetryEntry {
     pub context7_resolve_failed: u32,
     #[serde(default)]
     pub context7_query_failed: u32,
+    #[serde(default)]
+    pub context7_skipped_popular: u32,
+    #[serde(default)]
+    pub context7_budget_reduced: u32,
     /// #123 Layer 1 (Task 10): fraction of `Verdict::Fp` feedback entries
     /// that carry a `fp_kind` discriminator. Range [0.0, 1.0]. `None` when
     /// the loaded feedback store has no FP entries (denominator zero).
@@ -277,6 +281,8 @@ mod tests {
             context7_resolved: 0,
             context7_resolve_failed: 0,
             context7_query_failed: 0,
+            context7_skipped_popular: 0,
+            context7_budget_reduced: 0,
             fp_kind_utilization_rate: None,
         }
     }

--- a/tests/fixtures/comparison/README.md
+++ b/tests/fixtures/comparison/README.md
@@ -1,0 +1,47 @@
+# External Comparison Corpus
+
+Clean test fixtures for cross-tool comparisons. **Do not record quorum feedback
+for findings on these files** — they must remain uncontaminated for future A/B
+testing.
+
+## Samples
+
+Real-world open-source files covering Rust, Python, and TypeScript:
+
+| File | Source | Lines | Why chosen |
+|------|--------|-------|------------|
+| `index_writer.rs` | tantivy search engine | 2588 | Concurrency, thread pools, channel patterns |
+| `client.py` | httpx HTTP client | 2019 | Async/sync duality, transport lifecycle, redirects |
+| `router.ts` | tRPC framework | 565 | Type guards, recursive construction, lazy loading |
+
+## Running a comparison
+
+```bash
+# 1. Quorum
+quorum review tests/fixtures/comparison/samples/*.rs tests/fixtures/comparison/samples/*.py tests/fixtures/comparison/samples/*.ts --json > /tmp/cmp-quorum.json
+
+# 2. PAL (via MCP)
+# Use mcp__pal__codereview on each file
+
+# 3. Third-opinion
+third-opinion review tests/fixtures/comparison/samples/index_writer.rs --focus security,correctness > /tmp/cmp-to-rust.json
+third-opinion review tests/fixtures/comparison/samples/client.py --focus security,correctness > /tmp/cmp-to-python.json
+third-opinion review tests/fixtures/comparison/samples/router.ts --focus security,correctness > /tmp/cmp-to-ts.json
+```
+
+Then compare against the baseline in `baselines/`.
+
+## Baselines
+
+Each baseline records the exact findings from all three tools at a point in time.
+Compare new runs against the baseline to measure regressions or improvements.
+
+- `2026-05-10-precision-targeting.json` — first baseline, taken during Context7
+  precision-targeting PR #287. Quorum 19, PAL 9, Third-Opinion 10.
+
+## Rules
+
+1. Never record quorum feedback (`quorum feedback`) for these files
+2. Always use `--json` for quorum to get structured output
+3. Record the quorum version/commit, model, and third-opinion version in each baseline
+4. When upstream files change significantly, fetch fresh copies and start a new baseline series

--- a/tests/fixtures/comparison/baselines/2026-05-10-precision-targeting.json
+++ b/tests/fixtures/comparison/baselines/2026-05-10-precision-targeting.json
@@ -1,0 +1,133 @@
+{
+  "date": "2026-05-10",
+  "branch": "worktree-feat+context7-precision-targeting",
+  "quorum_version": "0.20.0-dev (precision-targeting)",
+  "model": "gpt-5.4",
+  "third_opinion_version": "1.17.0",
+  "notes": "First external corpus comparison. Feedback NOT recorded — preserved as clean test corpus.",
+  "files": [
+    {
+      "name": "index_writer.rs",
+      "source": "https://github.com/quickwit-oss/tantivy/blob/main/src/indexer/index_writer.rs",
+      "language": "rust",
+      "lines": 2588
+    },
+    {
+      "name": "client.py",
+      "source": "https://github.com/encode/httpx/blob/master/httpx/_client.py",
+      "language": "python",
+      "lines": 2019
+    },
+    {
+      "name": "router.ts",
+      "source": "https://github.com/trpc/trpc/blob/main/packages/server/src/unstable-core-do-not-import/router.ts",
+      "language": "typescript",
+      "lines": 565
+    }
+  ],
+  "results": {
+    "index_writer.rs": {
+      "quorum": {
+        "total": 4,
+        "findings": [
+          {"severity": "high", "category": "maintainability", "title": "wait_merging_threads returns early and detaches remaining threads"},
+          {"severity": "high", "category": "correctness", "title": "IndexWriter::new does not enforce MAX_NUM_THREAD"},
+          {"severity": "medium", "category": "performance", "title": "Function test_operation_strategy has cyclomatic complexity 51", "source": "local-ast"},
+          {"severity": "medium", "category": "error-handling", "title": "wait_merging_threads discards the original worker error details"}
+        ]
+      },
+      "pal": {
+        "total": 3,
+        "findings": [
+          {"severity": "high", "title": "MAX_NUM_THREAD not enforced in IndexWriter::new()"},
+          {"severity": "high", "title": "wait_merging_threads returns early, detaches remaining threads"},
+          {"severity": "medium", "title": "rollback() silently discards enqueued operations"}
+        ]
+      },
+      "third_opinion": {
+        "total": 4,
+        "score": 87,
+        "findings": [
+          {"severity": "medium", "title": "MAX_NUM_THREAD declared but never enforced"},
+          {"severity": "medium", "title": "rollback() silently drops queued operations"},
+          {"severity": "low", "title": "Thread join error handling inconsistent across file"},
+          {"severity": "low", "title": "test_writer_options_validation missing MAX_NUM_THREAD case"}
+        ]
+      }
+    },
+    "client.py": {
+      "quorum": {
+        "total": 8,
+        "findings": [
+          {"severity": "high", "category": "correctness", "title": "_merge_url drops query/fragment from relative URLs"},
+          {"severity": "high", "category": "concurrency", "title": "send races with close/aclose despite shared-use API claims"},
+          {"severity": "high", "category": "logic", "title": "_send_handling_redirects allows one redirect past max_redirects"},
+          {"severity": "medium", "category": "maintainability", "title": "AsyncClient.aclose leaks mounted transports on close errors"},
+          {"severity": "medium", "category": "maintainability", "title": "AsyncClient.__aenter__ leaks already-opened transports on failure"},
+          {"severity": "medium", "category": "maintainability", "title": "Client.close leaks mounted transports if base transport close fails"},
+          {"severity": "medium", "category": "maintainability", "title": "Client.__enter__ leaks already-opened transports on partial failure"},
+          {"severity": "medium", "category": "maintainability", "title": "assert-in-prod-code: assert is stripped by python -O", "source": "ast-grep"}
+        ]
+      },
+      "pal": {
+        "total": 3,
+        "findings": [
+          {"severity": "high", "title": "Off-by-one in max_redirects check"},
+          {"severity": "high", "title": "send() races with close()/aclose()"},
+          {"severity": "medium", "title": "Transport leak on close errors"}
+        ]
+      },
+      "third_opinion": {
+        "total": 3,
+        "score": 91,
+        "findings": [
+          {"severity": "medium", "title": "Off-by-one in redirect limit check"},
+          {"severity": "medium", "title": "Client.close() leaks mounted transports on error"},
+          {"severity": "info", "title": "_redirect_headers removes Authorization but not on cross-scheme downgrade"}
+        ]
+      }
+    },
+    "router.ts": {
+      "quorum": {
+        "total": 7,
+        "findings": [
+          {"severity": "high", "category": "correctness", "title": "getProcedureAtPath matches lazy routers by raw prefix"},
+          {"severity": "high", "category": "correctness", "title": "createRouterInner only rejects reserved words at top level"},
+          {"severity": "low", "category": "correctness", "title": "isProcedure accepts any function as a procedure"},
+          {"severity": "medium", "category": "correctness", "title": "isRouter treats any object with _def.router as a router"},
+          {"severity": "medium", "category": "maintainability", "title": "as-any-cast: Type assertion to any bypasses TypeScript type safety", "source": "ast-grep"},
+          {"severity": "medium", "category": "maintainability", "title": "non-null-assertion: Non-null assertion ! bypasses type safety", "source": "ast-grep"},
+          {"severity": "low", "category": "maintainability", "title": "Use of non-null assertion operator ! bypasses type safety", "source": "local-ast"}
+        ]
+      },
+      "pal": {
+        "total": 3,
+        "findings": [
+          {"severity": "high", "title": "getProcedureAtPath prefix matching allows path confusion"},
+          {"severity": "high", "title": "Reserved word check only at top level"},
+          {"severity": "medium", "title": "isProcedure too permissive type guard"}
+        ]
+      },
+      "third_opinion": {
+        "total": 3,
+        "score": 83,
+        "findings": [
+          {"severity": "high", "title": "getProcedureAtPath prefix matching can resolve wrong router"},
+          {"severity": "medium", "title": "Reserved word validation only at top level"},
+          {"severity": "info", "title": "lazy() validates imported modules before accepting as routers"}
+        ]
+      }
+    }
+  },
+  "summary": {
+    "quorum_total": 19,
+    "pal_total": 9,
+    "third_opinion_total": 10,
+    "quorum_unique": 8,
+    "pal_unique": 0,
+    "third_opinion_unique": 2,
+    "shared_across_all_3": 5,
+    "quorum_ast_grep_hits": 3,
+    "quorum_local_ast_hits": 2
+  }
+}

--- a/tests/fixtures/comparison/samples/client.py
+++ b/tests/fixtures/comparison/samples/client.py
@@ -1,0 +1,2019 @@
+from __future__ import annotations
+
+import datetime
+import enum
+import logging
+import time
+import typing
+import warnings
+from contextlib import asynccontextmanager, contextmanager
+from types import TracebackType
+
+from .__version__ import __version__
+from ._auth import Auth, BasicAuth, FunctionAuth
+from ._config import (
+    DEFAULT_LIMITS,
+    DEFAULT_MAX_REDIRECTS,
+    DEFAULT_TIMEOUT_CONFIG,
+    Limits,
+    Proxy,
+    Timeout,
+)
+from ._decoders import SUPPORTED_DECODERS
+from ._exceptions import (
+    InvalidURL,
+    RemoteProtocolError,
+    TooManyRedirects,
+    request_context,
+)
+from ._models import Cookies, Headers, Request, Response
+from ._status_codes import codes
+from ._transports.base import AsyncBaseTransport, BaseTransport
+from ._transports.default import AsyncHTTPTransport, HTTPTransport
+from ._types import (
+    AsyncByteStream,
+    AuthTypes,
+    CertTypes,
+    CookieTypes,
+    HeaderTypes,
+    ProxyTypes,
+    QueryParamTypes,
+    RequestContent,
+    RequestData,
+    RequestExtensions,
+    RequestFiles,
+    SyncByteStream,
+    TimeoutTypes,
+)
+from ._urls import URL, QueryParams
+from ._utils import URLPattern, get_environment_proxies
+
+if typing.TYPE_CHECKING:
+    import ssl  # pragma: no cover
+
+__all__ = ["USE_CLIENT_DEFAULT", "AsyncClient", "Client"]
+
+# The type annotation for @classmethod and context managers here follows PEP 484
+# https://www.python.org/dev/peps/pep-0484/#annotating-instance-and-class-methods
+T = typing.TypeVar("T", bound="Client")
+U = typing.TypeVar("U", bound="AsyncClient")
+
+
+def _is_https_redirect(url: URL, location: URL) -> bool:
+    """
+    Return 'True' if 'location' is a HTTPS upgrade of 'url'
+    """
+    if url.host != location.host:
+        return False
+
+    return (
+        url.scheme == "http"
+        and _port_or_default(url) == 80
+        and location.scheme == "https"
+        and _port_or_default(location) == 443
+    )
+
+
+def _port_or_default(url: URL) -> int | None:
+    if url.port is not None:
+        return url.port
+    return {"http": 80, "https": 443}.get(url.scheme)
+
+
+def _same_origin(url: URL, other: URL) -> bool:
+    """
+    Return 'True' if the given URLs share the same origin.
+    """
+    return (
+        url.scheme == other.scheme
+        and url.host == other.host
+        and _port_or_default(url) == _port_or_default(other)
+    )
+
+
+class UseClientDefault:
+    """
+    For some parameters such as `auth=...` and `timeout=...` we need to be able
+    to indicate the default "unset" state, in a way that is distinctly different
+    to using `None`.
+
+    The default "unset" state indicates that whatever default is set on the
+    client should be used. This is different to setting `None`, which
+    explicitly disables the parameter, possibly overriding a client default.
+
+    For example we use `timeout=USE_CLIENT_DEFAULT` in the `request()` signature.
+    Omitting the `timeout` parameter will send a request using whatever default
+    timeout has been configured on the client. Including `timeout=None` will
+    ensure no timeout is used.
+
+    Note that user code shouldn't need to use the `USE_CLIENT_DEFAULT` constant,
+    but it is used internally when a parameter is not included.
+    """
+
+
+USE_CLIENT_DEFAULT = UseClientDefault()
+
+
+logger = logging.getLogger("httpx")
+
+USER_AGENT = f"python-httpx/{__version__}"
+ACCEPT_ENCODING = ", ".join(
+    [key for key in SUPPORTED_DECODERS.keys() if key != "identity"]
+)
+
+
+class ClientState(enum.Enum):
+    # UNOPENED:
+    #   The client has been instantiated, but has not been used to send a request,
+    #   or been opened by entering the context of a `with` block.
+    UNOPENED = 1
+    # OPENED:
+    #   The client has either sent a request, or is within a `with` block.
+    OPENED = 2
+    # CLOSED:
+    #   The client has either exited the `with` block, or `close()` has
+    #   been called explicitly.
+    CLOSED = 3
+
+
+class BoundSyncStream(SyncByteStream):
+    """
+    A byte stream that is bound to a given response instance, and that
+    ensures the `response.elapsed` is set once the response is closed.
+    """
+
+    def __init__(
+        self, stream: SyncByteStream, response: Response, start: float
+    ) -> None:
+        self._stream = stream
+        self._response = response
+        self._start = start
+
+    def __iter__(self) -> typing.Iterator[bytes]:
+        for chunk in self._stream:
+            yield chunk
+
+    def close(self) -> None:
+        elapsed = time.perf_counter() - self._start
+        self._response.elapsed = datetime.timedelta(seconds=elapsed)
+        self._stream.close()
+
+
+class BoundAsyncStream(AsyncByteStream):
+    """
+    An async byte stream that is bound to a given response instance, and that
+    ensures the `response.elapsed` is set once the response is closed.
+    """
+
+    def __init__(
+        self, stream: AsyncByteStream, response: Response, start: float
+    ) -> None:
+        self._stream = stream
+        self._response = response
+        self._start = start
+
+    async def __aiter__(self) -> typing.AsyncIterator[bytes]:
+        async for chunk in self._stream:
+            yield chunk
+
+    async def aclose(self) -> None:
+        elapsed = time.perf_counter() - self._start
+        self._response.elapsed = datetime.timedelta(seconds=elapsed)
+        await self._stream.aclose()
+
+
+EventHook = typing.Callable[..., typing.Any]
+
+
+class BaseClient:
+    def __init__(
+        self,
+        *,
+        auth: AuthTypes | None = None,
+        params: QueryParamTypes | None = None,
+        headers: HeaderTypes | None = None,
+        cookies: CookieTypes | None = None,
+        timeout: TimeoutTypes = DEFAULT_TIMEOUT_CONFIG,
+        follow_redirects: bool = False,
+        max_redirects: int = DEFAULT_MAX_REDIRECTS,
+        event_hooks: None | (typing.Mapping[str, list[EventHook]]) = None,
+        base_url: URL | str = "",
+        trust_env: bool = True,
+        default_encoding: str | typing.Callable[[bytes], str] = "utf-8",
+    ) -> None:
+        event_hooks = {} if event_hooks is None else event_hooks
+
+        self._base_url = self._enforce_trailing_slash(URL(base_url))
+
+        self._auth = self._build_auth(auth)
+        self._params = QueryParams(params)
+        self.headers = Headers(headers)
+        self._cookies = Cookies(cookies)
+        self._timeout = Timeout(timeout)
+        self.follow_redirects = follow_redirects
+        self.max_redirects = max_redirects
+        self._event_hooks = {
+            "request": list(event_hooks.get("request", [])),
+            "response": list(event_hooks.get("response", [])),
+        }
+        self._trust_env = trust_env
+        self._default_encoding = default_encoding
+        self._state = ClientState.UNOPENED
+
+    @property
+    def is_closed(self) -> bool:
+        """
+        Check if the client being closed
+        """
+        return self._state == ClientState.CLOSED
+
+    @property
+    def trust_env(self) -> bool:
+        return self._trust_env
+
+    def _enforce_trailing_slash(self, url: URL) -> URL:
+        if url.raw_path.endswith(b"/"):
+            return url
+        return url.copy_with(raw_path=url.raw_path + b"/")
+
+    def _get_proxy_map(
+        self, proxy: ProxyTypes | None, allow_env_proxies: bool
+    ) -> dict[str, Proxy | None]:
+        if proxy is None:
+            if allow_env_proxies:
+                return {
+                    key: None if url is None else Proxy(url=url)
+                    for key, url in get_environment_proxies().items()
+                }
+            return {}
+        else:
+            proxy = Proxy(url=proxy) if isinstance(proxy, (str, URL)) else proxy
+            return {"all://": proxy}
+
+    @property
+    def timeout(self) -> Timeout:
+        return self._timeout
+
+    @timeout.setter
+    def timeout(self, timeout: TimeoutTypes) -> None:
+        self._timeout = Timeout(timeout)
+
+    @property
+    def event_hooks(self) -> dict[str, list[EventHook]]:
+        return self._event_hooks
+
+    @event_hooks.setter
+    def event_hooks(self, event_hooks: dict[str, list[EventHook]]) -> None:
+        self._event_hooks = {
+            "request": list(event_hooks.get("request", [])),
+            "response": list(event_hooks.get("response", [])),
+        }
+
+    @property
+    def auth(self) -> Auth | None:
+        """
+        Authentication class used when none is passed at the request-level.
+
+        See also [Authentication][0].
+
+        [0]: /quickstart/#authentication
+        """
+        return self._auth
+
+    @auth.setter
+    def auth(self, auth: AuthTypes) -> None:
+        self._auth = self._build_auth(auth)
+
+    @property
+    def base_url(self) -> URL:
+        """
+        Base URL to use when sending requests with relative URLs.
+        """
+        return self._base_url
+
+    @base_url.setter
+    def base_url(self, url: URL | str) -> None:
+        self._base_url = self._enforce_trailing_slash(URL(url))
+
+    @property
+    def headers(self) -> Headers:
+        """
+        HTTP headers to include when sending requests.
+        """
+        return self._headers
+
+    @headers.setter
+    def headers(self, headers: HeaderTypes) -> None:
+        client_headers = Headers(
+            {
+                b"Accept": b"*/*",
+                b"Accept-Encoding": ACCEPT_ENCODING.encode("ascii"),
+                b"Connection": b"keep-alive",
+                b"User-Agent": USER_AGENT.encode("ascii"),
+            }
+        )
+        client_headers.update(headers)
+        self._headers = client_headers
+
+    @property
+    def cookies(self) -> Cookies:
+        """
+        Cookie values to include when sending requests.
+        """
+        return self._cookies
+
+    @cookies.setter
+    def cookies(self, cookies: CookieTypes) -> None:
+        self._cookies = Cookies(cookies)
+
+    @property
+    def params(self) -> QueryParams:
+        """
+        Query parameters to include in the URL when sending requests.
+        """
+        return self._params
+
+    @params.setter
+    def params(self, params: QueryParamTypes) -> None:
+        self._params = QueryParams(params)
+
+    def build_request(
+        self,
+        method: str,
+        url: URL | str,
+        *,
+        content: RequestContent | None = None,
+        data: RequestData | None = None,
+        files: RequestFiles | None = None,
+        json: typing.Any | None = None,
+        params: QueryParamTypes | None = None,
+        headers: HeaderTypes | None = None,
+        cookies: CookieTypes | None = None,
+        timeout: TimeoutTypes | UseClientDefault = USE_CLIENT_DEFAULT,
+        extensions: RequestExtensions | None = None,
+    ) -> Request:
+        """
+        Build and return a request instance.
+
+        * The `params`, `headers` and `cookies` arguments
+        are merged with any values set on the client.
+        * The `url` argument is merged with any `base_url` set on the client.
+
+        See also: [Request instances][0]
+
+        [0]: /advanced/clients/#request-instances
+        """
+        url = self._merge_url(url)
+        headers = self._merge_headers(headers)
+        cookies = self._merge_cookies(cookies)
+        params = self._merge_queryparams(params)
+        extensions = {} if extensions is None else extensions
+        if "timeout" not in extensions:
+            timeout = (
+                self.timeout
+                if isinstance(timeout, UseClientDefault)
+                else Timeout(timeout)
+            )
+            extensions = dict(**extensions, timeout=timeout.as_dict())
+        return Request(
+            method,
+            url,
+            content=content,
+            data=data,
+            files=files,
+            json=json,
+            params=params,
+            headers=headers,
+            cookies=cookies,
+            extensions=extensions,
+        )
+
+    def _merge_url(self, url: URL | str) -> URL:
+        """
+        Merge a URL argument together with any 'base_url' on the client,
+        to create the URL used for the outgoing request.
+        """
+        merge_url = URL(url)
+        if merge_url.is_relative_url:
+            # To merge URLs we always append to the base URL. To get this
+            # behaviour correct we always ensure the base URL ends in a '/'
+            # separator, and strip any leading '/' from the merge URL.
+            #
+            # So, eg...
+            #
+            # >>> client = Client(base_url="https://www.example.com/subpath")
+            # >>> client.base_url
+            # URL('https://www.example.com/subpath/')
+            # >>> client.build_request("GET", "/path").url
+            # URL('https://www.example.com/subpath/path')
+            merge_raw_path = self.base_url.raw_path + merge_url.raw_path.lstrip(b"/")
+            return self.base_url.copy_with(raw_path=merge_raw_path)
+        return merge_url
+
+    def _merge_cookies(self, cookies: CookieTypes | None = None) -> CookieTypes | None:
+        """
+        Merge a cookies argument together with any cookies on the client,
+        to create the cookies used for the outgoing request.
+        """
+        if cookies or self.cookies:
+            merged_cookies = Cookies(self.cookies)
+            merged_cookies.update(cookies)
+            return merged_cookies
+        return cookies
+
+    def _merge_headers(self, headers: HeaderTypes | None = None) -> HeaderTypes | None:
+        """
+        Merge a headers argument together with any headers on the client,
+        to create the headers used for the outgoing request.
+        """
+        merged_headers = Headers(self.headers)
+        merged_headers.update(headers)
+        return merged_headers
+
+    def _merge_queryparams(
+        self, params: QueryParamTypes | None = None
+    ) -> QueryParamTypes | None:
+        """
+        Merge a queryparams argument together with any queryparams on the client,
+        to create the queryparams used for the outgoing request.
+        """
+        if params or self.params:
+            merged_queryparams = QueryParams(self.params)
+            return merged_queryparams.merge(params)
+        return params
+
+    def _build_auth(self, auth: AuthTypes | None) -> Auth | None:
+        if auth is None:
+            return None
+        elif isinstance(auth, tuple):
+            return BasicAuth(username=auth[0], password=auth[1])
+        elif isinstance(auth, Auth):
+            return auth
+        elif callable(auth):
+            return FunctionAuth(func=auth)
+        else:
+            raise TypeError(f'Invalid "auth" argument: {auth!r}')
+
+    def _build_request_auth(
+        self,
+        request: Request,
+        auth: AuthTypes | UseClientDefault | None = USE_CLIENT_DEFAULT,
+    ) -> Auth:
+        auth = (
+            self._auth if isinstance(auth, UseClientDefault) else self._build_auth(auth)
+        )
+
+        if auth is not None:
+            return auth
+
+        username, password = request.url.username, request.url.password
+        if username or password:
+            return BasicAuth(username=username, password=password)
+
+        return Auth()
+
+    def _build_redirect_request(self, request: Request, response: Response) -> Request:
+        """
+        Given a request and a redirect response, return a new request that
+        should be used to effect the redirect.
+        """
+        method = self._redirect_method(request, response)
+        url = self._redirect_url(request, response)
+        headers = self._redirect_headers(request, url, method)
+        stream = self._redirect_stream(request, method)
+        cookies = Cookies(self.cookies)
+        return Request(
+            method=method,
+            url=url,
+            headers=headers,
+            cookies=cookies,
+            stream=stream,
+            extensions=request.extensions,
+        )
+
+    def _redirect_method(self, request: Request, response: Response) -> str:
+        """
+        When being redirected we may want to change the method of the request
+        based on certain specs or browser behavior.
+        """
+        method = request.method
+
+        # https://tools.ietf.org/html/rfc7231#section-6.4.4
+        if response.status_code == codes.SEE_OTHER and method != "HEAD":
+            method = "GET"
+
+        # Do what the browsers do, despite standards...
+        # Turn 302s into GETs.
+        if response.status_code == codes.FOUND and method != "HEAD":
+            method = "GET"
+
+        # If a POST is responded to with a 301, turn it into a GET.
+        # This bizarre behaviour is explained in 'requests' issue 1704.
+        if response.status_code == codes.MOVED_PERMANENTLY and method == "POST":
+            method = "GET"
+
+        return method
+
+    def _redirect_url(self, request: Request, response: Response) -> URL:
+        """
+        Return the URL for the redirect to follow.
+        """
+        location = response.headers["Location"]
+
+        try:
+            url = URL(location)
+        except InvalidURL as exc:
+            raise RemoteProtocolError(
+                f"Invalid URL in location header: {exc}.", request=request
+            ) from None
+
+        # Handle malformed 'Location' headers that are "absolute" form, have no host.
+        # See: https://github.com/encode/httpx/issues/771
+        if url.scheme and not url.host:
+            url = url.copy_with(host=request.url.host)
+
+        # Facilitate relative 'Location' headers, as allowed by RFC 7231.
+        # (e.g. '/path/to/resource' instead of 'http://domain.tld/path/to/resource')
+        if url.is_relative_url:
+            url = request.url.join(url)
+
+        # Attach previous fragment if needed (RFC 7231 7.1.2)
+        if request.url.fragment and not url.fragment:
+            url = url.copy_with(fragment=request.url.fragment)
+
+        return url
+
+    def _redirect_headers(self, request: Request, url: URL, method: str) -> Headers:
+        """
+        Return the headers that should be used for the redirect request.
+        """
+        headers = Headers(request.headers)
+
+        if not _same_origin(url, request.url):
+            if not _is_https_redirect(request.url, url):
+                # Strip Authorization headers when responses are redirected
+                # away from the origin. (Except for direct HTTP to HTTPS redirects.)
+                headers.pop("Authorization", None)
+
+            # Update the Host header.
+            headers["Host"] = url.netloc.decode("ascii")
+
+        if method != request.method and method == "GET":
+            # If we've switch to a 'GET' request, then strip any headers which
+            # are only relevant to the request body.
+            headers.pop("Content-Length", None)
+            headers.pop("Transfer-Encoding", None)
+
+        # We should use the client cookie store to determine any cookie header,
+        # rather than whatever was on the original outgoing request.
+        headers.pop("Cookie", None)
+
+        return headers
+
+    def _redirect_stream(
+        self, request: Request, method: str
+    ) -> SyncByteStream | AsyncByteStream | None:
+        """
+        Return the body that should be used for the redirect request.
+        """
+        if method != request.method and method == "GET":
+            return None
+
+        return request.stream
+
+    def _set_timeout(self, request: Request) -> None:
+        if "timeout" not in request.extensions:
+            timeout = (
+                self.timeout
+                if isinstance(self.timeout, UseClientDefault)
+                else Timeout(self.timeout)
+            )
+            request.extensions = dict(**request.extensions, timeout=timeout.as_dict())
+
+
+class Client(BaseClient):
+    """
+    An HTTP client, with connection pooling, HTTP/2, redirects, cookie persistence, etc.
+
+    It can be shared between threads.
+
+    Usage:
+
+    ```python
+    >>> client = httpx.Client()
+    >>> response = client.get('https://example.org')
+    ```
+
+    **Parameters:**
+
+    * **auth** - *(optional)* An authentication class to use when sending
+    requests.
+    * **params** - *(optional)* Query parameters to include in request URLs, as
+    a string, dictionary, or sequence of two-tuples.
+    * **headers** - *(optional)* Dictionary of HTTP headers to include when
+    sending requests.
+    * **cookies** - *(optional)* Dictionary of Cookie items to include when
+    sending requests.
+    * **verify** - *(optional)* Either `True` to use an SSL context with the
+    default CA bundle, `False` to disable verification, or an instance of
+    `ssl.SSLContext` to use a custom context.
+    * **http2** - *(optional)* A boolean indicating if HTTP/2 support should be
+    enabled. Defaults to `False`.
+    * **proxy** - *(optional)* A proxy URL where all the traffic should be routed.
+    * **timeout** - *(optional)* The timeout configuration to use when sending
+    requests.
+    * **limits** - *(optional)* The limits configuration to use.
+    * **max_redirects** - *(optional)* The maximum number of redirect responses
+    that should be followed.
+    * **base_url** - *(optional)* A URL to use as the base when building
+    request URLs.
+    * **transport** - *(optional)* A transport class to use for sending requests
+    over the network.
+    * **trust_env** - *(optional)* Enables or disables usage of environment
+    variables for configuration.
+    * **default_encoding** - *(optional)* The default encoding to use for decoding
+    response text, if no charset information is included in a response Content-Type
+    header. Set to a callable for automatic character set detection. Default: "utf-8".
+    """
+
+    def __init__(
+        self,
+        *,
+        auth: AuthTypes | None = None,
+        params: QueryParamTypes | None = None,
+        headers: HeaderTypes | None = None,
+        cookies: CookieTypes | None = None,
+        verify: ssl.SSLContext | str | bool = True,
+        cert: CertTypes | None = None,
+        trust_env: bool = True,
+        http1: bool = True,
+        http2: bool = False,
+        proxy: ProxyTypes | None = None,
+        mounts: None | (typing.Mapping[str, BaseTransport | None]) = None,
+        timeout: TimeoutTypes = DEFAULT_TIMEOUT_CONFIG,
+        follow_redirects: bool = False,
+        limits: Limits = DEFAULT_LIMITS,
+        max_redirects: int = DEFAULT_MAX_REDIRECTS,
+        event_hooks: None | (typing.Mapping[str, list[EventHook]]) = None,
+        base_url: URL | str = "",
+        transport: BaseTransport | None = None,
+        default_encoding: str | typing.Callable[[bytes], str] = "utf-8",
+    ) -> None:
+        super().__init__(
+            auth=auth,
+            params=params,
+            headers=headers,
+            cookies=cookies,
+            timeout=timeout,
+            follow_redirects=follow_redirects,
+            max_redirects=max_redirects,
+            event_hooks=event_hooks,
+            base_url=base_url,
+            trust_env=trust_env,
+            default_encoding=default_encoding,
+        )
+
+        if http2:
+            try:
+                import h2  # noqa
+            except ImportError:  # pragma: no cover
+                raise ImportError(
+                    "Using http2=True, but the 'h2' package is not installed. "
+                    "Make sure to install httpx using `pip install httpx[http2]`."
+                ) from None
+
+        allow_env_proxies = trust_env and transport is None
+        proxy_map = self._get_proxy_map(proxy, allow_env_proxies)
+
+        self._transport = self._init_transport(
+            verify=verify,
+            cert=cert,
+            trust_env=trust_env,
+            http1=http1,
+            http2=http2,
+            limits=limits,
+            transport=transport,
+        )
+        self._mounts: dict[URLPattern, BaseTransport | None] = {
+            URLPattern(key): None
+            if proxy is None
+            else self._init_proxy_transport(
+                proxy,
+                verify=verify,
+                cert=cert,
+                trust_env=trust_env,
+                http1=http1,
+                http2=http2,
+                limits=limits,
+            )
+            for key, proxy in proxy_map.items()
+        }
+        if mounts is not None:
+            self._mounts.update(
+                {URLPattern(key): transport for key, transport in mounts.items()}
+            )
+
+        self._mounts = dict(sorted(self._mounts.items()))
+
+    def _init_transport(
+        self,
+        verify: ssl.SSLContext | str | bool = True,
+        cert: CertTypes | None = None,
+        trust_env: bool = True,
+        http1: bool = True,
+        http2: bool = False,
+        limits: Limits = DEFAULT_LIMITS,
+        transport: BaseTransport | None = None,
+    ) -> BaseTransport:
+        if transport is not None:
+            return transport
+
+        return HTTPTransport(
+            verify=verify,
+            cert=cert,
+            trust_env=trust_env,
+            http1=http1,
+            http2=http2,
+            limits=limits,
+        )
+
+    def _init_proxy_transport(
+        self,
+        proxy: Proxy,
+        verify: ssl.SSLContext | str | bool = True,
+        cert: CertTypes | None = None,
+        trust_env: bool = True,
+        http1: bool = True,
+        http2: bool = False,
+        limits: Limits = DEFAULT_LIMITS,
+    ) -> BaseTransport:
+        return HTTPTransport(
+            verify=verify,
+            cert=cert,
+            trust_env=trust_env,
+            http1=http1,
+            http2=http2,
+            limits=limits,
+            proxy=proxy,
+        )
+
+    def _transport_for_url(self, url: URL) -> BaseTransport:
+        """
+        Returns the transport instance that should be used for a given URL.
+        This will either be the standard connection pool, or a proxy.
+        """
+        for pattern, transport in self._mounts.items():
+            if pattern.matches(url):
+                return self._transport if transport is None else transport
+
+        return self._transport
+
+    def request(
+        self,
+        method: str,
+        url: URL | str,
+        *,
+        content: RequestContent | None = None,
+        data: RequestData | None = None,
+        files: RequestFiles | None = None,
+        json: typing.Any | None = None,
+        params: QueryParamTypes | None = None,
+        headers: HeaderTypes | None = None,
+        cookies: CookieTypes | None = None,
+        auth: AuthTypes | UseClientDefault | None = USE_CLIENT_DEFAULT,
+        follow_redirects: bool | UseClientDefault = USE_CLIENT_DEFAULT,
+        timeout: TimeoutTypes | UseClientDefault = USE_CLIENT_DEFAULT,
+        extensions: RequestExtensions | None = None,
+    ) -> Response:
+        """
+        Build and send a request.
+
+        Equivalent to:
+
+        ```python
+        request = client.build_request(...)
+        response = client.send(request, ...)
+        ```
+
+        See `Client.build_request()`, `Client.send()` and
+        [Merging of configuration][0] for how the various parameters
+        are merged with client-level configuration.
+
+        [0]: /advanced/clients/#merging-of-configuration
+        """
+        if cookies is not None:
+            message = (
+                "Setting per-request cookies=<...> is being deprecated, because "
+                "the expected behaviour on cookie persistence is ambiguous. Set "
+                "cookies directly on the client instance instead."
+            )
+            warnings.warn(message, DeprecationWarning, stacklevel=2)
+
+        request = self.build_request(
+            method=method,
+            url=url,
+            content=content,
+            data=data,
+            files=files,
+            json=json,
+            params=params,
+            headers=headers,
+            cookies=cookies,
+            timeout=timeout,
+            extensions=extensions,
+        )
+        return self.send(request, auth=auth, follow_redirects=follow_redirects)
+
+    @contextmanager
+    def stream(
+        self,
+        method: str,
+        url: URL | str,
+        *,
+        content: RequestContent | None = None,
+        data: RequestData | None = None,
+        files: RequestFiles | None = None,
+        json: typing.Any | None = None,
+        params: QueryParamTypes | None = None,
+        headers: HeaderTypes | None = None,
+        cookies: CookieTypes | None = None,
+        auth: AuthTypes | UseClientDefault | None = USE_CLIENT_DEFAULT,
+        follow_redirects: bool | UseClientDefault = USE_CLIENT_DEFAULT,
+        timeout: TimeoutTypes | UseClientDefault = USE_CLIENT_DEFAULT,
+        extensions: RequestExtensions | None = None,
+    ) -> typing.Iterator[Response]:
+        """
+        Alternative to `httpx.request()` that streams the response body
+        instead of loading it into memory at once.
+
+        **Parameters**: See `httpx.request`.
+
+        See also: [Streaming Responses][0]
+
+        [0]: /quickstart#streaming-responses
+        """
+        request = self.build_request(
+            method=method,
+            url=url,
+            content=content,
+            data=data,
+            files=files,
+            json=json,
+            params=params,
+            headers=headers,
+            cookies=cookies,
+            timeout=timeout,
+            extensions=extensions,
+        )
+        response = self.send(
+            request=request,
+            auth=auth,
+            follow_redirects=follow_redirects,
+            stream=True,
+        )
+        try:
+            yield response
+        finally:
+            response.close()
+
+    def send(
+        self,
+        request: Request,
+        *,
+        stream: bool = False,
+        auth: AuthTypes | UseClientDefault | None = USE_CLIENT_DEFAULT,
+        follow_redirects: bool | UseClientDefault = USE_CLIENT_DEFAULT,
+    ) -> Response:
+        """
+        Send a request.
+
+        The request is sent as-is, unmodified.
+
+        Typically you'll want to build one with `Client.build_request()`
+        so that any client-level configuration is merged into the request,
+        but passing an explicit `httpx.Request()` is supported as well.
+
+        See also: [Request instances][0]
+
+        [0]: /advanced/clients/#request-instances
+        """
+        if self._state == ClientState.CLOSED:
+            raise RuntimeError("Cannot send a request, as the client has been closed.")
+
+        self._state = ClientState.OPENED
+        follow_redirects = (
+            self.follow_redirects
+            if isinstance(follow_redirects, UseClientDefault)
+            else follow_redirects
+        )
+
+        self._set_timeout(request)
+
+        auth = self._build_request_auth(request, auth)
+
+        response = self._send_handling_auth(
+            request,
+            auth=auth,
+            follow_redirects=follow_redirects,
+            history=[],
+        )
+        try:
+            if not stream:
+                response.read()
+
+            return response
+
+        except BaseException as exc:
+            response.close()
+            raise exc
+
+    def _send_handling_auth(
+        self,
+        request: Request,
+        auth: Auth,
+        follow_redirects: bool,
+        history: list[Response],
+    ) -> Response:
+        auth_flow = auth.sync_auth_flow(request)
+        try:
+            request = next(auth_flow)
+
+            while True:
+                response = self._send_handling_redirects(
+                    request,
+                    follow_redirects=follow_redirects,
+                    history=history,
+                )
+                try:
+                    try:
+                        next_request = auth_flow.send(response)
+                    except StopIteration:
+                        return response
+
+                    response.history = list(history)
+                    response.read()
+                    request = next_request
+                    history.append(response)
+
+                except BaseException as exc:
+                    response.close()
+                    raise exc
+        finally:
+            auth_flow.close()
+
+    def _send_handling_redirects(
+        self,
+        request: Request,
+        follow_redirects: bool,
+        history: list[Response],
+    ) -> Response:
+        while True:
+            if len(history) > self.max_redirects:
+                raise TooManyRedirects(
+                    "Exceeded maximum allowed redirects.", request=request
+                )
+
+            for hook in self._event_hooks["request"]:
+                hook(request)
+
+            response = self._send_single_request(request)
+            try:
+                for hook in self._event_hooks["response"]:
+                    hook(response)
+                response.history = list(history)
+
+                if not response.has_redirect_location:
+                    return response
+
+                request = self._build_redirect_request(request, response)
+                history = history + [response]
+
+                if follow_redirects:
+                    response.read()
+                else:
+                    response.next_request = request
+                    return response
+
+            except BaseException as exc:
+                response.close()
+                raise exc
+
+    def _send_single_request(self, request: Request) -> Response:
+        """
+        Sends a single request, without handling any redirections.
+        """
+        transport = self._transport_for_url(request.url)
+        start = time.perf_counter()
+
+        if not isinstance(request.stream, SyncByteStream):
+            raise RuntimeError(
+                "Attempted to send an async request with a sync Client instance."
+            )
+
+        with request_context(request=request):
+            response = transport.handle_request(request)
+
+        assert isinstance(response.stream, SyncByteStream)
+
+        response.request = request
+        response.stream = BoundSyncStream(
+            response.stream, response=response, start=start
+        )
+        self.cookies.extract_cookies(response)
+        response.default_encoding = self._default_encoding
+
+        logger.info(
+            'HTTP Request: %s %s "%s %d %s"',
+            request.method,
+            request.url,
+            response.http_version,
+            response.status_code,
+            response.reason_phrase,
+        )
+
+        return response
+
+    def get(
+        self,
+        url: URL | str,
+        *,
+        params: QueryParamTypes | None = None,
+        headers: HeaderTypes | None = None,
+        cookies: CookieTypes | None = None,
+        auth: AuthTypes | UseClientDefault | None = USE_CLIENT_DEFAULT,
+        follow_redirects: bool | UseClientDefault = USE_CLIENT_DEFAULT,
+        timeout: TimeoutTypes | UseClientDefault = USE_CLIENT_DEFAULT,
+        extensions: RequestExtensions | None = None,
+    ) -> Response:
+        """
+        Send a `GET` request.
+
+        **Parameters**: See `httpx.request`.
+        """
+        return self.request(
+            "GET",
+            url,
+            params=params,
+            headers=headers,
+            cookies=cookies,
+            auth=auth,
+            follow_redirects=follow_redirects,
+            timeout=timeout,
+            extensions=extensions,
+        )
+
+    def options(
+        self,
+        url: URL | str,
+        *,
+        params: QueryParamTypes | None = None,
+        headers: HeaderTypes | None = None,
+        cookies: CookieTypes | None = None,
+        auth: AuthTypes | UseClientDefault = USE_CLIENT_DEFAULT,
+        follow_redirects: bool | UseClientDefault = USE_CLIENT_DEFAULT,
+        timeout: TimeoutTypes | UseClientDefault = USE_CLIENT_DEFAULT,
+        extensions: RequestExtensions | None = None,
+    ) -> Response:
+        """
+        Send an `OPTIONS` request.
+
+        **Parameters**: See `httpx.request`.
+        """
+        return self.request(
+            "OPTIONS",
+            url,
+            params=params,
+            headers=headers,
+            cookies=cookies,
+            auth=auth,
+            follow_redirects=follow_redirects,
+            timeout=timeout,
+            extensions=extensions,
+        )
+
+    def head(
+        self,
+        url: URL | str,
+        *,
+        params: QueryParamTypes | None = None,
+        headers: HeaderTypes | None = None,
+        cookies: CookieTypes | None = None,
+        auth: AuthTypes | UseClientDefault = USE_CLIENT_DEFAULT,
+        follow_redirects: bool | UseClientDefault = USE_CLIENT_DEFAULT,
+        timeout: TimeoutTypes | UseClientDefault = USE_CLIENT_DEFAULT,
+        extensions: RequestExtensions | None = None,
+    ) -> Response:
+        """
+        Send a `HEAD` request.
+
+        **Parameters**: See `httpx.request`.
+        """
+        return self.request(
+            "HEAD",
+            url,
+            params=params,
+            headers=headers,
+            cookies=cookies,
+            auth=auth,
+            follow_redirects=follow_redirects,
+            timeout=timeout,
+            extensions=extensions,
+        )
+
+    def post(
+        self,
+        url: URL | str,
+        *,
+        content: RequestContent | None = None,
+        data: RequestData | None = None,
+        files: RequestFiles | None = None,
+        json: typing.Any | None = None,
+        params: QueryParamTypes | None = None,
+        headers: HeaderTypes | None = None,
+        cookies: CookieTypes | None = None,
+        auth: AuthTypes | UseClientDefault = USE_CLIENT_DEFAULT,
+        follow_redirects: bool | UseClientDefault = USE_CLIENT_DEFAULT,
+        timeout: TimeoutTypes | UseClientDefault = USE_CLIENT_DEFAULT,
+        extensions: RequestExtensions | None = None,
+    ) -> Response:
+        """
+        Send a `POST` request.
+
+        **Parameters**: See `httpx.request`.
+        """
+        return self.request(
+            "POST",
+            url,
+            content=content,
+            data=data,
+            files=files,
+            json=json,
+            params=params,
+            headers=headers,
+            cookies=cookies,
+            auth=auth,
+            follow_redirects=follow_redirects,
+            timeout=timeout,
+            extensions=extensions,
+        )
+
+    def put(
+        self,
+        url: URL | str,
+        *,
+        content: RequestContent | None = None,
+        data: RequestData | None = None,
+        files: RequestFiles | None = None,
+        json: typing.Any | None = None,
+        params: QueryParamTypes | None = None,
+        headers: HeaderTypes | None = None,
+        cookies: CookieTypes | None = None,
+        auth: AuthTypes | UseClientDefault = USE_CLIENT_DEFAULT,
+        follow_redirects: bool | UseClientDefault = USE_CLIENT_DEFAULT,
+        timeout: TimeoutTypes | UseClientDefault = USE_CLIENT_DEFAULT,
+        extensions: RequestExtensions | None = None,
+    ) -> Response:
+        """
+        Send a `PUT` request.
+
+        **Parameters**: See `httpx.request`.
+        """
+        return self.request(
+            "PUT",
+            url,
+            content=content,
+            data=data,
+            files=files,
+            json=json,
+            params=params,
+            headers=headers,
+            cookies=cookies,
+            auth=auth,
+            follow_redirects=follow_redirects,
+            timeout=timeout,
+            extensions=extensions,
+        )
+
+    def patch(
+        self,
+        url: URL | str,
+        *,
+        content: RequestContent | None = None,
+        data: RequestData | None = None,
+        files: RequestFiles | None = None,
+        json: typing.Any | None = None,
+        params: QueryParamTypes | None = None,
+        headers: HeaderTypes | None = None,
+        cookies: CookieTypes | None = None,
+        auth: AuthTypes | UseClientDefault = USE_CLIENT_DEFAULT,
+        follow_redirects: bool | UseClientDefault = USE_CLIENT_DEFAULT,
+        timeout: TimeoutTypes | UseClientDefault = USE_CLIENT_DEFAULT,
+        extensions: RequestExtensions | None = None,
+    ) -> Response:
+        """
+        Send a `PATCH` request.
+
+        **Parameters**: See `httpx.request`.
+        """
+        return self.request(
+            "PATCH",
+            url,
+            content=content,
+            data=data,
+            files=files,
+            json=json,
+            params=params,
+            headers=headers,
+            cookies=cookies,
+            auth=auth,
+            follow_redirects=follow_redirects,
+            timeout=timeout,
+            extensions=extensions,
+        )
+
+    def delete(
+        self,
+        url: URL | str,
+        *,
+        params: QueryParamTypes | None = None,
+        headers: HeaderTypes | None = None,
+        cookies: CookieTypes | None = None,
+        auth: AuthTypes | UseClientDefault = USE_CLIENT_DEFAULT,
+        follow_redirects: bool | UseClientDefault = USE_CLIENT_DEFAULT,
+        timeout: TimeoutTypes | UseClientDefault = USE_CLIENT_DEFAULT,
+        extensions: RequestExtensions | None = None,
+    ) -> Response:
+        """
+        Send a `DELETE` request.
+
+        **Parameters**: See `httpx.request`.
+        """
+        return self.request(
+            "DELETE",
+            url,
+            params=params,
+            headers=headers,
+            cookies=cookies,
+            auth=auth,
+            follow_redirects=follow_redirects,
+            timeout=timeout,
+            extensions=extensions,
+        )
+
+    def close(self) -> None:
+        """
+        Close transport and proxies.
+        """
+        if self._state != ClientState.CLOSED:
+            self._state = ClientState.CLOSED
+
+            self._transport.close()
+            for transport in self._mounts.values():
+                if transport is not None:
+                    transport.close()
+
+    def __enter__(self: T) -> T:
+        if self._state != ClientState.UNOPENED:
+            msg = {
+                ClientState.OPENED: "Cannot open a client instance more than once.",
+                ClientState.CLOSED: (
+                    "Cannot reopen a client instance, once it has been closed."
+                ),
+            }[self._state]
+            raise RuntimeError(msg)
+
+        self._state = ClientState.OPENED
+
+        self._transport.__enter__()
+        for transport in self._mounts.values():
+            if transport is not None:
+                transport.__enter__()
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None = None,
+        exc_value: BaseException | None = None,
+        traceback: TracebackType | None = None,
+    ) -> None:
+        self._state = ClientState.CLOSED
+
+        self._transport.__exit__(exc_type, exc_value, traceback)
+        for transport in self._mounts.values():
+            if transport is not None:
+                transport.__exit__(exc_type, exc_value, traceback)
+
+
+class AsyncClient(BaseClient):
+    """
+    An asynchronous HTTP client, with connection pooling, HTTP/2, redirects,
+    cookie persistence, etc.
+
+    It can be shared between tasks.
+
+    Usage:
+
+    ```python
+    >>> async with httpx.AsyncClient() as client:
+    >>>     response = await client.get('https://example.org')
+    ```
+
+    **Parameters:**
+
+    * **auth** - *(optional)* An authentication class to use when sending
+    requests.
+    * **params** - *(optional)* Query parameters to include in request URLs, as
+    a string, dictionary, or sequence of two-tuples.
+    * **headers** - *(optional)* Dictionary of HTTP headers to include when
+    sending requests.
+    * **cookies** - *(optional)* Dictionary of Cookie items to include when
+    sending requests.
+    * **verify** - *(optional)* Either `True` to use an SSL context with the
+    default CA bundle, `False` to disable verification, or an instance of
+    `ssl.SSLContext` to use a custom context.
+    * **http2** - *(optional)* A boolean indicating if HTTP/2 support should be
+    enabled. Defaults to `False`.
+    * **proxy** - *(optional)* A proxy URL where all the traffic should be routed.
+    * **timeout** - *(optional)* The timeout configuration to use when sending
+    requests.
+    * **limits** - *(optional)* The limits configuration to use.
+    * **max_redirects** - *(optional)* The maximum number of redirect responses
+    that should be followed.
+    * **base_url** - *(optional)* A URL to use as the base when building
+    request URLs.
+    * **transport** - *(optional)* A transport class to use for sending requests
+    over the network.
+    * **trust_env** - *(optional)* Enables or disables usage of environment
+    variables for configuration.
+    * **default_encoding** - *(optional)* The default encoding to use for decoding
+    response text, if no charset information is included in a response Content-Type
+    header. Set to a callable for automatic character set detection. Default: "utf-8".
+    """
+
+    def __init__(
+        self,
+        *,
+        auth: AuthTypes | None = None,
+        params: QueryParamTypes | None = None,
+        headers: HeaderTypes | None = None,
+        cookies: CookieTypes | None = None,
+        verify: ssl.SSLContext | str | bool = True,
+        cert: CertTypes | None = None,
+        http1: bool = True,
+        http2: bool = False,
+        proxy: ProxyTypes | None = None,
+        mounts: None | (typing.Mapping[str, AsyncBaseTransport | None]) = None,
+        timeout: TimeoutTypes = DEFAULT_TIMEOUT_CONFIG,
+        follow_redirects: bool = False,
+        limits: Limits = DEFAULT_LIMITS,
+        max_redirects: int = DEFAULT_MAX_REDIRECTS,
+        event_hooks: None | (typing.Mapping[str, list[EventHook]]) = None,
+        base_url: URL | str = "",
+        transport: AsyncBaseTransport | None = None,
+        trust_env: bool = True,
+        default_encoding: str | typing.Callable[[bytes], str] = "utf-8",
+    ) -> None:
+        super().__init__(
+            auth=auth,
+            params=params,
+            headers=headers,
+            cookies=cookies,
+            timeout=timeout,
+            follow_redirects=follow_redirects,
+            max_redirects=max_redirects,
+            event_hooks=event_hooks,
+            base_url=base_url,
+            trust_env=trust_env,
+            default_encoding=default_encoding,
+        )
+
+        if http2:
+            try:
+                import h2  # noqa
+            except ImportError:  # pragma: no cover
+                raise ImportError(
+                    "Using http2=True, but the 'h2' package is not installed. "
+                    "Make sure to install httpx using `pip install httpx[http2]`."
+                ) from None
+
+        allow_env_proxies = trust_env and transport is None
+        proxy_map = self._get_proxy_map(proxy, allow_env_proxies)
+
+        self._transport = self._init_transport(
+            verify=verify,
+            cert=cert,
+            trust_env=trust_env,
+            http1=http1,
+            http2=http2,
+            limits=limits,
+            transport=transport,
+        )
+
+        self._mounts: dict[URLPattern, AsyncBaseTransport | None] = {
+            URLPattern(key): None
+            if proxy is None
+            else self._init_proxy_transport(
+                proxy,
+                verify=verify,
+                cert=cert,
+                trust_env=trust_env,
+                http1=http1,
+                http2=http2,
+                limits=limits,
+            )
+            for key, proxy in proxy_map.items()
+        }
+        if mounts is not None:
+            self._mounts.update(
+                {URLPattern(key): transport for key, transport in mounts.items()}
+            )
+        self._mounts = dict(sorted(self._mounts.items()))
+
+    def _init_transport(
+        self,
+        verify: ssl.SSLContext | str | bool = True,
+        cert: CertTypes | None = None,
+        trust_env: bool = True,
+        http1: bool = True,
+        http2: bool = False,
+        limits: Limits = DEFAULT_LIMITS,
+        transport: AsyncBaseTransport | None = None,
+    ) -> AsyncBaseTransport:
+        if transport is not None:
+            return transport
+
+        return AsyncHTTPTransport(
+            verify=verify,
+            cert=cert,
+            trust_env=trust_env,
+            http1=http1,
+            http2=http2,
+            limits=limits,
+        )
+
+    def _init_proxy_transport(
+        self,
+        proxy: Proxy,
+        verify: ssl.SSLContext | str | bool = True,
+        cert: CertTypes | None = None,
+        trust_env: bool = True,
+        http1: bool = True,
+        http2: bool = False,
+        limits: Limits = DEFAULT_LIMITS,
+    ) -> AsyncBaseTransport:
+        return AsyncHTTPTransport(
+            verify=verify,
+            cert=cert,
+            trust_env=trust_env,
+            http1=http1,
+            http2=http2,
+            limits=limits,
+            proxy=proxy,
+        )
+
+    def _transport_for_url(self, url: URL) -> AsyncBaseTransport:
+        """
+        Returns the transport instance that should be used for a given URL.
+        This will either be the standard connection pool, or a proxy.
+        """
+        for pattern, transport in self._mounts.items():
+            if pattern.matches(url):
+                return self._transport if transport is None else transport
+
+        return self._transport
+
+    async def request(
+        self,
+        method: str,
+        url: URL | str,
+        *,
+        content: RequestContent | None = None,
+        data: RequestData | None = None,
+        files: RequestFiles | None = None,
+        json: typing.Any | None = None,
+        params: QueryParamTypes | None = None,
+        headers: HeaderTypes | None = None,
+        cookies: CookieTypes | None = None,
+        auth: AuthTypes | UseClientDefault | None = USE_CLIENT_DEFAULT,
+        follow_redirects: bool | UseClientDefault = USE_CLIENT_DEFAULT,
+        timeout: TimeoutTypes | UseClientDefault = USE_CLIENT_DEFAULT,
+        extensions: RequestExtensions | None = None,
+    ) -> Response:
+        """
+        Build and send a request.
+
+        Equivalent to:
+
+        ```python
+        request = client.build_request(...)
+        response = await client.send(request, ...)
+        ```
+
+        See `AsyncClient.build_request()`, `AsyncClient.send()`
+        and [Merging of configuration][0] for how the various parameters
+        are merged with client-level configuration.
+
+        [0]: /advanced/clients/#merging-of-configuration
+        """
+
+        if cookies is not None:  # pragma: no cover
+            message = (
+                "Setting per-request cookies=<...> is being deprecated, because "
+                "the expected behaviour on cookie persistence is ambiguous. Set "
+                "cookies directly on the client instance instead."
+            )
+            warnings.warn(message, DeprecationWarning, stacklevel=2)
+
+        request = self.build_request(
+            method=method,
+            url=url,
+            content=content,
+            data=data,
+            files=files,
+            json=json,
+            params=params,
+            headers=headers,
+            cookies=cookies,
+            timeout=timeout,
+            extensions=extensions,
+        )
+        return await self.send(request, auth=auth, follow_redirects=follow_redirects)
+
+    @asynccontextmanager
+    async def stream(
+        self,
+        method: str,
+        url: URL | str,
+        *,
+        content: RequestContent | None = None,
+        data: RequestData | None = None,
+        files: RequestFiles | None = None,
+        json: typing.Any | None = None,
+        params: QueryParamTypes | None = None,
+        headers: HeaderTypes | None = None,
+        cookies: CookieTypes | None = None,
+        auth: AuthTypes | UseClientDefault | None = USE_CLIENT_DEFAULT,
+        follow_redirects: bool | UseClientDefault = USE_CLIENT_DEFAULT,
+        timeout: TimeoutTypes | UseClientDefault = USE_CLIENT_DEFAULT,
+        extensions: RequestExtensions | None = None,
+    ) -> typing.AsyncIterator[Response]:
+        """
+        Alternative to `httpx.request()` that streams the response body
+        instead of loading it into memory at once.
+
+        **Parameters**: See `httpx.request`.
+
+        See also: [Streaming Responses][0]
+
+        [0]: /quickstart#streaming-responses
+        """
+        request = self.build_request(
+            method=method,
+            url=url,
+            content=content,
+            data=data,
+            files=files,
+            json=json,
+            params=params,
+            headers=headers,
+            cookies=cookies,
+            timeout=timeout,
+            extensions=extensions,
+        )
+        response = await self.send(
+            request=request,
+            auth=auth,
+            follow_redirects=follow_redirects,
+            stream=True,
+        )
+        try:
+            yield response
+        finally:
+            await response.aclose()
+
+    async def send(
+        self,
+        request: Request,
+        *,
+        stream: bool = False,
+        auth: AuthTypes | UseClientDefault | None = USE_CLIENT_DEFAULT,
+        follow_redirects: bool | UseClientDefault = USE_CLIENT_DEFAULT,
+    ) -> Response:
+        """
+        Send a request.
+
+        The request is sent as-is, unmodified.
+
+        Typically you'll want to build one with `AsyncClient.build_request()`
+        so that any client-level configuration is merged into the request,
+        but passing an explicit `httpx.Request()` is supported as well.
+
+        See also: [Request instances][0]
+
+        [0]: /advanced/clients/#request-instances
+        """
+        if self._state == ClientState.CLOSED:
+            raise RuntimeError("Cannot send a request, as the client has been closed.")
+
+        self._state = ClientState.OPENED
+        follow_redirects = (
+            self.follow_redirects
+            if isinstance(follow_redirects, UseClientDefault)
+            else follow_redirects
+        )
+
+        self._set_timeout(request)
+
+        auth = self._build_request_auth(request, auth)
+
+        response = await self._send_handling_auth(
+            request,
+            auth=auth,
+            follow_redirects=follow_redirects,
+            history=[],
+        )
+        try:
+            if not stream:
+                await response.aread()
+
+            return response
+
+        except BaseException as exc:
+            await response.aclose()
+            raise exc
+
+    async def _send_handling_auth(
+        self,
+        request: Request,
+        auth: Auth,
+        follow_redirects: bool,
+        history: list[Response],
+    ) -> Response:
+        auth_flow = auth.async_auth_flow(request)
+        try:
+            request = await auth_flow.__anext__()
+
+            while True:
+                response = await self._send_handling_redirects(
+                    request,
+                    follow_redirects=follow_redirects,
+                    history=history,
+                )
+                try:
+                    try:
+                        next_request = await auth_flow.asend(response)
+                    except StopAsyncIteration:
+                        return response
+
+                    response.history = list(history)
+                    await response.aread()
+                    request = next_request
+                    history.append(response)
+
+                except BaseException as exc:
+                    await response.aclose()
+                    raise exc
+        finally:
+            await auth_flow.aclose()
+
+    async def _send_handling_redirects(
+        self,
+        request: Request,
+        follow_redirects: bool,
+        history: list[Response],
+    ) -> Response:
+        while True:
+            if len(history) > self.max_redirects:
+                raise TooManyRedirects(
+                    "Exceeded maximum allowed redirects.", request=request
+                )
+
+            for hook in self._event_hooks["request"]:
+                await hook(request)
+
+            response = await self._send_single_request(request)
+            try:
+                for hook in self._event_hooks["response"]:
+                    await hook(response)
+
+                response.history = list(history)
+
+                if not response.has_redirect_location:
+                    return response
+
+                request = self._build_redirect_request(request, response)
+                history = history + [response]
+
+                if follow_redirects:
+                    await response.aread()
+                else:
+                    response.next_request = request
+                    return response
+
+            except BaseException as exc:
+                await response.aclose()
+                raise exc
+
+    async def _send_single_request(self, request: Request) -> Response:
+        """
+        Sends a single request, without handling any redirections.
+        """
+        transport = self._transport_for_url(request.url)
+        start = time.perf_counter()
+
+        if not isinstance(request.stream, AsyncByteStream):
+            raise RuntimeError(
+                "Attempted to send a sync request with an AsyncClient instance."
+            )
+
+        with request_context(request=request):
+            response = await transport.handle_async_request(request)
+
+        assert isinstance(response.stream, AsyncByteStream)
+        response.request = request
+        response.stream = BoundAsyncStream(
+            response.stream, response=response, start=start
+        )
+        self.cookies.extract_cookies(response)
+        response.default_encoding = self._default_encoding
+
+        logger.info(
+            'HTTP Request: %s %s "%s %d %s"',
+            request.method,
+            request.url,
+            response.http_version,
+            response.status_code,
+            response.reason_phrase,
+        )
+
+        return response
+
+    async def get(
+        self,
+        url: URL | str,
+        *,
+        params: QueryParamTypes | None = None,
+        headers: HeaderTypes | None = None,
+        cookies: CookieTypes | None = None,
+        auth: AuthTypes | UseClientDefault | None = USE_CLIENT_DEFAULT,
+        follow_redirects: bool | UseClientDefault = USE_CLIENT_DEFAULT,
+        timeout: TimeoutTypes | UseClientDefault = USE_CLIENT_DEFAULT,
+        extensions: RequestExtensions | None = None,
+    ) -> Response:
+        """
+        Send a `GET` request.
+
+        **Parameters**: See `httpx.request`.
+        """
+        return await self.request(
+            "GET",
+            url,
+            params=params,
+            headers=headers,
+            cookies=cookies,
+            auth=auth,
+            follow_redirects=follow_redirects,
+            timeout=timeout,
+            extensions=extensions,
+        )
+
+    async def options(
+        self,
+        url: URL | str,
+        *,
+        params: QueryParamTypes | None = None,
+        headers: HeaderTypes | None = None,
+        cookies: CookieTypes | None = None,
+        auth: AuthTypes | UseClientDefault = USE_CLIENT_DEFAULT,
+        follow_redirects: bool | UseClientDefault = USE_CLIENT_DEFAULT,
+        timeout: TimeoutTypes | UseClientDefault = USE_CLIENT_DEFAULT,
+        extensions: RequestExtensions | None = None,
+    ) -> Response:
+        """
+        Send an `OPTIONS` request.
+
+        **Parameters**: See `httpx.request`.
+        """
+        return await self.request(
+            "OPTIONS",
+            url,
+            params=params,
+            headers=headers,
+            cookies=cookies,
+            auth=auth,
+            follow_redirects=follow_redirects,
+            timeout=timeout,
+            extensions=extensions,
+        )
+
+    async def head(
+        self,
+        url: URL | str,
+        *,
+        params: QueryParamTypes | None = None,
+        headers: HeaderTypes | None = None,
+        cookies: CookieTypes | None = None,
+        auth: AuthTypes | UseClientDefault = USE_CLIENT_DEFAULT,
+        follow_redirects: bool | UseClientDefault = USE_CLIENT_DEFAULT,
+        timeout: TimeoutTypes | UseClientDefault = USE_CLIENT_DEFAULT,
+        extensions: RequestExtensions | None = None,
+    ) -> Response:
+        """
+        Send a `HEAD` request.
+
+        **Parameters**: See `httpx.request`.
+        """
+        return await self.request(
+            "HEAD",
+            url,
+            params=params,
+            headers=headers,
+            cookies=cookies,
+            auth=auth,
+            follow_redirects=follow_redirects,
+            timeout=timeout,
+            extensions=extensions,
+        )
+
+    async def post(
+        self,
+        url: URL | str,
+        *,
+        content: RequestContent | None = None,
+        data: RequestData | None = None,
+        files: RequestFiles | None = None,
+        json: typing.Any | None = None,
+        params: QueryParamTypes | None = None,
+        headers: HeaderTypes | None = None,
+        cookies: CookieTypes | None = None,
+        auth: AuthTypes | UseClientDefault = USE_CLIENT_DEFAULT,
+        follow_redirects: bool | UseClientDefault = USE_CLIENT_DEFAULT,
+        timeout: TimeoutTypes | UseClientDefault = USE_CLIENT_DEFAULT,
+        extensions: RequestExtensions | None = None,
+    ) -> Response:
+        """
+        Send a `POST` request.
+
+        **Parameters**: See `httpx.request`.
+        """
+        return await self.request(
+            "POST",
+            url,
+            content=content,
+            data=data,
+            files=files,
+            json=json,
+            params=params,
+            headers=headers,
+            cookies=cookies,
+            auth=auth,
+            follow_redirects=follow_redirects,
+            timeout=timeout,
+            extensions=extensions,
+        )
+
+    async def put(
+        self,
+        url: URL | str,
+        *,
+        content: RequestContent | None = None,
+        data: RequestData | None = None,
+        files: RequestFiles | None = None,
+        json: typing.Any | None = None,
+        params: QueryParamTypes | None = None,
+        headers: HeaderTypes | None = None,
+        cookies: CookieTypes | None = None,
+        auth: AuthTypes | UseClientDefault = USE_CLIENT_DEFAULT,
+        follow_redirects: bool | UseClientDefault = USE_CLIENT_DEFAULT,
+        timeout: TimeoutTypes | UseClientDefault = USE_CLIENT_DEFAULT,
+        extensions: RequestExtensions | None = None,
+    ) -> Response:
+        """
+        Send a `PUT` request.
+
+        **Parameters**: See `httpx.request`.
+        """
+        return await self.request(
+            "PUT",
+            url,
+            content=content,
+            data=data,
+            files=files,
+            json=json,
+            params=params,
+            headers=headers,
+            cookies=cookies,
+            auth=auth,
+            follow_redirects=follow_redirects,
+            timeout=timeout,
+            extensions=extensions,
+        )
+
+    async def patch(
+        self,
+        url: URL | str,
+        *,
+        content: RequestContent | None = None,
+        data: RequestData | None = None,
+        files: RequestFiles | None = None,
+        json: typing.Any | None = None,
+        params: QueryParamTypes | None = None,
+        headers: HeaderTypes | None = None,
+        cookies: CookieTypes | None = None,
+        auth: AuthTypes | UseClientDefault = USE_CLIENT_DEFAULT,
+        follow_redirects: bool | UseClientDefault = USE_CLIENT_DEFAULT,
+        timeout: TimeoutTypes | UseClientDefault = USE_CLIENT_DEFAULT,
+        extensions: RequestExtensions | None = None,
+    ) -> Response:
+        """
+        Send a `PATCH` request.
+
+        **Parameters**: See `httpx.request`.
+        """
+        return await self.request(
+            "PATCH",
+            url,
+            content=content,
+            data=data,
+            files=files,
+            json=json,
+            params=params,
+            headers=headers,
+            cookies=cookies,
+            auth=auth,
+            follow_redirects=follow_redirects,
+            timeout=timeout,
+            extensions=extensions,
+        )
+
+    async def delete(
+        self,
+        url: URL | str,
+        *,
+        params: QueryParamTypes | None = None,
+        headers: HeaderTypes | None = None,
+        cookies: CookieTypes | None = None,
+        auth: AuthTypes | UseClientDefault = USE_CLIENT_DEFAULT,
+        follow_redirects: bool | UseClientDefault = USE_CLIENT_DEFAULT,
+        timeout: TimeoutTypes | UseClientDefault = USE_CLIENT_DEFAULT,
+        extensions: RequestExtensions | None = None,
+    ) -> Response:
+        """
+        Send a `DELETE` request.
+
+        **Parameters**: See `httpx.request`.
+        """
+        return await self.request(
+            "DELETE",
+            url,
+            params=params,
+            headers=headers,
+            cookies=cookies,
+            auth=auth,
+            follow_redirects=follow_redirects,
+            timeout=timeout,
+            extensions=extensions,
+        )
+
+    async def aclose(self) -> None:
+        """
+        Close transport and proxies.
+        """
+        if self._state != ClientState.CLOSED:
+            self._state = ClientState.CLOSED
+
+            await self._transport.aclose()
+            for proxy in self._mounts.values():
+                if proxy is not None:
+                    await proxy.aclose()
+
+    async def __aenter__(self: U) -> U:
+        if self._state != ClientState.UNOPENED:
+            msg = {
+                ClientState.OPENED: "Cannot open a client instance more than once.",
+                ClientState.CLOSED: (
+                    "Cannot reopen a client instance, once it has been closed."
+                ),
+            }[self._state]
+            raise RuntimeError(msg)
+
+        self._state = ClientState.OPENED
+
+        await self._transport.__aenter__()
+        for proxy in self._mounts.values():
+            if proxy is not None:
+                await proxy.__aenter__()
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None = None,
+        exc_value: BaseException | None = None,
+        traceback: TracebackType | None = None,
+    ) -> None:
+        self._state = ClientState.CLOSED
+
+        await self._transport.__aexit__(exc_type, exc_value, traceback)
+        for proxy in self._mounts.values():
+            if proxy is not None:
+                await proxy.__aexit__(exc_type, exc_value, traceback)

--- a/tests/fixtures/comparison/samples/index_writer.rs
+++ b/tests/fixtures/comparison/samples/index_writer.rs
@@ -1,0 +1,2588 @@
+use std::ops::Range;
+use std::sync::Arc;
+use std::thread;
+use std::thread::JoinHandle;
+
+use common::BitSet;
+use smallvec::smallvec;
+
+use super::operation::{AddOperation, UserOperation};
+use super::segment_updater::SegmentUpdater;
+use super::{AddBatch, AddBatchReceiver, AddBatchSender, PreparedCommit};
+use crate::directory::{DirectoryLock, GarbageCollectionResult, TerminatingWrite};
+use crate::error::TantivyError;
+use crate::fastfield::write_alive_bitset;
+use crate::index::{Index, Segment, SegmentComponent, SegmentId, SegmentMeta, SegmentReader};
+use crate::indexer::delete_queue::{DeleteCursor, DeleteQueue};
+use crate::indexer::doc_opstamp_mapping::DocToOpstampMapping;
+use crate::indexer::index_writer_status::IndexWriterStatus;
+use crate::indexer::operation::DeleteOperation;
+use crate::indexer::stamper::Stamper;
+use crate::indexer::{MergePolicy, SegmentEntry, SegmentWriter};
+use crate::query::{EnableScoring, Query, TermQuery};
+use crate::schema::document::Document;
+use crate::schema::{IndexRecordOption, TantivyDocument, Term};
+use crate::{FutureResult, Opstamp};
+
+// Size of the margin for the `memory_arena`. A segment is closed when the remaining memory
+// in the `memory_arena` goes below MARGIN_IN_BYTES.
+pub const MARGIN_IN_BYTES: usize = 1_000_000;
+
+// We impose the memory per thread to be at least 15 MB, as the baseline consumption is 12MB.
+pub const MEMORY_BUDGET_NUM_BYTES_MIN: usize = ((MARGIN_IN_BYTES as u32) * 15u32) as usize;
+pub const MEMORY_BUDGET_NUM_BYTES_MAX: usize = u32::MAX as usize - MARGIN_IN_BYTES;
+
+// We impose the number of index writer threads to be at most this.
+pub const MAX_NUM_THREAD: usize = 8;
+
+// Add document will block if the number of docs waiting in the queue to be indexed
+// reaches `PIPELINE_MAX_SIZE_IN_DOCS`
+const PIPELINE_MAX_SIZE_IN_DOCS: usize = 10_000;
+
+fn error_in_index_worker_thread(context: &str) -> TantivyError {
+    TantivyError::ErrorInThread(format!(
+        "{context}. A worker thread encountered an error (io::Error most likely) or panicked."
+    ))
+}
+
+#[derive(Clone, bon::Builder)]
+/// A builder for creating a new [IndexWriter] for an index.
+pub struct IndexWriterOptions {
+    #[builder(default = MEMORY_BUDGET_NUM_BYTES_MIN)]
+    /// The memory budget per indexer thread.
+    ///
+    /// When an indexer thread has buffered this much data in memory
+    /// it will flush the segment to disk (although this is not searchable until commit is called.)
+    memory_budget_per_thread: usize,
+    #[builder(default = 1)]
+    /// The number of indexer worker threads to use.
+    num_worker_threads: usize,
+    #[builder(default = 4)]
+    /// Defines the number of merger threads to use.
+    num_merge_threads: usize,
+}
+
+/// `IndexWriter` is the user entry-point to add document to an index.
+///
+/// It manages a small number of indexing thread, as well as a shared
+/// indexing queue.
+/// Each indexing thread builds its own independent [`Segment`], via
+/// a `SegmentWriter` object.
+pub struct IndexWriter<D: Document = TantivyDocument> {
+    // the lock is just used to bind the
+    // lifetime of the lock with that of the IndexWriter.
+    _directory_lock: Option<DirectoryLock>,
+
+    index: Index,
+
+    options: IndexWriterOptions,
+
+    workers_join_handle: Vec<JoinHandle<crate::Result<()>>>,
+
+    index_writer_status: IndexWriterStatus<D>,
+    operation_sender: AddBatchSender<D>,
+
+    segment_updater: SegmentUpdater,
+
+    worker_id: usize,
+
+    delete_queue: DeleteQueue,
+
+    stamper: Stamper,
+    committed_opstamp: Opstamp,
+}
+
+fn compute_deleted_bitset(
+    alive_bitset: &mut BitSet,
+    segment_reader: &SegmentReader,
+    delete_cursor: &mut DeleteCursor,
+    doc_opstamps: &DocToOpstampMapping,
+    target_opstamp: Opstamp,
+) -> crate::Result<bool> {
+    let mut might_have_changed = false;
+    while let Some(delete_op) = delete_cursor.get() {
+        if delete_op.opstamp > target_opstamp {
+            break;
+        }
+
+        // A delete operation should only affect
+        // document that were inserted before it.
+        delete_op
+            .target
+            .for_each_no_score(segment_reader, &mut |docs_matching_delete_query| {
+                for doc_matching_delete_query in docs_matching_delete_query.iter().cloned() {
+                    if doc_opstamps.is_deleted(doc_matching_delete_query, delete_op.opstamp) {
+                        alive_bitset.remove(doc_matching_delete_query);
+                        might_have_changed = true;
+                    }
+                }
+            })?;
+        delete_cursor.advance();
+    }
+    Ok(might_have_changed)
+}
+
+/// Advance delete for the given segment up to the target opstamp.
+///
+/// Note that there are no guarantee that the resulting `segment_entry` delete_opstamp
+/// is `==` target_opstamp.
+/// For instance, there was no delete operation between the state of the `segment_entry` and
+/// the `target_opstamp`, `segment_entry` is not updated.
+pub fn advance_deletes(
+    mut segment: Segment,
+    segment_entry: &mut SegmentEntry,
+    target_opstamp: Opstamp,
+) -> crate::Result<()> {
+    if segment_entry.meta().delete_opstamp() == Some(target_opstamp) {
+        // We are already up-to-date here.
+        return Ok(());
+    }
+
+    if segment_entry.alive_bitset().is_none() && segment_entry.delete_cursor().get().is_none() {
+        // There has been no `DeleteOperation` between the segment status and `target_opstamp`.
+        return Ok(());
+    }
+
+    let segment_reader = SegmentReader::open(&segment)?;
+
+    let max_doc = segment_reader.max_doc();
+    let mut alive_bitset: BitSet = match segment_entry.alive_bitset() {
+        Some(previous_alive_bitset) => (*previous_alive_bitset).clone(),
+        None => BitSet::with_max_value_and_full(max_doc),
+    };
+
+    let num_deleted_docs_before = segment.meta().num_deleted_docs();
+
+    compute_deleted_bitset(
+        &mut alive_bitset,
+        &segment_reader,
+        segment_entry.delete_cursor(),
+        &DocToOpstampMapping::None,
+        target_opstamp,
+    )?;
+
+    if let Some(seg_alive_bitset) = segment_reader.alive_bitset() {
+        alive_bitset.intersect_update(seg_alive_bitset.bitset());
+    }
+
+    let num_alive_docs: u32 = alive_bitset.len() as u32;
+    let num_deleted_docs = max_doc - num_alive_docs;
+    if num_deleted_docs > num_deleted_docs_before {
+        // There are new deletes. We need to write a new delete file.
+        segment = segment.with_delete_meta(num_deleted_docs, target_opstamp);
+        let mut alive_doc_file = segment.open_write(SegmentComponent::Delete)?;
+        write_alive_bitset(&alive_bitset, &mut alive_doc_file)?;
+        alive_doc_file.terminate()?;
+    }
+
+    segment_entry.set_meta(segment.meta().clone());
+    Ok(())
+}
+
+fn index_documents<D: Document>(
+    memory_budget: usize,
+    segment: Segment,
+    grouped_document_iterator: &mut dyn Iterator<Item = AddBatch<D>>,
+    segment_updater: &SegmentUpdater,
+    mut delete_cursor: DeleteCursor,
+) -> crate::Result<()> {
+    let mut segment_writer = SegmentWriter::for_segment(memory_budget, segment.clone())?;
+    for document_group in grouped_document_iterator {
+        for doc in document_group {
+            segment_writer.add_document(doc)?;
+        }
+        let mem_usage = segment_writer.mem_usage();
+        if mem_usage >= memory_budget - MARGIN_IN_BYTES {
+            info!(
+                "Buffer limit reached, flushing segment with maxdoc={}.",
+                segment_writer.max_doc()
+            );
+            break;
+        }
+    }
+
+    if !segment_updater.is_alive() {
+        return Ok(());
+    }
+
+    let max_doc = segment_writer.max_doc();
+
+    // this is ensured by the call to peek before starting
+    // the worker thread.
+    assert!(max_doc > 0);
+
+    let doc_opstamps: Vec<Opstamp> = segment_writer.finalize()?;
+
+    let segment_with_max_doc = segment.with_max_doc(max_doc);
+
+    let alive_bitset_opt = apply_deletes(&segment_with_max_doc, &mut delete_cursor, &doc_opstamps)?;
+
+    let meta = segment_with_max_doc.meta().clone();
+
+    // update segment_updater inventory to remove tempstore
+    let segment_entry = SegmentEntry::new(meta, delete_cursor, alive_bitset_opt);
+    segment_updater.schedule_add_segment(segment_entry).wait()?;
+    Ok(())
+}
+
+/// `doc_opstamps` is required to be non-empty.
+fn apply_deletes(
+    segment: &Segment,
+    delete_cursor: &mut DeleteCursor,
+    doc_opstamps: &[Opstamp],
+) -> crate::Result<Option<BitSet>> {
+    if delete_cursor.get().is_none() {
+        // if there are no delete operation in the queue, no need
+        // to even open the segment.
+        return Ok(None);
+    }
+
+    let max_doc_opstamp: Opstamp = doc_opstamps
+        .iter()
+        .cloned()
+        .max()
+        .expect("Empty DocOpstamp is forbidden");
+
+    let segment_reader = SegmentReader::open(segment)?;
+    let doc_to_opstamps = DocToOpstampMapping::WithMap(doc_opstamps);
+
+    let max_doc = segment.meta().max_doc();
+    let mut deleted_bitset = BitSet::with_max_value_and_full(max_doc);
+    let may_have_deletes = compute_deleted_bitset(
+        &mut deleted_bitset,
+        &segment_reader,
+        delete_cursor,
+        &doc_to_opstamps,
+        max_doc_opstamp,
+    )?;
+    Ok(if may_have_deletes {
+        Some(deleted_bitset)
+    } else {
+        None
+    })
+}
+
+impl<D: Document> IndexWriter<D> {
+    /// Create a new index writer. Attempts to acquire a lockfile.
+    ///
+    /// The lockfile should be deleted on drop, but it is possible
+    /// that due to a panic or other error, a stale lockfile will be
+    /// left in the index directory. If you are sure that no other
+    /// `IndexWriter` on the system is accessing the index directory,
+    /// it is safe to manually delete the lockfile.
+    ///
+    /// `num_threads` specifies the number of indexing workers that
+    /// should work at the same time.
+    /// # Errors
+    /// If the lockfile already exists, returns `Error::FileAlreadyExists`.
+    /// If the memory arena per thread is too small or too big, returns
+    /// `TantivyError::InvalidArgument`
+    pub(crate) fn new(
+        index: &Index,
+        options: IndexWriterOptions,
+        directory_lock: DirectoryLock,
+    ) -> crate::Result<Self> {
+        if options.memory_budget_per_thread < MEMORY_BUDGET_NUM_BYTES_MIN {
+            let err_msg = format!(
+                "The memory arena in bytes per thread needs to be at least \
+                 {MEMORY_BUDGET_NUM_BYTES_MIN}."
+            );
+            return Err(TantivyError::InvalidArgument(err_msg));
+        }
+        if options.memory_budget_per_thread >= MEMORY_BUDGET_NUM_BYTES_MAX {
+            let err_msg = format!(
+                "The memory arena in bytes per thread cannot exceed {MEMORY_BUDGET_NUM_BYTES_MAX}"
+            );
+            return Err(TantivyError::InvalidArgument(err_msg));
+        }
+        if options.num_worker_threads == 0 {
+            let err_msg = "At least one worker thread is required, got 0".to_string();
+            return Err(TantivyError::InvalidArgument(err_msg));
+        }
+
+        let (document_sender, document_receiver) =
+            crossbeam_channel::bounded(PIPELINE_MAX_SIZE_IN_DOCS);
+
+        let delete_queue = DeleteQueue::default();
+
+        let current_opstamp = index.load_metas()?.opstamp;
+
+        let stamper = Stamper::new(current_opstamp);
+
+        let segment_updater = SegmentUpdater::create(
+            index.clone(),
+            stamper.clone(),
+            &delete_queue.cursor(),
+            options.num_merge_threads,
+        )?;
+
+        let mut index_writer = Self {
+            _directory_lock: Some(directory_lock),
+
+            options: options.clone(),
+            index: index.clone(),
+            index_writer_status: IndexWriterStatus::from(document_receiver),
+            operation_sender: document_sender,
+
+            segment_updater,
+
+            workers_join_handle: vec![],
+
+            delete_queue,
+
+            committed_opstamp: current_opstamp,
+            stamper,
+
+            worker_id: 0,
+        };
+        index_writer.start_workers()?;
+        Ok(index_writer)
+    }
+
+    fn drop_sender(&mut self) {
+        let (sender, _receiver) = crossbeam_channel::bounded(1);
+        self.operation_sender = sender;
+    }
+
+    /// Accessor to the index.
+    pub fn index(&self) -> &Index {
+        &self.index
+    }
+
+    /// If there are some merging threads, blocks until they all finish their work and
+    /// then drop the `IndexWriter`.
+    pub fn wait_merging_threads(mut self) -> crate::Result<()> {
+        // this will stop the indexing thread,
+        // dropping the last reference to the segment_updater.
+        self.drop_sender();
+
+        let former_workers_handles = std::mem::take(&mut self.workers_join_handle);
+        for join_handle in former_workers_handles {
+            join_handle
+                .join()
+                .map_err(|_| error_in_index_worker_thread("Worker thread panicked."))?
+                .map_err(|_| error_in_index_worker_thread("Worker thread failed."))?;
+        }
+
+        let result = self
+            .segment_updater
+            .wait_merging_thread()
+            .map_err(|_| error_in_index_worker_thread("Failed to join merging thread."));
+
+        if let Err(ref e) = result {
+            error!("Some merging thread failed {e:?}");
+        }
+
+        result
+    }
+
+    #[doc(hidden)]
+    pub fn add_segment(&self, segment_meta: SegmentMeta) -> crate::Result<()> {
+        let delete_cursor = self.delete_queue.cursor();
+        let segment_entry = SegmentEntry::new(segment_meta, delete_cursor, None);
+        self.segment_updater
+            .schedule_add_segment(segment_entry)
+            .wait()
+    }
+
+    /// Creates a new segment.
+    ///
+    /// This method is useful only for users trying to do complex
+    /// operations, like converting an index format to another.
+    ///
+    /// It is safe to start writing file associated with the new `Segment`.
+    /// These will not be garbage collected as long as an instance object of
+    /// `SegmentMeta` object associated with the new `Segment` is "alive".
+    pub fn new_segment(&self) -> Segment {
+        self.index.new_segment()
+    }
+
+    fn operation_receiver(&self) -> crate::Result<AddBatchReceiver<D>> {
+        self.index_writer_status
+            .operation_receiver()
+            .ok_or_else(|| {
+                crate::TantivyError::ErrorInThread(
+                    "The index writer was killed. It can happen if an indexing worker encountered \
+                     an Io error for instance."
+                        .to_string(),
+                )
+            })
+    }
+
+    /// Spawns a new worker thread for indexing.
+    /// The thread consumes documents from the pipeline.
+    fn add_indexing_worker(&mut self) -> crate::Result<()> {
+        let document_receiver_clone = self.operation_receiver()?;
+        let index_writer_bomb = self.index_writer_status.create_bomb();
+
+        let segment_updater = self.segment_updater.clone();
+
+        let mut delete_cursor = self.delete_queue.cursor();
+
+        let mem_budget = self.options.memory_budget_per_thread;
+        let index = self.index.clone();
+        let join_handle: JoinHandle<crate::Result<()>> = thread::Builder::new()
+            .name(format!("thrd-tantivy-index{}", self.worker_id))
+            .spawn(move || {
+                loop {
+                    let mut document_iterator = document_receiver_clone
+                        .clone()
+                        .into_iter()
+                        .filter(|batch| !batch.is_empty())
+                        .peekable();
+
+                    // The peeking here is to avoid creating a new segment's files
+                    // if no document are available.
+                    //
+                    // This is a valid guarantee as the peeked document now belongs to
+                    // our local iterator.
+                    if let Some(batch) = document_iterator.peek() {
+                        assert!(!batch.is_empty());
+                        delete_cursor.skip_to(batch[0].opstamp);
+                    } else {
+                        // No more documents.
+                        // It happens when there is a commit, or if the `IndexWriter`
+                        // was dropped.
+                        index_writer_bomb.defuse();
+                        return Ok(());
+                    }
+
+                    index_documents(
+                        mem_budget,
+                        index.new_segment(),
+                        &mut document_iterator,
+                        &segment_updater,
+                        delete_cursor.clone(),
+                    )?;
+                }
+            })?;
+        self.worker_id += 1;
+        self.workers_join_handle.push(join_handle);
+        Ok(())
+    }
+
+    /// Accessor to the merge policy.
+    pub fn get_merge_policy(&self) -> Arc<dyn MergePolicy> {
+        self.segment_updater.get_merge_policy()
+    }
+
+    /// Setter for the merge policy.
+    pub fn set_merge_policy(&self, merge_policy: Box<dyn MergePolicy>) {
+        self.segment_updater.set_merge_policy(merge_policy);
+    }
+
+    fn start_workers(&mut self) -> crate::Result<()> {
+        for _ in 0..self.options.num_worker_threads {
+            self.add_indexing_worker()?;
+        }
+        Ok(())
+    }
+
+    /// Detects and removes the files that are not used by the index anymore.
+    pub fn garbage_collect_files(&self) -> FutureResult<GarbageCollectionResult> {
+        self.segment_updater.schedule_garbage_collect()
+    }
+
+    /// Deletes all documents from the index
+    ///
+    /// Requires `commit`ing
+    /// Enables users to rebuild the index,
+    /// by clearing and resubmitting necessary documents
+    ///
+    /// ```rust
+    /// use tantivy::collector::TopDocs;
+    /// use tantivy::query::QueryParser;
+    /// use tantivy::schema::*;
+    /// use tantivy::{doc, Index};
+    ///
+    /// fn main() -> tantivy::Result<()> {
+    ///     let mut schema_builder = Schema::builder();
+    ///     let title = schema_builder.add_text_field("title", TEXT | STORED);
+    ///     let schema = schema_builder.build();
+    ///
+    ///     let index = Index::create_in_ram(schema.clone());
+    ///
+    ///     let mut index_writer = index.writer_with_num_threads(1, 50_000_000)?;
+    ///     index_writer.add_document(doc!(title => "The modern Prometheus"))?;
+    ///     index_writer.commit()?;
+    ///
+    ///     let clear_res = index_writer.delete_all_documents().unwrap();
+    ///     // have to commit, otherwise deleted terms remain available
+    ///     index_writer.commit()?;
+    ///
+    ///     let searcher = index.reader()?.searcher();
+    ///     let query_parser = QueryParser::for_index(&index, vec![title]);
+    ///     let query_promo = query_parser.parse_query("Prometheus")?;
+    ///     let top_docs_promo = searcher.search(&query_promo, &TopDocs::with_limit(1).order_by_score())?;
+    ///
+    ///     assert!(top_docs_promo.is_empty());
+    ///     Ok(())
+    /// }
+    /// ```
+    pub fn delete_all_documents(&self) -> crate::Result<Opstamp> {
+        // Delete segments
+        self.segment_updater.remove_all_segments();
+        // Return new stamp - reverted stamp
+        self.stamper.revert(self.committed_opstamp);
+        Ok(self.committed_opstamp)
+    }
+
+    /// Merges a given list of segments.
+    ///
+    /// If all segments are empty no new segment will be created.
+    ///
+    /// `segment_ids` is required to be non-empty.
+    pub fn merge(&mut self, segment_ids: &[SegmentId]) -> FutureResult<Option<SegmentMeta>> {
+        let merge_operation = self.segment_updater.make_merge_operation(segment_ids);
+        let segment_updater = self.segment_updater.clone();
+        segment_updater.start_merge(merge_operation)
+    }
+
+    /// Closes the current document channel send.
+    /// and replace all the channels by new ones.
+    ///
+    /// The current workers will keep on indexing
+    /// the pending document and stop
+    /// when no documents are remaining.
+    ///
+    /// Returns the former segment_ready channel.
+    fn recreate_document_channel(&mut self) {
+        let (document_sender, document_receiver) =
+            crossbeam_channel::bounded(PIPELINE_MAX_SIZE_IN_DOCS);
+        self.operation_sender = document_sender;
+        self.index_writer_status = IndexWriterStatus::from(document_receiver);
+    }
+
+    /// Rollback to the last commit
+    ///
+    /// This cancels all of the updates that
+    /// happened after the last commit.
+    /// After calling rollback, the index is in the same
+    /// state as it was after the last commit.
+    ///
+    /// The opstamp at the last commit is returned.
+    pub fn rollback(&mut self) -> crate::Result<Opstamp> {
+        info!("Rolling back to opstamp {}", self.committed_opstamp);
+        // marks the segment updater as killed. From now on, all
+        // segment updates will be ignored.
+        self.segment_updater.kill();
+        let document_receiver_res = self.operation_receiver();
+
+        // take the directory lock to create a new index_writer.
+        let directory_lock = self
+            ._directory_lock
+            .take()
+            .expect("The IndexWriter does not have any lock. This is a bug, please report.");
+
+        let new_index_writer = IndexWriter::new(&self.index, self.options.clone(), directory_lock)?;
+
+        // the current `self` is dropped right away because of this call.
+        //
+        // This will drop the document queue, and the thread
+        // should terminate.
+        *self = new_index_writer;
+
+        // Drains the document receiver pipeline :
+        // Workers don't need to index the pending documents.
+        //
+        // This will reach an end as the only document_sender
+        // was dropped with the index_writer.
+        if let Ok(document_receiver) = document_receiver_res {
+            for _ in document_receiver {}
+        }
+
+        Ok(self.committed_opstamp)
+    }
+
+    /// Prepares a commit.
+    ///
+    /// Calling `prepare_commit()` will cut the indexing
+    /// queue. All pending documents will be sent to the
+    /// indexing workers. They will then terminate, regardless
+    /// of the size of their current segment and flush their
+    /// work on disk.
+    ///
+    /// Once a commit is "prepared", you can either
+    /// call
+    /// * `.commit()`: to accept this commit
+    /// * `.abort()`: to cancel this commit.
+    ///
+    /// In the current implementation, [`PreparedCommit`] borrows
+    /// the [`IndexWriter`] mutably so we are guaranteed that no new
+    /// document can be added as long as it is committed or is
+    /// dropped.
+    ///
+    /// It is also possible to add a payload to the `commit`
+    /// using this API.
+    /// See [`PreparedCommit::set_payload()`].
+    pub fn prepare_commit(&mut self) -> crate::Result<PreparedCommit<'_, D>> {
+        // Here, because we join all of the worker threads,
+        // all of the segment update for this commit have been
+        // sent.
+        //
+        // No document belonging to the next commit have been
+        // pushed too, because add_document can only happen
+        // on this thread.
+        //
+        // This will move uncommitted segments to the state of
+        // committed segments.
+        info!("Preparing commit");
+
+        // this will drop the current document channel
+        // and recreate a new one.
+        self.recreate_document_channel();
+
+        let former_workers_join_handle = std::mem::take(&mut self.workers_join_handle);
+
+        for worker_handle in former_workers_join_handle {
+            let indexing_worker_result = worker_handle
+                .join()
+                .map_err(|e| TantivyError::ErrorInThread(format!("{e:?}")))?;
+            indexing_worker_result?;
+            self.add_indexing_worker()?;
+        }
+
+        let commit_opstamp = self.stamper.stamp();
+        let prepared_commit = PreparedCommit::new(self, commit_opstamp);
+        info!("Prepared commit {commit_opstamp}");
+        Ok(prepared_commit)
+    }
+
+    /// Commits all of the pending changes
+    ///
+    /// A call to commit blocks.
+    /// After it returns, all of the document that
+    /// were added since the last commit are published
+    /// and persisted.
+    ///
+    /// In case of a crash or an hardware failure (as
+    /// long as the hard disk is spared), it will be possible
+    /// to resume indexing from this point.
+    ///
+    /// Commit returns the `opstamp` of the last document
+    /// that made it in the commit.
+    pub fn commit(&mut self) -> crate::Result<Opstamp> {
+        self.prepare_commit()?.commit()
+    }
+
+    pub(crate) fn segment_updater(&self) -> &SegmentUpdater {
+        &self.segment_updater
+    }
+
+    /// Delete all documents containing a given term.
+    ///
+    /// Delete operation only affects documents that
+    /// were added in previous commits, and documents
+    /// that were added previously in the same commit.
+    ///
+    /// Like adds, the deletion itself will be visible
+    /// only after calling `commit()`.
+    pub fn delete_term(&self, term: Term) -> Opstamp {
+        let query = TermQuery::new(term, IndexRecordOption::Basic);
+        // For backward compatibility, if Term is invalid for the index, do nothing but return an
+        // Opstamp
+        self.delete_query(Box::new(query))
+            .unwrap_or_else(|_| self.stamper.stamp())
+    }
+
+    /// Delete all documents matching a given query.
+    /// Returns an `Err` if the query can't be executed.
+    ///
+    /// Delete operation only affects documents that
+    /// were added in previous commits, and documents
+    /// that were added previously in the same commit.
+    ///
+    /// Like adds, the deletion itself will be visible
+    /// only after calling `commit()`.
+    #[doc(hidden)]
+    pub fn delete_query(&self, query: Box<dyn Query>) -> crate::Result<Opstamp> {
+        let weight = query.weight(EnableScoring::disabled_from_schema(&self.index.schema()))?;
+        let opstamp = self.stamper.stamp();
+        let delete_operation = DeleteOperation {
+            opstamp,
+            target: weight,
+        };
+        self.delete_queue.push(delete_operation);
+        Ok(opstamp)
+    }
+
+    /// Returns the opstamp of the last successful commit.
+    ///
+    /// This is, for instance, the opstamp the index will
+    /// rollback to if there is a failure like a power surge.
+    ///
+    /// This is also the opstamp of the commit that is currently
+    /// available for searchers.
+    pub fn commit_opstamp(&self) -> Opstamp {
+        self.committed_opstamp
+    }
+
+    /// Adds a document.
+    ///
+    /// If the indexing pipeline is full, this call may block.
+    ///
+    /// The opstamp is an increasing `u64` that can
+    /// be used by the client to align commits with its own
+    /// document queue.
+    pub fn add_document(&self, document: D) -> crate::Result<Opstamp> {
+        let opstamp = self.stamper.stamp();
+        self.send_add_documents_batch(smallvec![AddOperation { opstamp, document }])?;
+        Ok(opstamp)
+    }
+
+    /// Gets a range of stamps from the stamper and "pops" the last stamp
+    /// from the range returning a tuple of the last optstamp and the popped
+    /// range.
+    ///
+    /// The total number of stamps generated by this method is `count + 1`;
+    /// each operation gets a stamp from the `stamps` iterator and `last_opstamp`
+    /// is for the batch itself.
+    fn get_batch_opstamps(&self, count: Opstamp) -> (Opstamp, Range<Opstamp>) {
+        let Range { start, end } = self.stamper.stamps(count + 1u64);
+        let last_opstamp = end - 1;
+        (last_opstamp, start..last_opstamp)
+    }
+
+    /// Runs a group of document operations ensuring that the operations are
+    /// assigned contiguous u64 opstamps and that add operations of the same
+    /// group are flushed into the same segment.
+    ///
+    /// If the indexing pipeline is full, this call may block.
+    ///
+    /// Each operation of the given `user_operations` will receive an in-order,
+    /// contiguous u64 opstamp. The entire batch itself is also given an
+    /// opstamp that is 1 greater than the last given operation. This
+    /// `batch_opstamp` is the return value of `run`. An empty group of
+    /// `user_operations`, an empty `Vec<UserOperation>`, still receives
+    /// a valid opstamp even though no changes were _actually_ made to the index.
+    ///
+    /// Like adds and deletes (see `IndexWriter.add_document` and
+    /// `IndexWriter.delete_term`), the changes made by calling `run` will be
+    /// visible to readers only after calling `commit()`.
+    pub fn run<I>(&self, user_operations: I) -> crate::Result<Opstamp>
+    where
+        I: IntoIterator<Item = UserOperation<D>>,
+        I::IntoIter: ExactSizeIterator,
+    {
+        let user_operations_it = user_operations.into_iter();
+        let count = user_operations_it.len() as u64;
+        if count == 0 {
+            return Ok(self.stamper.stamp());
+        }
+        let (batch_opstamp, stamps) = self.get_batch_opstamps(count);
+
+        let mut adds = AddBatch::default();
+
+        for (user_op, opstamp) in user_operations_it.zip(stamps) {
+            match user_op {
+                UserOperation::Delete(term) => {
+                    let query = TermQuery::new(term, IndexRecordOption::Basic);
+                    let weight =
+                        query.weight(EnableScoring::disabled_from_schema(&self.index.schema()))?;
+                    let delete_operation = DeleteOperation {
+                        opstamp,
+                        target: weight,
+                    };
+                    self.delete_queue.push(delete_operation);
+                }
+                UserOperation::Add(document) => {
+                    let add_operation = AddOperation { opstamp, document };
+                    adds.push(add_operation);
+                }
+            }
+        }
+        self.send_add_documents_batch(adds)?;
+        Ok(batch_opstamp)
+    }
+
+    fn send_add_documents_batch(&self, add_ops: AddBatch<D>) -> crate::Result<()> {
+        if self.index_writer_status.is_alive() && self.operation_sender.send(add_ops).is_ok() {
+            Ok(())
+        } else {
+            Err(error_in_index_worker_thread("An index writer was killed."))
+        }
+    }
+}
+
+impl<D: Document> Drop for IndexWriter<D> {
+    fn drop(&mut self) {
+        self.segment_updater.kill();
+        self.drop_sender();
+        for work in self.workers_join_handle.drain(..) {
+            let _ = work.join();
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::{HashMap, HashSet};
+    use std::net::Ipv6Addr;
+
+    use columnar::{Column, MonotonicallyMappableToU128};
+    use itertools::Itertools;
+    use proptest::prop_oneof;
+
+    use super::super::operation::UserOperation;
+    use crate::collector::{Count, TopDocs};
+    use crate::directory::error::LockError;
+    use crate::error::*;
+    use crate::indexer::index_writer::MEMORY_BUDGET_NUM_BYTES_MIN;
+    use crate::indexer::{IndexWriterOptions, NoMergePolicy};
+    use crate::query::{QueryParser, TermQuery};
+    use crate::schema::{
+        self, Facet, FacetOptions, IndexRecordOption, IpAddrOptions, JsonObjectOptions,
+        NumericOptions, Schema, TextFieldIndexing, TextOptions, Value, FAST, INDEXED, STORED,
+        STRING, TEXT,
+    };
+    use crate::store::DOCSTORE_CACHE_CAPACITY;
+    use crate::{
+        DateTime, DocAddress, Index, IndexSettings, IndexWriter, ReloadPolicy, TantivyDocument,
+        Term,
+    };
+
+    const LOREM: &str = "Doc Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do \
+                         eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad \
+                         minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip \
+                         ex ea commodo consequat. Duis aute irure dolor in reprehenderit in \
+                         voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur \
+                         sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt \
+                         mollit anim id est laborum.";
+
+    #[test]
+    fn test_operations_group() {
+        // an operations group with 2 items should cause 3 opstamps 0, 1, and 2.
+        let mut schema_builder = schema::Schema::builder();
+        let text_field = schema_builder.add_text_field("text", TEXT);
+        let index = Index::create_in_ram(schema_builder.build());
+        let index_writer = index.writer_for_tests().unwrap();
+        let operations = vec![
+            UserOperation::Add(doc!(text_field=>"a")),
+            UserOperation::Add(doc!(text_field=>"b")),
+        ];
+        let batch_opstamp1 = index_writer.run(operations).unwrap();
+        assert_eq!(batch_opstamp1, 2u64);
+    }
+
+    #[test]
+    fn test_no_need_to_rewrite_delete_file_if_no_new_deletes() {
+        let mut schema_builder = schema::Schema::builder();
+        let text_field = schema_builder.add_text_field("text", TEXT);
+        let index = Index::create_in_ram(schema_builder.build());
+
+        let mut index_writer: IndexWriter = index.writer_for_tests().unwrap();
+        index_writer
+            .add_document(doc!(text_field => "hello1"))
+            .unwrap();
+        index_writer
+            .add_document(doc!(text_field => "hello2"))
+            .unwrap();
+        assert!(index_writer.commit().is_ok());
+
+        let reader = index.reader().unwrap();
+        let searcher = reader.searcher();
+        assert_eq!(searcher.segment_readers().len(), 1);
+        assert_eq!(searcher.segment_reader(0u32).num_docs(), 2);
+
+        index_writer.delete_term(Term::from_field_text(text_field, "hello1"));
+        assert!(index_writer.commit().is_ok());
+
+        assert!(reader.reload().is_ok());
+        let searcher = reader.searcher();
+        assert_eq!(searcher.segment_readers().len(), 1);
+        assert_eq!(searcher.segment_reader(0u32).num_docs(), 1);
+
+        let previous_delete_opstamp = index.load_metas().unwrap().segments[0].delete_opstamp();
+
+        // All docs containing hello1 have been already removed.
+        // We should not update the delete meta.
+        index_writer.delete_term(Term::from_field_text(text_field, "hello1"));
+        assert!(index_writer.commit().is_ok());
+
+        assert!(reader.reload().is_ok());
+        let searcher = reader.searcher();
+        assert_eq!(searcher.segment_readers().len(), 1);
+        assert_eq!(searcher.segment_reader(0u32).num_docs(), 1);
+
+        let after_delete_opstamp = index.load_metas().unwrap().segments[0].delete_opstamp();
+        assert_eq!(after_delete_opstamp, previous_delete_opstamp);
+    }
+
+    #[test]
+    fn test_ordered_batched_operations() {
+        // * one delete for `doc!(field=>"a")`
+        // * one add for `doc!(field=>"a")`
+        // * one add for `doc!(field=>"b")`
+        // * one delete for `doc!(field=>"b")`
+        // after commit there is one doc with "a" and 0 doc with "b"
+        let mut schema_builder = schema::Schema::builder();
+        let text_field = schema_builder.add_text_field("text", TEXT);
+        let index = Index::create_in_ram(schema_builder.build());
+        let reader = index
+            .reader_builder()
+            .reload_policy(ReloadPolicy::Manual)
+            .try_into()
+            .unwrap();
+        let mut index_writer: IndexWriter = index.writer_for_tests().unwrap();
+        let a_term = Term::from_field_text(text_field, "a");
+        let b_term = Term::from_field_text(text_field, "b");
+        let operations = vec![
+            UserOperation::Delete(a_term),
+            UserOperation::Add(doc!(text_field=>"a")),
+            UserOperation::Add(doc!(text_field=>"b")),
+            UserOperation::Delete(b_term),
+        ];
+
+        index_writer.run(operations).unwrap();
+        index_writer.commit().expect("failed to commit");
+        reader.reload().expect("failed to load searchers");
+
+        let a_term = Term::from_field_text(text_field, "a");
+        let b_term = Term::from_field_text(text_field, "b");
+
+        let a_query = TermQuery::new(a_term, IndexRecordOption::Basic);
+        let b_query = TermQuery::new(b_term, IndexRecordOption::Basic);
+
+        let searcher = reader.searcher();
+
+        let a_docs = searcher
+            .search(&a_query, &TopDocs::with_limit(1).order_by_score())
+            .expect("search for a failed");
+
+        let b_docs = searcher
+            .search(&b_query, &TopDocs::with_limit(1).order_by_score())
+            .expect("search for b failed");
+
+        assert_eq!(a_docs.len(), 1);
+        assert_eq!(b_docs.len(), 0);
+    }
+
+    #[test]
+    fn test_empty_operations_group() {
+        let schema_builder = schema::Schema::builder();
+        let index = Index::create_in_ram(schema_builder.build());
+        let index_writer: IndexWriter = index.writer_for_tests().unwrap();
+        let operations1 = vec![];
+        let batch_opstamp1 = index_writer.run(operations1).unwrap();
+        assert_eq!(batch_opstamp1, 0u64);
+        let operations2 = vec![];
+        let batch_opstamp2 = index_writer.run(operations2).unwrap();
+        assert_eq!(batch_opstamp2, 1u64);
+    }
+
+    #[test]
+    fn test_lockfile_stops_duplicates() {
+        let schema_builder = schema::Schema::builder();
+        let index = Index::create_in_ram(schema_builder.build());
+        let _index_writer: IndexWriter = index.writer_for_tests().unwrap();
+        match index.writer_for_tests::<TantivyDocument>() {
+            Err(TantivyError::LockFailure(LockError::LockBusy, _)) => {}
+            _ => panic!("Expected a `LockFailure` error"),
+        }
+    }
+
+    #[test]
+    fn test_lockfile_already_exists_error_msg() {
+        let schema_builder = schema::Schema::builder();
+        let index = Index::create_in_ram(schema_builder.build());
+        let _index_writer: IndexWriter = index.writer_for_tests().unwrap();
+        match index.writer_for_tests::<TantivyDocument>() {
+            Err(err) => {
+                let err_msg = err.to_string();
+                assert!(err_msg.contains("already an `IndexWriter`"));
+            }
+            _ => panic!("Expected LockfileAlreadyExists error"),
+        }
+    }
+
+    #[test]
+    fn test_set_merge_policy() {
+        let schema_builder = schema::Schema::builder();
+        let index = Index::create_in_ram(schema_builder.build());
+        let index_writer: IndexWriter = index.writer_for_tests().unwrap();
+        assert_eq!(
+            format!("{:?}", index_writer.get_merge_policy()),
+            "LogMergePolicy { min_num_segments: 8, max_docs_before_merge: 10000000, \
+             min_layer_size: 10000, level_log_size: 0.75, del_docs_ratio_before_merge: 1.0 }"
+        );
+        let merge_policy = Box::<NoMergePolicy>::default();
+        index_writer.set_merge_policy(merge_policy);
+        assert_eq!(
+            format!("{:?}", index_writer.get_merge_policy()),
+            "NoMergePolicy"
+        );
+    }
+
+    #[test]
+    fn test_lockfile_released_on_drop() {
+        let schema_builder = schema::Schema::builder();
+        let index = Index::create_in_ram(schema_builder.build());
+        {
+            let _index_writer: IndexWriter = index.writer_for_tests().unwrap();
+            // the lock should be released when the
+            // index_writer leaves the scope.
+        }
+        let _index_writer_two: IndexWriter = index.writer_for_tests().unwrap();
+    }
+
+    #[test]
+    fn test_commit_and_rollback() -> crate::Result<()> {
+        let mut schema_builder = schema::Schema::builder();
+        let text_field = schema_builder.add_text_field("text", TEXT);
+        let index = Index::create_in_ram(schema_builder.build());
+        let reader = index
+            .reader_builder()
+            .reload_policy(ReloadPolicy::Manual)
+            .try_into()?;
+        let num_docs_containing = |s: &str| {
+            let searcher = reader.searcher();
+            let term = Term::from_field_text(text_field, s);
+            searcher.doc_freq(&term).unwrap()
+        };
+
+        {
+            // writing the segment
+            let mut index_writer = index.writer_for_tests()?;
+            index_writer.add_document(doc!(text_field=>"a"))?;
+            index_writer.rollback()?;
+            assert_eq!(index_writer.commit_opstamp(), 0u64);
+            assert_eq!(num_docs_containing("a"), 0);
+            index_writer.add_document(doc!(text_field=>"b"))?;
+            index_writer.add_document(doc!(text_field=>"c"))?;
+            index_writer.commit()?;
+            reader.reload()?;
+            assert_eq!(num_docs_containing("a"), 0);
+            assert_eq!(num_docs_containing("b"), 1);
+            assert_eq!(num_docs_containing("c"), 1);
+        }
+        reader.reload()?;
+        reader.searcher();
+        Ok(())
+    }
+
+    #[test]
+    fn test_merge_on_empty_segments_single_segment() -> crate::Result<()> {
+        let mut schema_builder = schema::Schema::builder();
+        let text_field = schema_builder.add_text_field("text", TEXT);
+        let index = Index::create_in_ram(schema_builder.build());
+        let reader = index
+            .reader_builder()
+            .reload_policy(ReloadPolicy::Manual)
+            .try_into()?;
+        let num_docs_containing = |s: &str| {
+            let term_a = Term::from_field_text(text_field, s);
+            reader.searcher().doc_freq(&term_a).unwrap()
+        };
+        // writing the segment
+        let mut index_writer: IndexWriter = index.writer_for_tests().unwrap();
+        index_writer.add_document(doc!(text_field=>"a"))?;
+        index_writer.commit()?;
+        //  this should create 1 segment
+
+        let segments = index.searchable_segment_ids().unwrap();
+        assert_eq!(segments.len(), 1);
+
+        reader.reload().unwrap();
+        assert_eq!(num_docs_containing("a"), 1);
+
+        index_writer.delete_term(Term::from_field_text(text_field, "a"));
+        index_writer.commit()?;
+
+        reader.reload().unwrap();
+        assert_eq!(num_docs_containing("a"), 0);
+
+        index_writer.merge(&segments);
+        index_writer.wait_merging_threads().unwrap();
+
+        let segments = index.searchable_segment_ids().unwrap();
+        assert_eq!(segments.len(), 0);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_merge_on_empty_segments() -> crate::Result<()> {
+        let mut schema_builder = schema::Schema::builder();
+        let text_field = schema_builder.add_text_field("text", TEXT);
+        let index = Index::create_in_ram(schema_builder.build());
+        let reader = index
+            .reader_builder()
+            .reload_policy(ReloadPolicy::Manual)
+            .try_into()?;
+        let num_docs_containing = |s: &str| {
+            let term_a = Term::from_field_text(text_field, s);
+            reader.searcher().doc_freq(&term_a).unwrap()
+        };
+        // writing the segment
+        let mut index_writer: IndexWriter = index.writer_for_tests().unwrap();
+        index_writer.add_document(doc!(text_field=>"a"))?;
+        index_writer.commit()?;
+        index_writer.add_document(doc!(text_field=>"a"))?;
+        index_writer.commit()?;
+        index_writer.add_document(doc!(text_field=>"a"))?;
+        index_writer.commit()?;
+        index_writer.add_document(doc!(text_field=>"a"))?;
+        index_writer.commit()?;
+        //  this should create 4 segments
+
+        let segments = index.searchable_segment_ids().unwrap();
+        assert_eq!(segments.len(), 4);
+
+        reader.reload().unwrap();
+        assert_eq!(num_docs_containing("a"), 4);
+
+        index_writer.delete_term(Term::from_field_text(text_field, "a"));
+        index_writer.commit()?;
+
+        reader.reload().unwrap();
+        assert_eq!(num_docs_containing("a"), 0);
+
+        index_writer.merge(&segments);
+        index_writer.wait_merging_threads().unwrap();
+
+        let segments = index.searchable_segment_ids().unwrap();
+        assert_eq!(segments.len(), 0);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_with_merges() -> crate::Result<()> {
+        let mut schema_builder = schema::Schema::builder();
+        let text_field = schema_builder.add_text_field("text", TEXT);
+        let index = Index::create_in_ram(schema_builder.build());
+        let reader = index
+            .reader_builder()
+            .reload_policy(ReloadPolicy::Manual)
+            .try_into()?;
+        let num_docs_containing = |s: &str| {
+            let term_a = Term::from_field_text(text_field, s);
+            reader.searcher().doc_freq(&term_a).unwrap()
+        };
+        // writing the segment
+        let mut index_writer = index.writer(MEMORY_BUDGET_NUM_BYTES_MIN).unwrap();
+        // create 8 segments with 100 tiny docs
+        for _doc in 0..100 {
+            index_writer.add_document(doc!(text_field=>"a"))?;
+        }
+        index_writer.commit()?;
+        for _doc in 0..100 {
+            index_writer.add_document(doc!(text_field=>"a"))?;
+        }
+        //  this should create 8 segments and trigger a merge.
+        index_writer.commit()?;
+        index_writer.wait_merging_threads()?;
+        reader.reload()?;
+        assert_eq!(num_docs_containing("a"), 200);
+        assert!(index.searchable_segments()?.len() < 8);
+        Ok(())
+    }
+
+    #[test]
+    fn test_prepare_with_commit_message() -> crate::Result<()> {
+        let mut schema_builder = schema::Schema::builder();
+        let text_field = schema_builder.add_text_field("text", TEXT);
+        let index = Index::create_in_ram(schema_builder.build());
+
+        let mut index_writer = index.writer_for_tests()?;
+        for _doc in 0..100 {
+            index_writer.add_document(doc!(text_field => "a"))?;
+        }
+        {
+            let mut prepared_commit = index_writer.prepare_commit()?;
+            prepared_commit.set_payload("first commit");
+            prepared_commit.commit()?;
+        }
+        {
+            let metas = index.load_metas()?;
+            assert_eq!(metas.payload.unwrap(), "first commit");
+        }
+        for _doc in 0..100 {
+            index_writer.add_document(doc!(text_field => "a"))?;
+        }
+        index_writer.commit()?;
+        {
+            let metas = index.load_metas()?;
+            assert!(metas.payload.is_none());
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn test_prepare_but_rollback() -> crate::Result<()> {
+        let mut schema_builder = schema::Schema::builder();
+        let text_field = schema_builder.add_text_field("text", TEXT);
+        let index = Index::create_in_ram(schema_builder.build());
+
+        {
+            // writing the segment
+            let mut index_writer =
+                index.writer_with_num_threads(4, MEMORY_BUDGET_NUM_BYTES_MIN * 4)?;
+            // create 8 segments with 100 tiny docs
+            for _doc in 0..100 {
+                index_writer.add_document(doc!(text_field => "a"))?;
+            }
+            {
+                let mut prepared_commit = index_writer.prepare_commit()?;
+                prepared_commit.set_payload("first commit");
+                prepared_commit.abort()?;
+            }
+            {
+                let metas = index.load_metas()?;
+                assert!(metas.payload.is_none());
+            }
+            for _doc in 0..100 {
+                index_writer.add_document(doc!(text_field => "b"))?;
+            }
+            index_writer.commit()?;
+        }
+        let num_docs_containing = |s: &str| {
+            let term_a = Term::from_field_text(text_field, s);
+            index
+                .reader_builder()
+                .reload_policy(ReloadPolicy::Manual)
+                .try_into()?
+                .searcher()
+                .doc_freq(&term_a)
+        };
+        assert_eq!(num_docs_containing("a")?, 0);
+        assert_eq!(num_docs_containing("b")?, 100);
+        Ok(())
+    }
+
+    #[test]
+    fn test_add_then_delete_all_documents() {
+        let mut schema_builder = schema::Schema::builder();
+        let text_field = schema_builder.add_text_field("text", TEXT);
+        let index = Index::create_in_ram(schema_builder.build());
+        let reader = index
+            .reader_builder()
+            .reload_policy(ReloadPolicy::Manual)
+            .try_into()
+            .unwrap();
+        let num_docs_containing = |s: &str| {
+            reader.reload().unwrap();
+            let searcher = reader.searcher();
+            let term = Term::from_field_text(text_field, s);
+            searcher.doc_freq(&term).unwrap()
+        };
+        let mut index_writer = index
+            .writer_with_num_threads(4, MEMORY_BUDGET_NUM_BYTES_MIN * 4)
+            .unwrap();
+
+        let add_tstamp = index_writer.add_document(doc!(text_field => "a")).unwrap();
+        let commit_tstamp = index_writer.commit().unwrap();
+        assert!(commit_tstamp > add_tstamp);
+        index_writer.delete_all_documents().unwrap();
+        index_writer.commit().unwrap();
+
+        // Search for documents with the same term that we added
+        assert_eq!(num_docs_containing("a"), 0);
+    }
+
+    #[test]
+    fn test_delete_all_documents_rollback_correct_stamp() {
+        let mut schema_builder = schema::Schema::builder();
+        let text_field = schema_builder.add_text_field("text", TEXT);
+        let index = Index::create_in_ram(schema_builder.build());
+        let mut index_writer = index
+            .writer_with_num_threads(4, MEMORY_BUDGET_NUM_BYTES_MIN * 4)
+            .unwrap();
+
+        let add_tstamp = index_writer.add_document(doc!(text_field => "a")).unwrap();
+
+        // commit documents - they are now available
+        let first_commit = index_writer.commit();
+        assert!(first_commit.is_ok());
+        let first_commit_tstamp = first_commit.unwrap();
+        assert!(first_commit_tstamp > add_tstamp);
+
+        // delete_all_documents the index
+        let clear_tstamp = index_writer.delete_all_documents().unwrap();
+        assert_eq!(clear_tstamp, add_tstamp);
+
+        // commit the clear command - now documents aren't available
+        let second_commit = index_writer.commit();
+        assert!(second_commit.is_ok());
+        let second_commit_tstamp = second_commit.unwrap();
+
+        // add new documents again
+        for _ in 0..100 {
+            index_writer.add_document(doc!(text_field => "b")).unwrap();
+        }
+
+        // rollback to last commit, when index was empty
+        let rollback = index_writer.rollback();
+        assert!(rollback.is_ok());
+        let rollback_tstamp = rollback.unwrap();
+        assert_eq!(rollback_tstamp, second_commit_tstamp);
+
+        // working with an empty index == no documents
+        let term_b = Term::from_field_text(text_field, "b");
+        assert_eq!(
+            index
+                .reader()
+                .unwrap()
+                .searcher()
+                .doc_freq(&term_b)
+                .unwrap(),
+            0
+        );
+    }
+
+    #[test]
+    fn test_delete_all_documents_then_add() {
+        let mut schema_builder = schema::Schema::builder();
+        let text_field = schema_builder.add_text_field("text", TEXT);
+        let index = Index::create_in_ram(schema_builder.build());
+        // writing the segment
+        let mut index_writer = index
+            .writer_with_num_threads(4, MEMORY_BUDGET_NUM_BYTES_MIN * 4)
+            .unwrap();
+        let res = index_writer.delete_all_documents();
+        assert!(res.is_ok());
+
+        assert!(index_writer.commit().is_ok());
+        // add one simple doc
+        index_writer.add_document(doc!(text_field => "a")).unwrap();
+        assert!(index_writer.commit().is_ok());
+
+        let term_a = Term::from_field_text(text_field, "a");
+        // expect the document with that term to be in the index
+        assert_eq!(
+            index
+                .reader()
+                .unwrap()
+                .searcher()
+                .doc_freq(&term_a)
+                .unwrap(),
+            1
+        );
+    }
+
+    #[test]
+    fn test_delete_all_documents_and_rollback() {
+        let mut schema_builder = schema::Schema::builder();
+        let text_field = schema_builder.add_text_field("text", TEXT);
+        let index = Index::create_in_ram(schema_builder.build());
+        let mut index_writer = index
+            .writer_with_num_threads(4, MEMORY_BUDGET_NUM_BYTES_MIN * 4)
+            .unwrap();
+
+        // add one simple doc
+        assert!(index_writer.add_document(doc!(text_field => "a")).is_ok());
+        let comm = index_writer.commit();
+        assert!(comm.is_ok());
+        let commit_tstamp = comm.unwrap();
+
+        // clear but don't commit!
+        let clear_tstamp = index_writer.delete_all_documents().unwrap();
+        // clear_tstamp should reset to before the last commit
+        assert!(clear_tstamp < commit_tstamp);
+
+        // rollback
+        let _rollback_tstamp = index_writer.rollback().unwrap();
+        // Find original docs in the index
+        let term_a = Term::from_field_text(text_field, "a");
+        // expect the document with that term to be in the index
+        assert_eq!(
+            index
+                .reader()
+                .unwrap()
+                .searcher()
+                .doc_freq(&term_a)
+                .unwrap(),
+            1
+        );
+    }
+
+    #[test]
+    fn test_delete_all_documents_empty_index() {
+        let schema_builder = schema::Schema::builder();
+        let index = Index::create_in_ram(schema_builder.build());
+        let mut index_writer: IndexWriter = index
+            .writer_with_num_threads(4, MEMORY_BUDGET_NUM_BYTES_MIN * 4)
+            .unwrap();
+        let clear = index_writer.delete_all_documents();
+        let commit = index_writer.commit();
+        assert!(clear.is_ok());
+        assert!(commit.is_ok());
+    }
+
+    #[test]
+    fn test_delete_all_documents_index_twice() {
+        let schema_builder = schema::Schema::builder();
+        let index = Index::create_in_ram(schema_builder.build());
+        let mut index_writer: IndexWriter = index
+            .writer_with_num_threads(4, MEMORY_BUDGET_NUM_BYTES_MIN * 4)
+            .unwrap();
+        let clear = index_writer.delete_all_documents();
+        let commit = index_writer.commit();
+        assert!(clear.is_ok());
+        assert!(commit.is_ok());
+        let clear_again = index_writer.delete_all_documents();
+        let commit_again = index_writer.commit();
+        assert!(clear_again.is_ok());
+        assert!(commit_again.is_ok());
+    }
+
+    #[test]
+    fn test_delete_and_merge_removes_terms_fast_field_dict() {
+        let mut schema_builder = schema::Schema::builder();
+        let text_field = schema_builder.add_text_field("text", STRING | FAST);
+        let schema = schema_builder.build();
+
+        let index = Index::builder().schema(schema).create_in_ram().unwrap();
+        let mut index_writer: IndexWriter = index.writer_for_tests().unwrap();
+        index_writer
+            .add_document(doc!(text_field => "one"))
+            .unwrap();
+        index_writer
+            .add_document(doc!(text_field => "two"))
+            .unwrap();
+        index_writer
+            .add_document(doc!(text_field => "three"))
+            .unwrap();
+        index_writer.commit().unwrap();
+        let index_reader = index.reader().unwrap();
+        let searcher = index_reader.searcher();
+        let segment_reader = searcher.segment_reader(0);
+        let text_fast_field = segment_reader.fast_fields().str("text").unwrap().unwrap();
+        let mut buffer = String::new();
+        assert!(text_fast_field.ord_to_str(0, &mut buffer).unwrap());
+        assert_eq!(buffer, "one");
+        assert!(text_fast_field.ord_to_str(1, &mut buffer).unwrap());
+        assert_eq!(buffer, "three");
+        assert!(text_fast_field.ord_to_str(2, &mut buffer).unwrap());
+        assert_eq!(buffer, "two");
+        assert!(!text_fast_field.ord_to_str(3, &mut buffer).unwrap());
+
+        assert_eq!(segment_reader.max_doc(), 3);
+        index_writer.delete_term(Term::from_field_text(text_field, "three"));
+        index_writer.commit().unwrap();
+        index_writer
+            .merge(&[segment_reader.segment_id()])
+            .wait()
+            .unwrap();
+        index_reader.reload().unwrap();
+        let searcher = index_reader.searcher();
+        let segment_reader = searcher.segment_reader(0);
+        assert_eq!(segment_reader.max_doc(), 2);
+        let text_fast_field = segment_reader.fast_fields().str("text").unwrap().unwrap();
+        let mut buffer = String::new();
+        assert!(text_fast_field.ord_to_str(0, &mut buffer).unwrap());
+        assert_eq!(buffer, "one");
+        assert!(text_fast_field.ord_to_str(1, &mut buffer).unwrap());
+        assert_eq!(buffer, "two");
+        assert!(!text_fast_field.ord_to_str(2, &mut buffer).unwrap());
+        assert!(text_fast_field.term_ords(0).eq([0].into_iter()));
+        assert!(text_fast_field.term_ords(1).eq([1].into_iter()));
+    }
+
+    #[derive(Debug, Clone)]
+    enum IndexingOp {
+        AddMultipleDoc {
+            id: u64,
+            num_docs: u64,
+            value: IndexValue,
+        },
+        AddDoc {
+            id: u64,
+            value: IndexValue,
+        },
+        DeleteDoc {
+            id: u64,
+        },
+        DeleteDocQuery {
+            id: u64,
+        },
+        Commit,
+        Merge,
+    }
+    impl IndexingOp {
+        fn add(id: u64) -> Self {
+            IndexingOp::AddDoc {
+                id,
+                value: IndexValue::F64(id as f64),
+            }
+        }
+    }
+
+    use serde::Serialize;
+    #[derive(Debug, Clone, Serialize)]
+    #[serde(untagged)]
+    enum IndexValue {
+        Str(String),
+        F64(f64),
+        U64(u64),
+        I64(i64),
+    }
+    impl Default for IndexValue {
+        fn default() -> Self {
+            IndexValue::F64(0.0)
+        }
+    }
+
+    fn value_strategy() -> impl Strategy<Value = IndexValue> {
+        prop_oneof![
+            any::<f64>().prop_map(IndexValue::F64),
+            any::<u64>().prop_map(IndexValue::U64),
+            any::<i64>().prop_map(IndexValue::I64),
+            any::<String>().prop_map(IndexValue::Str),
+        ]
+    }
+
+    fn balanced_operation_strategy() -> impl Strategy<Value = IndexingOp> {
+        prop_oneof![
+            (0u64..20u64).prop_map(|id| IndexingOp::DeleteDoc { id }),
+            (0u64..20u64).prop_map(|id| IndexingOp::DeleteDocQuery { id }),
+            (0u64..20u64, value_strategy())
+                .prop_map(move |(id, value)| IndexingOp::AddDoc { id, value }),
+            ((0u64..20u64), (1u64..100), value_strategy()).prop_map(
+                move |(id, num_docs, value)| {
+                    IndexingOp::AddMultipleDoc {
+                        id,
+                        num_docs,
+                        value,
+                    }
+                }
+            ),
+            (0u64..1u64).prop_map(|_| IndexingOp::Commit),
+            (0u64..1u64).prop_map(|_| IndexingOp::Merge),
+        ]
+    }
+
+    fn adding_operation_strategy() -> impl Strategy<Value = IndexingOp> {
+        prop_oneof![
+            5 => (0u64..100u64).prop_map(|id| IndexingOp::DeleteDoc { id }),
+            5 => (0u64..100u64).prop_map(|id| IndexingOp::DeleteDocQuery { id }),
+            50 => (0u64..100u64, value_strategy())
+                .prop_map(move |(id, value)| IndexingOp::AddDoc { id, value }),
+            50 => (0u64..100u64, (1u64..100), value_strategy()).prop_map(
+                move |(id, num_docs, value)| {
+                    IndexingOp::AddMultipleDoc {
+                        id,
+                        num_docs,
+                        value,
+                    }
+                }
+            ),
+            2 => (0u64..1u64).prop_map(|_| IndexingOp::Commit),
+            1 => (0u64..1u64).prop_map(|_| IndexingOp::Merge),
+        ]
+    }
+
+    fn expected_ids(ops: &[IndexingOp]) -> (HashMap<u64, u64>, HashSet<u64>) {
+        let mut existing_ids = HashMap::new();
+        let mut deleted_ids = HashSet::new();
+        for op in ops {
+            match op {
+                IndexingOp::AddDoc { id, value: _ } => {
+                    *existing_ids.entry(*id).or_insert(0) += 1;
+                    deleted_ids.remove(id);
+                }
+                IndexingOp::AddMultipleDoc {
+                    id,
+                    num_docs,
+                    value: _,
+                } => {
+                    *existing_ids.entry(*id).or_insert(0) += num_docs;
+                    deleted_ids.remove(id);
+                }
+                IndexingOp::DeleteDoc { id } => {
+                    existing_ids.remove(id);
+                    deleted_ids.insert(*id);
+                }
+                IndexingOp::DeleteDocQuery { id } => {
+                    existing_ids.remove(id);
+                    deleted_ids.insert(*id);
+                }
+                _ => {}
+            }
+        }
+        (existing_ids, deleted_ids)
+    }
+
+    fn get_id_list(ops: &[IndexingOp]) -> Vec<u64> {
+        let mut id_list = Vec::new();
+        for op in ops {
+            match op {
+                IndexingOp::AddDoc { id, value: _ } => {
+                    id_list.push(*id);
+                }
+                IndexingOp::AddMultipleDoc { id, .. } => {
+                    id_list.push(*id);
+                }
+                IndexingOp::DeleteDoc { id } => {
+                    id_list.retain(|el| el != id);
+                }
+                IndexingOp::DeleteDocQuery { id } => {
+                    id_list.retain(|el| el != id);
+                }
+                _ => {}
+            }
+        }
+        id_list
+    }
+
+    fn test_operation_strategy(ops: &[IndexingOp], force_end_merge: bool) -> crate::Result<Index> {
+        let mut schema_builder = schema::Schema::builder();
+        let json_field = schema_builder.add_json_field("json", FAST | TEXT | STORED);
+        let ip_field = schema_builder.add_ip_addr_field("ip", FAST | INDEXED | STORED);
+        let ips_field = schema_builder
+            .add_ip_addr_field("ips", IpAddrOptions::default().set_fast().set_indexed());
+        let i64_field = schema_builder.add_i64_field("i64", INDEXED);
+        let id_field = schema_builder.add_u64_field("id", FAST | INDEXED | STORED);
+        let id_opt_field = schema_builder.add_u64_field("id_opt", FAST | INDEXED | STORED);
+        let f64_field = schema_builder.add_f64_field("f64", INDEXED);
+        let date_field = schema_builder.add_date_field("date", INDEXED);
+        let bytes_field = schema_builder.add_bytes_field("bytes", FAST | INDEXED | STORED);
+        let bool_field = schema_builder.add_bool_field("bool", FAST | INDEXED | STORED);
+        let text_field = schema_builder.add_text_field(
+            "text_field",
+            TextOptions::default()
+                .set_indexing_options(
+                    TextFieldIndexing::default()
+                        .set_index_option(schema::IndexRecordOption::WithFreqsAndPositions),
+                )
+                .set_stored(),
+        );
+
+        let large_text_field = schema_builder.add_text_field("large_text_field", TEXT | STORED);
+        let multi_text_fields = schema_builder.add_text_field("multi_text_fields", TEXT | STORED);
+
+        let multi_numbers = schema_builder.add_u64_field(
+            "multi_numbers",
+            NumericOptions::default().set_fast().set_stored(),
+        );
+        let multi_bools = schema_builder.add_bool_field(
+            "multi_bools",
+            NumericOptions::default().set_fast().set_stored(),
+        );
+        let facet_field = schema_builder.add_facet_field("facet", FacetOptions::default());
+        let schema = schema_builder.build();
+        let settings = {
+            IndexSettings {
+                ..Default::default()
+            }
+        };
+        let index = Index::builder()
+            .schema(schema)
+            .settings(settings)
+            .create_in_ram()?;
+        let mut index_writer = index.writer_for_tests()?;
+        index_writer.set_merge_policy(Box::new(NoMergePolicy));
+
+        let old_reader = index.reader()?;
+
+        // Every 3rd doc has only id field
+        let id_is_full_doc = |id| id % 3 != 0;
+
+        let multi_text_field_text1 = "test1 test2 test3 test1 test2 test3";
+        // rotate left
+        let multi_text_field_text2 = "test2 test3 test1 test2 test3 test1";
+        // rotate right
+        let multi_text_field_text3 = "test3 test1 test2 test3 test1 test2";
+
+        let ip_from_id = |id| Ipv6Addr::from_u128(id as u128);
+
+        let add_docs = |index_writer: &mut IndexWriter,
+                        id: u64,
+                        value: IndexValue,
+                        num: u64|
+         -> crate::Result<()> {
+            let facet = Facet::from(&("/cola/".to_string() + &id.to_string()));
+            let ip = ip_from_id(id);
+            let doc = if !id_is_full_doc(id) {
+                // every 3rd doc has no ip field
+                doc!(
+                    id_field=>id,
+                )
+            } else {
+                let json = json!({"date1": format!("2022-{id}-01T00:00:01Z"), "date2": format!("{id}-05-01T00:00:01Z"), "id": id, "ip": ip.to_string(), "val": value});
+                doc!(id_field=>id,
+                        json_field=>json,
+                        bytes_field => id.to_le_bytes().as_slice(),
+                        id_opt_field => id,
+                        ip_field => ip,
+                        ips_field => ip,
+                        ips_field => ip,
+                        multi_numbers=> id,
+                        multi_numbers => id,
+                        bool_field => (id % 2u64) != 0,
+                        i64_field => id as i64,
+                        f64_field => id as f64,
+                        date_field => DateTime::from_timestamp_secs(id as i64),
+                        multi_bools => (id % 2u64) != 0,
+                        multi_bools => (id % 2u64) == 0,
+                        text_field => id.to_string(),
+                        facet_field => facet,
+                        large_text_field => LOREM,
+                        multi_text_fields => multi_text_field_text1,
+                        multi_text_fields => multi_text_field_text2,
+                        multi_text_fields => multi_text_field_text3,
+                )
+            };
+            for _ in 0..num {
+                index_writer.add_document(doc.clone())?;
+            }
+            Ok(())
+        };
+        for op in ops {
+            match op.clone() {
+                IndexingOp::AddMultipleDoc {
+                    id,
+                    num_docs,
+                    value,
+                } => {
+                    add_docs(&mut index_writer, id, value, num_docs)?;
+                }
+                IndexingOp::AddDoc { id, value } => {
+                    add_docs(&mut index_writer, id, value, 1)?;
+                }
+                IndexingOp::DeleteDoc { id } => {
+                    index_writer.delete_term(Term::from_field_u64(id_field, id));
+                }
+                IndexingOp::DeleteDocQuery { id } => {
+                    let term = Term::from_field_u64(id_field, id);
+                    let query = TermQuery::new(term, Default::default());
+                    index_writer.delete_query(Box::new(query))?;
+                }
+                IndexingOp::Commit => {
+                    index_writer.commit()?;
+                }
+                IndexingOp::Merge => {
+                    let mut segment_ids = index
+                        .searchable_segment_ids()
+                        .expect("Searchable segments failed.");
+                    segment_ids.sort();
+                    if segment_ids.len() >= 2 {
+                        index_writer.merge(&segment_ids).wait().unwrap();
+                        assert!(index_writer.segment_updater().wait_merging_thread().is_ok());
+                    }
+                }
+            }
+        }
+        index_writer.commit()?;
+
+        let searcher = index.reader()?.searcher();
+        let num_segments_before_merge = searcher.segment_readers().len();
+        if force_end_merge {
+            index_writer.wait_merging_threads()?;
+            let mut index_writer: IndexWriter = index.writer_for_tests()?;
+            let segment_ids = index
+                .searchable_segment_ids()
+                .expect("Searchable segments failed.");
+            if segment_ids.len() >= 2 {
+                index_writer.merge(&segment_ids).wait().unwrap();
+                assert!(index_writer.wait_merging_threads().is_ok());
+            }
+        }
+        let num_segments_after_merge = searcher.segment_readers().len();
+
+        old_reader.reload()?;
+        let old_searcher = old_reader.searcher();
+
+        let ids_old_searcher: HashSet<u64> = old_searcher
+            .segment_readers()
+            .iter()
+            .flat_map(|segment_reader| {
+                let ff_reader = segment_reader.fast_fields().u64("id").unwrap();
+                segment_reader
+                    .doc_ids_alive()
+                    .flat_map(move |doc| ff_reader.values_for_doc(doc).collect_vec().into_iter())
+            })
+            .collect();
+
+        let ids: HashSet<u64> = searcher
+            .segment_readers()
+            .iter()
+            .flat_map(|segment_reader| {
+                let ff_reader = segment_reader.fast_fields().u64("id").unwrap();
+                segment_reader
+                    .doc_ids_alive()
+                    .flat_map(move |doc| ff_reader.values_for_doc(doc).collect_vec().into_iter())
+            })
+            .collect();
+
+        let (expected_ids_and_num_occurrences, deleted_ids) = expected_ids(ops);
+
+        let id_list = get_id_list(ops);
+
+        // multivalue fast field content
+        let mut all_ips = Vec::new();
+        let mut num_ips = 0;
+        for segment_reader in searcher.segment_readers().iter() {
+            let ip_reader: Column<Ipv6Addr> = segment_reader
+                .fast_fields()
+                .column_opt("ips")
+                .unwrap()
+                .unwrap();
+            for doc in segment_reader.doc_ids_alive() {
+                all_ips.extend(ip_reader.values_for_doc(doc));
+            }
+            num_ips += ip_reader.values.num_vals();
+        }
+
+        let num_docs_expected = expected_ids_and_num_occurrences
+            .values()
+            .map(|id_occurrences| *id_occurrences as usize)
+            .sum::<usize>();
+
+        let num_docs_with_values = expected_ids_and_num_occurrences
+            .iter()
+            .filter(|(id, _id_occurrences)| id_is_full_doc(**id))
+            .map(|(_, id_occurrences)| *id_occurrences as usize)
+            .sum::<usize>();
+
+        assert_eq!(searcher.num_docs() as usize, num_docs_expected);
+        assert_eq!(old_searcher.num_docs() as usize, num_docs_expected);
+        assert_eq!(
+            ids_old_searcher,
+            expected_ids_and_num_occurrences
+                .keys()
+                .cloned()
+                .collect::<HashSet<_>>()
+        );
+        assert_eq!(
+            ids,
+            expected_ids_and_num_occurrences
+                .keys()
+                .cloned()
+                .collect::<HashSet<_>>()
+        );
+
+        if force_end_merge && num_segments_before_merge > 1 && num_segments_after_merge == 1 {
+            let mut expected_multi_ips: Vec<_> = id_list
+                .iter()
+                .filter(|id| id_is_full_doc(**id))
+                .flat_map(|id| vec![ip_from_id(*id), ip_from_id(*id)])
+                .collect();
+            assert_eq!(num_ips, expected_multi_ips.len() as u32);
+
+            expected_multi_ips.sort();
+            all_ips.sort();
+            assert_eq!(expected_multi_ips, all_ips);
+
+            // Test fastfield num_docs
+            let num_docs: usize = searcher
+                .segment_readers()
+                .iter()
+                .map(|segment_reader| {
+                    let ff_reader = segment_reader
+                        .fast_fields()
+                        .column_opt::<Ipv6Addr>("ips")
+                        .unwrap()
+                        .unwrap();
+                    ff_reader.num_docs() as usize
+                })
+                .sum();
+            assert_eq!(num_docs, num_docs_expected);
+        }
+
+        // Load all ips addr
+        let mut ips: HashSet<Ipv6Addr> = Default::default();
+        for reader in searcher.segment_readers() {
+            if let Some(ff_reader) = reader.fast_fields().column_opt::<Ipv6Addr>("ips").unwrap() {
+                for doc in reader.doc_ids_alive() {
+                    ips.extend(ff_reader.values_for_doc(doc));
+                }
+            }
+        }
+
+        let expected_ips = expected_ids_and_num_occurrences
+            .keys()
+            .flat_map(|id| {
+                if !id_is_full_doc(*id) {
+                    None
+                } else {
+                    Some(Ipv6Addr::from_u128(*id as u128))
+                }
+            })
+            .collect::<HashSet<_>>();
+        assert_eq!(ips, expected_ips);
+
+        let expected_ips = expected_ids_and_num_occurrences
+            .keys()
+            .filter_map(|id| {
+                if !id_is_full_doc(*id) {
+                    None
+                } else {
+                    Some(Ipv6Addr::from_u128(*id as u128))
+                }
+            })
+            .collect::<HashSet<_>>();
+
+        let mut ips: HashSet<Ipv6Addr> = Default::default();
+        for reader in searcher.segment_readers() {
+            if let Some(ff_reader) = reader.fast_fields().column_opt::<Ipv6Addr>("ips").unwrap() {
+                for doc in reader.doc_ids_alive() {
+                    ips.extend(ff_reader.values_for_doc(doc));
+                }
+            }
+        }
+        assert_eq!(ips, expected_ips);
+
+        // multivalue fast field tests
+        for segment_reader in searcher.segment_readers().iter() {
+            let id_reader = segment_reader.fast_fields().u64("id").unwrap();
+            let ff_reader = segment_reader
+                .fast_fields()
+                .column_opt("multi_numbers")
+                .unwrap()
+                .unwrap();
+            let bool_ff_reader = segment_reader
+                .fast_fields()
+                .column_opt::<bool>("multi_bools")
+                .unwrap()
+                .unwrap();
+            for doc in segment_reader.doc_ids_alive() {
+                let id = id_reader.first(doc).unwrap();
+
+                let vals: Vec<u64> = ff_reader.values_for_doc(doc).collect();
+                if id_is_full_doc(id) {
+                    assert_eq!(vals.len(), 2);
+                    assert_eq!(vals[0], vals[1]);
+                    assert!(expected_ids_and_num_occurrences.contains_key(&vals[0]));
+                    assert_eq!(id_reader.first(doc), Some(vals[0]));
+                } else {
+                    assert_eq!(vals.len(), 0);
+                }
+
+                let bool_vals: Vec<bool> = bool_ff_reader.values_for_doc(doc).collect();
+                if id_is_full_doc(id) {
+                    assert_eq!(bool_vals.len(), 2);
+                    assert_ne!(bool_vals[0], bool_vals[1]);
+                } else {
+                    assert_eq!(bool_vals.len(), 0);
+                }
+            }
+        }
+
+        // doc store tests
+        for segment_reader in searcher.segment_readers().iter() {
+            let store_reader = segment_reader
+                .get_store_reader(DOCSTORE_CACHE_CAPACITY)
+                .unwrap();
+            // test store iterator
+            for doc in store_reader.iter::<TantivyDocument>(segment_reader.alive_bitset()) {
+                let id = doc
+                    .unwrap()
+                    .get_first(id_field)
+                    .unwrap()
+                    .as_value()
+                    .as_u64()
+                    .unwrap();
+                assert!(expected_ids_and_num_occurrences.contains_key(&id));
+            }
+            // test store random access
+            for doc_id in segment_reader.doc_ids_alive() {
+                let id = store_reader
+                    .get::<TantivyDocument>(doc_id)
+                    .unwrap()
+                    .get_first(id_field)
+                    .unwrap()
+                    .as_u64()
+                    .unwrap();
+                assert!(expected_ids_and_num_occurrences.contains_key(&id));
+                if id_is_full_doc(id) {
+                    let id2 = store_reader
+                        .get::<TantivyDocument>(doc_id)
+                        .unwrap()
+                        .get_first(multi_numbers)
+                        .unwrap()
+                        .as_u64()
+                        .unwrap();
+                    assert_eq!(id, id2);
+                    let bool = store_reader
+                        .get::<TantivyDocument>(doc_id)
+                        .unwrap()
+                        .get_first(bool_field)
+                        .unwrap()
+                        .as_bool()
+                        .unwrap();
+                    let doc = store_reader.get::<TantivyDocument>(doc_id).unwrap();
+                    let mut bool2 = doc.get_all(multi_bools);
+                    assert_eq!(bool, bool2.next().unwrap().as_bool().unwrap());
+                    assert_ne!(bool, bool2.next().unwrap().as_bool().unwrap());
+                    assert!(bool2.next().is_none())
+                }
+            }
+        }
+        // test search
+        let do_search = |term: &str, field| {
+            let query = QueryParser::for_index(&index, vec![field])
+                .parse_query(term)
+                .unwrap();
+            let top_docs: Vec<(f32, DocAddress)> = searcher
+                .search(&query, &TopDocs::with_limit(1000).order_by_score())
+                .unwrap();
+
+            top_docs.iter().map(|el| el.1).collect::<Vec<_>>()
+        };
+        let count_search = |term: &str, field| {
+            let query = QueryParser::for_index(&index, vec![field])
+                .parse_query(term)
+                .unwrap();
+            searcher.search(&query, &Count).unwrap()
+        };
+
+        let count_search2 = |term: Term| {
+            let query = TermQuery::new(term, IndexRecordOption::Basic);
+            searcher.search(&query, &Count).unwrap()
+        };
+
+        for (id, count) in &expected_ids_and_num_occurrences {
+            // skip expensive queries
+            let (existing_id, count) = (*id, *count);
+            let get_num_hits = |field| count_search(&existing_id.to_string(), field) as u64;
+            assert_eq!(get_num_hits(id_field), count);
+            if !id_is_full_doc(existing_id) {
+                continue;
+            }
+            assert_eq!(get_num_hits(text_field), count);
+            assert_eq!(get_num_hits(i64_field), count);
+            assert_eq!(get_num_hits(f64_field), count);
+
+            // Test multi text
+            if num_docs_with_values < 1000 {
+                assert_eq!(
+                    do_search("\"test1 test2\"", multi_text_fields).len(),
+                    num_docs_with_values
+                );
+                assert_eq!(
+                    do_search("\"test2 test3\"", multi_text_fields).len(),
+                    num_docs_with_values
+                );
+            }
+
+            // Test bytes
+            let term = Term::from_field_bytes(bytes_field, existing_id.to_le_bytes().as_slice());
+            assert_eq!(count_search2(term) as u64, count);
+
+            // Test date
+            let term = Term::from_field_date(
+                date_field,
+                DateTime::from_timestamp_secs(existing_id as i64),
+            );
+            assert_eq!(count_search2(term) as u64, count);
+        }
+        for deleted_id in deleted_ids {
+            let assert_field = |field| {
+                assert_eq!(count_search(&deleted_id.to_string(), field) as u64, 0);
+            };
+            assert_field(text_field);
+            assert_field(f64_field);
+            assert_field(i64_field);
+            assert_field(id_field);
+
+            // Test bytes
+            let term = Term::from_field_bytes(bytes_field, deleted_id.to_le_bytes().as_slice());
+            assert_eq!(count_search2(term), 0);
+
+            // Test date
+            let term =
+                Term::from_field_date(date_field, DateTime::from_timestamp_secs(deleted_id as i64));
+            assert_eq!(count_search2(term), 0);
+        }
+        // search ip address
+        //
+        for (existing_id, count) in &expected_ids_and_num_occurrences {
+            let (existing_id, count) = (*existing_id, *count);
+            if !id_is_full_doc(existing_id) {
+                continue;
+            }
+            let do_search_ip_field = |term: &str| count_search(term, ip_field) as u64;
+            let ip_addr = Ipv6Addr::from_u128(existing_id as u128);
+            // Test incoming ip as ipv6
+            assert_eq!(do_search_ip_field(&format!("\"{ip_addr}\"")), count);
+
+            let term = Term::from_field_ip_addr(ip_field, ip_addr);
+            assert_eq!(count_search2(term) as u64, count);
+
+            // Test incoming ip as ipv4
+            if let Some(ip_addr) = ip_addr.to_ipv4_mapped() {
+                assert_eq!(do_search_ip_field(&format!("\"{ip_addr}\"")), count);
+            }
+        }
+
+        // Range query
+        //
+        // Take half as sample
+        let mut sample: Vec<_> = expected_ids_and_num_occurrences.iter().collect();
+        sample.sort_by_key(|(k, _num_occurrences)| *k);
+        // sample.truncate(sample.len() / 2);
+        if !sample.is_empty() {
+            let (left_sample, right_sample) = sample.split_at(sample.len() / 2);
+
+            let calc_expected_count = |sample: &[(&u64, &u64)]| {
+                sample
+                    .iter()
+                    .filter(|(id, _)| id_is_full_doc(**id))
+                    .map(|(_id, num_occurrences)| **num_occurrences)
+                    .sum::<u64>()
+            };
+            fn gen_query_inclusive<T1: ToString, T2: ToString>(
+                field: &str,
+                from: T1,
+                to: T2,
+            ) -> String {
+                format!("{}:[{} TO {}]", field, &from.to_string(), &to.to_string())
+            }
+
+            // Query first half
+            let expected_count = calc_expected_count(left_sample);
+            if !left_sample.is_empty() && expected_count < 1000 {
+                let start_range = *left_sample[0].0;
+                let end_range = *left_sample.last().unwrap().0;
+                let query = gen_query_inclusive("id_opt", start_range, end_range);
+                assert_eq!(count_search(&query, id_opt_field) as u64, expected_count);
+
+                // Range query on ip field
+                let ip1 = ip_from_id(start_range);
+                let ip2 = ip_from_id(end_range);
+                let do_search_ip_field = |term: &str| count_search(term, ip_field) as u64;
+                let query = gen_query_inclusive("ip", ip1, ip2);
+                assert_eq!(do_search_ip_field(&query), expected_count);
+                let query = gen_query_inclusive("ip", "*", ip2);
+                assert_eq!(do_search_ip_field(&query), expected_count);
+                // Range query on multi value field
+                let query = gen_query_inclusive("ips", ip1, ip2);
+                assert_eq!(do_search_ip_field(&query), expected_count);
+                let query = gen_query_inclusive("ips", "*", ip2);
+                assert_eq!(do_search_ip_field(&query), expected_count);
+            }
+            // Query second half
+            let expected_count = calc_expected_count(right_sample);
+            if !right_sample.is_empty() && expected_count < 1000 {
+                let start_range = *right_sample[0].0;
+                let end_range = *right_sample.last().unwrap().0;
+                // Range query on id opt field
+                let query =
+                    gen_query_inclusive("id_opt", start_range.to_string(), end_range.to_string());
+                assert_eq!(count_search(&query, id_opt_field) as u64, expected_count);
+
+                // Range query on ip field
+                let ip1 = ip_from_id(start_range);
+                let ip2 = ip_from_id(end_range);
+                let do_search_ip_field = |term: &str| count_search(term, ip_field) as u64;
+                let query = gen_query_inclusive("ip", ip1, ip2);
+                assert_eq!(do_search_ip_field(&query), expected_count);
+                let query = gen_query_inclusive("ip", ip1, "*");
+                assert_eq!(do_search_ip_field(&query), expected_count);
+                // Range query on multi value field
+                let query = gen_query_inclusive("ips", ip1, ip2);
+                assert_eq!(do_search_ip_field(&query), expected_count);
+                let query = gen_query_inclusive("ips", ip1, "*");
+                assert_eq!(do_search_ip_field(&query), expected_count);
+            }
+        }
+
+        // ip range query on fast field
+        //
+        for (existing_id, count) in expected_ids_and_num_occurrences.iter().take(10) {
+            let (existing_id, count) = (*existing_id, *count);
+            if !id_is_full_doc(existing_id) {
+                continue;
+            }
+            let gen_query_inclusive = |field: &str, from: Ipv6Addr, to: Ipv6Addr| {
+                format!("{}:[{} TO {}]", field, &from.to_string(), &to.to_string())
+            };
+            let ip = ip_from_id(existing_id);
+
+            let do_search_ip_field = |term: &str| count_search(term, ip_field) as u64;
+            // Range query on single value field
+            let query = gen_query_inclusive("ip", ip, ip);
+            assert_eq!(do_search_ip_field(&query), count);
+
+            // Range query on multi value field
+            let query = gen_query_inclusive("ips", ip, ip);
+            assert_eq!(do_search_ip_field(&query), count);
+        }
+
+        // test facets
+        for segment_reader in searcher.segment_readers().iter() {
+            let facet_reader = segment_reader.facet_reader("facet").unwrap();
+            let ff_reader = segment_reader
+                .fast_fields()
+                .u64("id")
+                .unwrap()
+                .first_or_default_col(9999);
+            for doc_id in segment_reader.doc_ids_alive() {
+                let id = ff_reader.get_val(doc_id);
+                if !id_is_full_doc(id) {
+                    continue;
+                }
+                let facet_ords: Vec<u64> = facet_reader.facet_ords(doc_id).collect();
+                assert_eq!(facet_ords.len(), 1);
+                let mut facet = Facet::default();
+                facet_reader
+                    .facet_from_ord(facet_ords[0], &mut facet)
+                    .unwrap();
+                let facet_expected = Facet::from(&("/cola/".to_string() + &id.to_string()));
+
+                assert_eq!(facet, facet_expected);
+            }
+        }
+
+        Ok(index)
+    }
+
+    #[test]
+    fn test_fast_field_range() {
+        let ops: Vec<_> = (0..1000).map(IndexingOp::add).collect();
+        assert!(test_operation_strategy(&ops, true).is_ok());
+    }
+
+    #[test]
+    fn test_ip_range_query_multivalue_bug() {
+        assert!(test_operation_strategy(
+            &[
+                IndexingOp::add(2),
+                IndexingOp::Commit,
+                IndexingOp::add(1),
+                IndexingOp::add(1),
+                IndexingOp::Commit,
+                IndexingOp::Merge
+            ],
+            false
+        )
+        .is_ok());
+    }
+
+    #[test]
+    fn test_ff_num_ips_regression() {
+        assert!(test_operation_strategy(
+            &[
+                IndexingOp::add(13),
+                IndexingOp::add(1),
+                IndexingOp::Commit,
+                IndexingOp::DeleteDocQuery { id: 13 },
+                IndexingOp::add(1),
+                IndexingOp::Commit,
+            ],
+            true
+        )
+        .is_ok());
+    }
+
+    #[test]
+    fn test_minimal_sort_force_end_merge() {
+        assert!(
+            test_operation_strategy(&[IndexingOp::add(23), IndexingOp::add(13),], false).is_ok()
+        );
+    }
+
+    #[test]
+    fn test_minimal_no_force_end_merge() {
+        assert!(test_operation_strategy(
+            &[
+                IndexingOp::add(23),
+                IndexingOp::add(13),
+                IndexingOp::DeleteDoc { id: 13 }
+            ],
+            false
+        )
+        .is_ok());
+    }
+
+    use proptest::prelude::*;
+
+    proptest! {
+
+        #![proptest_config(ProptestConfig::with_cases(20))]
+        #[test]
+        fn test_delete_proptest_adding(ops in proptest::collection::vec(adding_operation_strategy(), 1..100)) {
+            assert!(test_operation_strategy(&ops[..],  false).is_ok());
+        }
+
+        #[test]
+        fn test_delete_proptest_with_merge_adding(ops in proptest::collection::vec(adding_operation_strategy(), 1..100)) {
+            assert!(test_operation_strategy(&ops[..],  true).is_ok());
+        }
+
+        #[test]
+        fn test_delete_proptest(ops in proptest::collection::vec(balanced_operation_strategy(), 1..10)) {
+            assert!(test_operation_strategy(&ops[..],  false).is_ok());
+        }
+
+        #[test]
+        fn test_delete_proptest_with_merge(ops in proptest::collection::vec(balanced_operation_strategy(), 1..100)) {
+            assert!(test_operation_strategy(&ops[..],  true).is_ok());
+        }
+    }
+
+    #[test]
+    fn test_delete_bug_reproduction_ip_addr() {
+        use IndexingOp::*;
+        let ops = &[
+            IndexingOp::add(1),
+            IndexingOp::add(2),
+            Commit,
+            IndexingOp::add(3),
+            DeleteDoc { id: 1 },
+            Commit,
+            Merge,
+            IndexingOp::add(4),
+            Commit,
+        ];
+        test_operation_strategy(&ops[..], true).unwrap();
+    }
+
+    #[test]
+    fn test_merge_regression_1() {
+        use IndexingOp::*;
+        let ops = &[
+            IndexingOp::add(15),
+            Commit,
+            IndexingOp::add(9),
+            Commit,
+            Merge,
+        ];
+        test_operation_strategy(&ops[..], true).unwrap();
+    }
+
+    #[test]
+    fn test_range_query_bug_1() {
+        use IndexingOp::*;
+        let ops = &[
+            IndexingOp::add(9),
+            IndexingOp::add(0),
+            IndexingOp::add(13),
+            Commit,
+        ];
+        test_operation_strategy(&ops[..], true).unwrap();
+    }
+
+    #[test]
+    fn test_range_query_bug_2() {
+        let ops = &[
+            IndexingOp::add(3),
+            IndexingOp::add(6),
+            IndexingOp::add(9),
+            IndexingOp::add(10),
+        ];
+        test_operation_strategy(&ops[..], false).unwrap();
+    }
+
+    #[test]
+    fn test_index_doc_missing_field() -> crate::Result<()> {
+        let mut schema_builder = schema::Schema::builder();
+        let idfield = schema_builder.add_text_field("id", STRING);
+        schema_builder.add_text_field("optfield", STRING);
+        let index = Index::create_in_ram(schema_builder.build());
+        let mut index_writer = index.writer_for_tests()?;
+        index_writer.add_document(doc!(idfield=>"myid"))?;
+        index_writer.commit()?;
+        Ok(())
+    }
+
+    #[test]
+    fn test_bug_1617_3() {
+        assert!(test_operation_strategy(
+            &[
+                IndexingOp::DeleteDoc { id: 0 },
+                IndexingOp::add(6),
+                IndexingOp::DeleteDocQuery { id: 11 },
+                IndexingOp::Commit,
+                IndexingOp::Merge,
+                IndexingOp::Commit,
+                IndexingOp::Commit
+            ],
+            false
+        )
+        .is_ok());
+    }
+
+    #[test]
+    fn test_bug_1617_2() {
+        test_operation_strategy(
+            &[
+                IndexingOp::AddDoc {
+                    id: 13,
+                    value: Default::default(),
+                },
+                IndexingOp::DeleteDoc { id: 13 },
+                IndexingOp::Commit,
+                IndexingOp::add(30),
+                IndexingOp::Commit,
+                IndexingOp::Merge,
+            ],
+            true,
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn test_bug_1617() -> crate::Result<()> {
+        let mut schema_builder = schema::Schema::builder();
+        let id_field = schema_builder.add_u64_field("id", INDEXED);
+
+        let schema = schema_builder.build();
+        let index = Index::builder().schema(schema).create_in_ram()?;
+        let mut index_writer = index.writer_for_tests()?;
+        index_writer.set_merge_policy(Box::new(NoMergePolicy));
+
+        let existing_id = 16u64;
+        let deleted_id = 13u64;
+        index_writer.add_document(doc!(
+            id_field=>existing_id,
+        ))?;
+        index_writer.add_document(doc!(
+            id_field=>deleted_id,
+        ))?;
+        index_writer.delete_term(Term::from_field_u64(id_field, deleted_id));
+        index_writer.commit()?;
+
+        // Merge
+        {
+            assert!(index_writer.wait_merging_threads().is_ok());
+            let mut index_writer: IndexWriter = index.writer_for_tests()?;
+            let segment_ids = index
+                .searchable_segment_ids()
+                .expect("Searchable segments failed.");
+            index_writer.merge(&segment_ids).wait().unwrap();
+            assert!(index_writer.wait_merging_threads().is_ok());
+        }
+        let searcher = index.reader()?.searcher();
+
+        let query = TermQuery::new(
+            Term::from_field_u64(id_field, existing_id),
+            IndexRecordOption::Basic,
+        );
+        let top_docs: Vec<(f32, DocAddress)> = searcher
+            .search(&query, &TopDocs::with_limit(10).order_by_score())
+            .unwrap();
+
+        assert_eq!(top_docs.len(), 1); // Was failing
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_bug_1618() -> crate::Result<()> {
+        let mut schema_builder = schema::Schema::builder();
+        let id_field = schema_builder.add_i64_field("id", INDEXED);
+
+        let schema = schema_builder.build();
+        let index = Index::builder().schema(schema).create_in_ram()?;
+        let mut index_writer = index.writer_for_tests()?;
+        index_writer.set_merge_policy(Box::new(NoMergePolicy));
+
+        index_writer.add_document(doc!(
+            id_field=>10i64,
+        ))?;
+        index_writer.add_document(doc!(
+            id_field=>30i64,
+        ))?;
+        index_writer.commit()?;
+
+        // Merge
+        {
+            assert!(index_writer.wait_merging_threads().is_ok());
+            let mut index_writer: IndexWriter = index.writer_for_tests()?;
+            let segment_ids = index
+                .searchable_segment_ids()
+                .expect("Searchable segments failed.");
+            index_writer.merge(&segment_ids).wait().unwrap();
+            assert!(index_writer.wait_merging_threads().is_ok());
+        }
+        let searcher = index.reader()?.searcher();
+
+        let query = TermQuery::new(
+            Term::from_field_i64(id_field, 10i64),
+            IndexRecordOption::Basic,
+        );
+        let top_docs: Vec<(f32, DocAddress)> = searcher
+            .search(&query, &TopDocs::with_limit(10).order_by_score())
+            .unwrap();
+
+        assert_eq!(top_docs.len(), 1); // Fails
+
+        let query = TermQuery::new(
+            Term::from_field_i64(id_field, 30i64),
+            IndexRecordOption::Basic,
+        );
+        let top_docs: Vec<(f32, DocAddress)> = searcher
+            .search(&query, &TopDocs::with_limit(10).order_by_score())
+            .unwrap();
+
+        assert_eq!(top_docs.len(), 1); // Fails
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_bug_2442_reserved_character_fast_field() -> crate::Result<()> {
+        let mut schema_builder = schema::Schema::builder();
+        let json_field = schema_builder.add_json_field("json", FAST | TEXT);
+
+        let schema = schema_builder.build();
+        let index = Index::builder().schema(schema).create_in_ram()?;
+        let mut index_writer = index.writer_for_tests()?;
+        index_writer.set_merge_policy(Box::new(NoMergePolicy));
+
+        index_writer
+            .add_document(doc!(
+                json_field=>json!({"\u{0000}B":"1"})
+            ))
+            .unwrap();
+        index_writer
+            .add_document(doc!(
+                json_field=>json!({" A":"1"})
+            ))
+            .unwrap();
+        index_writer.commit()?;
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_bug_2442_reserved_character_columnar() -> crate::Result<()> {
+        let mut schema_builder = Schema::builder();
+        let options = JsonObjectOptions::from(FAST).set_expand_dots_enabled();
+        let field = schema_builder.add_json_field("json", options);
+        let index = Index::create_in_ram(schema_builder.build());
+        let mut index_writer = index.writer_for_tests().unwrap();
+        index_writer
+            .add_document(doc!(field=>json!({"\u{0000}": "A"})))
+            .unwrap();
+        index_writer
+            .add_document(doc!(field=>json!({format!("\u{0000}\u{0000}"): "A"})))
+            .unwrap();
+        index_writer.commit().unwrap();
+        Ok(())
+    }
+
+    #[test]
+    fn test_writer_options_validation() {
+        let mut schema_builder = Schema::builder();
+        let _field = schema_builder.add_bool_field("example", STORED);
+        let index = Index::create_in_ram(schema_builder.build());
+
+        let opt_wo_threads = IndexWriterOptions::builder().num_worker_threads(0).build();
+        let result = index.writer_with_options::<TantivyDocument>(opt_wo_threads);
+        assert!(result.is_err(), "Writer should reject 0 thread count");
+        assert!(matches!(result, Err(TantivyError::InvalidArgument(_))));
+
+        let opt_with_low_memory = IndexWriterOptions::builder()
+            .memory_budget_per_thread(10 << 10)
+            .build();
+        let result = index.writer_with_options::<TantivyDocument>(opt_with_low_memory);
+        assert!(
+            result.is_err(),
+            "Writer should reject options with too low memory size"
+        );
+        assert!(matches!(result, Err(TantivyError::InvalidArgument(_))));
+
+        let opt_with_low_memory = IndexWriterOptions::builder()
+            .memory_budget_per_thread(5 << 30)
+            .build();
+        let result = index.writer_with_options::<TantivyDocument>(opt_with_low_memory);
+        assert!(
+            result.is_err(),
+            "Writer should reject options with too high memory size"
+        );
+        assert!(matches!(result, Err(TantivyError::InvalidArgument(_))));
+    }
+}

--- a/tests/fixtures/comparison/samples/router.ts
+++ b/tests/fixtures/comparison/samples/router.ts
@@ -1,0 +1,565 @@
+import type { Observable } from '../observable';
+import { createRecursiveProxy } from './createProxy';
+import { defaultFormatter } from './error/formatter';
+import { getTRPCErrorFromUnknown, TRPCError } from './error/TRPCError';
+import type {
+  AnyProcedure,
+  ErrorHandlerOptions,
+  inferProcedureInput,
+  inferProcedureOutput,
+  LegacyObservableSubscriptionProcedure,
+} from './procedure';
+import type { ProcedureCallOptions } from './procedureBuilder';
+import type { AnyRootTypes, RootConfig } from './rootConfig';
+import { defaultTransformer } from './transformer';
+import type { MaybePromise, ValueOf } from './types';
+import {
+  emptyObject,
+  isFunction,
+  isObject,
+  mergeWithoutOverrides,
+} from './utils';
+
+export interface RouterRecord {
+  [key: string]: AnyProcedure | RouterRecord;
+}
+
+type DecorateProcedure<TProcedure extends AnyProcedure> = (
+  input: inferProcedureInput<TProcedure>,
+) => Promise<
+  TProcedure['_def']['type'] extends 'subscription'
+    ? TProcedure extends LegacyObservableSubscriptionProcedure<any>
+      ? Observable<inferProcedureOutput<TProcedure>, TRPCError>
+      : inferProcedureOutput<TProcedure>
+    : inferProcedureOutput<TProcedure>
+>;
+
+/**
+ * @internal
+ */
+export type DecorateRouterRecord<TRecord extends RouterRecord> = {
+  [TKey in keyof TRecord]: TRecord[TKey] extends infer $Value
+    ? $Value extends AnyProcedure
+      ? DecorateProcedure<$Value>
+      : $Value extends RouterRecord
+        ? DecorateRouterRecord<$Value>
+        : never
+    : never;
+};
+
+/**
+ * @internal
+ */
+
+export type RouterCallerErrorHandler<TContext> = (
+  opts: ErrorHandlerOptions<TContext>,
+) => void;
+
+/**
+ * @internal
+ */
+export type RouterCaller<
+  TRoot extends AnyRootTypes,
+  TRecord extends RouterRecord,
+> = (
+  /**
+   * @note
+   * If passing a function, we recommend it's a cached function
+   * e.g. wrapped in `React.cache` to avoid unnecessary computations
+   */
+  ctx: TRoot['ctx'] | (() => MaybePromise<TRoot['ctx']>),
+  options?: {
+    onError?: RouterCallerErrorHandler<TRoot['ctx']>;
+    signal?: AbortSignal;
+  },
+) => DecorateRouterRecord<TRecord>;
+
+/**
+ * @internal
+ */
+const lazyMarker = 'lazyMarker' as 'lazyMarker' & {
+  __brand: 'lazyMarker';
+};
+export type Lazy<TAny> = (() => Promise<TAny>) & { [lazyMarker]: true };
+
+type LazyLoader<TAny> = {
+  load: () => Promise<void>;
+  ref: Lazy<TAny>;
+};
+
+function once<T>(fn: () => T): () => T {
+  const uncalled = Symbol();
+  let result: T | typeof uncalled = uncalled;
+  return (): T => {
+    if (result === uncalled) {
+      result = fn();
+    }
+    return result;
+  };
+}
+
+/**
+ * Lazy load a router
+ * @see https://trpc.io/docs/server/merging-routers#lazy-load
+ */
+export function lazy<TRouter extends AnyRouter>(
+  importRouter: () => Promise<
+    | TRouter
+    | {
+        [key: string]: TRouter;
+      }
+  >,
+): Lazy<NoInfer<TRouter>> {
+  async function resolve(): Promise<TRouter> {
+    const mod = await importRouter();
+
+    // if the module is a router, return it
+    if (isRouter(mod)) {
+      return mod;
+    }
+
+    const routers = Object.values(mod);
+
+    if (routers.length !== 1 || !isRouter(routers[0])) {
+      throw new Error(
+        "Invalid router module - either define exactly 1 export or return the router directly.\nExample: `lazy(() => import('./slow.js').then((m) => m.slowRouter))`",
+      );
+    }
+
+    return routers[0];
+  }
+
+  (resolve as Lazy<NoInfer<TRouter>>)[lazyMarker] = true as const;
+
+  return resolve as Lazy<NoInfer<TRouter>>;
+}
+
+function isLazy<TAny>(input: unknown): input is Lazy<TAny> {
+  return typeof input === 'function' && lazyMarker in input;
+}
+
+/**
+ * @internal
+ */
+export interface RouterDef<
+  TRoot extends AnyRootTypes,
+  TRecord extends RouterRecord,
+> {
+  _config: RootConfig<TRoot>;
+  router: true;
+  procedure?: never;
+  procedures: TRecord;
+  record: TRecord;
+  lazy: Record<string, LazyLoader<AnyRouter>>;
+}
+
+export interface Router<
+  TRoot extends AnyRootTypes,
+  TRecord extends RouterRecord,
+> {
+  _def: RouterDef<TRoot, TRecord>;
+  /**
+   * @see https://trpc.io/docs/v11/server/server-side-calls
+   */
+  createCaller: RouterCaller<TRoot, TRecord>;
+}
+
+export type BuiltRouter<
+  TRoot extends AnyRootTypes,
+  TRecord extends RouterRecord,
+> = Router<TRoot, TRecord> & TRecord;
+
+export interface RouterBuilder<TRoot extends AnyRootTypes> {
+  <TIn extends CreateRouterOptions>(
+    _: TIn,
+  ): BuiltRouter<TRoot, DecorateCreateRouterOptions<TIn>>;
+}
+
+export type AnyRouter = Router<any, any>;
+
+export type inferRouterRootTypes<TRouter extends AnyRouter> =
+  TRouter['_def']['_config']['$types'];
+
+export type inferRouterContext<TRouter extends AnyRouter> =
+  inferRouterRootTypes<TRouter>['ctx'];
+export type inferRouterError<TRouter extends AnyRouter> =
+  inferRouterRootTypes<TRouter>['errorShape'];
+export type inferRouterMeta<TRouter extends AnyRouter> =
+  inferRouterRootTypes<TRouter>['meta'];
+
+function isRouter(value: unknown): value is AnyRouter {
+  return (
+    isObject(value) && isObject(value['_def']) && 'router' in value['_def']
+  );
+}
+
+const emptyRouter = {
+  _ctx: null as any,
+  _errorShape: null as any,
+  _meta: null as any,
+  queries: {},
+  mutations: {},
+  subscriptions: {},
+  errorFormatter: defaultFormatter,
+  transformer: defaultTransformer,
+};
+
+/**
+ * Reserved words that can't be used as router or procedure names
+ */
+const reservedWords = [
+  /**
+   * Then is a reserved word because otherwise we can't return a promise that returns a Proxy
+   * since JS will think that `.then` is something that exists
+   */
+  'then',
+  /**
+   * `fn.call()` and `fn.apply()` are reserved words because otherwise we can't call a function using `.call` or `.apply`
+   */
+  'call',
+  'apply',
+];
+
+/** @internal */
+export type CreateRouterOptions = {
+  [key: string]:
+    | AnyProcedure
+    | AnyRouter
+    | CreateRouterOptions
+    | Lazy<AnyRouter>;
+};
+
+/** @internal */
+export type DecorateCreateRouterOptions<
+  TRouterOptions extends CreateRouterOptions,
+> = {
+  [K in keyof TRouterOptions]: TRouterOptions[K] extends infer $Value
+    ? $Value extends AnyProcedure
+      ? $Value
+      : $Value extends Router<any, infer TRecord>
+        ? TRecord
+        : $Value extends Lazy<Router<any, infer TRecord>>
+          ? TRecord
+          : $Value extends CreateRouterOptions
+            ? DecorateCreateRouterOptions<$Value>
+            : never
+    : never;
+};
+
+/**
+ * @internal
+ */
+export function createRouterFactory<TRoot extends AnyRootTypes>(
+  config: RootConfig<TRoot>,
+) {
+  function createRouterInner<TInput extends CreateRouterOptions>(
+    input: TInput,
+  ): BuiltRouter<TRoot, DecorateCreateRouterOptions<TInput>> {
+    const reservedWordsUsed = new Set(
+      Object.keys(input).filter((v) => reservedWords.includes(v)),
+    );
+    if (reservedWordsUsed.size > 0) {
+      throw new Error(
+        'Reserved words used in `router({})` call: ' +
+          Array.from(reservedWordsUsed).join(', '),
+      );
+    }
+
+    const procedures: Record<string, AnyProcedure> = emptyObject();
+    const lazy: Record<string, LazyLoader<AnyRouter>> = emptyObject();
+
+    function createLazyLoader(opts: {
+      ref: Lazy<AnyRouter>;
+      path: readonly string[];
+      key: string;
+      aggregate: RouterRecord;
+    }): LazyLoader<AnyRouter> {
+      return {
+        ref: opts.ref,
+        load: once(async () => {
+          const router = await opts.ref();
+          const lazyPath = [...opts.path, opts.key];
+          const lazyKey = lazyPath.join('.');
+
+          opts.aggregate[opts.key] = step(router._def.record, lazyPath);
+
+          delete lazy[lazyKey];
+
+          // add lazy loaders for nested routers
+          for (const [nestedKey, nestedItem] of Object.entries(
+            router._def.lazy,
+          )) {
+            const nestedRouterKey = [...lazyPath, nestedKey].join('.');
+
+            // console.log('adding lazy', nestedRouterKey);
+            lazy[nestedRouterKey] = createLazyLoader({
+              ref: nestedItem.ref,
+              path: lazyPath,
+              key: nestedKey,
+              aggregate: opts.aggregate[opts.key] as RouterRecord,
+            });
+          }
+        }),
+      };
+    }
+
+    function step(from: CreateRouterOptions, path: readonly string[] = []) {
+      const aggregate: RouterRecord = emptyObject();
+      for (const [key, item] of Object.entries(from ?? {})) {
+        if (isLazy(item)) {
+          lazy[[...path, key].join('.')] = createLazyLoader({
+            path,
+            ref: item,
+            key,
+            aggregate,
+          });
+          continue;
+        }
+        if (isRouter(item)) {
+          aggregate[key] = step(item._def.record, [...path, key]);
+          continue;
+        }
+        if (!isProcedure(item)) {
+          // RouterRecord
+          aggregate[key] = step(item, [...path, key]);
+          continue;
+        }
+
+        const newPath = [...path, key].join('.');
+
+        if (procedures[newPath]) {
+          throw new Error(`Duplicate key: ${newPath}`);
+        }
+
+        procedures[newPath] = item;
+        aggregate[key] = item;
+      }
+
+      return aggregate;
+    }
+    const record = step(input);
+
+    const _def: AnyRouter['_def'] = {
+      _config: config,
+      router: true,
+      procedures,
+      lazy,
+      ...emptyRouter,
+      record,
+    };
+
+    const router: BuiltRouter<TRoot, {}> = {
+      ...(record as {}),
+      _def,
+      createCaller: createCallerFactory<TRoot>()({
+        _def,
+      }),
+    };
+    return router as BuiltRouter<TRoot, DecorateCreateRouterOptions<TInput>>;
+  }
+
+  return createRouterInner;
+}
+
+function isProcedure(
+  procedureOrRouter: ValueOf<CreateRouterOptions>,
+): procedureOrRouter is AnyProcedure {
+  return typeof procedureOrRouter === 'function';
+}
+
+/**
+ * @internal
+ */
+export async function getProcedureAtPath(
+  router: Pick<Router<any, any>, '_def'>,
+  path: string,
+): Promise<AnyProcedure | null> {
+  const { _def } = router;
+  let procedure = _def.procedures[path];
+
+  while (!procedure) {
+    const key = Object.keys(_def.lazy).find((key) => path.startsWith(key));
+    // console.log(`found lazy: ${key ?? 'NOPE'} (fullPath: ${fullPath})`);
+
+    if (!key) {
+      return null;
+    }
+    // console.log('loading', key, '.......');
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    const lazyRouter = _def.lazy[key]!;
+    await lazyRouter.load();
+
+    procedure = _def.procedures[path];
+  }
+
+  return procedure;
+}
+
+/**
+ * @internal
+ */
+export async function callProcedure(
+  opts: ProcedureCallOptions<unknown> & {
+    router: AnyRouter;
+    allowMethodOverride?: boolean;
+  },
+) {
+  const { type, path } = opts;
+  const proc = await getProcedureAtPath(opts.router, path);
+  if (
+    !proc ||
+    !isProcedure(proc) ||
+    (proc._def.type !== type && !opts.allowMethodOverride)
+  ) {
+    throw new TRPCError({
+      code: 'NOT_FOUND',
+      message: `No "${type}"-procedure on path "${path}"`,
+    });
+  }
+
+  /* istanbul ignore if -- @preserve */
+  if (
+    proc._def.type !== type &&
+    opts.allowMethodOverride &&
+    proc._def.type === 'subscription'
+  ) {
+    throw new TRPCError({
+      code: 'METHOD_NOT_SUPPORTED',
+      message: `Method override is not supported for subscriptions`,
+    });
+  }
+
+  return proc(opts);
+}
+
+export interface RouterCallerFactory<TRoot extends AnyRootTypes> {
+  <TRecord extends RouterRecord>(
+    router: Pick<Router<TRoot, TRecord>, '_def'>,
+  ): RouterCaller<TRoot, TRecord>;
+}
+
+export function createCallerFactory<
+  TRoot extends AnyRootTypes,
+>(): RouterCallerFactory<TRoot> {
+  return function createCallerInner<TRecord extends RouterRecord>(
+    router: Pick<Router<TRoot, TRecord>, '_def'>,
+  ): RouterCaller<TRoot, TRecord> {
+    const { _def } = router;
+    type Context = TRoot['ctx'];
+
+    return function createCaller(ctxOrCallback, opts) {
+      return createRecursiveProxy<ReturnType<RouterCaller<any, any>>>(
+        async (innerOpts) => {
+          const { path, args } = innerOpts;
+          const fullPath = path.join('.');
+
+          if (path.length === 1 && path[0] === '_def') {
+            return _def;
+          }
+
+          const procedure = await getProcedureAtPath(router, fullPath);
+
+          let ctx: Context | undefined = undefined;
+          try {
+            if (!procedure) {
+              throw new TRPCError({
+                code: 'NOT_FOUND',
+                message: `No procedure found on path "${path}"`,
+              });
+            }
+            ctx = isFunction(ctxOrCallback)
+              ? await Promise.resolve(ctxOrCallback())
+              : ctxOrCallback;
+
+            return await procedure({
+              path: fullPath,
+              getRawInput: async () => args[0],
+              ctx,
+              type: procedure._def.type,
+              signal: opts?.signal,
+              batchIndex: 0,
+            });
+          } catch (cause) {
+            opts?.onError?.({
+              ctx,
+              error: getTRPCErrorFromUnknown(cause),
+              input: args[0],
+              path: fullPath,
+              type: procedure?._def.type ?? 'unknown',
+            });
+            throw cause;
+          }
+        },
+      );
+    };
+  };
+}
+
+/** @internal */
+export type MergeRouters<
+  TRouters extends AnyRouter[],
+  TRoot extends AnyRootTypes = TRouters[0]['_def']['_config']['$types'],
+  TRecord extends RouterRecord = {},
+> = TRouters extends [
+  infer Head extends AnyRouter,
+  ...infer Tail extends AnyRouter[],
+]
+  ? MergeRouters<Tail, TRoot, Head['_def']['record'] & TRecord>
+  : BuiltRouter<TRoot, TRecord>;
+
+export function mergeRouters<TRouters extends AnyRouter[]>(
+  ...routerList: [...TRouters]
+): MergeRouters<TRouters> {
+  const record = mergeWithoutOverrides(
+    {},
+    ...routerList.map((r) => r._def.record),
+  );
+  const errorFormatter = routerList.reduce(
+    (currentErrorFormatter, nextRouter) => {
+      if (
+        nextRouter._def._config.errorFormatter &&
+        nextRouter._def._config.errorFormatter !== defaultFormatter
+      ) {
+        if (
+          currentErrorFormatter !== defaultFormatter &&
+          currentErrorFormatter !== nextRouter._def._config.errorFormatter
+        ) {
+          throw new Error('You seem to have several error formatters');
+        }
+        return nextRouter._def._config.errorFormatter;
+      }
+      return currentErrorFormatter;
+    },
+    defaultFormatter,
+  );
+
+  const transformer = routerList.reduce((prev, current) => {
+    if (
+      current._def._config.transformer &&
+      current._def._config.transformer !== defaultTransformer
+    ) {
+      if (
+        prev !== defaultTransformer &&
+        prev !== current._def._config.transformer
+      ) {
+        throw new Error('You seem to have several transformers');
+      }
+      return current._def._config.transformer;
+    }
+    return prev;
+  }, defaultTransformer);
+
+  const router = createRouterFactory({
+    errorFormatter,
+    transformer,
+    isDev: routerList.every((r) => r._def._config.isDev),
+    allowOutsideOfServer: routerList.every(
+      (r) => r._def._config.allowOutsideOfServer,
+    ),
+    isServer: routerList.every((r) => r._def._config.isServer),
+    $types: routerList[0]?._def._config.$types,
+    sse: routerList[0]?._def._config.sse,
+  })(record);
+
+  return router as MergeRouters<TRouters>;
+}


### PR DESCRIPTION
## Summary

- **Skip-list gate**: ~70 well-known libraries (serde, tokio, React, Django, etc.) are skipped immediately — the LLM already knows them from training data
- **Usage relevance gate**: deps the file barely touches (0-1 imports) get reduced or zero enrichment budget
- **Doc quality gate**: Context7 benchmark score + snippet count must pass threshold before tokens are spent
- **Popularity tiers (Phase 2, opt-in)**: `--live-registry` flag enables download-count lookups from crates.io/npm/PyPI to tier token budgets for the long tail
- **Telemetry**: `context7_skipped_popular` and `context7_budget_reduced` counters in reviews.jsonl and `--trace` output

Resolves the followup tuning noted in #29 — enrichment is now precision-targeted instead of always-on.

## Architecture

Three-layer decision pipeline per dependency:

```
dep in file → usage gate → skip-list → popularity tier → quality gate → token budget (0-3000)
```

| Signal | Source | Effect |
|--------|--------|--------|
| Usage relevance | Import count from hydration | None/Low = skip/reduce |
| Mainstream skip-list | Bundled ~70 libs | Skip entirely |
| Popularity tier | Registry download counts (opt-in) | VeryHigh/High=0, Medium=1500, Low=3000 |
| Doc quality | Context7 benchmark + snippets | Gate + budget multiplier |

## Test plan

- [x] 1346 tests pass (32 new)
- [x] Backward-compat: old telemetry rows deserialize with new fields defaulting to 0
- [x] Integration: mainstream dep (serde) skipped, niche dep (fastembed) enriched
- [x] Curated frameworks (HA/ESPHome) bypass policy
- [ ] Manual: `cargo run -- review src/enrichment_policy.rs` — verify serde/tokio not enriched
- [ ] Manual: `cargo run -- review` on a file using a niche dep — verify enrichment fires

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Live registry option to enable on-demand package-registry lookups (crates.io, npm, PyPI).
  * Policy-aware enrichment that skips mainstream deps, assigns per-dependency token budgets using popularity/usage/quality signals.
  * Dependency resolution now surfaces richer metadata (scores, snippet counts, reputation).

* **Chores**
  * Telemetry extended with skipped-popular and budget-reduced counters.

* **Tests**
  * Added precision-targeting baselines, comparison fixtures, and unit/integration tests covering policy and registry behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jsnyder/quorum/pull/287)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->