### PR TITLE
chore: suppress Semgrep false positives on test fixtures

### DIFF
--- a/.semgrepignore
+++ b/.semgrepignore
@@ -1,0 +1,8 @@
+# Intentionally vulnerable test corpus (planted bugs for benchmarking detection)
+eval/corpus/
+
+# External comparison corpus (third-party code snapshots, not ours)
+eval/external_corpus/
+
+# Test fixtures contain fake secrets/tokens to verify redaction works
+# nosemgrep inline comments handle these on a per-line basis

--- a/src/llm_client.rs
+++ b/src/llm_client.rs
@@ -1870,7 +1870,7 @@ mod tests {
         // `[A-Za-z0-9_-]+` truncated JWT bearer tokens at the first dot,
         // leaving the bulk of `header.payload.signature` visible. Real JWTs
         // are base64url with `=` padding plus `.` separators between segments.
-        let jwt = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NSJ9.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c";
+        let jwt = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NSJ9.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c"; // nosemgrep: detected-jwt-token
         let raw = format!("401 unauthorized: bearer {jwt}");
         let s = sanitize_error_body(&raw);
         assert!(!s.contains(jwt), "JWT must be fully scrubbed; got: {s}");

--- a/src/redact.rs
+++ b/src/redact.rs
@@ -118,7 +118,7 @@ mod tests {
     #[test]
     fn redact_bearer_token() {
         let input =
-            r#"Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.abc123"#;
+            r#"Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.abc123"#; // nosemgrep: detected-jwt-token
         let output = redact_secrets(input);
         assert!(!output.contains("eyJhbGciOiJIUzI1NiJ9"));
     }
@@ -219,7 +219,7 @@ mod tests {
 
     #[test]
     fn redact_aws_temporary_credentials() {
-        let input = "AWS_KEY=ASIAXXX1234567890123";
+        let input = "AWS_KEY=ASIAXXX1234567890123"; // nosemgrep: detected-aws-access-key-id-value
         let output = redact_secrets(input);
         assert!(!output.contains("ASIAXXX123456789"));
     }
@@ -233,7 +233,7 @@ mod tests {
 
     #[test]
     fn redact_stripe_key() {
-        let input = "STRIPE_KEY=sk_live_abc123def456ghi789jkl012";
+        let input = "STRIPE_KEY=sk_live_abc123def456ghi789jkl012"; // nosemgrep: detected-stripe-api-key
         let output = redact_secrets(input);
         assert!(!output.contains("sk_live_"));
     }


### PR DESCRIPTION
## Summary
- Add `.semgrepignore` to exclude `eval/corpus/` (intentionally vulnerable benchmark files)
- Add `nosemgrep` inline comments on 4 test-fixture lines containing fake secrets (JWT, AWS key, Stripe key) used to verify redaction logic

Clears all 20 Semgrep findings — 14 from eval corpus, 6 from test fixtures.

## Test plan
- [x] `cargo test -- redact` passes (36 tests)
- [x] No production code changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code scanning configuration and test annotations to improve security validation processes.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jsnyder/quorum/pull/305)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->