### PR TITLE
fix: squash 5 quick-win bugs (#241, #270, #276, #288, #291)

### DIFF
--- a/src/calibrator.rs
+++ b/src/calibrator.rs
@@ -177,6 +177,24 @@ struct CoreDecision {
 /// Returns a [`CoreDecision`] that the caller uses to update counters and
 /// decide whether to keep the finding in the output vec.
 #[allow(clippy::too_many_arguments)]
+fn sanitize_threshold(t: Option<f64>) -> Option<f64> {
+    t.and_then(|v| {
+        if !v.is_finite() {
+            tracing::warn!(
+                raw = v,
+                "non-finite threshold replaced with None (legacy fallback)"
+            );
+            None
+        } else if !(0.0..=1.0).contains(&v) {
+            let clamped = v.clamp(0.0, 1.0);
+            tracing::warn!(raw = v, clamped, "threshold outside [0,1] clamped");
+            Some(clamped)
+        } else {
+            Some(v)
+        }
+    })
+}
+
 fn calibrate_core_decision(
     finding: &mut Finding,
     config: &CalibratorConfig,
@@ -192,13 +210,17 @@ fn calibrate_core_decision(
     let mut suppressed = false;
     let mut boosted = false;
 
+    let force_threshold = sanitize_threshold(config.force_threshold);
+    let suppress_threshold = sanitize_threshold(config.suppress_threshold);
+    let boost_threshold = sanitize_threshold(config.boost_threshold);
+
     // PR3: compute score once for data-driven threshold decisions.
     let total = tp_weight + fp_weight;
     let score = if total > 0.0 { tp_weight / total } else { 0.5 };
 
     // Full suppress: FP weight only. Wontfix no longer contributes.
     let full_suppress_weight = fp_weight;
-    let suppress_thresh = config.force_threshold.or(config.suppress_threshold);
+    let suppress_thresh = force_threshold.or(suppress_threshold);
     if let Some(thresh) = suppress_thresh {
         // Data-driven path: suppress when score is below the threshold and
         // there is at least some FP evidence.
@@ -265,7 +287,7 @@ fn calibrate_core_decision(
     }
 
     // Boost: TP clearly dominates FP.
-    let boost_thresh = config.force_threshold.or(config.boost_threshold);
+    let boost_thresh = force_threshold.or(boost_threshold);
     let boost_triggered = if let Some(thresh) = boost_thresh {
         // Data-driven path: boost when score is at or above the threshold
         // and there is at least some TP evidence.
@@ -4748,6 +4770,74 @@ mod tests {
         assert!(
             trace.matched_precedents[0].same_file,
             "review path 'src/a.rs' should match entry path './src/a.rs' after normalization",
+        );
+    }
+
+    // -------------------------------------------------------------------
+    // Threshold validation tests (#291)
+    // -------------------------------------------------------------------
+
+    #[test]
+    fn out_of_range_boost_threshold_clamped_allows_pure_tp_boost() {
+        // #291: boost_threshold=1.5 means score (max 1.0) can never reach it,
+        // so pure-TP findings silently never boost. After clamping to 1.0,
+        // score=1.0 >= 1.0 triggers boost.
+        let mut finding = FindingBuilder::new()
+            .title("SQL injection via user input")
+            .category(Category::Security)
+            .severity(Severity::Medium)
+            .build();
+        let config = CalibratorConfig {
+            boost_threshold: Some(1.5),
+            ..Default::default()
+        };
+        // tp=1.0, fp=0.0 -> score = 1.0
+        let decision = calibrate_core_decision(
+            &mut finding,
+            &config,
+            1.0,
+            0.0,
+            0.0,
+            0.0,
+            vec![],
+            Severity::Medium,
+            "",
+        );
+        assert!(
+            decision.boosted,
+            "boost_threshold > 1.0 should be clamped to 1.0; pure TP must boost"
+        );
+    }
+
+    #[test]
+    fn nan_suppress_threshold_falls_back_to_legacy() {
+        // NaN threshold enters data-driven path but NaN comparison always fails,
+        // silently disabling BOTH data-driven and legacy suppress. With the fix,
+        // NaN is treated as None, enabling the legacy path.
+        let mut finding = FindingBuilder::new()
+            .title("test finding")
+            .category(Category::Security)
+            .severity(Severity::High)
+            .build();
+        let config = CalibratorConfig {
+            suppress_threshold: Some(f64::NAN),
+            ..Default::default()
+        };
+        // tp=0.0, fp=2.0 -> legacy: fp=2.0 >= 1.5 && fp > tp*2 -> suppress.
+        let decision = calibrate_core_decision(
+            &mut finding,
+            &config,
+            0.0,
+            2.0,
+            0.0,
+            2.0,
+            vec![],
+            Severity::High,
+            "",
+        );
+        assert!(
+            decision.suppressed,
+            "NaN threshold should fall back to legacy which suppresses at fp=2.0"
         );
     }
 }

--- a/src/calibrator.rs
+++ b/src/calibrator.rs
@@ -195,6 +195,7 @@ fn sanitize_threshold(t: Option<f64>) -> Option<f64> {
     })
 }
 
+#[allow(clippy::too_many_arguments)]
 fn calibrate_core_decision(
     finding: &mut Finding,
     config: &CalibratorConfig,

--- a/src/context_enrichment.rs
+++ b/src/context_enrichment.rs
@@ -766,6 +766,7 @@ fn parse_context7_body(body_text: &str, max_tokens: usize) -> Option<String> {
                 return Some(combined);
             }
         }
+        return None;
     }
 
     let truncated: String = body_text.chars().take(max_tokens * 4).collect();
@@ -2005,8 +2006,6 @@ axum = "0.7"
     fn parse_context7_body_empty_content_and_snippets_returns_none_for_json() {
         let body = r#"{"content":"","snippets":[]}"#;
         let result = parse_context7_body(body, 4000);
-        // Empty content + empty snippets in JSON → falls through to raw truncation,
-        // but the raw text is valid JSON so it gets returned as-is.
-        assert!(result.is_some());
+        assert!(result.is_none());
     }
 }

--- a/src/context_enrichment.rs
+++ b/src/context_enrichment.rs
@@ -124,6 +124,7 @@ fn parse_rust_use(stmt: &str) -> Vec<String> {
 
 fn first_use_segment(s: &str) -> Option<String> {
     let head = s.split("::").find(|seg| !seg.is_empty())?.trim();
+    let head = head.split_whitespace().next().unwrap_or(head);
     (!head.is_empty()).then(|| head.to_string())
 }
 
@@ -740,32 +741,35 @@ impl ContextFetcher for Context7HttpFetcher {
             }
         };
 
-        if body_text.trim().is_empty() {
-            return None;
-        }
-
-        // Context7 API may return plain text/markdown or JSON
-        if let Ok(json) = serde_json::from_str::<serde_json::Value>(&body_text) {
-            if let Some(content) = json["content"].as_str()
-                && !content.is_empty()
-            {
-                return Some(content.to_string());
-            }
-            if let Some(snippets) = json["snippets"].as_array() {
-                let combined: String = snippets
-                    .iter()
-                    .filter_map(|s| s["content"].as_str())
-                    .collect::<Vec<_>>()
-                    .join("\n\n---\n\n");
-                if !combined.is_empty() {
-                    return Some(combined);
-                }
-            }
-        }
-
-        let truncated: String = body_text.chars().take(max_tokens * 4).collect();
-        Some(truncated)
+        parse_context7_body(&body_text, max_tokens)
     }
+}
+
+fn parse_context7_body(body_text: &str, max_tokens: usize) -> Option<String> {
+    if body_text.trim().is_empty() {
+        return None;
+    }
+
+    if let Ok(json) = serde_json::from_str::<serde_json::Value>(body_text) {
+        if let Some(content) = json["content"].as_str()
+            && !content.trim().is_empty()
+        {
+            return Some(content.to_string());
+        }
+        if let Some(snippets) = json["snippets"].as_array() {
+            let combined: String = snippets
+                .iter()
+                .filter_map(|s| s["content"].as_str())
+                .collect::<Vec<_>>()
+                .join("\n\n---\n\n");
+            if !combined.is_empty() {
+                return Some(combined);
+            }
+        }
+    }
+
+    let truncated: String = body_text.chars().take(max_tokens * 4).collect();
+    Some(truncated)
 }
 
 #[cfg(test)]
@@ -975,6 +979,25 @@ mod tests {
             normalize_import_to_dep_names("HashMap: use ::std::collections::HashMap;"),
             vec!["std"]
         );
+    }
+
+    #[test]
+    fn normalize_rust_hydration_form_handles_aliased_use() {
+        // #288: `use chrono as time_lib;` must extract "chrono", not "chrono as time_lib".
+        assert_eq!(
+            normalize_import_to_dep_names("time_lib: use chrono as time_lib;"),
+            vec!["chrono"]
+        );
+        assert_eq!(
+            normalize_import_to_dep_names("tl: use chrono as tl;"),
+            vec!["chrono"]
+        );
+    }
+
+    #[test]
+    fn parse_rust_use_alias_top_level() {
+        assert_eq!(parse_rust_use("chrono as time_lib"), vec!["chrono"]);
+        assert_eq!(parse_rust_use("foo as bar"), vec!["foo"]);
     }
 
     #[test]
@@ -1962,5 +1985,28 @@ axum = "0.7"
         assert_eq!(result.benchmark_score, Some(83.7));
         assert_eq!(result.snippet_count, Some(366));
         assert_eq!(result.reputation.as_deref(), Some("High"));
+    }
+
+    #[test]
+    fn parse_context7_body_whitespace_content_falls_through_to_snippets() {
+        let body = r#"{"content":"   ","snippets":[{"content":"real snippet"}]}"#;
+        let result = parse_context7_body(body, 4000);
+        assert_eq!(result, Some("real snippet".to_string()));
+    }
+
+    #[test]
+    fn parse_context7_body_valid_content_returned() {
+        let body = r#"{"content":"useful docs","snippets":[]}"#;
+        let result = parse_context7_body(body, 4000);
+        assert_eq!(result, Some("useful docs".to_string()));
+    }
+
+    #[test]
+    fn parse_context7_body_empty_content_and_snippets_returns_none_for_json() {
+        let body = r#"{"content":"","snippets":[]}"#;
+        let result = parse_context7_body(body, 4000);
+        // Empty content + empty snippets in JSON → falls through to raw truncation,
+        // but the raw text is valid JSON so it gets returned as-is.
+        assert!(result.is_some());
     }
 }

--- a/src/finding.rs
+++ b/src/finding.rs
@@ -124,7 +124,11 @@ impl Finding {
         let base = match &self.source {
             Source::LocalAst => 0.95,
             Source::Linter(_) => 0.90,
-            Source::Llm(_) => self.grounding_confidence.unwrap_or(0.5),
+            Source::Llm(_) => self
+                .grounding_confidence
+                .filter(|c| c.is_finite())
+                .map(|c| c.clamp(0.0, 1.0))
+                .unwrap_or(0.5),
         };
         let cal_factor = match self.calibrator_action {
             Some(CalibratorAction::Confirmed) => 1.1,
@@ -880,5 +884,42 @@ mod tests {
         // 1.0 * 1.0 * (0.85 + 0.099) = 0.949
         assert!(f.confidence.unwrap() < 1.0);
         assert!(f.confidence.unwrap() > 0.9);
+    }
+
+    #[test]
+    fn confidence_nan_grounding_uses_default() {
+        let mut f = FindingBuilder::new()
+            .source(Source::Llm("gpt-5.4".into()))
+            .build();
+        f.grounding_confidence = Some(f32::NAN);
+        f.compute_confidence();
+        let c = f.confidence.unwrap();
+        assert!(c.is_finite(), "NaN grounding must not propagate");
+        assert!((c - 0.5).abs() < 0.01, "should fall back to 0.5 default");
+    }
+
+    #[test]
+    fn confidence_inf_grounding_uses_default() {
+        let mut f = FindingBuilder::new()
+            .source(Source::Llm("gpt-5.4".into()))
+            .build();
+        f.grounding_confidence = Some(f32::INFINITY);
+        f.compute_confidence();
+        let c = f.confidence.unwrap();
+        assert!(c.is_finite(), "Inf grounding must not propagate");
+        assert!((c - 0.5).abs() < 0.01);
+    }
+
+    #[test]
+    fn confidence_out_of_range_grounding_clamped() {
+        let mut f = FindingBuilder::new()
+            .source(Source::Llm("gpt-5.4".into()))
+            .build();
+        f.grounding_confidence = Some(1.5);
+        f.compute_confidence();
+        assert!(
+            f.confidence.unwrap() <= 1.0,
+            "grounding > 1.0 must be clamped"
+        );
     }
 }

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -328,7 +328,9 @@ pub fn format_compact_review(file_path: &str, findings: &[Finding]) -> String {
         return format!("{}: clean", file_path);
     }
 
-    let mut lines: Vec<String> = findings.iter().map(format_compact_finding).collect();
+    let mut lines: Vec<String> = Vec::with_capacity(findings.len() + 2);
+    lines.push(file_path.to_string());
+    lines.extend(findings.iter().map(format_compact_finding));
 
     let critical = findings
         .iter()
@@ -795,9 +797,26 @@ mod tests {
         ];
         let out = format_compact_review("src/main.rs", &findings);
         let lines: Vec<&str> = out.lines().collect();
-        assert_eq!(lines[0], "!|security|L42|Bug A");
-        assert_eq!(lines[1], "~|maintainability|L10|Bug B");
-        assert!(lines[2].contains("2 findings"));
+        assert_eq!(lines[0], "src/main.rs");
+        assert_eq!(lines[1], "!|security|L42|Bug A");
+        assert_eq!(lines[2], "~|maintainability|L10|Bug B");
+        assert!(lines[3].contains("2 findings"));
+    }
+
+    #[test]
+    fn compact_review_findings_include_file_header() {
+        let findings = vec![
+            FindingBuilder::new()
+                .title("Bug A")
+                .severity(Severity::Critical)
+                .category("security".into())
+                .lines(42, 42)
+                .build(),
+        ];
+        let out = format_compact_review("src/main.rs", &findings);
+        let lines: Vec<&str> = out.lines().collect();
+        assert_eq!(lines[0], "src/main.rs", "file header must be first line");
+        assert!(lines[1].contains("Bug A"), "finding follows header");
     }
 
     #[test]

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -324,12 +324,13 @@ pub fn format_compact_finding(f: &Finding) -> String {
 }
 
 pub fn format_compact_review(file_path: &str, findings: &[Finding]) -> String {
+    let safe_path = strip_control_chars(file_path);
     if findings.is_empty() {
-        return format!("{}: clean", file_path);
+        return format!("{}: clean", safe_path);
     }
 
     let mut lines: Vec<String> = Vec::with_capacity(findings.len() + 2);
-    lines.push(file_path.to_string());
+    lines.push(safe_path);
     lines.extend(findings.iter().map(format_compact_finding));
 
     let critical = findings


### PR DESCRIPTION
## Summary
- **#241**: whitespace-only Context7 content now falls through to snippets fallback
- **#270**: NaN/Inf `grounding_confidence` no longer propagates through `compute_confidence`
- **#276**: compact output includes file header before findings in multi-file reviews
- **#288**: `use foo as bar` alias correctly extracts crate name in `parse_rust_use`
- **#291**: calibrator thresholds outside [0,1] are clamped; NaN/Inf falls back to legacy

## Test plan
- [x] 11 new TDD tests (red-green verified)
- [x] 2,277 total tests passing
- [x] clippy + rustfmt clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved input validation for numeric thresholds and confidence values with safe fallbacks for invalid data (NaN, Infinity, out-of-range values).
  * Enhanced parsing of aliased imports to correctly extract dependency names.
  * Stricter JSON response handling to prevent empty or whitespace-only content from causing silent failures.

* **Chores**
  * Refactored output formatting for better structure and clarity.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jsnyder/quorum/pull/297)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->