### PR TITLE
feat(ast): add 8 high-precision AST rules for Python, Rust, TypeScript

### DIFF
--- a/docs/plans/LOWER_PRECISION_RULES.md
+++ b/docs/plans/LOWER_PRECISION_RULES.md
@@ -1,0 +1,28 @@
+# Candidate AST Rules (Lower Precision / Requires Judge)
+
+The following rules were identified as high-value but may have lower precision or higher false-positive rates. They should be evaluated by a judge before promotion to bundled rules.
+
+## 1. subprocess-no-check (Python)
+- **Risk:** `subprocess.run()` without `check=True` ignores non-zero exit codes.
+- **Precision Issue:** Some codebases use `returncode` manually; a naive AST rule might flag these valid cases.
+- **Action:** Need to judge if manual check follows or if code is "fire and forget".
+
+## 2. re-compile-in-loop (Python)
+- **Risk:** Performance bottleneck when compiling the same regex inside a loop.
+- **Precision Issue:** Hard to distinguish if the regex is truly static or depends on loop variables without deeper analysis.
+
+## 3. string-byte-slice (Rust)
+- **Risk:** `&s[..n]` can panic if `n` is not on a UTF-8 character boundary.
+- **Precision Issue:** Many string slices are safe (e.g., ASCII-only or validated). High FP noise for non-localized strings.
+
+## 4. jinja-loop-variable-scoping (YAML/Home Assistant)
+- **Risk:** Accessing loop variables outside the loop scope (legacy behavior).
+- **Precision Issue:** Regex-based detection in YAML templates is fragile and can miss context.
+
+## 5. broad-exception-catch (Python)
+- **Risk:** `except Exception:` catches everything.
+- **Precision Issue:** Frequently used intentionally in top-level runners.
+
+## 6. nullish-coalescing-preferred (TypeScript)
+- **Risk:** Using `||` instead of `??` when `0`, `""`, or `false` are valid values.
+- **Precision Issue:** Intent is often ambiguous; `||` is idiomatic when those falsy values should also trigger the default.

--- a/rules/python/bare-except-with-logic.yml
+++ b/rules/python/bare-except-with-logic.yml
@@ -1,0 +1,27 @@
+id: bare-except-with-logic
+language: Python
+severity: warning
+message: "A bare `except:` with logic inside catches all exceptions, including SystemExit and KeyboardInterrupt. This can hide bugs and make it hard to stop the program. Specify the exception type(s) you intend to catch (e.g., `except Exception:`)."
+rule:
+  kind: except_clause
+  all:
+    - not:
+        has:
+          kind: identifier
+    - not:
+        has:
+          kind: attribute
+    - not:
+        has:
+          kind: call
+    - not:
+        has:
+          kind: list
+    - not:
+        has:
+          kind: tuple
+  has:
+    kind: block
+    has:
+      not:
+        kind: pass_statement

--- a/rules/python/db-connection-no-context-manager.yml
+++ b/rules/python/db-connection-no-context-manager.yml
@@ -1,0 +1,13 @@
+id: db-connection-no-context-manager
+language: Python
+severity: warning
+message: "A database connection was opened but not within a `with` statement. This can lead to connection leaks if exceptions occur. Use a context manager (`with ... as conn:`) to ensure connections are closed."
+rule:
+  kind: assignment
+  pattern: $VAR = $LIB.connect($$$)
+  not:
+    inside:
+      kind: with_item
+constraints:
+  LIB:
+    regex: '^(sqlite3|psycopg2|mysql\.connector)$'

--- a/rules/python/flask-unsafe-form-access.yml
+++ b/rules/python/flask-unsafe-form-access.yml
@@ -1,0 +1,6 @@
+id: flask-unsafe-form-access
+language: Python
+severity: warning
+message: "Directly accessing `request.form['key']` can raise a `KeyError` if the key is missing. Use `request.form.get('key')` to handle missing keys gracefully."
+rule:
+  pattern: request.form['$KEY']

--- a/rules/python/tests/bare-except-with-logic.py
+++ b/rules/python/tests/bare-except-with-logic.py
@@ -1,0 +1,27 @@
+# TP: should match
+try:
+    do_something()
+except:  # ruleid: bare-except-with-logic
+    print("Error")
+
+try:
+    do_something()
+except:  # ruleid: bare-except-with-logic
+    logger.error("Failed")
+    return None
+
+# FP: should NOT match
+try:
+    do_something()
+except:  # ok: bare-except-with-logic
+    pass
+
+try:
+    do_something()
+except Exception:  # ok: bare-except-with-logic
+    print("Error")
+
+try:
+    do_something()
+except ValueError:  # ok: bare-except-with-logic
+    print("Error")

--- a/rules/python/tests/bare-except-with-logic.py
+++ b/rules/python/tests/bare-except-with-logic.py
@@ -8,7 +8,7 @@ try:
     do_something()
 except:  # ruleid: bare-except-with-logic
     logger.error("Failed")
-    return None
+    pass
 
 # FP: should NOT match
 try:

--- a/rules/python/tests/db-connection-no-context-manager.py
+++ b/rules/python/tests/db-connection-no-context-manager.py
@@ -1,0 +1,15 @@
+import sqlite3
+import psycopg2
+import mysql.connector
+
+# TP: should match
+conn = sqlite3.connect("app.db")  # ruleid: db-connection-no-context-manager
+conn2 = psycopg2.connect("dbname=test")  # ruleid: db-connection-no-context-manager
+conn3 = mysql.connector.connect(user='scott')  # ruleid: db-connection-no-context-manager
+
+# FP: should NOT match
+with sqlite3.connect("app.db") as conn4:  # ok: db-connection-no-context-manager
+    pass
+
+with psycopg2.connect("dbname=test") as conn5:  # ok: db-connection-no-context-manager
+    pass

--- a/rules/python/tests/flask-unsafe-form-access.py
+++ b/rules/python/tests/flask-unsafe-form-access.py
@@ -1,0 +1,9 @@
+from flask import request
+
+# TP: should match
+username = request.form['username']  # ruleid: flask-unsafe-form-access
+password = request.form['password']  # ruleid: flask-unsafe-form-access
+
+# FP: should NOT match
+username = request.form.get('username')  # ok: flask-unsafe-form-access
+password = request.form.get('password', 'default')  # ok: flask-unsafe-form-access

--- a/rules/python/tests/use-sys-exit.py
+++ b/rules/python/tests/use-sys-exit.py
@@ -1,0 +1,9 @@
+import sys
+
+# TP: should match
+if error:
+    exit(1)  # ruleid: use-sys-exit
+
+# FP: should NOT match
+if error:
+    sys.exit(1)  # ok: use-sys-exit

--- a/rules/python/use-sys-exit.yml
+++ b/rules/python/use-sys-exit.yml
@@ -1,0 +1,6 @@
+id: use-sys-exit
+language: Python
+severity: hint
+message: "`exit()` is intended for use in the interactive interpreter. In scripts, `sys.exit()` is preferred as it is always available and more conventional."
+rule:
+  pattern: exit($$$)

--- a/rules/rust/tests/unwrap-on-duration-since.rs
+++ b/rules/rust/tests/unwrap-on-duration-since.rs
@@ -1,0 +1,17 @@
+use std::time::{SystemTime, UNIX_EPOCH};
+
+fn main() {
+    let now = SystemTime::now();
+    // TP: should match
+    let duration = now.duration_since(UNIX_EPOCH).unwrap(); // ruleid: unwrap-on-duration-since
+}
+
+fn test_ok() {
+    let now = SystemTime::now();
+    // FP: should NOT match
+    let duration = now.duration_since(UNIX_EPOCH).expect("Time went backwards"); // ok: unwrap-on-duration-since
+    
+    if let Ok(d) = now.duration_since(UNIX_EPOCH) { // ok: unwrap-on-duration-since
+        println!("{:?}", d);
+    }
+}

--- a/rules/rust/unwrap-on-duration-since.yml
+++ b/rules/rust/unwrap-on-duration-since.yml
@@ -1,0 +1,6 @@
+id: unwrap-on-duration-since
+language: Rust
+severity: warning
+message: "`duration_since()` returns a Result because it can fail if the start time is earlier than the provided time. Calling `.unwrap()` on it can cause a panic if the system clock is set incorrectly or the input is unexpected."
+rule:
+  pattern: $TIME.duration_since($$$).unwrap()

--- a/rules/typescript/tests/ts-regex-word-merge.ts
+++ b/rules/typescript/tests/ts-regex-word-merge.ts
@@ -1,0 +1,8 @@
+// TP: should match
+const s1 = text.replace(/[^a-z0-9]/g, ''); // ruleid: ts-regex-word-merge
+const s2 = text.replace(/[\W_]/g, ''); // ruleid: ts-regex-word-merge
+
+// FP: should NOT match
+const s3 = text.replace(/[^a-z0-9]/g, ' '); // ok: ts-regex-word-merge
+const s4 = text.replace(/foo/g, ''); // ok: ts-regex-word-merge
+const s5 = text.replace(/[a-z]/g, ''); // ok: ts-regex-word-merge

--- a/rules/typescript/tests/ts-test-fixed-wait.ts
+++ b/rules/typescript/tests/ts-test-fixed-wait.ts
@@ -1,0 +1,21 @@
+it('should do something', async () => {
+    // TP: should match
+    await new Promise(resolve => setTimeout(resolve, 100)); // ruleid: ts-test-fixed-wait
+});
+
+test('another test', async () => {
+    // TP: should match
+    setTimeout(() => {}, 500); // ruleid: ts-test-fixed-wait
+});
+
+describe('suite', () => {
+    beforeEach(() => {
+        // TP: should match
+        setTimeout(() => {}, 10); // ruleid: ts-test-fixed-wait
+    });
+});
+
+// FP: should NOT match
+function helper() {
+    setTimeout(() => {}, 1000); // ok: ts-test-fixed-wait
+}

--- a/rules/typescript/tests/ts-weak-crypto-random.ts
+++ b/rules/typescript/tests/ts-weak-crypto-random.ts
@@ -1,0 +1,11 @@
+import * as crypto from 'crypto';
+
+// TP: should match
+const b1 = crypto.randomBytes(4); // ruleid: ts-weak-crypto-random
+const b2 = crypto.randomBytes(7); // ruleid: ts-weak-crypto-random
+const b3 = crypto.randomBytes(0); // ruleid: ts-weak-crypto-random
+
+// FP: should NOT match
+const b4 = crypto.randomBytes(8); // ok: ts-weak-crypto-random
+const b5 = crypto.randomBytes(16); // ok: ts-weak-crypto-random
+const b6 = crypto.randomBytes(num); // ok: ts-weak-crypto-random

--- a/rules/typescript/ts-regex-word-merge.yml
+++ b/rules/typescript/ts-regex-word-merge.yml
@@ -1,0 +1,9 @@
+id: ts-regex-word-merge
+language: TypeScript
+severity: warning
+message: "This regex replaces punctuation with an empty string, which can incorrectly merge adjacent words (e.g., 'hello.world' becomes 'helloworld'). Consider replacing with a space ' ' instead of an empty string '' to preserve word boundaries."
+rule:
+  pattern: $S.replace($REGEX, '')
+constraints:
+  REGEX:
+    regex: "(\\^|\\\\W)"

--- a/rules/typescript/ts-test-fixed-wait.yml
+++ b/rules/typescript/ts-test-fixed-wait.yml
@@ -1,0 +1,12 @@
+id: ts-test-fixed-wait
+language: TypeScript
+severity: warning
+message: "Avoid fixed-duration waits with setTimeout in tests. They lead to flaky and slow tests. Use async utilities from your test framework to wait for specific events or conditions."
+rule:
+  pattern: setTimeout($$$)
+  inside:
+    stopBy: end
+    kind: call_expression
+    has:
+      field: "function"
+      regex: "^(it|test|beforeEach|afterEach)$"

--- a/rules/typescript/ts-weak-crypto-random.yml
+++ b/rules/typescript/ts-weak-crypto-random.yml
@@ -1,0 +1,10 @@
+id: ts-weak-crypto-random
+language: TypeScript
+severity: error
+message: "crypto.randomBytes() called with less than 8 bytes (64 bits) of entropy. This is insufficient for generating secure random identifiers, as it may lead to collisions."
+rule:
+  pattern: crypto.randomBytes($BYTES)
+constraints:
+  BYTES:
+    kind: number
+    regex: "^[0-7]$"

--- a/src/ast_grep.rs
+++ b/src/ast_grep.rs
@@ -1125,6 +1125,54 @@ rule:
                 "bind-in-event-listener",
                 2,
             ),
+            (
+                "rules/python/tests/db-connection-no-context-manager.py",
+                "py",
+                "db-connection-no-context-manager",
+                3,
+            ),
+            (
+                "rules/python/tests/flask-unsafe-form-access.py",
+                "py",
+                "flask-unsafe-form-access",
+                2,
+            ),
+            (
+                "rules/python/tests/bare-except-with-logic.py",
+                "py",
+                "bare-except-with-logic",
+                2,
+            ),
+            (
+                "rules/python/tests/use-sys-exit.py",
+                "py",
+                "use-sys-exit",
+                1,
+            ),
+            (
+                "rules/rust/tests/unwrap-on-duration-since.rs",
+                "rs",
+                "unwrap-on-duration-since",
+                1,
+            ),
+            (
+                "rules/typescript/tests/ts-test-fixed-wait.ts",
+                "ts",
+                "ts-test-fixed-wait",
+                3,
+            ),
+            (
+                "rules/typescript/tests/ts-weak-crypto-random.ts",
+                "ts",
+                "ts-weak-crypto-random",
+                3,
+            ),
+            (
+                "rules/typescript/tests/ts-regex-word-merge.ts",
+                "ts",
+                "ts-regex-word-merge",
+                2,
+            ),
         ];
 
         let mut failures = Vec::new();


### PR DESCRIPTION
## Summary
- Add 8 new ast-grep rules identified from feedback pattern mining in a Gemini CLI session
- Python (4): `bare-except-with-logic`, `db-connection-no-context-manager`, `flask-unsafe-form-access`, `use-sys-exit`
- Rust (1): `unwrap-on-duration-since`
- TypeScript (3): `ts-regex-word-merge`, `ts-test-fixed-wait`, `ts-weak-crypto-random`
- All rules include test fixtures with positive and negative cases
- Document lower-precision rule candidates for future evaluation

## Test plan
- [x] All 55 ast-grep tests pass (`cargo test --lib -- ast_grep`)
- [x] Each rule verified against test fixtures (expected match counts confirmed)
- [x] Rebased onto current main (no unrelated regressions)
- [x] Quorum self-review: 0 new findings introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)