### PR TITLE
chore: bump to v0.21.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,35 @@
 
 ## [Unreleased]
 
+## [0.21.0] - 2026-05-10
+
+### Review quality
+
+- **Confidence decoupled from LLM self-report (#249, #266).** Finding confidence is now computed from objective signals (AST grounding, ensemble agreement) rather than trusting the LLM's self-assessed confidence score. Removes a source of miscalibration where models reported high confidence on hallucinated findings.
+
+- **Cross-model ensemble agreement (#248, #267).** When `--ensemble` is used, model agreement across families is captured as a confidence signal. Findings confirmed by multiple independent models receive higher confidence; single-model findings are flagged.
+
+- **Grounding confidence signal (#256).** Grounding no longer demotes severity directly. Instead, grounding results feed into the confidence signal, allowing downstream consumers to filter by confidence without losing severity information.
+
+- **Hydration-aware grounding (#259, #260).** Grounder now checks hydration context for symbol existence before penalizing. Diff-fallback warning narrowed to actual path-resolution failures, eliminating false warnings on non-git-repo reviews.
+
+- **max_tokens cap removed (#247, #255).** Removed hardcoded `max_tokens: 16384` from LLM calls. A/B testing showed the cap subtly altered model behavior even when output didn't approach the limit. The `finish_reason=length` truncation guard remains as a safety net.
+
 ### Feedback
 
-- **Per-file few-shot scoping (#124).** Few-shot precedent retrieval now boosts same-file candidates (+0.05 additive similarity bonus) and reserves at least one selection slot for same-file precedents when available. Prevents cross-file feedback from silently displacing relevant precedents. Deterministic tie-breaking by `(similarity, timestamp, file_path)` ensures stable retrieval across runs.
+- **Few-shot selection bias fix (#264).** Eliminated TP-first selection bias in few-shot precedent retrieval. Previously, TP precedents were always selected first, which could crowd out FP precedents that would have provided useful negative signal. Now uses interleaved selection for balanced TP/FP representation.
 
-- **Per-file calibrator boost (#124).** Same-file feedback entries now carry +0.05 additional similarity weight in the calibrator's suppress/boost weight accumulation. Applied after the embedding threshold filter (cannot rescue sub-threshold entries). Calibrator traces include `same_file_precedent_count` and per-precedent `same_file` / `effective_similarity` for observability. `normalize_file_path` and `SAME_FILE_BOOST` extracted to shared `file_util` module.
+- **Per-file few-shot scoping (#124, #286).** Few-shot precedent retrieval now boosts same-file candidates (+0.05 additive similarity bonus) and reserves at least one selection slot for same-file precedents when available. Prevents cross-file feedback from silently displacing relevant precedents. Deterministic tie-breaking by `(similarity, timestamp, file_path)` ensures stable retrieval across runs.
+
+- **Per-file calibrator boost (#124, #293).** Same-file feedback entries now carry +0.05 additional similarity weight in the calibrator's suppress/boost weight accumulation. Applied after the embedding threshold filter (cannot rescue sub-threshold entries). Calibrator traces include `same_file_precedent_count` and per-precedent `same_file` / `effective_similarity` for observability. `normalize_file_path` and `SAME_FILE_BOOST` extracted to shared `file_util` module.
+
+### Context7
+
+- **Precision targeting (#287).** Three-layer decision pipeline for Context7 enrichment: usage gate (must appear in imports), skip-list for mainstream libs (~70 entries), and popularity-tier token budgets. `--live-registry` flag enables download-count lookups (crates.io/npm/PyPI, cached 7d). New telemetry: `context7_skipped_popular`, `context7_budget_reduced`.
+
+### Stats
+
+- **File hotspot view (#18, #274).** `quorum stats --by-file` ranks files by finding frequency from the feedback corpus. `--top N` limits output rows. Useful for identifying files that consistently attract findings.
 
 ## [0.20.0] - 2026-05-07
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,14 +10,21 @@ git config core.hooksPath .githooks    # enable pre-commit hooks (fmt, clippy, c
 
 ```bash
 cargo build                    # compile
-cargo test --bin quorum        # run unit tests (662 tests)
+cargo test --bin quorum        # run unit tests (1363 tests)
 cargo test                     # run all tests (includes CLI integration)
 cargo build --release          # release build (31MB binary)
 cargo run -- version           # check version
 cargo run -- review src/main.rs              # review a file
 cargo run -- review src/*.rs --json          # JSON output (grouped by file)
+cargo run -- review src/*.rs --ensemble      # cross-model ensemble review
+cargo run -- review file.rs --mode plan      # review mode: code (default), plan, docs
+cargo run -- review file.rs --skip-context7  # skip Context7 framework enrichment
+cargo run -- review file.rs --live-registry  # enable download-count popularity lookups
+cargo run -- review file.rs --framework home-assistant  # override framework detection
 cargo run -- stats --by-repo                 # dimensional stats by repo
 cargo run -- stats --by-caller               # dimensional stats by caller
+cargo run -- stats --by-file                 # file hotspot ranking from feedback
+cargo run -- stats --by-file --top 10        # top N file hotspots
 cargo run -- stats --rolling 50              # rolling 50-review windows
 cargo run -- review file.yaml --deep         # multi-turn agent loop
 cargo run -- review file.rs --diff-file d.patch  # change-scoped review
@@ -34,6 +41,7 @@ QUORUM_BASE_URL=https://litellm.example.com   # OpenAI-compatible endpoint
 QUORUM_API_KEY=sk-...                          # enables LLM review
 QUORUM_MODEL=gpt-5.4                           # default model
 QUORUM_ENSEMBLE_MODELS=gpt-5.4,gemini-2.5-pro  # for --ensemble
+QUORUM_CONTEXT7_LIVE_REGISTRY=1                # enable live registry lookups (alt: --live-registry flag)
 
 # HTTP timeouts (#117, v0.18.0+)
 QUORUM_HTTP_TIMEOUT=300        # total request timeout, seconds (default 300)
@@ -115,6 +123,8 @@ The recency weight is `exp(-age_days / τ)` so half-life ≈ τ × ln 2. `fp_kin
 
 **pyproject.toml precedence:** `[project].dependencies` (PEP 621) wins over `[tool.poetry.dependencies]`. Either section *present but with the wrong TOML type* (e.g. a string instead of an array/table) is treated as "explicitly empty" — we do **not** fall back to `requirements.txt`, since the user clearly intended to declare deps in pyproject. A warning is logged via `tracing::warn` so the malformed manifest is visible. Falling through would silently surface stale or unrelated deps.
 
+**Precision targeting (v0.21.0+, #287):** three-layer decision pipeline filters enrichment to reduce noise. Layer 1: usage gate (dep must appear in the file's imports). Layer 2: skip-list for ~70 mainstream libs (React, lodash, etc.) whose docs add bulk without novelty. Layer 3: popularity-tier token budgets (niche libs get full budget, popular libs get reduced). `--live-registry` or `QUORUM_CONTEXT7_LIVE_REGISTRY=1` enables download-count lookups (crates.io/npm/PyPI, cached 7d) for data-driven tier assignment. New telemetry: `context7_skipped_popular`, `context7_budget_reduced`.
+
 **Bootstrap failure (CR8):** when `Context7HttpFetcher::new()` fails at `run_review` start, `PipelineConfig.context7_disabled` is set to `true` and per-file enrichment is skipped cleanly via the `context7_skip_reason` predicate in `src/pipeline.rs`. Without this, each file would re-fail `Context7HttpFetcher::new()?` and abort the whole review.
 
 ## Context Injection (v0.16.0+)
@@ -131,4 +141,4 @@ The `context7_resolved`, `context7_resolve_failed`, and `context7_query_failed` 
 
 `invoked_from` auto-detected from env vars (`CLAUDE_CODE`, `CODEX_CI`, `GEMINI_CLI`, `AGENT`, else tty/pipe) or overridden with `--caller <name>`.
 
-Dimensional views aggregate this log: `stats --by-repo`, `--by-caller`, `--rolling N`. Sample-size gate at `MIN_SAMPLE=5`. Human output uses inline semigraphics (`█·` bars, `▁▂▃▄▅▆▇█` sparklines, ↑↓→ arrows) with ASCII fallback; compact mode is glyph-free single-line.
+Dimensional views aggregate this log: `stats --by-repo`, `--by-caller`, `--by-file`, `--rolling N`. `--by-file` ranks files by finding frequency from feedback (hotspot detection); `--top N` limits output rows. Sample-size gate at `MIN_SAMPLE=5`. Human output uses inline semigraphics (`█·` bars, `▁▂▃▄▅▆▇█` sparklines, ↑↓→ arrows) with ASCII fallback; compact mode is glyph-free single-line.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2713,7 +2713,7 @@ checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quorum"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quorum"
-version = "0.20.0"
+version = "0.21.0"
 edition = "2024"
 # `str::floor_char_boundary` (used in src/agent.rs and src/tools.rs to
 # truncate UTF-8 safely) stabilized in Rust 1.93. Older constraints —


### PR DESCRIPTION
## Summary

- Bump version to 0.21.0
- Add changelog entries for all features shipped since v0.20.0
- Update CLAUDE.md: new CLI flags (`--ensemble`, `--by-file`, `--top`, `--skip-context7`, `--live-registry`, `--framework`, `--mode`), test count (662 -> 1363), Context7 precision targeting docs, `--by-file` stats docs

## What's in v0.21.0

### Review quality
- Confidence decoupled from LLM self-report (#249, #266)
- Cross-model ensemble agreement (#248, #267)
- Grounding confidence signal replaces severity demotion (#256)
- Hydration-aware grounding (#259, #260)
- max_tokens cap removed (#247, #255)

### Feedback
- Few-shot selection bias fix (#264)
- Per-file few-shot scoping (#124, #286)
- Per-file calibrator boost (#124, #293)

### Context7
- Precision targeting: skip-list, popularity tiers, token budgets (#287)

### Stats
- File hotspot view: `--by-file` / `--top N` (#18, #274)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>