### PR TITLE
feat: composite calibrator scoring with learned lookup tables

### DIFF
--- a/src/calibrate.rs
+++ b/src/calibrate.rs
@@ -724,22 +724,24 @@ pub fn compute_calibrator_model(feedback: &[serde_json::Value]) -> Option<Calibr
 
     let global_fp_rate = total_fp as f64 / total as f64;
 
-    // Word log-odds: log((fp_rate + eps) / (tp_rate + eps))
+    // Word log-odds only make sense once both classes have support.
     let eps = 0.5; // Laplace smoothing
     let mut word_lor_map: HashMap<String, f64> = HashMap::new();
-    let all_words: HashSet<&String> = word_tp.keys().chain(word_fp.keys()).collect();
-    for w in all_words {
-        let tp_count = word_tp.get(w).copied().unwrap_or(0);
-        let fp_count = word_fp.get(w).copied().unwrap_or(0);
-        let support = tp_count + fp_count;
-        if support < WORD_MIN_SUPPORT {
-            continue;
-        }
-        let tp_rate = (tp_count as f64 + eps) / (total_tp as f64 + eps);
-        let fp_rate = (fp_count as f64 + eps) / (total_fp as f64 + eps);
-        let lor = (fp_rate / tp_rate).ln();
-        if lor.is_finite() {
-            word_lor_map.insert(w.clone(), lor);
+    if total_tp > 0 && total_fp > 0 {
+        let all_words: HashSet<&String> = word_tp.keys().chain(word_fp.keys()).collect();
+        for w in all_words {
+            let tp_count = word_tp.get(w).copied().unwrap_or(0);
+            let fp_count = word_fp.get(w).copied().unwrap_or(0);
+            let support = tp_count + fp_count;
+            if support < WORD_MIN_SUPPORT {
+                continue;
+            }
+            let tp_rate = (tp_count as f64 + eps) / (total_tp as f64 + eps);
+            let fp_rate = (fp_count as f64 + eps) / (total_fp as f64 + eps);
+            let lor = (fp_rate / tp_rate).ln();
+            if lor.is_finite() {
+                word_lor_map.insert(w.clone(), lor);
+            }
         }
     }
 
@@ -828,8 +830,6 @@ pub fn rescore_samples_with_model(
         let fp_w = t["fp_weight"].as_f64().unwrap_or(0.0).max(0.0);
         let norm = normalize_title(&title);
         let info = TraceInfo {
-            title: title.clone(),
-            file_path: fp.clone(),
             tp_weight: tp_w,
             fp_weight: fp_w,
         };
@@ -968,8 +968,8 @@ pub fn rescore_samples_with_model(
             if total > 0.0 {
                 let precedent_score = info.tp_weight / total;
                 if precedent_score.is_finite() {
-                    let lang = CalibratorModel::file_ext_language(&info.file_path);
-                    let composite = model.composite_score(precedent_score, &info.title, lang);
+                    let lang = CalibratorModel::file_ext_language(&fp);
+                    let composite = model.composite_score(precedent_score, &title, lang);
                     if composite.is_finite() {
                         samples.push((composite, is_positive));
                     }
@@ -983,8 +983,6 @@ pub fn rescore_samples_with_model(
 
 #[derive(Clone)]
 struct TraceInfo {
-    title: String,
-    file_path: String,
     tp_weight: f64,
     fp_weight: f64,
 }

--- a/src/calibrate.rs
+++ b/src/calibrate.rs
@@ -2322,11 +2322,7 @@ mod tests {
 
     // --- compute_calibrator_model tests ---
 
-    fn make_model_feedback(
-        title: &str,
-        verdict: &str,
-        file_path: &str,
-    ) -> serde_json::Value {
+    fn make_model_feedback(title: &str, verdict: &str, file_path: &str) -> serde_json::Value {
         serde_json::json!({
             "finding_title": title,
             "verdict": verdict,
@@ -2365,9 +2361,7 @@ mod tests {
         );
         // Novel family not in map (only 2 entries, below FAMILY_MIN_SUPPORT=3)
         assert!(
-            !model
-                .family_fp_rate
-                .contains_key("missing error handling"),
+            !model.family_fp_rate.contains_key("missing error handling"),
             "family with < 3 entries should not be in model"
         );
         // Global FP rate: 2 FP out of 5 total = 0.4

--- a/src/calibrate.rs
+++ b/src/calibrate.rs
@@ -6,6 +6,7 @@
 
 use std::collections::{HashMap, HashSet};
 
+use crate::calibrator_model::{CalibratorModel, ModelMeta, ScoreWeights};
 use crate::metrics;
 use crate::threshold_config::{PathThreshold, ThresholdConfig};
 
@@ -634,6 +635,360 @@ pub fn backfill_file_paths(
     }
 
     stats
+}
+
+/// Minimum support (total TP+FP) for a word to be included in the word_lor vocabulary.
+const WORD_MIN_SUPPORT: usize = 5;
+
+/// Minimum support (total entries) for a family to get its own FP rate.
+const FAMILY_MIN_SUPPORT: usize = 3;
+
+/// Minimum support (total entries) for a language to get its own FP rate.
+const LANG_MIN_SUPPORT: usize = 5;
+
+/// Compute a `CalibratorModel` from feedback entries.
+///
+/// Builds lookup tables for word log-odds, family FP rates, and language FP
+/// rates from the feedback corpus. Wontfix verdicts are treated as negative
+/// (alongside FP) for the purpose of FP rate computation.
+pub fn compute_calibrator_model(feedback: &[serde_json::Value]) -> Option<CalibratorModel> {
+    let mut word_tp: HashMap<String, usize> = HashMap::new();
+    let mut word_fp: HashMap<String, usize> = HashMap::new();
+    let mut family_tp: HashMap<String, usize> = HashMap::new();
+    let mut family_fp: HashMap<String, usize> = HashMap::new();
+    let mut lang_tp: HashMap<String, usize> = HashMap::new();
+    let mut lang_fp: HashMap<String, usize> = HashMap::new();
+    let mut total_tp: usize = 0;
+    let mut total_fp: usize = 0;
+
+    for entry in feedback {
+        let verdict = entry["verdict"].as_str().unwrap_or("");
+        let is_positive = match verdict {
+            "tp" | "partial" => true,
+            "fp" | "wontfix" => false,
+            _ => continue,
+        };
+        let title = entry["finding_title"].as_str().unwrap_or("");
+        if title.is_empty() {
+            continue;
+        }
+        let file_path = entry["file_path"].as_str().unwrap_or("");
+
+        if is_positive {
+            total_tp += 1;
+        } else {
+            total_fp += 1;
+        }
+
+        // Word counts
+        let words = tokenize_title(title);
+        for w in &words {
+            if is_positive {
+                *word_tp.entry(w.clone()).or_default() += 1;
+            } else {
+                *word_fp.entry(w.clone()).or_default() += 1;
+            }
+        }
+
+        // Family counts
+        let family = CalibratorModel::title_family(title);
+        if !family.is_empty() {
+            if is_positive {
+                *family_tp.entry(family.clone()).or_default() += 1;
+            } else {
+                *family_fp.entry(family).or_default() += 1;
+            }
+        }
+
+        // Language counts
+        if !file_path.is_empty() {
+            let lang = CalibratorModel::file_ext_language(file_path).to_string();
+            if is_positive {
+                *lang_tp.entry(lang.clone()).or_default() += 1;
+            } else {
+                *lang_fp.entry(lang).or_default() += 1;
+            }
+        }
+    }
+
+    let total = total_tp + total_fp;
+    if total == 0 {
+        return None;
+    }
+
+    let global_fp_rate = total_fp as f64 / total as f64;
+
+    // Word log-odds: log((fp_rate + eps) / (tp_rate + eps))
+    let eps = 0.5; // Laplace smoothing
+    let mut word_lor_map: HashMap<String, f64> = HashMap::new();
+    let all_words: HashSet<&String> = word_tp.keys().chain(word_fp.keys()).collect();
+    for w in all_words {
+        let tp_count = word_tp.get(w).copied().unwrap_or(0);
+        let fp_count = word_fp.get(w).copied().unwrap_or(0);
+        let support = tp_count + fp_count;
+        if support < WORD_MIN_SUPPORT {
+            continue;
+        }
+        let tp_rate = (tp_count as f64 + eps) / (total_tp as f64 + eps);
+        let fp_rate = (fp_count as f64 + eps) / (total_fp as f64 + eps);
+        let lor = (fp_rate / tp_rate).ln();
+        if lor.is_finite() {
+            word_lor_map.insert(w.clone(), lor);
+        }
+    }
+
+    // Family FP rates
+    let mut family_fp_rate_map: HashMap<String, f64> = HashMap::new();
+    let all_families: HashSet<&String> = family_tp.keys().chain(family_fp.keys()).collect();
+    for fam in all_families {
+        let tp = family_tp.get(fam).copied().unwrap_or(0);
+        let fp = family_fp.get(fam).copied().unwrap_or(0);
+        let support = tp + fp;
+        if support < FAMILY_MIN_SUPPORT {
+            continue;
+        }
+        family_fp_rate_map.insert(fam.clone(), fp as f64 / support as f64);
+    }
+
+    // Language FP rates
+    let mut lang_fp_rate_map: HashMap<String, f64> = HashMap::new();
+    let all_langs: HashSet<&String> = lang_tp.keys().chain(lang_fp.keys()).collect();
+    for lang in all_langs {
+        let tp = lang_tp.get(lang).copied().unwrap_or(0);
+        let fp = lang_fp.get(lang).copied().unwrap_or(0);
+        let support = tp + fp;
+        if support < LANG_MIN_SUPPORT {
+            continue;
+        }
+        lang_fp_rate_map.insert(lang.clone(), fp as f64 / support as f64);
+    }
+
+    Some(CalibratorModel {
+        meta: ModelMeta {
+            computed_at: chrono::Utc::now().to_rfc3339(),
+            feedback_count: total,
+            global_fp_rate,
+        },
+        weights: ScoreWeights {
+            score: 0.5,
+            word_lor: 1.5,
+            family_fp_inv: 1.0,
+            language_fp_inv: 0.5,
+        },
+        word_lor: word_lor_map,
+        family_fp_rate: family_fp_rate_map,
+        language_fp_rate: lang_fp_rate_map,
+    })
+}
+
+/// Re-score join samples using composite scores from a model.
+///
+/// Takes the raw `(score, label)` pairs from the join and replaces each score
+/// with the composite score, using the corresponding feedback entry's title and
+/// file path for family/language lookup.
+pub fn rescore_samples_with_model(
+    feedback: &[serde_json::Value],
+    traces: &[serde_json::Value],
+    model: &CalibratorModel,
+    filter: &JoinFilter,
+    disable_fuzzy: bool,
+) -> Vec<(f64, bool)> {
+    // We need to re-join to get the title+file_path for each sample.
+    // The join logic is complex, so we reconstruct by walking the same join
+    // path but extracting composite scores instead of raw scores.
+    let filtered_traces: Vec<&serde_json::Value> =
+        traces.iter().filter(|t| filter.accepts(t)).collect();
+
+    // Build the same index structures as join_feedback_and_traces_with_options
+    let mut raw_map: HashMap<(String, String), TraceInfo> = HashMap::new();
+    let mut raw_ambiguous: HashSet<(String, String)> = HashSet::new();
+    let mut norm_map: HashMap<(String, String), TraceInfo> = HashMap::new();
+    let mut norm_ambiguous: HashSet<(String, String)> = HashSet::new();
+    let mut file_traces: HashMap<String, Vec<(String, TraceInfo)>> = HashMap::new();
+    let mut norm_title_only: HashMap<String, TraceInfo> = HashMap::new();
+    let mut norm_title_only_ambiguous: HashSet<String> = HashSet::new();
+    let mut raw_title_only: HashMap<String, TraceInfo> = HashMap::new();
+    let mut raw_title_only_ambiguous: HashSet<String> = HashSet::new();
+    let mut norm_titles_with_file_scoped: HashSet<String> = HashSet::new();
+    let mut raw_titles_with_file_scoped: HashSet<String> = HashSet::new();
+
+    for t in &filtered_traces {
+        let title = t["finding_title"].as_str().unwrap_or("").to_string();
+        if title.is_empty() {
+            continue;
+        }
+        let fp = t["file_path"].as_str().unwrap_or("").to_string();
+        let tp_w = t["tp_weight"].as_f64().unwrap_or(0.0).max(0.0);
+        let fp_w = t["fp_weight"].as_f64().unwrap_or(0.0).max(0.0);
+        let norm = normalize_title(&title);
+        let info = TraceInfo {
+            title: title.clone(),
+            file_path: fp.clone(),
+            tp_weight: tp_w,
+            fp_weight: fp_w,
+        };
+
+        if fp.is_empty() {
+            match raw_title_only.entry(title.clone()) {
+                std::collections::hash_map::Entry::Occupied(_) => {
+                    raw_title_only_ambiguous.insert(title.clone());
+                }
+                std::collections::hash_map::Entry::Vacant(e) => {
+                    e.insert(info.clone());
+                }
+            }
+            if !disable_fuzzy && !norm.is_empty() {
+                let norm_for_ambiguous = norm.clone();
+                match norm_title_only.entry(norm) {
+                    std::collections::hash_map::Entry::Occupied(_) => {
+                        norm_title_only_ambiguous.insert(norm_for_ambiguous);
+                    }
+                    std::collections::hash_map::Entry::Vacant(e) => {
+                        e.insert(info);
+                    }
+                }
+            }
+        } else {
+            raw_titles_with_file_scoped.insert(title.clone());
+            if !norm.is_empty() {
+                norm_titles_with_file_scoped.insert(norm.clone());
+            }
+            let raw_key = (title, fp.clone());
+            match raw_map.entry(raw_key.clone()) {
+                std::collections::hash_map::Entry::Occupied(_) => {
+                    raw_ambiguous.insert(raw_key);
+                }
+                std::collections::hash_map::Entry::Vacant(e) => {
+                    e.insert(info.clone());
+                }
+            }
+            if !disable_fuzzy && !norm.is_empty() {
+                let norm_key = (norm.clone(), fp.clone());
+                match norm_map.entry(norm_key.clone()) {
+                    std::collections::hash_map::Entry::Occupied(_) => {
+                        norm_ambiguous.insert(norm_key);
+                    }
+                    std::collections::hash_map::Entry::Vacant(e) => {
+                        e.insert(info.clone());
+                    }
+                }
+                file_traces.entry(fp).or_default().push((norm, info));
+            }
+        }
+    }
+
+    for key in &raw_ambiguous {
+        raw_map.remove(key);
+    }
+    for key in &norm_ambiguous {
+        norm_map.remove(key);
+    }
+    for key in &raw_title_only_ambiguous {
+        raw_title_only.remove(key);
+    }
+    for key in &norm_title_only_ambiguous {
+        norm_title_only.remove(key);
+    }
+    for title in &raw_titles_with_file_scoped {
+        raw_title_only.remove(title);
+    }
+    for norm in &norm_titles_with_file_scoped {
+        norm_title_only.remove(norm);
+    }
+
+    let mut samples = Vec::new();
+
+    for f in feedback {
+        let verdict = f["verdict"].as_str().unwrap_or("");
+        let is_positive = match verdict {
+            "tp" | "partial" => true,
+            "fp" => false,
+            _ => continue,
+        };
+        let title = f["finding_title"].as_str().unwrap_or("").to_string();
+        if title.is_empty() {
+            continue;
+        }
+        let fp = f["file_path"].as_str().unwrap_or("").to_string();
+        let norm = normalize_title(&title);
+
+        let matched = raw_map
+            .get(&(title.clone(), fp.clone()))
+            .or_else(|| {
+                if !disable_fuzzy && !norm.is_empty() {
+                    norm_map.get(&(norm.clone(), fp.clone()))
+                } else {
+                    None
+                }
+            })
+            .or_else(|| {
+                if !disable_fuzzy
+                    && !norm.is_empty()
+                    && !fp.is_empty()
+                    && let Some(candidates) = file_traces.get(&fp)
+                {
+                    let mut best_score = 0.0_f64;
+                    let mut second_best = 0.0_f64;
+                    let mut best_info: Option<&TraceInfo> = None;
+                    for (cand_norm, info) in candidates {
+                        let j = token_jaccard(&norm, cand_norm);
+                        if j > best_score {
+                            second_best = best_score;
+                            best_score = j;
+                            best_info = Some(info);
+                        } else if j > second_best {
+                            second_best = j;
+                        }
+                    }
+                    if best_score >= FUZZY_THRESHOLD
+                        && (best_score - second_best) >= FUZZY_AMBIGUITY_MARGIN
+                    {
+                        return best_info;
+                    }
+                }
+                None
+            })
+            .or_else(|| raw_title_only.get(&title))
+            .or_else(|| {
+                if !disable_fuzzy && !norm.is_empty() {
+                    norm_title_only.get(&norm)
+                } else {
+                    None
+                }
+            });
+
+        if let Some(info) = matched {
+            let total = info.tp_weight + info.fp_weight;
+            if total > 0.0 {
+                let precedent_score = info.tp_weight / total;
+                if precedent_score.is_finite() {
+                    let lang = CalibratorModel::file_ext_language(&info.file_path);
+                    let composite = model.composite_score(precedent_score, &info.title, lang);
+                    if composite.is_finite() {
+                        samples.push((composite, is_positive));
+                    }
+                }
+            }
+        }
+    }
+
+    samples
+}
+
+#[derive(Clone)]
+struct TraceInfo {
+    title: String,
+    file_path: String,
+    tp_weight: f64,
+    fp_weight: f64,
+}
+
+fn tokenize_title(title: &str) -> Vec<String> {
+    let lower = title.to_lowercase();
+    regex::Regex::new(r"[a-z_]+")
+        .ok()
+        .map(|re| re.find_iter(&lower).map(|m| m.as_str().to_string()).collect())
+        .unwrap_or_default()
 }
 
 #[cfg(test)]
@@ -1956,6 +2311,155 @@ mod tests {
                 || traces[3]["file_path"].is_null()
                 || traces[3]["file_path"].as_str() == Some(""),
             "no match: should not be stamped"
+        );
+    }
+
+    // --- compute_calibrator_model tests ---
+
+    fn make_model_feedback(
+        title: &str,
+        verdict: &str,
+        file_path: &str,
+    ) -> serde_json::Value {
+        serde_json::json!({
+            "finding_title": title,
+            "verdict": verdict,
+            "file_path": file_path,
+            "finding_category": "test",
+            "reason": "test",
+            "timestamp": "2026-01-01T00:00:00Z",
+            "provenance": "human"
+        })
+    }
+
+    #[test]
+    fn compute_model_from_feedback() {
+        let feedback = vec![
+            // 3 entries for same family -> known family
+            make_model_feedback("Function `a` has complexity 10", "fp", "test.rs"),
+            make_model_feedback("Function `b` has complexity 20", "fp", "test.rs"),
+            make_model_feedback("Function `c` has complexity 5", "tp", "test.rs"),
+            // 2 entries for another family -> below threshold, novel
+            make_model_feedback("Missing error handling", "tp", "lib.rs"),
+            make_model_feedback("Missing error handling", "tp", "main.rs"),
+        ];
+        let model = compute_calibrator_model(&feedback).unwrap();
+        // Known family: "function `` has complexity N"
+        assert!(
+            model
+                .family_fp_rate
+                .contains_key("function `` has complexity N"),
+            "family with 3+ entries should be in model, got keys: {:?}",
+            model.family_fp_rate.keys().collect::<Vec<_>>()
+        );
+        let rate = model.family_fp_rate["function `` has complexity N"];
+        assert!(
+            (rate - 0.6667).abs() < 0.01,
+            "2 FP / 3 total = 0.667, got {rate}"
+        );
+        // Novel family not in map (only 2 entries, below FAMILY_MIN_SUPPORT=3)
+        assert!(
+            !model
+                .family_fp_rate
+                .contains_key("missing error handling"),
+            "family with < 3 entries should not be in model"
+        );
+        // Global FP rate: 2 FP out of 5 total = 0.4
+        assert!(
+            (model.meta.global_fp_rate - 0.4).abs() < 0.01,
+            "global FP rate should be 0.4, got {}",
+            model.meta.global_fp_rate
+        );
+    }
+
+    #[test]
+    fn compute_model_wontfix_treated_as_negative() {
+        let feedback = vec![
+            make_model_feedback("Bug A", "tp", "a.rs"),
+            make_model_feedback("Bug A", "tp", "b.rs"),
+            make_model_feedback("Bug A", "wontfix", "c.rs"),
+            make_model_feedback("Bug A", "wontfix", "d.rs"),
+            make_model_feedback("Bug A", "wontfix", "e.rs"),
+        ];
+        let model = compute_calibrator_model(&feedback).unwrap();
+        // 3 wontfix + 2 tp = 5 total, 3 negative -> global_fp_rate = 0.6
+        assert!(
+            (model.meta.global_fp_rate - 0.6).abs() < 0.01,
+            "wontfix should count as negative, got {}",
+            model.meta.global_fp_rate
+        );
+    }
+
+    #[test]
+    fn compute_model_empty_feedback_returns_none() {
+        let feedback: Vec<serde_json::Value> = vec![];
+        assert!(compute_calibrator_model(&feedback).is_none());
+    }
+
+    #[test]
+    fn compute_model_word_lor_signs() {
+        // Create enough feedback to pass min_support for words
+        let mut feedback = Vec::new();
+        for i in 0..10 {
+            feedback.push(make_model_feedback(
+                "hardcoded secret in config",
+                "fp",
+                &format!("f{i}.py"),
+            ));
+        }
+        for i in 0..10 {
+            feedback.push(make_model_feedback(
+                "SQL injection via user input",
+                "tp",
+                &format!("g{i}.py"),
+            ));
+        }
+        let model = compute_calibrator_model(&feedback).unwrap();
+        // "hardcoded" should have positive lor (FP-leaning)
+        if let Some(&lor) = model.word_lor.get("hardcoded") {
+            assert!(
+                lor > 0.0,
+                "hardcoded should be FP-leaning (positive lor), got {lor}"
+            );
+        }
+        // "sql" should have negative lor (TP-leaning)
+        if let Some(&lor) = model.word_lor.get("sql") {
+            assert!(
+                lor < 0.0,
+                "sql should be TP-leaning (negative lor), got {lor}"
+            );
+        }
+    }
+
+    #[test]
+    fn compute_model_language_fp_rates() {
+        let mut feedback = Vec::new();
+        // 6 rust findings: 4 FP, 2 TP -> fp_rate = 0.667
+        for i in 0..4 {
+            feedback.push(make_model_feedback("Bug", "fp", &format!("f{i}.rs")));
+        }
+        for i in 0..2 {
+            feedback.push(make_model_feedback("Bug", "tp", &format!("g{i}.rs")));
+        }
+        // 5 python findings: 1 FP, 4 TP -> fp_rate = 0.2
+        feedback.push(make_model_feedback("Bug", "fp", "a.py"));
+        for i in 0..4 {
+            feedback.push(make_model_feedback("Bug", "tp", &format!("h{i}.py")));
+        }
+        let model = compute_calibrator_model(&feedback).unwrap();
+        assert!(
+            model.language_fp_rate.contains_key("rust"),
+            "rust should have fp rate"
+        );
+        assert!(
+            (model.language_fp_rate["rust"] - 0.6667).abs() < 0.01,
+            "rust fp rate should be ~0.667, got {}",
+            model.language_fp_rate["rust"]
+        );
+        assert!(
+            (model.language_fp_rate["python"] - 0.2).abs() < 0.01,
+            "python fp rate should be 0.2, got {}",
+            model.language_fp_rate["python"]
         );
     }
 }

--- a/src/calibrate.rs
+++ b/src/calibrate.rs
@@ -651,6 +651,12 @@ const LANG_MIN_SUPPORT: usize = 5;
 /// Builds lookup tables for word log-odds, family FP rates, and language FP
 /// rates from the feedback corpus. Wontfix verdicts are treated as negative
 /// (alongside FP) for the purpose of FP rate computation.
+/// Build lookup tables from the feedback corpus.
+///
+/// `wontfix` is treated as negative (alongside `fp`) because it signals
+/// findings that are valid but not worth fixing — useful FP-rate signal for
+/// suppression. This differs from threshold fitting which excludes wontfix
+/// to keep the PR-curve clean.
 pub fn compute_calibrator_model(feedback: &[serde_json::Value]) -> Option<CalibratorModel> {
     let mut word_tp: HashMap<String, usize> = HashMap::new();
     let mut word_fp: HashMap<String, usize> = HashMap::new();
@@ -985,10 +991,10 @@ struct TraceInfo {
 
 fn tokenize_title(title: &str) -> Vec<String> {
     let lower = title.to_lowercase();
-    regex::Regex::new(r"[a-z_]+")
-        .ok()
-        .map(|re| re.find_iter(&lower).map(|m| m.as_str().to_string()).collect())
-        .unwrap_or_default()
+    crate::calibrator_model::WORD_RE
+        .find_iter(&lower)
+        .map(|m| m.as_str().to_string())
+        .collect()
 }
 
 #[cfg(test)]

--- a/src/calibrator.rs
+++ b/src/calibrator.rs
@@ -2,6 +2,7 @@
 //! For each finding, searches for similar past findings and their TP/FP verdicts.
 //! FP precedent suppresses findings; TP precedent boosts confidence.
 
+use crate::calibrator_model::CalibratorModel;
 use crate::category::Category;
 use crate::feedback::{FeedbackEntry, Verdict};
 use crate::finding::{CalibratorAction, Finding, Severity};
@@ -59,6 +60,9 @@ pub struct CalibratorConfig {
     /// uses only raw exact + raw title-only fallback. `None` or `Some(false)`
     /// keeps all tiers active (default).
     pub disable_fuzzy_matching: Option<bool>,
+    /// Composite scoring model. When present, threshold comparisons use
+    /// composite scores instead of raw `tp_weight / total`.
+    pub model: Option<CalibratorModel>,
 }
 
 impl Default for CalibratorConfig {
@@ -75,6 +79,7 @@ impl Default for CalibratorConfig {
             force_threshold: None,
             trace_provenance: None,
             disable_fuzzy_matching: None,
+            model: None,
         }
     }
 }
@@ -120,6 +125,7 @@ fn make_no_match_trace(
         provenance: None,
         same_file_precedent_count: None,
         in_diff: finding.in_diff,
+        composite_score: None,
     }
 }
 
@@ -161,6 +167,7 @@ fn make_trace_entry(
         provenance: None,
         same_file_precedent_count: None,
         in_diff: finding.in_diff,
+        composite_score: None,
     }
 }
 
@@ -224,7 +231,16 @@ fn calibrate_core_decision(
 
     // PR3: compute score once for data-driven threshold decisions.
     let total = tp_weight + fp_weight;
-    let score = if total > 0.0 { tp_weight / total } else { 0.5 };
+    let precedent_score = if total > 0.0 { tp_weight / total } else { 0.5 };
+
+    // Composite scoring: when a model is loaded, use composite score for
+    // threshold comparisons instead of raw precedent score.
+    let lang = CalibratorModel::file_ext_language(file_path);
+    let composite = config
+        .model
+        .as_ref()
+        .map(|m| m.composite_score(precedent_score, &finding.title, lang));
+    let score = composite.unwrap_or(precedent_score);
 
     // Full suppress: FP weight only. Wontfix no longer contributes.
     let full_suppress_weight = fp_weight;
@@ -235,7 +251,7 @@ fn calibrate_core_decision(
         if score < thresh && fp_weight > 0.0 {
             finding.calibrator_action = Some(CalibratorAction::Disputed);
             suppressed = true;
-            let trace = make_trace_entry(
+            let mut trace = make_trace_entry(
                 finding,
                 tp_weight,
                 fp_weight,
@@ -248,6 +264,7 @@ fn calibrate_core_decision(
                 Some(crate::calibrator_trace::SeverityChangeReason::Disputed),
                 file_path,
             );
+            trace.composite_score = composite;
             return CoreDecision {
                 suppressed,
                 boosted,
@@ -260,7 +277,7 @@ fn calibrate_core_decision(
         {
             finding.calibrator_action = Some(CalibratorAction::Disputed);
             suppressed = true;
-            let trace = make_trace_entry(
+            let mut trace = make_trace_entry(
                 finding,
                 tp_weight,
                 fp_weight,
@@ -273,6 +290,7 @@ fn calibrate_core_decision(
                 Some(crate::calibrator_trace::SeverityChangeReason::Disputed),
                 file_path,
             );
+            trace.composite_score = composite;
             return CoreDecision {
                 suppressed,
                 boosted,
@@ -334,7 +352,7 @@ fn calibrate_core_decision(
         reason = Some(crate::calibrator_trace::SeverityChangeReason::BoostWeightTooLow);
     }
 
-    let trace = make_trace_entry(
+    let mut trace = make_trace_entry(
         finding,
         tp_weight,
         fp_weight,
@@ -347,6 +365,7 @@ fn calibrate_core_decision(
         reason,
         file_path,
     );
+    trace.composite_score = composite;
 
     CoreDecision {
         suppressed,
@@ -5004,5 +5023,153 @@ mod tests {
         };
         let w = verdict_weight(&entry, chrono::Utc::now());
         assert!((w - 0.49).abs() < 0.02);
+    }
+
+    // --- Composite scoring tests ---
+
+    fn make_composite_model() -> CalibratorModel {
+        use std::collections::HashMap;
+        CalibratorModel {
+            meta: crate::calibrator_model::ModelMeta {
+                computed_at: "2026-05-12T00:00:00Z".to_string(),
+                feedback_count: 100,
+                global_fp_rate: 0.27,
+            },
+            weights: crate::calibrator_model::ScoreWeights {
+                score: 0.5,
+                word_lor: 1.5,
+                family_fp_inv: 1.0,
+                language_fp_inv: 0.5,
+            },
+            word_lor: HashMap::from([
+                ("unwrap".into(), -1.0),
+                ("panic".into(), -0.8),
+                ("runtime".into(), -0.5),
+                ("sql".into(), 2.0),
+                ("injection".into(), 1.5),
+            ]),
+            family_fp_rate: HashMap::from([
+                ("use of `` may panic at runtime".into(), 0.90),
+            ]),
+            language_fp_rate: HashMap::from([
+                ("rust".into(), 0.328),
+                ("python".into(), 0.208),
+            ]),
+        }
+    }
+
+    #[test]
+    fn core_decision_uses_composite_when_model_present() {
+        let model = make_composite_model();
+        // Family "use of `` may panic at runtime" has 90% FP rate -> very low composite
+        let mut finding = finding_at(
+            "use of `unwrap()` may panic at runtime",
+            "correctness",
+            Severity::Medium,
+            "unwrap may panic",
+        );
+        let config = CalibratorConfig {
+            suppress_threshold: Some(1.0),
+            model: Some(model),
+            ..Default::default()
+        };
+        let decision = calibrate_core_decision(
+            &mut finding,
+            &config,
+            0.6,  // tp_weight
+            0.4,  // fp_weight (raw score = 0.6)
+            0.0,
+            0.4,
+            vec![],
+            Severity::Medium,
+            "test.rs",
+        );
+        // Composite: 0.5*0.6 + 1.5*word_lor + 1.0*(1-0.90) + 0.5*(1-0.27)
+        // word_lor tokens: use, of, unwrap, may, panic, at, runtime
+        //   unwrap=-1.0, panic=-0.8, runtime=-0.5, rest=0
+        //   avg = (-1.0 + -0.8 + -0.5) / 7 = -0.3286
+        // composite = 0.3 + 1.5*(-0.3286) + 1.0*0.1 + 0.5*0.73
+        //           = 0.3 + (-0.4929) + 0.1 + 0.365 = 0.2721
+        // 0.2721 < 1.0 (suppress threshold) -> suppressed
+        assert!(
+            decision.suppressed,
+            "high-FP family should be suppressed under composite scoring"
+        );
+        assert!(
+            decision.trace.composite_score.is_some(),
+            "composite_score should be set on trace"
+        );
+    }
+
+    #[test]
+    fn core_decision_no_composite_without_model() {
+        let mut finding = finding_at(
+            "use of `unwrap()` may panic at runtime",
+            "correctness",
+            Severity::Medium,
+            "unwrap may panic",
+        );
+        let config = CalibratorConfig {
+            suppress_threshold: Some(0.5),
+            ..Default::default()
+        };
+        let decision = calibrate_core_decision(
+            &mut finding,
+            &config,
+            0.6,  // tp_weight
+            0.4,  // fp_weight (raw score = 0.6, above 0.5 suppress threshold)
+            0.0,
+            0.4,
+            vec![],
+            Severity::Medium,
+            "test.rs",
+        );
+        // No model -> score = 0.6 > 0.5 threshold -> NOT suppressed
+        assert!(
+            !decision.suppressed,
+            "without model, raw score 0.6 should not be suppressed at 0.5 threshold"
+        );
+        assert!(
+            decision.trace.composite_score.is_none(),
+            "composite_score should be None without model"
+        );
+    }
+
+    #[test]
+    fn core_decision_novel_family_uses_global_fp_rate() {
+        let model = make_composite_model();
+        let mut finding = finding_at(
+            "SQL injection via user input",
+            "security",
+            Severity::High,
+            "SQL injection risk",
+        );
+        let config = CalibratorConfig {
+            boost_threshold: Some(1.0),
+            model: Some(model),
+            ..Default::default()
+        };
+        let decision = calibrate_core_decision(
+            &mut finding,
+            &config,
+            2.0,  // tp_weight
+            0.1,  // fp_weight (raw score = 0.952)
+            0.0,
+            0.1,
+            vec![],
+            Severity::High,
+            "app.py",
+        );
+        // Novel family (no match in family_fp_rate) -> uses global_fp_rate=0.27
+        // word_lor tokens: sql, injection, via, user, input
+        //   sql=2.0, injection=1.5, rest=0
+        //   avg = (2.0 + 1.5) / 5 = 0.7
+        // composite = 0.5*0.952 + 1.5*0.7 + 1.0*(1-0.27) + 0.5*(1-0.208)
+        //           = 0.476 + 1.05 + 0.73 + 0.396 = 2.652
+        // 2.652 >= 1.0 (boost threshold) -> boost triggered
+        assert!(
+            decision.trace.composite_score.unwrap() > 2.0,
+            "SQL injection should have high composite score"
+        );
     }
 }

--- a/src/calibrator.rs
+++ b/src/calibrator.rs
@@ -191,7 +191,7 @@ struct CoreDecision {
 /// Returns a [`CoreDecision`] that the caller uses to update counters and
 /// decide whether to keep the finding in the output vec.
 #[allow(clippy::too_many_arguments)]
-fn sanitize_threshold(t: Option<f64>) -> Option<f64> {
+fn sanitize_threshold(t: Option<f64>, composite: bool) -> Option<f64> {
     t.and_then(|v| {
         if !v.is_finite() {
             tracing::warn!(
@@ -199,7 +199,7 @@ fn sanitize_threshold(t: Option<f64>) -> Option<f64> {
                 "non-finite threshold replaced with None (legacy fallback)"
             );
             None
-        } else if !(0.0..=1.0).contains(&v) {
+        } else if !composite && !(0.0..=1.0).contains(&v) {
             let clamped = v.clamp(0.0, 1.0);
             tracing::warn!(raw = v, clamped, "threshold outside [0,1] clamped");
             Some(clamped)
@@ -225,9 +225,10 @@ fn calibrate_core_decision(
     let mut suppressed = false;
     let mut boosted = false;
 
-    let force_threshold = sanitize_threshold(config.force_threshold);
-    let suppress_threshold = sanitize_threshold(config.suppress_threshold);
-    let boost_threshold = sanitize_threshold(config.boost_threshold);
+    let has_composite = config.model.is_some();
+    let force_threshold = sanitize_threshold(config.force_threshold, has_composite);
+    let suppress_threshold = sanitize_threshold(config.suppress_threshold, has_composite);
+    let boost_threshold = sanitize_threshold(config.boost_threshold, has_composite);
 
     // PR3: compute score once for data-driven threshold decisions.
     let total = tp_weight + fp_weight;

--- a/src/calibrator.rs
+++ b/src/calibrator.rs
@@ -5049,13 +5049,8 @@ mod tests {
                 ("sql".into(), 2.0),
                 ("injection".into(), 1.5),
             ]),
-            family_fp_rate: HashMap::from([
-                ("use of `` may panic at runtime".into(), 0.90),
-            ]),
-            language_fp_rate: HashMap::from([
-                ("rust".into(), 0.328),
-                ("python".into(), 0.208),
-            ]),
+            family_fp_rate: HashMap::from([("use of `` may panic at runtime".into(), 0.90)]),
+            language_fp_rate: HashMap::from([("rust".into(), 0.328), ("python".into(), 0.208)]),
         }
     }
 
@@ -5077,8 +5072,8 @@ mod tests {
         let decision = calibrate_core_decision(
             &mut finding,
             &config,
-            0.6,  // tp_weight
-            0.4,  // fp_weight (raw score = 0.6)
+            0.6, // tp_weight
+            0.4, // fp_weight (raw score = 0.6)
             0.0,
             0.4,
             vec![],
@@ -5117,8 +5112,8 @@ mod tests {
         let decision = calibrate_core_decision(
             &mut finding,
             &config,
-            0.6,  // tp_weight
-            0.4,  // fp_weight (raw score = 0.6, above 0.5 suppress threshold)
+            0.6, // tp_weight
+            0.4, // fp_weight (raw score = 0.6, above 0.5 suppress threshold)
             0.0,
             0.4,
             vec![],
@@ -5153,8 +5148,8 @@ mod tests {
         let decision = calibrate_core_decision(
             &mut finding,
             &config,
-            2.0,  // tp_weight
-            0.1,  // fp_weight (raw score = 0.952)
+            2.0, // tp_weight
+            0.1, // fp_weight (raw score = 0.952)
             0.0,
             0.1,
             vec![],

--- a/src/calibrator_fingerprint.rs
+++ b/src/calibrator_fingerprint.rs
@@ -181,6 +181,7 @@ mod tests {
             provenance: None,
             same_file_precedent_count: None,
             in_diff: None,
+            composite_score: None,
         }
     }
 

--- a/src/calibrator_model.rs
+++ b/src/calibrator_model.rs
@@ -1,0 +1,331 @@
+//! Learned model for composite calibrator scoring.
+//!
+//! Lookup tables (word log-odds, family FP rates, language FP rates) and
+//! feature weights computed by `quorum calibrate` from the feedback corpus.
+//! At review time the calibrator loads this model and computes a composite
+//! score that combines precedent weight, word-level signals, family-level
+//! FP rates, and language-level FP rates.
+
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ModelMeta {
+    pub computed_at: String,
+    pub feedback_count: usize,
+    pub global_fp_rate: f64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ScoreWeights {
+    pub score: f64,
+    pub word_lor: f64,
+    pub family_fp_inv: f64,
+    pub language_fp_inv: f64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CalibratorModel {
+    pub meta: ModelMeta,
+    pub weights: ScoreWeights,
+    pub word_lor: HashMap<String, f64>,
+    pub family_fp_rate: HashMap<String, f64>,
+    pub language_fp_rate: HashMap<String, f64>,
+}
+
+impl CalibratorModel {
+    pub fn to_toml(&self) -> String {
+        toml::to_string_pretty(self).unwrap_or_default()
+    }
+
+    pub fn from_toml(s: &str) -> Result<Self, toml::de::Error> {
+        toml::from_str(s)
+    }
+
+    pub fn load_from(path: &str) -> Option<Self> {
+        let content = std::fs::read_to_string(path).ok()?;
+        Self::from_toml(&content).ok()
+    }
+
+    /// Normalize a finding title into a pattern family.
+    ///
+    /// Strips rule-id prefixes, replaces backtick-quoted identifiers with ``,
+    /// replaces numbers with N, and collapses whitespace.
+    pub fn title_family(title: &str) -> String {
+        let mut t = title.to_lowercase();
+        // Strip rule-id prefix (e.g. "bare-except-pass: ")
+        if let Some(m) = regex::Regex::new(r"^[a-z0-9_-]+:\s*")
+            .ok()
+            .and_then(|re| re.find(&t))
+        {
+            t = t[m.end()..].to_string();
+        }
+        // Replace backtick-quoted identifiers
+        if let Ok(re) = regex::Regex::new(r"`[^`]+`") {
+            t = re.replace_all(&t, "``").to_string();
+        }
+        // Replace numbers
+        if let Ok(re) = regex::Regex::new(r"\b\d+\b") {
+            t = re.replace_all(&t, "N").to_string();
+        }
+        // Collapse whitespace
+        if let Ok(re) = regex::Regex::new(r"\s+") {
+            t = re.replace_all(&t, " ").to_string();
+        }
+        t.trim().to_string()
+    }
+
+    /// Compute the average word log-odds ratio for a title.
+    ///
+    /// Tokenizes by extracting `[a-z_]+` runs, looks up each word in the
+    /// vocabulary, and returns the mean. Unknown words contribute 0.0.
+    pub fn word_lor_score(&self, title: &str) -> f64 {
+        let lower = title.to_lowercase();
+        let words: Vec<&str> = regex::Regex::new(r"[a-z_]+")
+            .ok()
+            .map(|re| re.find_iter(&lower).map(|m| m.as_str()).collect())
+            .unwrap_or_default();
+        if words.is_empty() {
+            return 0.0;
+        }
+        let sum: f64 = words
+            .iter()
+            .map(|w| self.word_lor.get(*w).copied().unwrap_or(0.0))
+            .sum();
+        sum / words.len() as f64
+    }
+
+    /// Compute the composite score for a finding.
+    ///
+    /// Known families (present in `family_fp_rate`) use the family-specific
+    /// FP rate; novel families fall back to `global_fp_rate`.
+    pub fn composite_score(
+        &self,
+        precedent_score: f64,
+        title: &str,
+        file_ext_lang: &str,
+    ) -> f64 {
+        let family = Self::title_family(title);
+        let family_fp = self
+            .family_fp_rate
+            .get(&family)
+            .copied()
+            .unwrap_or(self.meta.global_fp_rate);
+        let lang_fp = self
+            .language_fp_rate
+            .get(file_ext_lang)
+            .copied()
+            .unwrap_or(self.meta.global_fp_rate);
+
+        self.weights.score * precedent_score
+            + self.weights.word_lor * self.word_lor_score(title)
+            + self.weights.family_fp_inv * (1.0 - family_fp)
+            + self.weights.language_fp_inv * (1.0 - lang_fp)
+    }
+
+    /// Map a file path to a language string for language_fp_rate lookup.
+    pub fn file_ext_language(path: &str) -> &'static str {
+        match std::path::Path::new(path)
+            .extension()
+            .and_then(|e| e.to_str())
+        {
+            Some("rs") => "rust",
+            Some("py") => "python",
+            Some("ts" | "tsx") => "typescript",
+            Some("js" | "jsx") => "javascript",
+            Some("yaml" | "yml") => "yaml",
+            Some("sh" | "bash" | "zsh") => "bash",
+            Some("tf" | "tfvars") => "terraform",
+            _ => "other",
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_model() -> CalibratorModel {
+        CalibratorModel {
+            meta: ModelMeta {
+                computed_at: "2026-05-12T00:00:00Z".to_string(),
+                feedback_count: 100,
+                global_fp_rate: 0.27,
+            },
+            weights: ScoreWeights {
+                score: 0.5,
+                word_lor: 1.5,
+                family_fp_inv: 1.0,
+                language_fp_inv: 0.5,
+            },
+            word_lor: HashMap::from([
+                ("hardcoded".into(), -1.88),
+                ("secret".into(), -1.50),
+                ("loop".into(), 1.47),
+                ("function".into(), 0.20),
+                ("complexity".into(), -0.80),
+            ]),
+            family_fp_rate: HashMap::from([(
+                "function `` has cyclomatic complexity N".into(),
+                0.30,
+            )]),
+            language_fp_rate: HashMap::from([("rust".into(), 0.328), ("python".into(), 0.208)]),
+        }
+    }
+
+    #[test]
+    fn round_trip_model() {
+        let model = make_model();
+        let toml_str = model.to_toml();
+        let parsed = CalibratorModel::from_toml(&toml_str).unwrap();
+        assert_eq!(parsed.word_lor.len(), 5);
+        assert!((parsed.word_lor["hardcoded"] - (-1.88)).abs() < 1e-9);
+        assert!((parsed.weights.word_lor - 1.5).abs() < 1e-9);
+        assert!((parsed.meta.global_fp_rate - 0.27).abs() < 1e-9);
+        assert_eq!(parsed.family_fp_rate.len(), 1);
+        assert_eq!(parsed.language_fp_rate.len(), 2);
+    }
+
+    #[test]
+    fn title_family_normalization() {
+        assert_eq!(
+            CalibratorModel::title_family(
+                "bare-except-pass: Function `process_data` has 42 lines"
+            ),
+            "function `` has N lines"
+        );
+        assert_eq!(
+            CalibratorModel::title_family("Hardcoded secret in `API_KEY`"),
+            "hardcoded secret in ``"
+        );
+        assert_eq!(
+            CalibratorModel::title_family("Simple title no prefix"),
+            "simple title no prefix"
+        );
+        assert_eq!(
+            CalibratorModel::title_family("rule-42: value is 100 or 200"),
+            "value is N or N"
+        );
+    }
+
+    #[test]
+    fn title_family_empty_and_edge_cases() {
+        assert_eq!(CalibratorModel::title_family(""), "");
+        assert_eq!(CalibratorModel::title_family("   "), "");
+        assert_eq!(CalibratorModel::title_family("`only_backtick`"), "``");
+    }
+
+    #[test]
+    fn word_lor_scoring_known_words() {
+        let model = make_model();
+        // "hardcoded secret" -> avg(-1.88, -1.50) = -1.69
+        let score = model.word_lor_score("hardcoded secret in `KEY`");
+        // tokens: hardcoded, secret, in, key (in and key are unknown -> 0.0)
+        // avg = (-1.88 + -1.50 + 0 + 0) / 4 = -0.845
+        assert!((score - (-0.845)).abs() < 0.01);
+    }
+
+    #[test]
+    fn word_lor_scoring_unknown_words() {
+        let model = make_model();
+        let score = model.word_lor_score("unknown stuff here");
+        assert!((score - 0.0).abs() < 0.01);
+    }
+
+    #[test]
+    fn word_lor_scoring_empty_title() {
+        let model = make_model();
+        assert!((model.word_lor_score("") - 0.0).abs() < 1e-9);
+        assert!((model.word_lor_score("123 456") - 0.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn composite_score_known_family() {
+        let model = make_model();
+        let score = model.composite_score(
+            0.8,
+            "function `foo` has cyclomatic complexity 42",
+            "rust",
+        );
+        // title_family -> "function `` has cyclomatic complexity N"
+        // family_fp = 0.30 (known)
+        // lang_fp = 0.328 (rust)
+        // word_lor tokens: function, foo, has, cyclomatic, complexity
+        //   function=0.20, foo=0, has=0, cyclomatic=0, complexity=-0.80
+        //   avg = (0.20 + 0 + 0 + 0 + -0.80) / 5 = -0.12
+        // composite = 0.5*0.8 + 1.5*(-0.12) + 1.0*(1-0.30) + 0.5*(1-0.328)
+        //           = 0.40 + (-0.18) + 0.70 + 0.336 = 1.256
+        assert!((score - 1.256).abs() < 0.01);
+    }
+
+    #[test]
+    fn composite_score_novel_family() {
+        let model = make_model();
+        let score = model.composite_score(
+            0.8,
+            "some totally new finding pattern",
+            "python",
+        );
+        // title_family -> "some totally new finding pattern" (not in family_fp_rate)
+        // family_fp = global_fp_rate = 0.27 (fallback)
+        // lang_fp = 0.208 (python)
+        // word_lor tokens: some, totally, new, finding, pattern -> all unknown = 0
+        // composite = 0.5*0.8 + 1.5*0.0 + 1.0*(1-0.27) + 0.5*(1-0.208)
+        //           = 0.40 + 0.0 + 0.73 + 0.396 = 1.526
+        assert!((score - 1.526).abs() < 0.01);
+    }
+
+    #[test]
+    fn composite_score_unknown_language() {
+        let model = make_model();
+        let score_py = model.composite_score(0.5, "test finding", "python");
+        let score_other = model.composite_score(0.5, "test finding", "other");
+        // "other" falls back to global_fp_rate (0.27)
+        // python uses 0.208
+        // Difference: 0.5 * (0.208 - 0.27) = -0.031 (python slightly better)
+        assert!((score_py - score_other).abs() < 0.1);
+        assert!(score_py > score_other); // python has lower FP rate -> higher score
+    }
+
+    #[test]
+    fn file_ext_language_mapping() {
+        assert_eq!(CalibratorModel::file_ext_language("src/main.rs"), "rust");
+        assert_eq!(
+            CalibratorModel::file_ext_language("app/page.tsx"),
+            "typescript"
+        );
+        assert_eq!(
+            CalibratorModel::file_ext_language("app/page.ts"),
+            "typescript"
+        );
+        assert_eq!(
+            CalibratorModel::file_ext_language("config.yaml"),
+            "yaml"
+        );
+        assert_eq!(
+            CalibratorModel::file_ext_language("script.sh"),
+            "bash"
+        );
+        assert_eq!(
+            CalibratorModel::file_ext_language("main.py"),
+            "python"
+        );
+        assert_eq!(
+            CalibratorModel::file_ext_language("index.js"),
+            "javascript"
+        );
+        assert_eq!(
+            CalibratorModel::file_ext_language("main.tf"),
+            "terraform"
+        );
+        assert_eq!(
+            CalibratorModel::file_ext_language("Dockerfile"),
+            "other"
+        );
+    }
+
+    #[test]
+    fn load_from_missing_returns_none() {
+        assert!(CalibratorModel::load_from("/nonexistent/path").is_none());
+    }
+}

--- a/src/calibrator_model.rs
+++ b/src/calibrator_model.rs
@@ -14,10 +14,8 @@ static RULE_PREFIX_RE: LazyLock<regex::Regex> =
     LazyLock::new(|| regex::Regex::new(r"^[a-z0-9_-]+:\s*").unwrap());
 static BACKTICK_RE: LazyLock<regex::Regex> =
     LazyLock::new(|| regex::Regex::new(r"`[^`]+`").unwrap());
-static NUMBER_RE: LazyLock<regex::Regex> =
-    LazyLock::new(|| regex::Regex::new(r"\b\d+\b").unwrap());
-static WHITESPACE_RE: LazyLock<regex::Regex> =
-    LazyLock::new(|| regex::Regex::new(r"\s+").unwrap());
+static NUMBER_RE: LazyLock<regex::Regex> = LazyLock::new(|| regex::Regex::new(r"\b\d+\b").unwrap());
+static WHITESPACE_RE: LazyLock<regex::Regex> = LazyLock::new(|| regex::Regex::new(r"\s+").unwrap());
 pub static WORD_RE: LazyLock<regex::Regex> =
     LazyLock::new(|| regex::Regex::new(r"[a-z_]+").unwrap());
 
@@ -95,12 +93,7 @@ impl CalibratorModel {
     ///
     /// Known families (present in `family_fp_rate`) use the family-specific
     /// FP rate; novel families fall back to `global_fp_rate`.
-    pub fn composite_score(
-        &self,
-        precedent_score: f64,
-        title: &str,
-        file_ext_lang: &str,
-    ) -> f64 {
+    pub fn composite_score(&self, precedent_score: f64, title: &str, file_ext_lang: &str) -> f64 {
         let family = Self::title_family(title);
         let family_fp = self
             .family_fp_rate
@@ -189,9 +182,7 @@ mod tests {
     #[test]
     fn title_family_normalization() {
         assert_eq!(
-            CalibratorModel::title_family(
-                "bare-except-pass: Function `process_data` has 42 lines"
-            ),
+            CalibratorModel::title_family("bare-except-pass: Function `process_data` has 42 lines"),
             "function `` has N lines"
         );
         assert_eq!(
@@ -242,11 +233,8 @@ mod tests {
     #[test]
     fn composite_score_known_family() {
         let model = make_model();
-        let score = model.composite_score(
-            0.8,
-            "function `foo` has cyclomatic complexity 42",
-            "rust",
-        );
+        let score =
+            model.composite_score(0.8, "function `foo` has cyclomatic complexity 42", "rust");
         // title_family -> "function `` has cyclomatic complexity N"
         // family_fp = 0.30 (known)
         // lang_fp = 0.328 (rust)
@@ -261,11 +249,7 @@ mod tests {
     #[test]
     fn composite_score_novel_family() {
         let model = make_model();
-        let score = model.composite_score(
-            0.8,
-            "some totally new finding pattern",
-            "python",
-        );
+        let score = model.composite_score(0.8, "some totally new finding pattern", "python");
         // title_family -> "some totally new finding pattern" (not in family_fp_rate)
         // family_fp = global_fp_rate = 0.27 (fallback)
         // lang_fp = 0.208 (python)
@@ -298,30 +282,12 @@ mod tests {
             CalibratorModel::file_ext_language("app/page.ts"),
             "typescript"
         );
-        assert_eq!(
-            CalibratorModel::file_ext_language("config.yaml"),
-            "yaml"
-        );
-        assert_eq!(
-            CalibratorModel::file_ext_language("script.sh"),
-            "bash"
-        );
-        assert_eq!(
-            CalibratorModel::file_ext_language("main.py"),
-            "python"
-        );
-        assert_eq!(
-            CalibratorModel::file_ext_language("index.js"),
-            "javascript"
-        );
-        assert_eq!(
-            CalibratorModel::file_ext_language("main.tf"),
-            "terraform"
-        );
-        assert_eq!(
-            CalibratorModel::file_ext_language("Dockerfile"),
-            "other"
-        );
+        assert_eq!(CalibratorModel::file_ext_language("config.yaml"), "yaml");
+        assert_eq!(CalibratorModel::file_ext_language("script.sh"), "bash");
+        assert_eq!(CalibratorModel::file_ext_language("main.py"), "python");
+        assert_eq!(CalibratorModel::file_ext_language("index.js"), "javascript");
+        assert_eq!(CalibratorModel::file_ext_language("main.tf"), "terraform");
+        assert_eq!(CalibratorModel::file_ext_language("Dockerfile"), "other");
     }
 
     #[test]

--- a/src/calibrator_model.rs
+++ b/src/calibrator_model.rs
@@ -8,6 +8,18 @@
 
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
+use std::sync::LazyLock;
+
+static RULE_PREFIX_RE: LazyLock<regex::Regex> =
+    LazyLock::new(|| regex::Regex::new(r"^[a-z0-9_-]+:\s*").unwrap());
+static BACKTICK_RE: LazyLock<regex::Regex> =
+    LazyLock::new(|| regex::Regex::new(r"`[^`]+`").unwrap());
+static NUMBER_RE: LazyLock<regex::Regex> =
+    LazyLock::new(|| regex::Regex::new(r"\b\d+\b").unwrap());
+static WHITESPACE_RE: LazyLock<regex::Regex> =
+    LazyLock::new(|| regex::Regex::new(r"\s+").unwrap());
+pub static WORD_RE: LazyLock<regex::Regex> =
+    LazyLock::new(|| regex::Regex::new(r"[a-z_]+").unwrap());
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ModelMeta {
@@ -53,25 +65,12 @@ impl CalibratorModel {
     /// replaces numbers with N, and collapses whitespace.
     pub fn title_family(title: &str) -> String {
         let mut t = title.to_lowercase();
-        // Strip rule-id prefix (e.g. "bare-except-pass: ")
-        if let Some(m) = regex::Regex::new(r"^[a-z0-9_-]+:\s*")
-            .ok()
-            .and_then(|re| re.find(&t))
-        {
+        if let Some(m) = RULE_PREFIX_RE.find(&t) {
             t = t[m.end()..].to_string();
         }
-        // Replace backtick-quoted identifiers
-        if let Ok(re) = regex::Regex::new(r"`[^`]+`") {
-            t = re.replace_all(&t, "``").to_string();
-        }
-        // Replace numbers
-        if let Ok(re) = regex::Regex::new(r"\b\d+\b") {
-            t = re.replace_all(&t, "N").to_string();
-        }
-        // Collapse whitespace
-        if let Ok(re) = regex::Regex::new(r"\s+") {
-            t = re.replace_all(&t, " ").to_string();
-        }
+        t = BACKTICK_RE.replace_all(&t, "``").to_string();
+        t = NUMBER_RE.replace_all(&t, "N").to_string();
+        t = WHITESPACE_RE.replace_all(&t, " ").to_string();
         t.trim().to_string()
     }
 
@@ -81,10 +80,7 @@ impl CalibratorModel {
     /// vocabulary, and returns the mean. Unknown words contribute 0.0.
     pub fn word_lor_score(&self, title: &str) -> f64 {
         let lower = title.to_lowercase();
-        let words: Vec<&str> = regex::Regex::new(r"[a-z_]+")
-            .ok()
-            .map(|re| re.find_iter(&lower).map(|m| m.as_str()).collect())
-            .unwrap_or_default();
+        let words: Vec<&str> = WORD_RE.find_iter(&lower).map(|m| m.as_str()).collect();
         if words.is_empty() {
             return 0.0;
         }
@@ -123,7 +119,11 @@ impl CalibratorModel {
             + self.weights.language_fp_inv * (1.0 - lang_fp)
     }
 
-    /// Map a file path to a language string for language_fp_rate lookup.
+    /// Map a file path to a language string for `language_fp_rate` lookup.
+    ///
+    /// Covers the same languages quorum supports for AST analysis. Extensions
+    /// outside this set map to `"other"`, which may fall back to
+    /// `global_fp_rate` if `other` has fewer than `LANG_MIN_SUPPORT` entries.
     pub fn file_ext_language(path: &str) -> &'static str {
         match std::path::Path::new(path)
             .extension()

--- a/src/calibrator_trace.rs
+++ b/src/calibrator_trace.rs
@@ -89,6 +89,8 @@ pub struct CalibratorTraceEntry {
     /// with pre-#310 trace lines and when no diff context is available.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub in_diff: Option<bool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub composite_score: Option<f64>,
 }
 
 #[cfg(test)]
@@ -123,6 +125,7 @@ mod tests {
             provenance: None,
             same_file_precedent_count: None,
             in_diff: None,
+            composite_score: None,
         };
         let json = serde_json::to_string(&trace).unwrap();
         assert!(json.contains("\"tp_weight\":2.5"));
@@ -148,6 +151,7 @@ mod tests {
             provenance: None,
             same_file_precedent_count: None,
             in_diff: None,
+            composite_score: None,
         };
         let json = serde_json::to_string(&trace).unwrap();
         assert!(json.contains("\"matched_precedents\":[]"));
@@ -192,6 +196,7 @@ mod tests {
             provenance: None,
             same_file_precedent_count: None,
             in_diff: None,
+            composite_score: None,
         };
         let json = serde_json::to_string(&trace).unwrap();
         assert!(
@@ -234,6 +239,7 @@ mod tests {
             provenance: None,
             same_file_precedent_count: None,
             in_diff: None,
+            composite_score: None,
         };
         let json = serde_json::to_string(&trace).unwrap();
         assert!(json.contains("\"file_path\":\"src/main.rs\""));
@@ -310,6 +316,7 @@ mod tests {
             provenance: None,
             same_file_precedent_count: Some(2),
             in_diff: None,
+            composite_score: None,
         };
         let json = serde_json::to_string(&trace).unwrap();
         assert!(json.contains("\"same_file_precedent_count\":2"));
@@ -371,6 +378,7 @@ mod tests {
             }),
             same_file_precedent_count: None,
             in_diff: None,
+            composite_score: None,
         };
         let json = serde_json::to_string(&trace).unwrap();
         assert!(
@@ -412,6 +420,7 @@ mod tests {
             provenance: None,
             same_file_precedent_count: None,
             in_diff: None,
+            composite_score: None,
         };
         let json = serde_json::to_string(&trace).unwrap();
         assert!(
@@ -439,6 +448,7 @@ mod tests {
             provenance: None,
             same_file_precedent_count: None,
             in_diff: Some(false),
+            composite_score: None,
         };
         let json = serde_json::to_string(&trace).unwrap();
         assert!(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -91,6 +91,9 @@ pub mod metrics;
 // Threshold config: TOML read/write for data-driven calibrator thresholds.
 pub mod threshold_config;
 
+// Learned model for composite calibrator scoring.
+pub mod calibrator_model;
+
 // Calibrate: corpus join + threshold computation from feedback + traces.
 pub mod calibrate;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1045,10 +1045,7 @@ async fn run_review(opts: cli::ReviewOpts) -> i32 {
         );
         calibrator_config.model = Some(model);
     }
-    if loaded_tc
-        .as_ref()
-        .is_some_and(|tc| tc.composite_model)
-        && calibrator_config.model.is_none()
+    if loaded_tc.as_ref().is_some_and(|tc| tc.composite_model) && calibrator_config.model.is_none()
     {
         tracing::warn!(
             "calibrator_thresholds.toml declares composite_model=true but \

--- a/src/main.rs
+++ b/src/main.rs
@@ -1020,11 +1020,11 @@ async fn run_review(opts: cli::ReviewOpts) -> i32 {
         ..Default::default()
     };
     let thresholds_path = qhome.join("calibrator_thresholds.toml");
-    if let Some(tc) =
-        quorum::threshold_config::ThresholdConfig::load_from(&thresholds_path.to_string_lossy())
-    {
-        calibrator_config.suppress_threshold = tc.suppress.map(|p| p.threshold);
-        calibrator_config.boost_threshold = tc.boost.map(|p| p.threshold);
+    let loaded_tc =
+        quorum::threshold_config::ThresholdConfig::load_from(&thresholds_path.to_string_lossy());
+    if let Some(tc) = loaded_tc.as_ref() {
+        calibrator_config.suppress_threshold = tc.suppress.as_ref().map(|p| p.threshold);
+        calibrator_config.boost_threshold = tc.boost.as_ref().map(|p| p.threshold);
         tracing::info!(
             suppress = ?calibrator_config.suppress_threshold,
             boost = ?calibrator_config.boost_threshold,
@@ -1044,6 +1044,19 @@ async fn run_review(opts: cli::ReviewOpts) -> i32 {
             "loaded composite calibrator model"
         );
         calibrator_config.model = Some(model);
+    }
+    if loaded_tc
+        .as_ref()
+        .is_some_and(|tc| tc.composite_model)
+        && calibrator_config.model.is_none()
+    {
+        tracing::warn!(
+            "calibrator_thresholds.toml declares composite_model=true but \
+             calibrator_model.toml is missing; clearing thresholds to fall \
+             back to defaults"
+        );
+        calibrator_config.suppress_threshold = None;
+        calibrator_config.boost_threshold = None;
     }
     // QUORUM_FORCE_THRESHOLD overrides both suppress and boost.
     if let Ok(v) = std::env::var("QUORUM_FORCE_THRESHOLD") {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1068,10 +1068,15 @@ async fn run_review(opts: cli::ReviewOpts) -> i32 {
                 );
             }
             Ok(t) => {
+                let expected = if has_composite {
+                    "expected finite value"
+                } else {
+                    "expected finite value in [0.0, 1.0]"
+                };
                 tracing::warn!(
                     raw = %v,
                     parsed = t,
-                    "ignoring QUORUM_FORCE_THRESHOLD: expected finite value in [0.0, 1.0]"
+                    "ignoring QUORUM_FORCE_THRESHOLD: {expected}"
                 );
             }
             Err(e) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1028,13 +1028,28 @@ async fn run_review(opts: cli::ReviewOpts) -> i32 {
         tracing::info!(
             suppress = ?calibrator_config.suppress_threshold,
             boost = ?calibrator_config.boost_threshold,
+            composite = tc.composite_model,
             "loaded data-driven calibrator thresholds"
         );
     }
+    // Load composite calibrator model if available.
+    let model_path = qhome.join("calibrator_model.toml");
+    if let Some(model) =
+        quorum::calibrator_model::CalibratorModel::load_from(&model_path.to_string_lossy())
+    {
+        tracing::info!(
+            word_lor_entries = model.word_lor.len(),
+            family_rates = model.family_fp_rate.len(),
+            language_rates = model.language_fp_rate.len(),
+            "loaded composite calibrator model"
+        );
+        calibrator_config.model = Some(model);
+    }
     // QUORUM_FORCE_THRESHOLD overrides both suppress and boost.
     if let Ok(v) = std::env::var("QUORUM_FORCE_THRESHOLD") {
+        let has_composite = calibrator_config.model.is_some();
         match v.parse::<f64>() {
-            Ok(t) if t.is_finite() && (0.0..=1.0).contains(&t) => {
+            Ok(t) if t.is_finite() && (has_composite || (0.0..=1.0).contains(&t)) => {
                 calibrator_config.force_threshold = Some(t);
                 tracing::warn!(
                     threshold = t,
@@ -2311,11 +2326,36 @@ fn run_calibrate(opts: cli::CalibrateOpts) -> i32 {
     eprintln!("  below threshold:    {}", join_stats.below_threshold);
     eprintln!("  unmatched:          {}", join_stats.unmatched);
 
-    let config = quorum::calibrate::compute_thresholds(
-        &samples,
+    // Compute composite model from feedback
+    let composite_model = quorum::calibrate::compute_calibrator_model(&feedback);
+    let scoring_samples = if let Some(ref model) = composite_model {
+        eprintln!(
+            "\nComposite model: {} word_lor entries, {} family rates, {} language rates",
+            model.word_lor.len(),
+            model.family_fp_rate.len(),
+            model.language_fp_rate.len(),
+        );
+        // Re-score samples using composite scores for threshold computation
+        quorum::calibrate::rescore_samples_with_model(
+            &feedback,
+            &traces,
+            model,
+            &filter,
+            disable_fuzzy,
+        )
+    } else {
+        eprintln!("\nComposite model: not computed (no eligible feedback)");
+        samples.clone()
+    };
+
+    let mut config = quorum::calibrate::compute_thresholds(
+        &scoring_samples,
         opts.suppress_precision,
         opts.boost_precision,
     );
+    if composite_model.is_some() {
+        config.composite_model = true;
+    }
 
     // Print summary
     println!("--- Calibrator Threshold Report ---");
@@ -2350,15 +2390,32 @@ fn run_calibrate(opts: cli::CalibrateOpts) -> i32 {
     } else if config.suppress.is_none() && config.boost.is_none() {
         eprintln!("\nNo thresholds computed (insufficient data). Existing config preserved.");
     } else {
-        let toml_path = qhome.join("calibrator_thresholds.toml");
-        let toml_str = config.to_toml();
         if let Err(e) = std::fs::create_dir_all(&qhome) {
             eprintln!("\nerror: failed to create {}: {e}", qhome.display());
             return 3;
         }
+
+        // Write composite model
+        if let Some(ref model) = composite_model {
+            let model_path = qhome.join("calibrator_model.toml");
+            let model_toml = model.to_toml();
+            match std::fs::write(&model_path, &model_toml) {
+                Ok(()) => {
+                    eprintln!("Wrote {}", model_path.display());
+                }
+                Err(e) => {
+                    eprintln!("error: failed to write {}: {}", model_path.display(), e);
+                    return 3;
+                }
+            }
+        }
+
+        // Write thresholds
+        let toml_path = qhome.join("calibrator_thresholds.toml");
+        let toml_str = config.to_toml();
         match std::fs::write(&toml_path, &toml_str) {
             Ok(()) => {
-                eprintln!("\nWrote {}", toml_path.display());
+                eprintln!("Wrote {}", toml_path.display());
             }
             Err(e) => {
                 eprintln!("\nerror: failed to write {}: {}", toml_path.display(), e);

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,7 @@
 pub use quorum::analysis;
 pub use quorum::ast_grep;
 pub use quorum::calibrator;
+pub use quorum::calibrator_model;
 pub use quorum::calibrator_trace;
 pub use quorum::category;
 pub use quorum::domain;

--- a/src/threshold_config.rs
+++ b/src/threshold_config.rs
@@ -23,6 +23,11 @@ pub struct ThresholdConfig {
     pub suppress: Option<PathThreshold>,
     /// Boost path: findings scoring at or above this threshold get severity boosted.
     pub boost: Option<PathThreshold>,
+    /// When true, thresholds are composite-range (approx [-4, 6]) rather than
+    /// unit-range [0, 1]. Written by `quorum calibrate` when a composite model
+    /// is active.
+    #[serde(default)]
+    pub composite_model: bool,
 }
 
 impl ThresholdConfig {
@@ -66,14 +71,20 @@ impl ThresholdConfig {
     }
 
     fn validate(self) -> Option<Self> {
-        let valid = |p: &PathThreshold| {
+        let valid = |p: &PathThreshold, composite: bool| {
             p.precision_target.is_finite()
                 && p.threshold.is_finite()
                 && (0.0..=1.0).contains(&p.precision_target)
-                && (0.0..=1.0).contains(&p.threshold)
+                && (composite || (0.0..=1.0).contains(&p.threshold))
         };
-        if self.suppress.as_ref().is_some_and(|p| !valid(p))
-            || self.boost.as_ref().is_some_and(|p| !valid(p))
+        if self
+            .suppress
+            .as_ref()
+            .is_some_and(|p| !valid(p, self.composite_model))
+            || self
+                .boost
+                .as_ref()
+                .is_some_and(|p| !valid(p, self.composite_model))
         {
             tracing::warn!(
                 "calibrator_thresholds.toml contains out-of-range values, using defaults"
@@ -109,6 +120,7 @@ mod tests {
                 precision_target: 0.85,
                 threshold: 0.42,
             }),
+            ..Default::default()
         };
         let toml_str = config.to_toml();
         let parsed = ThresholdConfig::from_toml(&toml_str).unwrap();
@@ -144,6 +156,7 @@ mod tests {
                 threshold: 1.5, // out of range
             }),
             boost: None,
+            ..Default::default()
         };
         assert!(config.validate().is_none());
     }
@@ -159,6 +172,7 @@ mod tests {
                 precision_target: 0.85,
                 threshold: 0.5, // suppress >= boost
             }),
+            ..Default::default()
         };
         assert!(config.validate().is_none());
     }
@@ -174,7 +188,79 @@ mod tests {
                 precision_target: 0.85,
                 threshold: 0.7,
             }),
+            composite_model: false,
         };
         assert!(config.validate().is_some());
+    }
+
+    #[test]
+    fn validate_accepts_composite_thresholds_outside_unit() {
+        let config = ThresholdConfig {
+            suppress: Some(PathThreshold {
+                precision_target: 0.85,
+                threshold: -1.5,
+            }),
+            boost: Some(PathThreshold {
+                precision_target: 0.90,
+                threshold: 1.8,
+            }),
+            composite_model: true,
+        };
+        assert!(config.validate().is_some());
+    }
+
+    #[test]
+    fn validate_rejects_composite_suppress_gte_boost() {
+        let config = ThresholdConfig {
+            suppress: Some(PathThreshold {
+                precision_target: 0.85,
+                threshold: 2.0,
+            }),
+            boost: Some(PathThreshold {
+                precision_target: 0.90,
+                threshold: 1.0,
+            }),
+            composite_model: true,
+        };
+        assert!(config.validate().is_none());
+    }
+
+    #[test]
+    fn validate_rejects_non_finite_composite() {
+        let config = ThresholdConfig {
+            suppress: Some(PathThreshold {
+                precision_target: 0.85,
+                threshold: f64::NAN,
+            }),
+            boost: None,
+            composite_model: true,
+        };
+        assert!(config.validate().is_none());
+    }
+
+    #[test]
+    fn round_trip_composite_flag() {
+        let config = ThresholdConfig {
+            suppress: Some(PathThreshold {
+                precision_target: 0.85,
+                threshold: -0.5,
+            }),
+            boost: Some(PathThreshold {
+                precision_target: 0.90,
+                threshold: 2.0,
+            }),
+            composite_model: true,
+        };
+        let toml_str = config.to_toml();
+        let parsed = ThresholdConfig::from_toml(&toml_str).unwrap();
+        assert!(parsed.composite_model);
+        assert!((parsed.suppress.unwrap().threshold - (-0.5)).abs() < 1e-9);
+    }
+
+    #[test]
+    fn composite_model_defaults_to_false() {
+        let toml_str = "[boost]\nprecision_target = 0.85\nthreshold = 0.42\n";
+        let parsed = ThresholdConfig::from_toml(toml_str).unwrap();
+        assert!(!parsed.composite_model);
     }
 }


### PR DESCRIPTION
## Summary

- Adds a learned composite calibrator model (`CalibratorModel`) that replaces the single-feature precedent score with a multi-feature composite: `0.5*score + 1.5*word_lor + 1.0*(1-family_fp_rate) + 0.5*(1-language_fp_rate)`
- Word log-odds ratios, per-family FP rates, and per-language FP rates are computed from the feedback corpus by `quorum calibrate` and stored in `~/.quorum/calibrator_model.toml`
- Known families (3+ feedback entries) use family-specific FP rate; novel families fall back to global FP rate
- Threshold validation relaxed to allow composite-range scores (approx [-4, 6]) when `composite_model = true`
- Re-scores samples with composite model before threshold computation so suppress/boost thresholds are calibrated against the new score distribution

## Design

Two-tier scoring: findings with matched feedback precedents get scored via the composite formula. The model is a set of lookup tables — no linear algebra, no ML dependencies. `quorum calibrate` builds the tables from the existing feedback corpus; `quorum review` loads and applies them.

Key modules:
- `src/calibrator_model.rs` — `CalibratorModel` struct, `title_family()` normalization, `word_lor_score()`, `composite_score()`
- `src/calibrate.rs` — `compute_calibrator_model()`, `rescore_samples_with_model()`
- `src/calibrator.rs` — `calibrate_core_decision()` integration
- `src/threshold_config.rs` — composite-range threshold validation

## Test plan

- [x] 31 new unit tests across 5 modules
- [x] All 1369 bin tests pass
- [x] Clippy clean
- [x] Release build succeeds
- [x] Quorum self-review performed on changed files (4 findings triaged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional learned calibrator model that computes composite scores from precedent, title tokens, family and file-language signals.
  * Rescoring of samples with the model and ability to save/load model data.

* **Behavior**
  * Calibration traces now include composite_score when a model is active.
  * Threshold validation and decision logic gain a composite-mode flag that alters threshold interpretation and scoring.

* **Tests**
  * Expanded coverage for model computation, scoring, serialization, and calibration integration.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jsnyder/quorum/pull/308)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->