### PR TITLE
feat: AST finding judge with rule_id tracing and speculative rule support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2744,6 +2744,7 @@ dependencies = [
  "rust-mcp-sdk",
  "serde",
  "serde_json",
+ "serde_yaml",
  "sha2",
  "sqlite-vec",
  "tempfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ clap = { version = "4", features = ["derive"] }
 reqwest = { version = "0.12", features = ["json", "stream", "blocking"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+serde_yaml = "0.9"
 
 # Error handling
 anyhow = "1"

--- a/docs/superpowers/plans/2026-05-12-ast-judge.md
+++ b/docs/superpowers/plans/2026-05-12-ast-judge.md
@@ -1,0 +1,1887 @@
+# AST Finding Judge Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add rule_id tracing to findings, per-rule precision stats, and an LLM micro-judge pipeline stage that validates speculative AST rules before merge.
+
+**Architecture:** Two phases. Phase 1 adds `rule_id` to Finding, populates it at all AST construction sites, and wires `stats --by-rule`. Phase 2 adds rule metadata (precision/judge), a batched LLM judge stage parallel with the reviewer, verdict caching, and 10 pilot speculative rules. The judge runs between AST collection and merge; rejected findings are dropped (required) or clamped (optional).
+
+**Tech Stack:** Rust, serde, ast-grep, tree-sitter, OpenAI-compatible LLM API
+
+**Spec:** `docs/superpowers/specs/2026-05-12-ast-judge-design.md`
+
+---
+
+## File Map
+
+### Phase 1: Rule Identity
+| File | Action | Responsibility |
+|------|--------|---------------|
+| `src/finding.rs` | Modify | Add `rule_id` field to Finding, builder method, update `compute_confidence` |
+| `src/ast_grep.rs` | Modify | Populate `rule_id` from rule.id + language in scan_file |
+| `src/analysis.rs` | Modify | Populate `rule_id` at all 63 LocalAst construction sites |
+| `src/dimensions.rs` | Modify | Add `group_by_rule()` function |
+| `src/cli/mod.rs` | Modify | Add `--by-rule` flag to StatsOpts |
+| `src/main.rs` | Modify | Wire `--by-rule` to `group_by_rule()` |
+
+### Phase 2: Judge Infrastructure
+| File | Action | Responsibility |
+|------|--------|---------------|
+| `src/finding.rs` | Modify | Add `judge_verdict`, `judge_confidence`, `precision_tier` fields |
+| `src/ast_grep.rs` | Modify | Parse `metadata` block from YAML, `RuleMetadata`/`PrecisionTier`/`JudgeRequirement` types |
+| `src/judge.rs` | Create | Judge trait, LLM implementation, batching, verdict cache |
+| `src/pipeline.rs` | Modify | Insert judge stage between AST collection and merge |
+| `src/merge.rs` | Modify | Mixed-source confidence precedence (max) |
+| `src/telemetry.rs` | Modify | Judge counters |
+| `src/cli/mod.rs` | Modify | `--judge` flag, `QUORUM_JUDGE_MODEL` env var |
+| `rules/python/*.yml` | Create | 5 speculative rules |
+| `rules/typescript/*.yml` | Create | 2 speculative rules |
+| `rules/rust/*.yml` | Create | 2 speculative rules |
+| `rules/yaml/*.yml` | Create | 1 speculative rule |
+
+---
+
+## Phase 1: Rule Identity and Per-Rule Stats
+
+### Task 1: Add rule_id to Finding struct
+
+**Files:**
+- Modify: `src/finding.rs:79-116` (Finding struct)
+- Modify: `src/finding.rs:170-320` (FindingBuilder)
+
+- [ ] **Step 1: Write test for rule_id field**
+
+In `src/finding.rs`, inside `mod tests`, add:
+
+```rust
+#[test]
+fn finding_rule_id_defaults_to_none() {
+    let f = FindingBuilder::new().build();
+    assert_eq!(f.rule_id, None);
+}
+
+#[test]
+fn finding_rule_id_set_via_builder() {
+    let f = FindingBuilder::new()
+        .rule_id("ast-grep:python/bare-except-pass")
+        .build();
+    assert_eq!(f.rule_id.as_deref(), Some("ast-grep:python/bare-except-pass"));
+}
+
+#[test]
+fn finding_rule_id_survives_json_roundtrip() {
+    let f = FindingBuilder::new()
+        .rule_id("local-ast:complexity")
+        .build();
+    let json = serde_json::to_string(&f).unwrap();
+    let parsed: Finding = serde_json::from_str(&json).unwrap();
+    assert_eq!(parsed.rule_id.as_deref(), Some("local-ast:complexity"));
+}
+
+#[test]
+fn finding_without_rule_id_omits_from_json() {
+    let f = FindingBuilder::new().build();
+    let json = serde_json::to_string(&f).unwrap();
+    assert!(!json.contains("rule_id"));
+}
+
+#[test]
+fn legacy_json_without_rule_id_deserializes_as_none() {
+    let json = r#"{"title":"t","description":"d","severity":"info","category":"maintainability","source":"local-ast","line_start":1,"line_end":1,"evidence":[],"similar_precedent":[]}"#;
+    let f: Finding = serde_json::from_str(json).unwrap();
+    assert_eq!(f.rule_id, None);
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cargo test --lib finding -- rule_id`
+Expected: compilation error — `rule_id` field does not exist
+
+- [ ] **Step 3: Add rule_id field to Finding struct**
+
+In `src/finding.rs`, after the `model_agreement` field (line ~115), add:
+
+```rust
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub rule_id: Option<String>,
+```
+
+- [ ] **Step 4: Add rule_id to FindingBuilder default**
+
+In `FindingBuilder::new()` (line ~183), add in the inner Finding initialization:
+
+```rust
+                rule_id: None,
+```
+
+- [ ] **Step 5: Add builder method for rule_id**
+
+In `impl FindingBuilder`, after the `precedent` method (line ~315), add:
+
+```rust
+    pub fn rule_id(mut self, r: &str) -> Self {
+        self.inner.rule_id = Some(r.into());
+        self
+    }
+```
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `cargo test --lib finding -- rule_id`
+Expected: all 5 new tests pass
+
+- [ ] **Step 7: Fix compilation errors in analysis.rs and ast_grep.rs**
+
+Every `Finding { ... }` literal in `src/analysis.rs` and `src/ast_grep.rs` now needs `rule_id: None`. There are ~63 sites in analysis.rs and 1 in ast_grep.rs. Add `rule_id: None,` to each.
+
+Search pattern to find them all:
+```bash
+grep -n 'model_agreement: None,' src/analysis.rs src/ast_grep.rs
+```
+
+Each of those lines should be followed by a new `rule_id: None,` line.
+
+- [ ] **Step 8: Run full test suite**
+
+Run: `cargo test --bin quorum`
+Expected: all tests pass, no compilation errors
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src/finding.rs src/analysis.rs src/ast_grep.rs
+git commit -m "feat(finding): add rule_id field to Finding struct
+
+Adds Option<String> rule_id with serde(default) for backward compat.
+FindingBuilder gains .rule_id() method. All existing construction
+sites set rule_id: None (populated in next commit). Addresses #11."
+```
+
+---
+
+### Task 2: Populate rule_id in ast_grep.rs
+
+**Files:**
+- Modify: `src/ast_grep.rs:242-305` (scan_file function)
+
+- [ ] **Step 1: Write test for rule_id population**
+
+In `src/ast_grep.rs`, inside `mod tests`, add:
+
+```rust
+#[test]
+fn scan_file_populates_rule_id_with_language_and_rule_name() {
+    let yaml = std::fs::read_to_string(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/rules/typescript/as-any-cast.yml"
+    ))
+    .unwrap();
+    let rules: Vec<RuleConfig<SupportLang>> =
+        from_yaml_string(&yaml, &GlobalRules::default()).unwrap();
+    let source = "const x = foo as any;";
+    let findings = scan_file(source, "ts", &rules);
+    assert!(!findings.is_empty());
+    assert_eq!(
+        findings[0].rule_id.as_deref(),
+        Some("ast-grep:typescript/as-any-cast")
+    );
+}
+
+#[test]
+fn scan_file_python_rule_id_uses_python_prefix() {
+    let yaml = std::fs::read_to_string(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/rules/python/bare-except-pass.yml"
+    ))
+    .unwrap();
+    let rules: Vec<RuleConfig<SupportLang>> =
+        from_yaml_string(&yaml, &GlobalRules::default()).unwrap();
+    let source = "try:\n    x()\nexcept:\n    pass\n";
+    let findings = scan_file(source, "py", &rules);
+    assert!(!findings.is_empty());
+    assert_eq!(
+        findings[0].rule_id.as_deref(),
+        Some("ast-grep:python/bare-except-pass")
+    );
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cargo test --lib ast_grep -- rule_id`
+Expected: FAIL — rule_id is None, not the expected string
+
+- [ ] **Step 3: Populate rule_id in scan_file**
+
+In `src/ast_grep.rs`, inside the `scan_file` function, in the Finding construction (line ~277), change:
+
+```rust
+rule_id: None,
+```
+
+to:
+
+```rust
+rule_id: Some(format!("ast-grep:{}/{}", lang_name(lang), rule.id)),
+```
+
+Add a helper function above `scan_file`:
+
+```rust
+fn lang_name(lang: &SupportLang) -> &'static str {
+    match lang {
+        SupportLang::Python => "python",
+        SupportLang::TypeScript => "typescript",
+        SupportLang::Tsx => "tsx",
+        SupportLang::JavaScript => "javascript",
+        SupportLang::Rust => "rust",
+        SupportLang::Bash => "bash",
+        SupportLang::Yaml => "yaml",
+        SupportLang::Hcl => "hcl",
+        _ => "unknown",
+    }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cargo test --lib ast_grep -- rule_id`
+Expected: both new tests pass
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/ast_grep.rs
+git commit -m "feat(ast-grep): populate rule_id on findings
+
+Format: ast-grep:{language}/{rule.id}, e.g.
+ast-grep:python/bare-except-pass. Addresses #11."
+```
+
+---
+
+### Task 3: Populate rule_id in analysis.rs
+
+**Files:**
+- Modify: `src/analysis.rs` (all ~63 Finding construction sites)
+
+- [ ] **Step 1: Write tests for LocalAst rule_id**
+
+In `src/analysis.rs`, inside `mod tests`, add:
+
+```rust
+#[test]
+fn complexity_finding_has_rule_id() {
+    let source = r#"
+fn deeply_nested() {
+    if true { if true { if true { if true { if true {
+        if true { if true { if true { if true { if true {
+            if true { }
+        }}}}
+    }}}}}
+}
+"#;
+    let mut parser = tree_sitter::Parser::new();
+    parser.set_language(&tree_sitter_rust::LANGUAGE.into()).unwrap();
+    let tree = parser.parse(source, None).unwrap();
+    let findings = analyze_complexity(&tree, source, Language::Rust, 5);
+    assert!(!findings.is_empty());
+    assert_eq!(findings[0].rule_id.as_deref(), Some("local-ast:complexity"));
+}
+
+#[test]
+fn insecure_pattern_has_language_prefixed_rule_id() {
+    let source = "eval('hello')";
+    let mut parser = tree_sitter::Parser::new();
+    parser.set_language(&tree_sitter_python::LANGUAGE.into()).unwrap();
+    let tree = parser.parse(source, None).unwrap();
+    let findings = analyze_insecure_patterns(&tree, source, Language::Python);
+    let eval_finding = findings.iter().find(|f| f.title.contains("eval"));
+    assert!(eval_finding.is_some());
+    let f = eval_finding.unwrap();
+    assert!(
+        f.rule_id.as_ref().unwrap().starts_with("local-ast:python/"),
+        "rule_id should start with local-ast:python/, got {:?}",
+        f.rule_id
+    );
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cargo test --lib analysis -- rule_id`
+Expected: FAIL — rule_id is None
+
+- [ ] **Step 3: Populate rule_id at all construction sites**
+
+This is a mechanical change across ~63 sites. The pattern:
+
+For `analyze_complexity` findings:
+```rust
+rule_id: Some("local-ast:complexity".into()),
+```
+
+For language-specific patterns in `scan_insecure_*`, derive the name from the pattern being detected. Use a consistent naming scheme:
+
+```rust
+// In scan_insecure_python:
+// eval/exec detection
+rule_id: Some("local-ast:python/eval-exec".into()),
+// hardcoded secret
+rule_id: Some("local-ast:python/hardcoded-secret".into()),
+// SQL injection
+rule_id: Some("local-ast:python/sql-injection".into()),
+// open() no encoding
+rule_id: Some("local-ast:python/open-no-encoding".into()),
+// mutable default
+rule_id: Some("local-ast:python/mutable-default".into()),
+// bind 0.0.0.0
+rule_id: Some("local-ast:python/bind-all-interfaces".into()),
+// debug=True
+rule_id: Some("local-ast:python/debug-true".into()),
+
+// In scan_insecure_rust:
+rule_id: Some("local-ast:rust/unsafe-block".into()),
+rule_id: Some("local-ast:rust/unwrap-in-non-test".into()),
+
+// In scan_insecure_typescript:
+rule_id: Some("local-ast:typescript/eval".into()),
+rule_id: Some("local-ast:typescript/innerhtml-xss".into()),
+rule_id: Some("local-ast:typescript/empty-catch".into()),
+rule_id: Some("local-ast:typescript/sync-in-async".into()),
+rule_id: Some("local-ast:typescript/hardcoded-secret".into()),
+rule_id: Some("local-ast:typescript/tautological-length".into()),
+
+// In scan_insecure_bash:
+rule_id: Some("local-ast:bash/no-shebang".into()),
+rule_id: Some("local-ast:bash/no-set-e".into()),
+rule_id: Some("local-ast:bash/eval".into()),
+rule_id: Some("local-ast:bash/chmod-777".into()),
+rule_id: Some("local-ast:bash/curl-pipe-bash".into()),
+rule_id: Some("local-ast:bash/hardcoded-secret".into()),
+
+// In scan_insecure_yaml:
+rule_id: Some("local-ast:yaml/ha-automation".into()),
+rule_id: Some("local-ast:yaml/hardcoded-secret".into()),
+rule_id: Some("local-ast:yaml/duplicate-key".into()),
+
+// In scan_insecure_dockerfile:
+rule_id: Some("local-ast:dockerfile/from-latest".into()),
+rule_id: Some("local-ast:dockerfile/no-healthcheck".into()),
+rule_id: Some("local-ast:dockerfile/no-user".into()),
+rule_id: Some("local-ast:dockerfile/multiple-cmd".into()),
+
+// In scan_insecure_terraform:
+rule_id: Some("local-ast:terraform/hardcoded-secret".into()),
+rule_id: Some("local-ast:terraform/no-version-pin".into()),
+rule_id: Some("local-ast:terraform/no-required-providers".into()),
+```
+
+For patterns that share the same detection function but differ by context, use the most specific name that matches the title/description of the finding.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cargo test --lib analysis -- rule_id`
+Expected: both new tests pass
+
+- [ ] **Step 5: Run full test suite**
+
+Run: `cargo test --bin quorum`
+Expected: all tests pass
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/analysis.rs
+git commit -m "feat(analysis): populate rule_id at all LocalAst construction sites
+
+63 sites across 7 languages. Format: local-ast:{lang}/{pattern-name}.
+Enables per-rule precision tracking via stats --by-rule. Addresses #11."
+```
+
+---
+
+### Task 4: Add stats --by-rule dimension
+
+**Files:**
+- Modify: `src/dimensions.rs`
+- Modify: `src/cli/mod.rs:297-363` (StatsOpts)
+- Modify: `src/main.rs` (stats command handler)
+
+- [ ] **Step 1: Write test for group_by_rule**
+
+In `src/dimensions.rs`, inside `mod tests`, add:
+
+```rust
+#[test]
+fn group_by_rule_buckets_feedback_by_rule_id() {
+    use crate::feedback::{FeedbackEntry, Verdict, Provenance};
+
+    let entries = vec![
+        FeedbackEntry {
+            file_path: "a.py".into(),
+            finding_title: "eval".into(),
+            finding_category: "security".into(),
+            verdict: Verdict::Tp,
+            reason: "".into(),
+            model: "".into(),
+            timestamp: chrono::Utc::now(),
+            provenance: Provenance::Human,
+            fp_kind: None,
+            finding_id: None,
+            rule_id: Some("local-ast:python/eval-exec".into()),
+            // fill remaining fields with defaults
+            ..Default::default()
+        },
+        FeedbackEntry {
+            rule_id: Some("local-ast:python/eval-exec".into()),
+            verdict: Verdict::Fp,
+            ..Default::default()
+        },
+        FeedbackEntry {
+            rule_id: Some("ast-grep:python/bare-except-pass".into()),
+            verdict: Verdict::Tp,
+            ..Default::default()
+        },
+        FeedbackEntry {
+            rule_id: None,
+            verdict: Verdict::Tp,
+            ..Default::default()
+        },
+    ];
+
+    let slices = group_by_rule(&entries, None);
+    // Should have 2 buckets (None entries excluded)
+    assert_eq!(slices.len(), 2);
+    let eval_slice = slices.iter().find(|s| s.key == "local-ast:python/eval-exec").unwrap();
+    assert_eq!(eval_slice.tp, 1);
+    assert_eq!(eval_slice.fp, 1);
+}
+
+#[test]
+fn group_by_rule_filters_by_glob() {
+    use crate::feedback::{FeedbackEntry, Verdict};
+
+    let entries = vec![
+        FeedbackEntry {
+            rule_id: Some("local-ast:python/eval-exec".into()),
+            verdict: Verdict::Tp,
+            ..Default::default()
+        },
+        FeedbackEntry {
+            rule_id: Some("ast-grep:typescript/as-any-cast".into()),
+            verdict: Verdict::Tp,
+            ..Default::default()
+        },
+    ];
+
+    let slices = group_by_rule(&entries, Some("local-ast:python/*"));
+    assert_eq!(slices.len(), 1);
+    assert_eq!(slices[0].key, "local-ast:python/eval-exec");
+}
+```
+
+NOTE: The test above uses a `RuleDimensionSlice` struct. Adjust field names to match the actual implementation. The key fields needed: `key` (rule_id string), `tp`, `fp`, `partial`, `wontfix`, `precision` (tp / (tp + fp)), `total`.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test --lib dimensions -- group_by_rule`
+Expected: compilation error — `group_by_rule` does not exist
+
+- [ ] **Step 3: Implement RuleDimensionSlice and group_by_rule**
+
+In `src/dimensions.rs`, add:
+
+```rust
+#[derive(Debug, Clone, Serialize)]
+pub struct RuleDimensionSlice {
+    pub key: String,
+    pub tp: usize,
+    pub fp: usize,
+    pub partial: usize,
+    pub wontfix: usize,
+    pub total: usize,
+    pub precision: f64,
+    pub low_sample: bool,
+}
+
+const RULE_MIN_SAMPLE: usize = 5;
+
+pub fn group_by_rule(
+    entries: &[crate::feedback::FeedbackEntry],
+    glob_filter: Option<&str>,
+) -> Vec<RuleDimensionSlice> {
+    use std::collections::HashMap;
+
+    let mut buckets: HashMap<String, (usize, usize, usize, usize)> = HashMap::new();
+
+    for entry in entries {
+        let rule_id = match &entry.rule_id {
+            Some(r) => r,
+            None => continue,
+        };
+
+        if let Some(pattern) = glob_filter {
+            if !glob_match(pattern, rule_id) {
+                continue;
+            }
+        }
+
+        let counts = buckets.entry(rule_id.clone()).or_default();
+        match entry.verdict {
+            crate::feedback::Verdict::Tp => counts.0 += 1,
+            crate::feedback::Verdict::Fp => counts.1 += 1,
+            crate::feedback::Verdict::Partial => counts.2 += 1,
+            crate::feedback::Verdict::Wontfix => counts.3 += 1,
+            _ => {}
+        }
+    }
+
+    let mut slices: Vec<RuleDimensionSlice> = buckets
+        .into_iter()
+        .map(|(key, (tp, fp, partial, wontfix))| {
+            let total = tp + fp + partial + wontfix;
+            let precision = if tp + fp > 0 {
+                tp as f64 / (tp + fp) as f64
+            } else {
+                0.0
+            };
+            RuleDimensionSlice {
+                key,
+                tp,
+                fp,
+                partial,
+                wontfix,
+                total,
+                precision,
+                low_sample: total < RULE_MIN_SAMPLE,
+            }
+        })
+        .collect();
+
+    slices.sort_by(|a, b| b.total.cmp(&a.total));
+    slices
+}
+
+fn glob_match(pattern: &str, value: &str) -> bool {
+    if let Some(prefix) = pattern.strip_suffix('*') {
+        value.starts_with(prefix)
+    } else {
+        value == pattern
+    }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cargo test --lib dimensions -- group_by_rule`
+Expected: PASS
+
+- [ ] **Step 5: Add --by-rule flag to StatsOpts**
+
+In `src/cli/mod.rs`, inside `StatsOpts` (after `by_file` field, line ~341), add:
+
+```rust
+    /// Per-rule TP/FP/precision breakdown from feedback
+    #[arg(long, conflicts_with_all = ["by_repo", "by_caller", "rolling", "by_source", "by_reviewed_repo", "misleading", "by_file"])]
+    pub by_rule: bool,
+
+    /// Filter rules by glob pattern (e.g. "ast-grep:python/*")
+    #[arg(long, requires = "by_rule")]
+    pub rule: Option<String>,
+```
+
+- [ ] **Step 6: Wire --by-rule in stats command handler**
+
+In `src/main.rs`, in the stats command handler, add a branch for `by_rule`:
+
+```rust
+if opts.by_rule {
+    let entries = feedback_store.load_all()?;
+    let slices = dimensions::group_by_rule(&entries, opts.rule.as_deref());
+    // Render table using existing table rendering pattern
+    // Columns: Rule ID | TP | FP | Partial | Precision | Total | Sample
+    for s in &slices {
+        println!(
+            "{:<50} {:>4} {:>4} {:>4} {:>6.1}% {:>5} {}",
+            s.key, s.tp, s.fp, s.partial,
+            s.precision * 100.0, s.total,
+            if s.low_sample { "(low sample)" } else { "" }
+        );
+    }
+    return Ok(());
+}
+```
+
+Adapt the rendering to match the existing table style used by `--by-repo` and `--by-caller`.
+
+- [ ] **Step 7: Run full test suite**
+
+Run: `cargo test --bin quorum`
+Expected: all tests pass
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/dimensions.rs src/cli/mod.rs src/main.rs
+git commit -m "feat(stats): add --by-rule dimension for per-rule precision tracking
+
+groups feedback entries by rule_id, computes TP/FP/precision per rule.
+Supports glob filtering via --rule. Addresses #17."
+```
+
+---
+
+## Phase 2: LLM Micro-Judge
+
+### Task 5: Add PrecisionTier, JudgeRequirement, JudgeVerdict types
+
+**Files:**
+- Modify: `src/finding.rs`
+
+- [ ] **Step 1: Write tests for new types**
+
+In `src/finding.rs`, inside `mod tests`, add:
+
+```rust
+#[test]
+fn precision_tier_default_is_high() {
+    let tier: PrecisionTier = Default::default();
+    assert_eq!(tier, PrecisionTier::High);
+}
+
+#[test]
+fn precision_tier_serde_roundtrip() {
+    let tier = PrecisionTier::Speculative;
+    let json = serde_json::to_string(&tier).unwrap();
+    assert_eq!(json, "\"speculative\"");
+    let parsed: PrecisionTier = serde_json::from_str(&json).unwrap();
+    assert_eq!(parsed, PrecisionTier::Speculative);
+}
+
+#[test]
+fn judge_requirement_default_is_skip() {
+    let req: JudgeRequirement = Default::default();
+    assert_eq!(req, JudgeRequirement::Skip);
+}
+
+#[test]
+fn judge_verdict_serde_roundtrip() {
+    let v = JudgeVerdict::Approved;
+    let json = serde_json::to_string(&v).unwrap();
+    assert_eq!(json, "\"approved\"");
+    let parsed: JudgeVerdict = serde_json::from_str(&json).unwrap();
+    assert_eq!(parsed, JudgeVerdict::Approved);
+}
+
+#[test]
+fn finding_judge_fields_default_to_none() {
+    let f = FindingBuilder::new().build();
+    assert_eq!(f.judge_verdict, None);
+    assert_eq!(f.judge_confidence, None);
+    assert_eq!(f.precision_tier, None);
+}
+
+#[test]
+fn finding_with_judge_fields_survives_roundtrip() {
+    let mut f = FindingBuilder::new().build();
+    f.judge_verdict = Some(JudgeVerdict::Approved);
+    f.judge_confidence = Some(0.85);
+    f.precision_tier = Some(PrecisionTier::Speculative);
+    let json = serde_json::to_string(&f).unwrap();
+    let parsed: Finding = serde_json::from_str(&json).unwrap();
+    assert_eq!(parsed.judge_verdict, Some(JudgeVerdict::Approved));
+    assert_eq!(parsed.judge_confidence, Some(0.85));
+    assert_eq!(parsed.precision_tier, Some(PrecisionTier::Speculative));
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cargo test --lib finding -- precision_tier judge`
+Expected: compilation errors
+
+- [ ] **Step 3: Add types and fields**
+
+In `src/finding.rs`, after `CalibratorAction` enum (line ~40), add:
+
+```rust
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum PrecisionTier {
+    #[default]
+    High,
+    Medium,
+    Speculative,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum JudgeRequirement {
+    Required,
+    Optional,
+    #[default]
+    Skip,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum JudgeVerdict {
+    Approved,
+    Rejected,
+    Uncertain,
+    Skipped,
+}
+```
+
+Add fields to `Finding` struct (after `rule_id`):
+
+```rust
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub judge_verdict: Option<JudgeVerdict>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub judge_confidence: Option<f32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub precision_tier: Option<PrecisionTier>,
+```
+
+Add to `FindingBuilder::new()` inner defaults:
+
+```rust
+                judge_verdict: None,
+                judge_confidence: None,
+                precision_tier: None,
+```
+
+- [ ] **Step 4: Fix compilation — add new fields to all Finding literals**
+
+Same pattern as Task 1 Step 7. Add these three fields (all `None`) to every Finding literal in `src/analysis.rs`, `src/ast_grep.rs`, and anywhere else that constructs Finding directly.
+
+```bash
+grep -rn 'rule_id:' src/analysis.rs src/ast_grep.rs | head -5
+```
+
+After each `rule_id: ...` line, add:
+
+```rust
+                    judge_verdict: None,
+                    judge_confidence: None,
+                    precision_tier: None,
+```
+
+- [ ] **Step 5: Run tests**
+
+Run: `cargo test --bin quorum`
+Expected: all tests pass
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/finding.rs src/analysis.rs src/ast_grep.rs
+git commit -m "feat(finding): add PrecisionTier, JudgeRequirement, JudgeVerdict types
+
+New fields on Finding: judge_verdict, judge_confidence, precision_tier.
+All optional with serde(default) for backward compat. Addresses #281."
+```
+
+---
+
+### Task 6: Update compute_confidence for precision tiers
+
+**Files:**
+- Modify: `src/finding.rs:123-148` (compute_confidence)
+
+- [ ] **Step 1: Write tests for tier-aware confidence**
+
+In `src/finding.rs`, `mod tests`, add:
+
+```rust
+#[test]
+fn confidence_speculative_local_ast_is_050() {
+    let mut f = FindingBuilder::new().build();
+    f.precision_tier = Some(PrecisionTier::Speculative);
+    f.source = Source::LocalAst;
+    f.compute_confidence();
+    assert!((f.confidence.unwrap() - 0.50).abs() < 0.01);
+}
+
+#[test]
+fn confidence_medium_linter_is_075() {
+    let mut f = FindingBuilder::new()
+        .source(Source::Linter("ast-grep".into()))
+        .build();
+    f.precision_tier = Some(PrecisionTier::Medium);
+    f.compute_confidence();
+    assert!((f.confidence.unwrap() - 0.75).abs() < 0.01);
+}
+
+#[test]
+fn confidence_judge_overrides_base() {
+    let mut f = FindingBuilder::new().build();
+    f.precision_tier = Some(PrecisionTier::Speculative);
+    f.judge_confidence = Some(0.85);
+    f.source = Source::LocalAst;
+    f.compute_confidence();
+    // Judge 0.85 overrides speculative 0.50
+    assert!((f.confidence.unwrap() - 0.85).abs() < 0.01);
+}
+
+#[test]
+fn confidence_no_tier_matches_legacy_behavior() {
+    let mut f = FindingBuilder::new().build();
+    f.source = Source::LocalAst;
+    f.precision_tier = None;
+    f.compute_confidence();
+    assert!((f.confidence.unwrap() - 0.95).abs() < 0.01);
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cargo test --lib finding -- confidence_speculative confidence_medium confidence_judge confidence_no_tier`
+Expected: FAIL — speculative still returns 0.95
+
+- [ ] **Step 3: Update compute_confidence**
+
+Replace the `compute_confidence` method body in `src/finding.rs`:
+
+```rust
+    pub fn compute_confidence(&mut self) {
+        let base = match (&self.source, &self.precision_tier) {
+            (Source::LocalAst, Some(PrecisionTier::High)) | (Source::LocalAst, None) => 0.95,
+            (Source::LocalAst, Some(PrecisionTier::Medium)) => 0.80,
+            (Source::LocalAst, Some(PrecisionTier::Speculative)) => 0.50,
+            (Source::Linter(_), Some(PrecisionTier::High)) | (Source::Linter(_), None) => 0.90,
+            (Source::Linter(_), Some(PrecisionTier::Medium)) => 0.75,
+            (Source::Linter(_), Some(PrecisionTier::Speculative)) => 0.45,
+            (Source::Llm(_), _) => self
+                .grounding_confidence
+                .filter(|c| c.is_finite())
+                .map(|c| c.clamp(0.0, 1.0))
+                .unwrap_or(0.5),
+        };
+        let base = self
+            .judge_confidence
+            .filter(|c| c.is_finite())
+            .map(|c| c.clamp(0.0, 1.0))
+            .unwrap_or(base);
+        let cal_factor = match self.calibrator_action {
+            Some(CalibratorAction::Confirmed) => 1.1,
+            Some(CalibratorAction::Disputed) => 0.6,
+            Some(CalibratorAction::Adjusted) => 0.85,
+            Some(CalibratorAction::Added) => 0.7,
+            None => 1.0,
+        };
+        let agreement_factor = match (&self.source, self.model_agreement) {
+            (Source::Llm(_), Some(a)) if a.is_finite() => {
+                let a = a.clamp(0.0, 1.0);
+                0.85 + 0.30 * a
+            }
+            _ => 1.0,
+        };
+        self.confidence = Some((base * cal_factor * agreement_factor).clamp(0.0, 1.0));
+    }
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `cargo test --lib finding`
+Expected: all tests pass (new and existing)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/finding.rs
+git commit -m "feat(finding): tier-aware confidence with judge override
+
+compute_confidence now uses precision_tier for base score and
+judge_confidence as override. Existing rules (tier=None) produce
+identical results to before."
+```
+
+---
+
+### Task 7: Parse rule metadata from ast-grep YAML
+
+**Files:**
+- Modify: `src/ast_grep.rs`
+
+- [ ] **Step 1: Write tests**
+
+```rust
+#[test]
+fn parse_metadata_from_yaml_with_metadata_block() {
+    let yaml = r#"
+id: test-rule
+language: Python
+severity: warning
+message: "test"
+rule:
+  pattern: "eval($X)"
+metadata:
+  precision: speculative
+  judge: required
+"#;
+    let meta = parse_rule_metadata(yaml);
+    assert_eq!(meta.precision, PrecisionTier::Speculative);
+    assert_eq!(meta.judge, JudgeRequirement::Required);
+}
+
+#[test]
+fn parse_metadata_defaults_when_no_metadata_block() {
+    let yaml = r#"
+id: test-rule
+language: Python
+severity: warning
+message: "test"
+rule:
+  pattern: "eval($X)"
+"#;
+    let meta = parse_rule_metadata(yaml);
+    assert_eq!(meta.precision, PrecisionTier::High);
+    assert_eq!(meta.judge, JudgeRequirement::Skip);
+}
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `cargo test --lib ast_grep -- parse_metadata`
+Expected: compilation error
+
+- [ ] **Step 3: Implement parse_rule_metadata**
+
+In `src/ast_grep.rs`, add:
+
+```rust
+use crate::finding::{PrecisionTier, JudgeRequirement};
+
+#[derive(Debug, Clone, Default, serde::Deserialize)]
+pub struct RuleMetadata {
+    #[serde(default)]
+    pub precision: PrecisionTier,
+    #[serde(default)]
+    pub judge: JudgeRequirement,
+}
+
+#[derive(serde::Deserialize)]
+struct YamlWithMetadata {
+    #[serde(default)]
+    metadata: Option<RuleMetadata>,
+}
+
+pub fn parse_rule_metadata(yaml_str: &str) -> RuleMetadata {
+    serde_yaml::from_str::<YamlWithMetadata>(yaml_str)
+        .ok()
+        .and_then(|y| y.metadata)
+        .unwrap_or_default()
+}
+```
+
+- [ ] **Step 4: Wire metadata into scan_file**
+
+Update `load_rules` to return metadata alongside rules. Change the return type or add a parallel metadata map. The simplest approach: store metadata in a `HashMap<String, RuleMetadata>` keyed by rule id, built during `load_rules`, and pass it to `scan_file`.
+
+Update `scan_file` signature:
+
+```rust
+pub fn scan_file(
+    source: &str,
+    ext: &str,
+    rules: &[RuleConfig<SupportLang>],
+    metadata: &HashMap<String, RuleMetadata>,
+) -> Vec<Finding>
+```
+
+In the finding construction, look up metadata and set `precision_tier`:
+
+```rust
+let meta = metadata.get(&rule.id).cloned().unwrap_or_default();
+// ... in Finding construction:
+precision_tier: Some(meta.precision),
+```
+
+Update the call site in `pipeline.rs` to pass the metadata map.
+
+- [ ] **Step 5: Run tests**
+
+Run: `cargo test --bin quorum`
+Expected: all tests pass
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/ast_grep.rs src/pipeline.rs
+git commit -m "feat(ast-grep): parse rule metadata (precision/judge) from YAML
+
+Secondary YAML parse extracts optional metadata block. Existing
+rules default to precision:high, judge:skip. scan_file now accepts
+metadata map and sets precision_tier on findings."
+```
+
+---
+
+### Task 8: Implement judge module with verdict cache
+
+**Files:**
+- Create: `src/judge.rs`
+- Modify: `src/main.rs` (add `mod judge;`)
+
+- [ ] **Step 1: Write tests for verdict cache**
+
+In `src/judge.rs`:
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cache_key_deterministic() {
+        let k1 = verdict_cache_key("ast-grep:python/bare-except-pass", "except:\n    pass");
+        let k2 = verdict_cache_key("ast-grep:python/bare-except-pass", "except:\n    pass");
+        assert_eq!(k1, k2);
+    }
+
+    #[test]
+    fn cache_key_differs_for_different_evidence() {
+        let k1 = verdict_cache_key("rule-a", "code1");
+        let k2 = verdict_cache_key("rule-a", "code2");
+        assert_ne!(k1, k2);
+    }
+
+    #[test]
+    fn cache_key_differs_for_different_rules() {
+        let k1 = verdict_cache_key("rule-a", "code");
+        let k2 = verdict_cache_key("rule-b", "code");
+        assert_ne!(k1, k2);
+    }
+
+    #[test]
+    fn cache_roundtrip() {
+        let dir = tempfile::tempdir().unwrap();
+        let cache_path = dir.path().join("judge_cache.jsonl");
+        let entry = CacheEntry {
+            cache_key: "abc123".into(),
+            rule_id: "ast-grep:python/test".into(),
+            verdict: JudgeVerdict::Approved,
+            confidence: 0.85,
+            reason: "looks good".into(),
+            timestamp: chrono::Utc::now(),
+        };
+        write_cache_entry(&cache_path, &entry).unwrap();
+        let loaded = load_cache(&cache_path).unwrap();
+        assert_eq!(loaded.len(), 1);
+        assert_eq!(loaded["abc123"].verdict, JudgeVerdict::Approved);
+    }
+
+    #[test]
+    fn cache_ttl_expires_old_entries() {
+        let dir = tempfile::tempdir().unwrap();
+        let cache_path = dir.path().join("judge_cache.jsonl");
+        let old_entry = CacheEntry {
+            cache_key: "old".into(),
+            rule_id: "rule".into(),
+            verdict: JudgeVerdict::Approved,
+            confidence: 0.9,
+            reason: "".into(),
+            timestamp: chrono::Utc::now() - chrono::Duration::days(8),
+        };
+        write_cache_entry(&cache_path, &old_entry).unwrap();
+        let loaded = load_cache(&cache_path).unwrap();
+        assert!(loaded.is_empty()); // 7-day TTL expired
+    }
+}
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `cargo test --lib judge`
+Expected: compilation error
+
+- [ ] **Step 3: Implement cache and key generation**
+
+```rust
+use crate::finding::JudgeVerdict;
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use std::collections::HashMap;
+use std::path::Path;
+
+const CACHE_TTL_DAYS: i64 = 7;
+
+pub fn verdict_cache_key(rule_id: &str, evidence: &str) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(rule_id.as_bytes());
+    hasher.update(b"\0");
+    hasher.update(evidence.as_bytes());
+    format!("{:x}", hasher.finalize())
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CacheEntry {
+    pub cache_key: String,
+    pub rule_id: String,
+    pub verdict: JudgeVerdict,
+    pub confidence: f32,
+    pub reason: String,
+    pub timestamp: DateTime<Utc>,
+}
+
+pub fn load_cache(path: &Path) -> std::io::Result<HashMap<String, CacheEntry>> {
+    let mut map = HashMap::new();
+    let content = match std::fs::read_to_string(path) {
+        Ok(c) => c,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(map),
+        Err(e) => return Err(e),
+    };
+    let cutoff = Utc::now() - chrono::Duration::days(CACHE_TTL_DAYS);
+    for line in content.lines() {
+        if let Ok(entry) = serde_json::from_str::<CacheEntry>(line) {
+            if entry.timestamp > cutoff {
+                map.insert(entry.cache_key.clone(), entry);
+            }
+        }
+    }
+    Ok(map)
+}
+
+pub fn write_cache_entry(path: &Path, entry: &CacheEntry) -> std::io::Result<()> {
+    use std::io::Write;
+    let mut file = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(path)?;
+    let json = serde_json::to_string(entry).map_err(|e| {
+        std::io::Error::new(std::io::ErrorKind::InvalidData, e)
+    })?;
+    writeln!(file, "{}", json)
+}
+```
+
+- [ ] **Step 4: Add mod judge to main.rs**
+
+In `src/main.rs`, add:
+
+```rust
+mod judge;
+```
+
+- [ ] **Step 5: Run tests**
+
+Run: `cargo test --lib judge`
+Expected: all cache tests pass
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/judge.rs src/main.rs
+git commit -m "feat(judge): verdict cache with sha256 key and 7-day TTL
+
+Cache keyed on sha256(rule_id + evidence_text). Entries expire
+after 7 days. JSONL storage at ~/.quorum/judge_cache.jsonl."
+```
+
+---
+
+### Task 9: Implement LLM judge client
+
+**Files:**
+- Modify: `src/judge.rs`
+
+- [ ] **Step 1: Write tests for judge request/response types**
+
+In `src/judge.rs`, add tests:
+
+```rust
+#[test]
+fn judge_response_deserializes_from_json() {
+    let json = r#"[
+        {"rule_id": "ast-grep:python/test", "verdict": "tp", "confidence": 0.85, "reason": "valid"},
+        {"rule_id": "ast-grep:python/other", "verdict": "fp", "confidence": 0.92, "reason": "safe"}
+    ]"#;
+    let verdicts: Vec<JudgeResponseItem> = serde_json::from_str(json).unwrap();
+    assert_eq!(verdicts.len(), 2);
+    assert_eq!(verdicts[0].verdict, "tp");
+    assert_eq!(verdicts[1].verdict, "fp");
+}
+
+#[test]
+fn map_verdict_string_to_enum() {
+    assert_eq!(parse_verdict("tp"), JudgeVerdict::Approved);
+    assert_eq!(parse_verdict("fp"), JudgeVerdict::Rejected);
+    assert_eq!(parse_verdict("uncertain"), JudgeVerdict::Uncertain);
+    assert_eq!(parse_verdict("garbage"), JudgeVerdict::Uncertain); // fallback
+}
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `cargo test --lib judge -- judge_response map_verdict`
+Expected: compilation error
+
+- [ ] **Step 3: Implement types and verdict mapping**
+
+In `src/judge.rs`, add:
+
+```rust
+#[derive(Debug, Deserialize)]
+pub struct JudgeResponseItem {
+    pub rule_id: String,
+    pub verdict: String,
+    pub confidence: f32,
+    pub reason: String,
+}
+
+pub fn parse_verdict(s: &str) -> JudgeVerdict {
+    match s {
+        "tp" => JudgeVerdict::Approved,
+        "fp" => JudgeVerdict::Rejected,
+        "uncertain" => JudgeVerdict::Uncertain,
+        _ => JudgeVerdict::Uncertain,
+    }
+}
+```
+
+- [ ] **Step 4: Implement judge prompt builder**
+
+```rust
+pub fn build_judge_prompt(
+    source_code: &str,
+    findings: &[(String, String, u32, u32, String)], // (rule_id, title, line_start, line_end, evidence)
+) -> String {
+    let mut prompt = String::from(
+        "You are a code review judge. For each finding below, determine if it is a true positive (tp), false positive (fp), or uncertain.\n\n"
+    );
+    prompt.push_str("Source code:\n```\n");
+    prompt.push_str(source_code);
+    prompt.push_str("\n```\n\nFindings to judge:\n");
+
+    for (i, (rule_id, title, start, end, evidence)) in findings.iter().enumerate() {
+        prompt.push_str(&format!(
+            "{}. rule_id={}, title=\"{}\", lines {}-{}, evidence=\"{}\"\n",
+            i + 1, rule_id, title, start, end, evidence
+        ));
+    }
+
+    prompt.push_str("\nRespond with ONLY a JSON array. Each element: {\"rule_id\": \"...\", \"verdict\": \"tp\"|\"fp\"|\"uncertain\", \"confidence\": 0.0-1.0, \"reason\": \"...\"}\n");
+    prompt
+}
+```
+
+- [ ] **Step 5: Implement judge_findings function (integrates cache + LLM)**
+
+```rust
+use crate::finding::{Finding, JudgeVerdict, PrecisionTier};
+use crate::ast_grep::{JudgeRequirement, RuleMetadata};
+
+pub struct JudgeResult {
+    pub approved: usize,
+    pub rejected: usize,
+    pub uncertain: usize,
+    pub skipped: usize,
+    pub cache_hits: usize,
+    pub latency_ms: u64,
+}
+
+pub fn judge_findings(
+    findings: &mut Vec<Finding>,
+    source_code: &str,
+    metadata: &HashMap<String, RuleMetadata>,
+    cache: &HashMap<String, CacheEntry>,
+    cache_path: &Path,
+    llm_client: Option<&dyn Fn(&str) -> Option<String>>, // simple callable for LLM
+    timeout_ms: u64,
+) -> JudgeResult {
+    let start = std::time::Instant::now();
+    let mut result = JudgeResult {
+        approved: 0, rejected: 0, uncertain: 0, skipped: 0, cache_hits: 0, latency_ms: 0,
+    };
+
+    // Partition: needs-judge vs skip
+    let mut to_judge: Vec<usize> = Vec::new();
+    for (i, f) in findings.iter().enumerate() {
+        let meta = f.rule_id.as_ref()
+            .and_then(|rid| metadata.get(rid))
+            .cloned()
+            .unwrap_or_default();
+        if meta.judge == JudgeRequirement::Skip {
+            // Leave finding unchanged
+            result.skipped += 1;
+            continue;
+        }
+        // Check cache
+        let evidence = f.evidence.first().map(|s| s.as_str()).unwrap_or("");
+        let rule_id = f.rule_id.as_deref().unwrap_or("");
+        let key = verdict_cache_key(rule_id, evidence);
+        if let Some(cached) = cache.get(&key) {
+            findings[i].judge_verdict = Some(cached.verdict.clone());
+            findings[i].judge_confidence = Some(cached.confidence);
+            result.cache_hits += 1;
+            match cached.verdict {
+                JudgeVerdict::Approved => result.approved += 1,
+                JudgeVerdict::Rejected => result.rejected += 1,
+                JudgeVerdict::Uncertain => result.uncertain += 1,
+                JudgeVerdict::Skipped => result.skipped += 1,
+            }
+            continue;
+        }
+        to_judge.push(i);
+    }
+
+    // Build batched prompt for uncached findings
+    if !to_judge.is_empty() {
+        if let Some(llm) = llm_client {
+            let items: Vec<_> = to_judge.iter().map(|&i| {
+                let f = &findings[i];
+                (
+                    f.rule_id.clone().unwrap_or_default(),
+                    f.title.clone(),
+                    f.line_start,
+                    f.line_end,
+                    f.evidence.first().cloned().unwrap_or_default(),
+                )
+            }).collect();
+
+            let prompt = build_judge_prompt(source_code, &items);
+            if let Some(response) = llm(&prompt) {
+                if let Ok(verdicts) = serde_json::from_str::<Vec<JudgeResponseItem>>(&response) {
+                    for v in &verdicts {
+                        let idx = to_judge.iter().find(|&&i| {
+                            findings[i].rule_id.as_deref() == Some(&v.rule_id)
+                        });
+                        if let Some(&i) = idx {
+                            let verdict = parse_verdict(&v.verdict);
+                            findings[i].judge_verdict = Some(verdict.clone());
+                            findings[i].judge_confidence = Some(v.confidence);
+                            // Write to cache
+                            let evidence = findings[i].evidence.first().map(|s| s.as_str()).unwrap_or("");
+                            let key = verdict_cache_key(&v.rule_id, evidence);
+                            let _ = write_cache_entry(cache_path, &CacheEntry {
+                                cache_key: key,
+                                rule_id: v.rule_id.clone(),
+                                verdict: verdict.clone(),
+                                confidence: v.confidence,
+                                reason: v.reason.clone(),
+                                timestamp: Utc::now(),
+                            });
+                            match verdict {
+                                JudgeVerdict::Approved => result.approved += 1,
+                                JudgeVerdict::Rejected => result.rejected += 1,
+                                _ => result.uncertain += 1,
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // Apply rejection policy: remove Required+Rejected findings
+    findings.retain(|f| {
+        let meta = f.rule_id.as_ref()
+            .and_then(|rid| metadata.get(rid))
+            .cloned()
+            .unwrap_or_default();
+        if meta.judge == JudgeRequirement::Required
+            && f.judge_verdict == Some(JudgeVerdict::Rejected)
+        {
+            return false; // drop
+        }
+        // Optional + Rejected: clamp confidence to 0.05
+        if meta.judge == JudgeRequirement::Optional
+            && f.judge_verdict == Some(JudgeVerdict::Rejected)
+        {
+            // confidence will be set in compute_confidence via judge_confidence
+        }
+        true
+    });
+
+    result.latency_ms = start.elapsed().as_millis() as u64;
+    result
+}
+```
+
+- [ ] **Step 6: Run tests**
+
+Run: `cargo test --lib judge`
+Expected: all tests pass
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/judge.rs
+git commit -m "feat(judge): LLM judge client with batched prompts and cache integration
+
+judge_findings partitions by metadata, checks cache, batches uncached
+findings into one LLM call, applies rejection policy (drop for
+required, clamp for optional). Writes verdicts to cache."
+```
+
+---
+
+### Task 10: Wire judge into pipeline
+
+**Files:**
+- Modify: `src/pipeline.rs:650-700` (between AST collection and merge)
+- Modify: `src/cli/mod.rs` (add --judge flag)
+- Modify: `src/telemetry.rs` (add judge counters)
+
+- [ ] **Step 1: Add --judge flag to ReviewOpts**
+
+In `src/cli/mod.rs`, find the `ReviewOpts` struct and add:
+
+```rust
+    /// Enable LLM micro-judge for speculative AST rules
+    #[arg(long, env = "QUORUM_JUDGE")]
+    pub judge: bool,
+
+    /// Model for judge calls (default: gpt-5-nano)
+    #[arg(long, env = "QUORUM_JUDGE_MODEL", default_value = "gpt-5-nano")]
+    pub judge_model: String,
+```
+
+- [ ] **Step 2: Add judge counters to TelemetryEntry**
+
+In `src/telemetry.rs`, add to `TelemetryEntry`:
+
+```rust
+    #[serde(default)]
+    pub judge_calls: u32,
+    #[serde(default)]
+    pub judge_approved: u32,
+    #[serde(default)]
+    pub judge_rejected: u32,
+    #[serde(default)]
+    pub judge_uncertain: u32,
+    #[serde(default)]
+    pub judge_skipped: u32,
+    #[serde(default)]
+    pub judge_cache_hits: u32,
+    #[serde(default)]
+    pub judge_latency_ms: u64,
+```
+
+- [ ] **Step 3: Wire judge stage in pipeline.rs**
+
+In `src/pipeline.rs`, after ast-grep findings are collected (after line ~688, `all_sources.push(ag_findings)`), add the judge stage:
+
+```rust
+    // Source 2b: Judge speculative AST findings (if enabled)
+    if pipeline_config.judge_enabled {
+        let _span = tracing::info_span!("phase.judge", file = %file_str).entered();
+        let cache_path = home_dir.join(".quorum").join("judge_cache.jsonl");
+        let cache = judge::load_cache(&cache_path).unwrap_or_default();
+
+        // Collect all AST findings that need judging
+        // all_sources contains local_findings at [0] and ag_findings at [1]
+        for source_findings in all_sources.iter_mut() {
+            let result = judge::judge_findings(
+                source_findings,
+                source,
+                &rule_metadata,
+                &cache,
+                &cache_path,
+                llm_judge_client.as_ref().map(|c| c as &dyn Fn(&str) -> Option<String>),
+                5000, // 5s timeout
+            );
+            telemetry.judge_calls += if result.approved + result.rejected + result.uncertain > 0 { 1 } else { 0 };
+            telemetry.judge_approved += result.approved as u32;
+            telemetry.judge_rejected += result.rejected as u32;
+            telemetry.judge_uncertain += result.uncertain as u32;
+            telemetry.judge_skipped += result.skipped as u32;
+            telemetry.judge_cache_hits += result.cache_hits as u32;
+            telemetry.judge_latency_ms += result.latency_ms;
+        }
+
+        tracing::info!(
+            phase = "judge",
+            approved = telemetry.judge_approved,
+            rejected = telemetry.judge_rejected,
+            cache_hits = telemetry.judge_cache_hits,
+            "phase complete"
+        );
+    }
+```
+
+NOTE: This is a sketch. The exact integration depends on how `pipeline_config` is structured and how the LLM client is passed. Follow the existing pattern for how `llm` (the reviewer) is constructed and create a similar client for the judge model.
+
+- [ ] **Step 4: Update merge to handle mixed-source confidence**
+
+In `src/merge.rs`, in the merge loop where findings are combined (line ~21), when merging two findings, apply max confidence precedence:
+
+```rust
+// After merging severity, lines, evidence:
+if let Some(jc) = finding.judge_confidence {
+    match existing.judge_confidence {
+        Some(ec) => existing.judge_confidence = Some(ec.max(jc)),
+        None => existing.judge_confidence = Some(jc),
+    }
+}
+if finding.judge_verdict.is_some() && existing.judge_verdict.is_none() {
+    existing.judge_verdict = finding.judge_verdict.clone();
+}
+if let Some(gc) = finding.grounding_confidence {
+    match existing.grounding_confidence {
+        Some(ec) => existing.grounding_confidence = Some(ec.max(gc)),
+        None => existing.grounding_confidence = Some(gc),
+    }
+}
+```
+
+- [ ] **Step 5: Run full test suite**
+
+Run: `cargo test --bin quorum`
+Expected: all tests pass
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/pipeline.rs src/cli/mod.rs src/telemetry.rs src/merge.rs
+git commit -m "feat(pipeline): wire judge stage between AST collection and merge
+
+Judge runs after ast-grep scan, before merge_findings. Gated by
+--judge flag / QUORUM_JUDGE env var. Telemetry tracks judge calls,
+verdicts, cache hits, and latency. Merge uses max() for mixed-source
+confidence precedence."
+```
+
+---
+
+### Task 11: Add pilot speculative rules
+
+**Files:**
+- Create: 10 new YAML rule files in `rules/`
+- Create: test fixtures in `rules/*/tests/`
+
+- [ ] **Step 1: Create Python speculative rules**
+
+Create `rules/python/broad-exception-catch.yml`:
+
+```yaml
+id: broad-exception-catch
+language: Python
+severity: warning
+message: "Catching broad Exception may mask specific errors. Consider catching specific exception types."
+rule:
+  kind: except_clause
+  has:
+    kind: identifier
+    regex: "^Exception$"
+metadata:
+  precision: speculative
+  judge: required
+```
+
+Create `rules/python/subprocess-no-check.yml`:
+
+```yaml
+id: subprocess-no-check
+language: Python
+severity: warning
+message: "subprocess.run() without check=True silently ignores non-zero exit codes."
+rule:
+  pattern: subprocess.run($$$ARGS)
+  not:
+    has:
+      pattern: check=True
+metadata:
+  precision: speculative
+  judge: required
+```
+
+Create `rules/python/missing-await.yml`:
+
+```yaml
+id: missing-await
+language: Python
+severity: warning
+message: "Async function called without await. Return value may be an unawaited coroutine."
+rule:
+  kind: call
+  inside:
+    kind: expression_statement
+    inside:
+      kind: function_definition
+      has:
+        kind: async
+  not:
+    inside:
+      kind: await_expression
+metadata:
+  precision: speculative
+  judge: required
+```
+
+Create `rules/python/re-compile-in-loop.yml`:
+
+```yaml
+id: re-compile-in-loop
+language: Python
+severity: info
+message: "re.compile() inside a loop recompiles the regex each iteration. Consider hoisting to module level."
+rule:
+  pattern: re.compile($PATTERN)
+  inside:
+    kind: for_statement
+metadata:
+  precision: speculative
+  judge: required
+```
+
+Create `rules/python/logging-debug-leak.yml`:
+
+```yaml
+id: logging-debug-leak
+language: Python
+severity: info
+message: "Debug-level logging may leak sensitive data in production. Ensure debug logging is disabled in production configuration."
+rule:
+  pattern: logging.debug($$$ARGS)
+metadata:
+  precision: speculative
+  judge: required
+```
+
+- [ ] **Step 2: Create TypeScript speculative rules**
+
+Create `rules/typescript/nullish-coalescing-broad.yml`:
+
+```yaml
+id: nullish-coalescing-broad
+language: TypeScript
+severity: info
+message: "Using || where ?? may be intended. If 0, empty string, or false are valid values, use nullish coalescing (??) instead."
+rule:
+  kind: binary_expression
+  has:
+    kind: "||"
+metadata:
+  precision: speculative
+  judge: required
+```
+
+Create `rules/typescript/string-format-sql.yml`:
+
+```yaml
+id: string-format-sql
+language: TypeScript
+severity: warning
+message: "String interpolation in SQL query may indicate SQL injection risk. Use parameterized queries."
+rule:
+  kind: template_string
+  regex: "(?i)(SELECT|INSERT|UPDATE|DELETE|DROP)\\s"
+metadata:
+  precision: speculative
+  judge: required
+```
+
+- [ ] **Step 3: Create Rust speculative rules**
+
+Create `rules/rust/discarded-result.yml`:
+
+```yaml
+id: discarded-result
+language: Rust
+severity: warning
+message: "Result value discarded with `let _ =`. If the error is intentional, add a comment explaining why."
+rule:
+  pattern: let _ = $EXPR;
+  has:
+    kind: call_expression
+metadata:
+  precision: speculative
+  judge: required
+```
+
+Create `rules/rust/string-byte-slice-broad.yml`:
+
+```yaml
+id: string-byte-slice-broad
+language: Rust
+severity: warning
+message: "String byte slicing (&s[..n]) can panic on non-ASCII boundaries. Consider using s.get(..n) or char_indices."
+rule:
+  pattern: "&$S[$$$RANGE]"
+metadata:
+  precision: speculative
+  judge: required
+```
+
+- [ ] **Step 4: Create YAML speculative rule**
+
+Create `rules/yaml/jinja-loop-variable-scoping.yml`:
+
+```yaml
+id: jinja-loop-variable-scoping
+language: Yaml
+severity: warning
+message: "Variable set inside Jinja for-loop may not persist outside the loop scope due to Jinja2 scoping rules."
+rule:
+  kind: block_scalar
+  regex: "\\{%.*set\\s+\\w+.*%\\}.*\\{%.*for\\s"
+metadata:
+  precision: speculative
+  judge: required
+```
+
+- [ ] **Step 5: Create test fixtures**
+
+For each rule, add a positive and negative test fixture in `rules/<lang>/tests/`. Example for `rules/python/tests/broad-exception-catch-test.py`:
+
+```python
+# Should match:
+try:
+    risky()
+except Exception as e:
+    logger.error(e)
+    raise
+
+# Should NOT match (specific exception):
+try:
+    risky()
+except ValueError as e:
+    pass
+```
+
+- [ ] **Step 6: Run ast-grep tests**
+
+Run: `cargo test --lib ast_grep`
+Expected: all tests pass
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add rules/
+git commit -m "feat(rules): add 10 pilot speculative rules with judge:required metadata
+
+5 Python, 2 TypeScript, 2 Rust, 1 YAML. All marked precision:speculative,
+judge:required. Includes test fixtures. These rules only produce output
+when --judge is enabled."
+```
+
+---
+
+### Task 12: Integration test — end-to-end judge flow
+
+**Files:**
+- Add integration test in `tests/` or inline in `src/judge.rs`
+
+- [ ] **Step 1: Write integration test**
+
+```rust
+#[test]
+fn judge_flow_end_to_end_with_cache() {
+    use crate::finding::{FindingBuilder, Source, PrecisionTier, JudgeVerdict};
+    use crate::ast_grep::{RuleMetadata, JudgeRequirement};
+
+    let mut findings = vec![
+        {
+            let mut f = FindingBuilder::new()
+                .title("broad-exception-catch: Catching broad Exception")
+                .source(Source::Linter("ast-grep".into()))
+                .rule_id("ast-grep:python/broad-exception-catch")
+                .evidence("except Exception as e:")
+                .build();
+            f.precision_tier = Some(PrecisionTier::Speculative);
+            f
+        },
+        {
+            let mut f = FindingBuilder::new()
+                .title("as-any-cast: as any cast")
+                .source(Source::Linter("ast-grep".into()))
+                .rule_id("ast-grep:typescript/as-any-cast")
+                .evidence("foo as any")
+                .build();
+            // High precision, no judge needed
+            f.precision_tier = Some(PrecisionTier::High);
+            f
+        },
+    ];
+
+    let mut metadata = HashMap::new();
+    metadata.insert("ast-grep:python/broad-exception-catch".into(), RuleMetadata {
+        precision: PrecisionTier::Speculative,
+        judge: JudgeRequirement::Required,
+    });
+    metadata.insert("ast-grep:typescript/as-any-cast".into(), RuleMetadata {
+        precision: PrecisionTier::High,
+        judge: JudgeRequirement::Skip,
+    });
+
+    let dir = tempfile::tempdir().unwrap();
+    let cache_path = dir.path().join("cache.jsonl");
+    let cache = HashMap::new();
+
+    // Mock LLM: always approve
+    let mock_llm = |_prompt: &str| -> Option<String> {
+        Some(r#"[{"rule_id":"ast-grep:python/broad-exception-catch","verdict":"tp","confidence":0.85,"reason":"valid"}]"#.into())
+    };
+
+    let result = judge_findings(
+        &mut findings,
+        "source code here",
+        &metadata,
+        &cache,
+        &cache_path,
+        Some(&mock_llm),
+        5000,
+    );
+
+    assert_eq!(result.approved, 1);
+    assert_eq!(result.skipped, 1);
+    assert_eq!(findings.len(), 2); // none dropped (approved)
+    assert_eq!(findings[0].judge_verdict, Some(JudgeVerdict::Approved));
+    assert_eq!(findings[0].judge_confidence, Some(0.85));
+    assert_eq!(findings[1].judge_verdict, None); // skipped
+
+    // Verify cache was written
+    let loaded_cache = load_cache(&cache_path).unwrap();
+    assert_eq!(loaded_cache.len(), 1);
+}
+
+#[test]
+fn judge_drops_required_rejected_findings() {
+    // Similar setup but mock returns fp verdict
+    let mock_llm = |_prompt: &str| -> Option<String> {
+        Some(r#"[{"rule_id":"ast-grep:python/broad-exception-catch","verdict":"fp","confidence":0.92,"reason":"intentional"}]"#.into())
+    };
+
+    // ... setup findings with judge:required ...
+
+    let result = judge_findings(&mut findings, "code", &metadata, &cache, &cache_path, Some(&mock_llm), 5000);
+    assert_eq!(result.rejected, 1);
+    assert_eq!(findings.len(), 1); // speculative finding was dropped
+}
+```
+
+- [ ] **Step 2: Run tests**
+
+Run: `cargo test --lib judge -- judge_flow judge_drops`
+Expected: PASS
+
+- [ ] **Step 3: Run full test suite**
+
+Run: `cargo test --bin quorum`
+Expected: all tests pass
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/judge.rs
+git commit -m "test(judge): end-to-end integration tests for judge flow
+
+Tests cache roundtrip, skip logic, approval, rejection with
+Required policy (drop), and mock LLM responses."
+```
+
+---
+
+## Final Verification
+
+- [ ] `cargo test --bin quorum` — all tests pass
+- [ ] `cargo clippy` — no warnings
+- [ ] `cargo build --release` — compiles cleanly
+- [ ] Manual smoke test: `cargo run -- review src/finding.rs --json 2>/dev/null | jq '.[].rule_id'` — shows rule_ids
+- [ ] Manual smoke test: `cargo run -- stats --by-rule` — shows per-rule breakdown (if feedback exists)

--- a/docs/superpowers/specs/2026-05-12-ast-judge-design.md
+++ b/docs/superpowers/specs/2026-05-12-ast-judge-design.md
@@ -1,0 +1,303 @@
+# AST Finding Judge and Rule Growth
+
+**Date:** 2026-05-12
+**Issues:** #11 (rule_id tracing), #17 (stats --by-rule), #281 (semantic grounding)
+**Branch:** TBD
+
+## Problem
+
+AST findings get hardcoded confidence (0.95 for LocalAst, 0.90 for Linter) and skip grounding. This limits the rule set to high-precision patterns only. 51% of TP findings (852 in the feedback corpus) come from LLM-only review with no AST rule equivalent. Many of those patterns are syntactically matchable but need semantic validation to avoid false positives.
+
+There is no `rule_id` on Finding, so per-rule precision is unmeasurable. `Source::Linter` carries the tool name ("ast-grep") but not the individual rule ID.
+
+## Design
+
+Two phases. Phase 1 ships independently and provides the observability foundation. Phase 2 adds the judge and speculative rules.
+
+---
+
+## Phase 1: Rule Identity and Per-Rule Stats
+
+### 1.1 Finding struct changes
+
+Add to `Finding` in `src/finding.rs`:
+
+```rust
+#[serde(default, skip_serializing_if = "Option::is_none")]
+pub rule_id: Option<String>,
+```
+
+Format convention:
+
+| Source | rule_id example | Derivation |
+|--------|----------------|------------|
+| ast-grep | `ast-grep:python/bare-except-pass` | `ast-grep:{lang}/{rule.id}` |
+| LocalAst | `local-ast:complexity` | `local-ast:{pattern-name}` |
+| LocalAst | `local-ast:python/eval-exec` | `local-ast:{lang}/{pattern-name}` |
+| Linter (future) | `ruff:E501` | `{linter}:{rule-code}` |
+| LLM | `None` | LLM findings have no rule |
+
+Backward compat: `serde(default)` means legacy JSON without the field deserializes as `None`.
+
+### 1.2 Populate rule_id at construction sites
+
+**ast_grep.rs:277** -- the rule id and language are both available in the scan loop:
+```rust
+rule_id: Some(format!("ast-grep:{}/{}", lang_str, rule.id)),
+```
+
+Where `lang_str` is derived from the `SupportLang` loop variable (e.g., "python", "typescript").
+
+**analysis.rs** -- each `Finding` construction (~30 sites) gets a descriptive rule_id. Pattern naming:
+- `local-ast:complexity` for `analyze_complexity`
+- `local-ast:{lang}/{pattern}` for language-specific patterns in `scan_insecure_*`, e.g., `local-ast:python/eval-exec`, `local-ast:rust/unwrap-in-non-test`
+
+**LLM findings** -- remain `rule_id: None`.
+
+### 1.3 Feedback linkage
+
+Add `rule_id: Option<String>` to `FeedbackEntry` in the feedback store. When recording a verdict against a finding that has a `rule_id`, copy it through. Same `serde(default, skip_serializing_if)` pattern for backward compat with existing `feedback.jsonl` rows.
+
+### 1.4 Stats dimensions
+
+New CLI subcommands:
+- `quorum stats --by-rule` -- per-rule TP/FP/partial breakdown with precision rate
+- `quorum stats --by-source` -- aggregated by source kind (local-ast, ast-grep, llm)
+
+Same MIN_SAMPLE gate, table UI, and sparkline rendering as existing `--by-repo` / `--by-caller`. Support glob filtering: `quorum stats --by-rule --rule "ast-grep:python/*"`.
+
+---
+
+## Phase 2: LLM Micro-Judge
+
+### 2.1 Rule metadata schema
+
+Add optional `metadata` block to ast-grep YAML rules. ast-grep ignores unknown top-level keys; quorum parses it separately.
+
+```yaml
+id: broad-exception-catch
+language: Python
+severity: warning
+message: "Catching broad Exception may mask errors"
+rule:
+  pattern: "except Exception"
+metadata:
+  precision: speculative    # high | medium | speculative
+  judge: required           # required | optional | skip
+```
+
+Defaults for all existing rules: `precision: high`, `judge: skip`. No YAML changes needed for the existing 53 rules.
+
+Parsed in `ast_grep.rs` into:
+
+```rust
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct RuleMetadata {
+    pub precision: PrecisionTier,
+    pub judge: JudgeRequirement,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum PrecisionTier {
+    #[default]
+    High,
+    Medium,
+    Speculative,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum JudgeRequirement {
+    Required,
+    Optional,
+    #[default]
+    Skip,
+}
+```
+
+Built-in patterns in `analysis.rs` define their metadata in code. All existing patterns: `precision: High, judge: Skip`.
+
+### 2.2 Pipeline placement
+
+New stage between AST collection and merge in `pipeline.rs`. Runs in parallel with the LLM review call (they are independent):
+
+```
+Parse -> Hydrate -> Local AST -> ast-grep -> [JUDGE] -> Merge -> Grounding -> Calibrate -> Output
+                                              [LLM] ----^
+```
+
+The judge and LLM reviewer run concurrently. Both feed into `merge_findings`.
+
+### 2.3 Judge protocol
+
+Batched per-file: one LLM call per file containing all findings that need judging. The source code is sent once.
+
+**Prompt structure:**
+- Redacted source code (same as LLM reviewer gets)
+- For each finding: rule_id, title, line range, matched evidence snippet
+
+**Expected response (structured JSON):**
+```json
+[
+  {
+    "rule_id": "ast-grep:python/broad-exception-catch",
+    "verdict": "tp",
+    "confidence": 0.85,
+    "reason": "This catches Exception at a low-level utility, not a top-level handler"
+  },
+  {
+    "rule_id": "ast-grep:python/missing-await",
+    "verdict": "fp",
+    "confidence": 0.92,
+    "reason": "Return value is passed to asyncio.create_task, await not needed"
+  }
+]
+```
+
+Verdicts: `tp` (keep, use judge confidence), `fp` (floor confidence at 0.15), `uncertain` (keep with reduced confidence).
+
+### 2.4 Gating logic
+
+```
+for each AST/ast-grep finding:
+  match metadata.judge:
+    Skip     -> pass through unchanged (existing behavior)
+    Required -> must pass judge to enter merge; if judge unavailable, hold at metadata baseline
+    Optional -> judge if available, pass through if judge offline
+```
+
+Findings rejected by the judge (`fp` verdict) are not dropped. They get:
+- `confidence` floored at 0.15
+- `calibrator_action: Some(Disputed)`
+- Ranked very low in output
+
+This avoids silently suppressing true positives.
+
+### 2.5 Confidence model changes
+
+Add to `Finding`:
+
+```rust
+#[serde(default, skip_serializing_if = "Option::is_none")]
+pub judge_confidence: Option<f32>,
+
+#[serde(default, skip_serializing_if = "Option::is_none")]
+pub precision_tier: Option<PrecisionTier>,
+```
+
+Updated `compute_confidence`:
+
+```rust
+let base = match (&self.source, &self.precision_tier) {
+    (Source::LocalAst, Some(PrecisionTier::High)) | (Source::LocalAst, None) => 0.95,
+    (Source::LocalAst, Some(PrecisionTier::Medium))                          => 0.80,
+    (Source::LocalAst, Some(PrecisionTier::Speculative))                     => 0.50,
+    (Source::Linter(_), Some(PrecisionTier::High)) | (Source::Linter(_), None) => 0.90,
+    (Source::Linter(_), Some(PrecisionTier::Medium))                          => 0.75,
+    (Source::Linter(_), Some(PrecisionTier::Speculative))                     => 0.45,
+    (Source::Llm(_), _) => self.grounding_confidence
+        .filter(|c| c.is_finite())
+        .map(|c| c.clamp(0.0, 1.0))
+        .unwrap_or(0.5),
+};
+
+// Judge overrides base (not multiplies)
+let base = self.judge_confidence
+    .filter(|c| c.is_finite())
+    .map(|c| c.clamp(0.0, 1.0))
+    .unwrap_or(base);
+
+// Then apply calibrator and agreement factors as before
+```
+
+Existing high-precision rules behave identically (precision_tier defaults to None, judge_confidence stays None).
+
+### 2.6 Cost control
+
+- Only speculative/medium rules with `judge: required|optional` hit the judge
+- High-precision rules bypass entirely (zero additional cost for existing rules)
+- Judge uses a configurable model (default: fast/cheap model)
+- If zero findings need judging for a file, no judge call is made
+- Judge timeout: 5 seconds per file, fail-open (findings pass through unjudged with metadata baseline confidence)
+- `QUORUM_JUDGE_MODEL` env var for model selection
+
+### 2.7 Feature flag
+
+- `--judge` CLI flag or `QUORUM_JUDGE=1` env var to enable
+- Off by default until validated on the pilot rule set
+- When disabled, speculative rules still fire but use their metadata baseline confidence (no LLM call)
+
+### 2.8 Telemetry
+
+New counters on `TelemetryEntry`:
+
+| Counter | Description |
+|---------|-------------|
+| `judge_calls` | Number of LLM judge calls made |
+| `judge_approved` | Findings approved (tp verdict) |
+| `judge_rejected` | Findings rejected (fp verdict) |
+| `judge_uncertain` | Findings marked uncertain |
+| `judge_skipped` | Findings that bypassed judge (high precision) |
+| `judge_timeout` | Calls that timed out (fail-open) |
+
+All counters use `serde(default)` for backward compat.
+
+---
+
+## Phase 2 Pilot: Speculative Rules
+
+Initial set of 10 rules marked `precision: speculative, judge: required`. Drawn from `docs/plans/LOWER_PRECISION_RULES.md` and `docs/feedback-pattern-mining.md` gap analysis.
+
+| # | Language | Rule ID | Source Doc | TP Cluster | Why Judge Needed |
+|---|----------|---------|------------|------------|-----------------|
+| 1 | Python | `broad-exception-catch` | LOWER_PRECISION_RULES | async_issue, missing_validation | Intentional at top-level handlers |
+| 2 | Python | `subprocess-no-check` | LOWER_PRECISION_RULES | missing_validation | May check returncode manually |
+| 3 | Python | `re-compile-in-loop` | LOWER_PRECISION_RULES | regex_issue (21 TPs) | Loop variable may be dynamic |
+| 4 | Python | `missing-await` | gap analysis | async_issue (34 TPs) | Fire-and-forget / task spawning |
+| 5 | Python | `logging-debug-leak` | gap analysis | logging_debug (30 TPs) | Debug logging sometimes intentional |
+| 6 | TypeScript | `nullish-coalescing-broad` | LOWER_PRECISION_RULES | null_undef (21 TPs) | `\|\|` is idiomatic for some falsy cases |
+| 7 | Rust | `string-byte-slice-broad` | LOWER_PRECISION_RULES | -- | ASCII-only slices are safe |
+| 8 | Rust | `discarded-result` | gap analysis | missing_validation | Intentional cleanup paths |
+| 9 | TypeScript | `string-format-sql` | gap analysis | type_safety (18 TPs) | May use query builder |
+| 10 | YAML | `jinja-loop-variable-scoping` | LOWER_PRECISION_RULES | yaml_issue (38 TPs) | Regex-based detection is fragile |
+
+Rules 6 and 7 are broader variants of existing high-precision rules (`nullish-coalescing-preferred`, `string-byte-slice`). They widen the match pattern and rely on the judge to filter.
+
+### Graduation criteria
+
+- >80% judge TP rate after 2-3 weeks -> promote to `precision: medium, judge: optional`
+- 50-80% -> keep as speculative, tune pattern
+- <50% -> retire or rewrite the rule
+- Measured via `quorum stats --by-rule`
+
+---
+
+## Files Modified
+
+### Phase 1
+- `src/finding.rs` -- add `rule_id` field, update `compute_confidence`
+- `src/ast_grep.rs` -- populate `rule_id` from `rule.id` + language
+- `src/analysis.rs` -- populate `rule_id` at ~30 Finding construction sites
+- `src/feedback.rs` -- add `rule_id` to `FeedbackEntry` (line 91)
+- `src/dimensions.rs` -- add `group_by_rule` and `group_by_source` dimension functions
+- `src/main.rs` -- wire new CLI flags
+
+### Phase 2
+- `src/ast_grep.rs` -- parse `metadata` block, add `RuleMetadata`/`PrecisionTier`/`JudgeRequirement` types
+- `src/finding.rs` -- add `judge_confidence`, `precision_tier` fields, update `compute_confidence`
+- `src/pipeline.rs` -- insert judge stage between AST collection and merge
+- `src/judge.rs` -- new module: judge trait, LLM judge implementation, batching, timeout
+- `src/telemetry.rs` -- add judge counters
+- `src/main.rs` -- `--judge` flag, `QUORUM_JUDGE_MODEL` env var
+- `rules/python/` -- add 5 new speculative rule YAMLs
+- `rules/typescript/` -- add 2 new speculative rule YAMLs
+- `rules/rust/` -- add 2 new speculative rule YAMLs
+- `rules/yaml/` -- add 1 new speculative rule YAML
+
+## Non-Goals
+
+- Replacing the LLM reviewer with AST rules -- the judge validates AST findings, it does not replace the full LLM review
+- Scope-tree semantic grounding (#281) -- complementary approach that can layer in later as a zero-cost optimization for patterns where tree-sitter provides enough context
+- Automated rule generation -- future work; this design provides the measurement infrastructure
+- Judge for LLM findings -- LLM findings already have grounding; the judge is for AST findings only

--- a/docs/superpowers/specs/2026-05-12-ast-judge-design.md
+++ b/docs/superpowers/specs/2026-05-12-ast-judge-design.md
@@ -155,7 +155,7 @@ Batched per-file: one LLM call per file containing all findings that need judgin
 ]
 ```
 
-Verdicts: `tp` (keep, use judge confidence), `fp` (floor confidence at 0.15), `uncertain` (keep with reduced confidence).
+Verdicts: `tp` (keep, use judge confidence), `fp` (reject — see gating logic), `uncertain` (keep with reduced confidence).
 
 ### 2.4 Gating logic
 
@@ -167,12 +167,33 @@ for each AST/ast-grep finding:
     Optional -> judge if available, pass through if judge offline
 ```
 
-Findings rejected by the judge (`fp` verdict) are not dropped. They get:
-- `confidence` floored at 0.15
-- `calibrator_action: Some(Disputed)`
-- Ranked very low in output
+**Rejection behavior depends on judge requirement:**
+- `judge: required` + `fp` verdict → **drop the finding entirely**. It does not enter merge or output. Telemetry records the rejection.
+- `judge: optional` + `fp` verdict → **clamp confidence to 0.05** and mark `judge_verdict: Rejected`. Finding appears in output only at the lowest rank.
+- `uncertain` verdict → keep the finding, use judge confidence (typically 0.3-0.5), mark `judge_verdict: Uncertain`.
 
-This avoids silently suppressing true positives.
+This is safe because speculative rules are opt-in (`--judge` flag) and we have per-rule telemetry to detect over-suppression via `stats --by-rule`.
+
+### 2.4.1 Judge verdict field
+
+Add a dedicated field to `Finding` rather than overloading `calibrator_action` (which reflects human feedback):
+
+```rust
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum JudgeVerdict {
+    Approved,
+    Rejected,
+    Uncertain,
+    Skipped,
+}
+
+// On Finding:
+#[serde(default, skip_serializing_if = "Option::is_none")]
+pub judge_verdict: Option<JudgeVerdict>,
+```
+
+`Skipped` = high-precision rule that bypassed the judge. `None` = judge feature not enabled.
 
 ### 2.5 Confidence model changes
 
@@ -213,22 +234,50 @@ let base = self.judge_confidence
 
 Existing high-precision rules behave identically (precision_tier defaults to None, judge_confidence stays None).
 
-### 2.6 Cost control
+### 2.5.1 Merge precedence for mixed-source findings
+
+When an AST finding (with `judge_confidence`) merges with an LLM finding (with `grounding_confidence`) in `merge_findings`, the merged finding takes `max(judge_confidence, grounding_confidence)`. Both sources independently confirmed the issue, so the higher confidence wins. The merged finding retains `judge_verdict` from the AST side and `grounding_status` from the LLM side.
+
+### 2.6 Caching
+
+Two complementary caching layers minimize redundant judge calls:
+
+**Layer 1: Local verdict cache** at `~/.quorum/judge_cache.jsonl`. Keyed on `sha256(rule_id + evidence_text)` where evidence_text is the matched AST node text (already captured at finding construction). Fields:
+
+```json
+{
+  "cache_key": "a1b2c3...",
+  "rule_id": "ast-grep:python/broad-exception-catch",
+  "verdict": "tp",
+  "confidence": 0.85,
+  "reason": "...",
+  "timestamp": "2026-05-12T00:00:00Z"
+}
+```
+
+TTL: 7 days (matches registry cache). On cache hit, skip the LLM call entirely and apply the cached verdict. Primary benefit: **repeat runs on unfixed findings** — the most common case during iterative development.
+
+**Layer 2: LiteLLM prompt caching** — achieved by building judge prompts deterministically. Findings sorted by `(rule_id, line_start)` before prompt construction ensures stable cache keys. This is free and covers identical full-file re-reviews.
+
+Cache invalidation: evidence_text changes when the matched code changes, so the sha256 key naturally invalidates. No manual cache busting needed.
+
+### 2.7 Cost control
 
 - Only speculative/medium rules with `judge: required|optional` hit the judge
 - High-precision rules bypass entirely (zero additional cost for existing rules)
+- Local verdict cache eliminates re-judging unfixed findings across runs
 - Judge uses a configurable model (default: fast/cheap model)
 - If zero findings need judging for a file, no judge call is made
 - Judge timeout: 5 seconds per file, fail-open (findings pass through unjudged with metadata baseline confidence)
 - `QUORUM_JUDGE_MODEL` env var for model selection
 
-### 2.7 Feature flag
+### 2.8 Feature flag
 
 - `--judge` CLI flag or `QUORUM_JUDGE=1` env var to enable
 - Off by default until validated on the pilot rule set
 - When disabled, speculative rules still fire but use their metadata baseline confidence (no LLM call)
 
-### 2.8 Telemetry
+### 2.9 Telemetry
 
 New counters on `TelemetryEntry`:
 
@@ -240,6 +289,8 @@ New counters on `TelemetryEntry`:
 | `judge_uncertain` | Findings marked uncertain |
 | `judge_skipped` | Findings that bypassed judge (high precision) |
 | `judge_timeout` | Calls that timed out (fail-open) |
+| `judge_cache_hits` | Findings resolved from local verdict cache |
+| `judge_latency_ms` | Total judge wall-clock time (LLM + cache lookups) |
 
 All counters use `serde(default)` for backward compat.
 
@@ -285,9 +336,9 @@ Rules 6 and 7 are broader variants of existing high-precision rules (`nullish-co
 
 ### Phase 2
 - `src/ast_grep.rs` -- parse `metadata` block, add `RuleMetadata`/`PrecisionTier`/`JudgeRequirement` types
-- `src/finding.rs` -- add `judge_confidence`, `precision_tier` fields, update `compute_confidence`
+- `src/finding.rs` -- add `judge_confidence`, `judge_verdict`, `precision_tier` fields, update `compute_confidence`
 - `src/pipeline.rs` -- insert judge stage between AST collection and merge
-- `src/judge.rs` -- new module: judge trait, LLM judge implementation, batching, timeout
+- `src/judge.rs` -- new module: judge trait, LLM judge implementation, batching, timeout, verdict cache
 - `src/telemetry.rs` -- add judge counters
 - `src/main.rs` -- `--judge` flag, `QUORUM_JUDGE_MODEL` env var
 - `rules/python/` -- add 5 new speculative rule YAMLs

--- a/docs/superpowers/specs/2026-05-12-ast-judge-design.md
+++ b/docs/superpowers/specs/2026-05-12-ast-judge-design.md
@@ -266,7 +266,7 @@ Cache invalidation: evidence_text changes when the matched code changes, so the 
 - Only speculative/medium rules with `judge: required|optional` hit the judge
 - High-precision rules bypass entirely (zero additional cost for existing rules)
 - Local verdict cache eliminates re-judging unfixed findings across runs
-- Judge uses a configurable model (default: fast/cheap model)
+- Judge uses a configurable model via `QUORUM_JUDGE_MODEL` (default: smallest model capable of reliable JSON classification — e.g., `gpt-5-nano`, `gpt-5.1-codex-mini`, or equivalent. The judge task is structured classification, not open-ended generation, so the cheapest model that follows a JSON schema reliably is optimal)
 - If zero findings need judging for a file, no judge call is made
 - Judge timeout: 5 seconds per file, fail-open (findings pass through unjudged with metadata baseline confidence)
 - `QUORUM_JUDGE_MODEL` env var for model selection

--- a/rules/python/logging-debug-leak.yml
+++ b/rules/python/logging-debug-leak.yml
@@ -1,0 +1,9 @@
+id: logging-debug-leak
+language: Python
+severity: info
+message: "Debug-level logging may leak sensitive data in production. Ensure debug logging is disabled in production configuration."
+rule:
+  pattern: logging.debug($$$ARGS)
+metadata:
+  precision: speculative
+  judge: required

--- a/rules/python/missing-await.yml
+++ b/rules/python/missing-await.yml
@@ -1,0 +1,19 @@
+id: missing-await
+language: Python
+severity: warning
+message: "Async function called without await. Return value may be an unawaited coroutine."
+rule:
+  kind: call
+  inside:
+    kind: expression_statement
+    inside:
+      kind: function_definition
+      regex: "^\\s*async\\s+def\\b"
+      stopBy: end
+  not:
+    inside:
+      kind: await
+      stopBy: neighbor
+metadata:
+  precision: speculative
+  judge: required

--- a/rules/python/tests/logging-debug-leak-test.py
+++ b/rules/python/tests/logging-debug-leak-test.py
@@ -1,0 +1,23 @@
+# Fixture: logging-debug-leak
+import logging
+
+user_password = "secret123"
+api_key = "sk-prod-key"
+
+# match: debug logging with sensitive variable
+logging.debug(user_password)  # ruleid: logging-debug-leak
+
+# match: debug logging with formatted string
+logging.debug("User token: %s", api_key)  # ruleid: logging-debug-leak
+
+# match: debug logging with f-string
+logging.debug(f"Request payload: {api_key}")  # ruleid: logging-debug-leak
+
+# no-match: info level logging
+logging.info("Application started")  # ok: logging-debug-leak
+
+# no-match: warning level
+logging.warning("Rate limit approaching")  # ok: logging-debug-leak
+
+# no-match: error level
+logging.error("Connection failed")  # ok: logging-debug-leak

--- a/rules/python/tests/missing-await-test.py
+++ b/rules/python/tests/missing-await-test.py
@@ -1,0 +1,31 @@
+# Fixture: missing-await
+import asyncio
+
+async def fetch_data():
+    pass
+
+async def save_data():
+    pass
+
+# match: async function called without await inside async context
+async def process():
+    fetch_data()  # ruleid: missing-await
+
+# match: another unawaited call
+async def run():
+    save_data()  # ruleid: missing-await
+
+# no-match: properly awaited
+async def proper_process():
+    await fetch_data()  # ok: missing-await
+
+# no-match: sync function call inside async context is fine
+def sync_helper():
+    pass
+
+async def sync_usage():
+    sync_helper()  # ok: missing-await - not an async call pattern
+
+# no-match: call in sync function
+def sync_caller():
+    fetch_data()  # ok: missing-await - not inside async function

--- a/rules/rust/discarded-result.yml
+++ b/rules/rust/discarded-result.yml
@@ -1,0 +1,11 @@
+id: discarded-result
+language: Rust
+severity: warning
+message: "Result value discarded with `let _ =`. If the error is intentional, add a comment explaining why."
+rule:
+  pattern: let _ = $EXPR;
+  has:
+    kind: call_expression
+metadata:
+  precision: speculative
+  judge: required

--- a/rules/rust/string-byte-slice-broad.yml
+++ b/rules/rust/string-byte-slice-broad.yml
@@ -1,0 +1,9 @@
+id: string-byte-slice-broad
+language: Rust
+severity: warning
+message: "String byte slicing (&s[..n]) can panic on non-ASCII boundaries. Consider using s.get(..n) or char_indices."
+rule:
+  pattern: "&$S[$$$RANGE]"
+metadata:
+  precision: speculative
+  judge: required

--- a/rules/rust/tests/discarded-result-test.rs
+++ b/rules/rust/tests/discarded-result-test.rs
@@ -1,0 +1,32 @@
+// Fixture: discarded-result
+use std::fs;
+
+fn write_file() -> std::io::Result<()> {
+    fs::write("output.txt", "data")
+}
+
+fn send_notification() -> Result<(), String> {
+    Ok(())
+}
+
+// match: discarding Result from a function call
+fn fire_and_forget() {
+    let _ = write_file();  // ruleid: discarded-result
+}
+
+// match: discarding Result from another call
+fn ignore_notification() {
+    let _ = send_notification();  // ruleid: discarded-result
+}
+
+// no-match: properly handling the result
+fn handle_result() {
+    if let Err(e) = write_file() {
+        eprintln!("Write failed: {}", e);
+    }
+}
+
+// no-match: let _ discarding a non-call expression
+fn discard_literal() {
+    let _ = 42;  // ok: discarded-result - not a call
+}

--- a/rules/rust/tests/string-byte-slice-broad-test.rs
+++ b/rules/rust/tests/string-byte-slice-broad-test.rs
@@ -1,0 +1,22 @@
+// Fixture: string-byte-slice-broad
+fn truncate_broad(s: &str) -> &str {
+    &s[..100]  // ruleid: string-byte-slice-broad
+}
+
+fn mid_slice_broad(s: &str) -> &str {
+    &s[10..50]  // ruleid: string-byte-slice-broad
+}
+
+// no-match: safe alternatives
+fn safe_truncate(s: &str) -> String {
+    s.chars().take(100).collect()  // ok: string-byte-slice-broad
+}
+
+fn safe_get(s: &str) -> Option<&str> {
+    s.get(..100)  // ok: string-byte-slice-broad
+}
+
+// no-match: byte slice on a Vec (not a string)
+fn vec_slice(v: &[u8]) -> &[u8] {
+    &v[..10]  // ok: string-byte-slice-broad - Vec slice, not string
+}

--- a/rules/typescript/nullish-coalescing-broad.yml
+++ b/rules/typescript/nullish-coalescing-broad.yml
@@ -1,0 +1,17 @@
+id: nullish-coalescing-broad
+language: TypeScript
+severity: info
+message: "Using || where ?? may be intended. If 0, empty string, or false are valid values, use nullish coalescing (??) instead."
+rule:
+  kind: binary_expression
+  all:
+    - has:
+        field: operator
+        regex: "^\\|\\|$"
+  not:
+    inside:
+      kind: if_statement
+      stopBy: neighbor
+metadata:
+  precision: speculative
+  judge: required

--- a/rules/typescript/string-format-sql.yml
+++ b/rules/typescript/string-format-sql.yml
@@ -1,0 +1,10 @@
+id: string-format-sql
+language: TypeScript
+severity: warning
+message: "String interpolation in SQL query may indicate SQL injection risk. Use parameterized queries."
+rule:
+  kind: template_string
+  regex: "(?i)(SELECT|INSERT|UPDATE|DELETE|DROP)\\s"
+metadata:
+  precision: speculative
+  judge: required

--- a/rules/typescript/tests/nullish-coalescing-broad-test.ts
+++ b/rules/typescript/tests/nullish-coalescing-broad-test.ts
@@ -1,0 +1,19 @@
+// Fixture: nullish-coalescing-broad
+declare const count: number | null;
+declare const label: string | null;
+declare const flag: boolean | null;
+
+// match: || where ?? may be more appropriate
+const displayCount = count || 0;  // ruleid: nullish-coalescing-broad
+
+// match: || with string default
+const displayLabel = label || "default";  // ruleid: nullish-coalescing-broad
+
+// match: || with boolean default
+const isEnabled = flag || false;  // ruleid: nullish-coalescing-broad
+
+// no-match: already using ??
+const safeCount = count ?? 0;  // ok: nullish-coalescing-broad
+
+// no-match: ?? with string
+const safeLabel = label ?? "default";  // ok: nullish-coalescing-broad

--- a/rules/typescript/tests/string-format-sql-test.ts
+++ b/rules/typescript/tests/string-format-sql-test.ts
@@ -1,0 +1,19 @@
+// Fixture: string-format-sql
+declare const db: { query: (sql: string) => any };
+declare const userId: string;
+declare const tableName: string;
+
+// match: SELECT with interpolation in template string
+db.query(`SELECT * FROM users WHERE id = ${userId}`);  // ruleid: string-format-sql
+
+// match: INSERT with interpolation
+db.query(`INSERT INTO logs VALUES (${userId})`);  // ruleid: string-format-sql
+
+// match: DELETE with interpolation
+db.query(`DELETE FROM sessions WHERE user = ${userId}`);  // ruleid: string-format-sql
+
+// no-match: plain string literal (no interpolation)
+db.query(`SELECT * FROM users WHERE id = ?`);  // ok: string-format-sql
+
+// no-match: non-SQL template string
+const greeting = `Hello, ${userId}!`;  // ok: string-format-sql

--- a/rules/yaml/jinja-loop-variable-scoping.yml
+++ b/rules/yaml/jinja-loop-variable-scoping.yml
@@ -4,7 +4,7 @@ severity: warning
 message: "Variable set inside Jinja for-loop may not persist outside the loop scope due to Jinja2 scoping rules."
 rule:
   kind: block_scalar
-  regex: "\\{%.*set\\s+\\w+.*%\\}.*\\{%.*for\\s"
+  regex: "\\{%.*for\\s.*%\\}.*\\{%.*set\\s+\\w+.*%\\}"
 metadata:
   precision: speculative
   judge: required

--- a/rules/yaml/jinja-loop-variable-scoping.yml
+++ b/rules/yaml/jinja-loop-variable-scoping.yml
@@ -1,0 +1,10 @@
+id: jinja-loop-variable-scoping
+language: Yaml
+severity: warning
+message: "Variable set inside Jinja for-loop may not persist outside the loop scope due to Jinja2 scoping rules."
+rule:
+  kind: block_scalar
+  regex: "\\{%.*set\\s+\\w+.*%\\}.*\\{%.*for\\s"
+metadata:
+  precision: speculative
+  judge: required

--- a/rules/yaml/tests/jinja-loop-variable-scoping-test.yaml
+++ b/rules/yaml/tests/jinja-loop-variable-scoping-test.yaml
@@ -1,0 +1,30 @@
+# Fixture: jinja-loop-variable-scoping
+# match: set before for-loop, reassigned inside (scoping issue)
+bad_template:
+  sensor:
+    - name: "Counter loses state"
+      state: >
+        {% set count = 0 %}
+        {% for item in items %}
+          {% set count = count + 1 %}
+        {% endfor %}
+        {{ count }}
+
+# no-match: uses namespace() for proper mutable state in loop
+good_template:
+  sensor:
+    - name: "Counter works correctly"
+      state: >
+        {% set ns = namespace(count=0) %}
+        {% for item in items %}
+          {% set ns.count = ns.count + 1 %}
+        {% endfor %}
+        {{ ns.count }}
+
+# no-match: set without for-loop
+simple_template:
+  sensor:
+    - name: "Simple assignment"
+      state: >
+        {% set value = 42 %}
+        {{ value }}

--- a/src/analysis.rs
+++ b/src/analysis.rs
@@ -68,7 +68,7 @@ pub fn analyze_complexity(
                     grounding_status: None,
                     grounding_confidence: None,
                 model_agreement: None,
-                rule_id: None,
+                rule_id: Some("local-ast:complexity".into()),
                 });
             }
         }
@@ -252,7 +252,7 @@ fn scan_insecure_rust(node: &tree_sitter::Node, source: &str, findings: &mut Vec
                     grounding_status: None,
                     grounding_confidence: None,
         model_agreement: None,
-        rule_id: None,
+        rule_id: Some("local-ast:rust/unsafe-block".into()),
         });
     }
 
@@ -289,7 +289,7 @@ fn scan_insecure_rust(node: &tree_sitter::Node, source: &str, findings: &mut Vec
                 grounding_status: None,
                 grounding_confidence: None,
                 model_agreement: None,
-                rule_id: None,
+                rule_id: Some("local-ast:rust/unwrap-in-non-test".into()),
             });
         }
     }
@@ -329,7 +329,7 @@ fn scan_insecure_python(node: &tree_sitter::Node, source: &str, findings: &mut V
                     grounding_status: None,
                     grounding_confidence: None,
                     model_agreement: None,
-                    rule_id: None,
+                    rule_id: Some("local-ast:python/eval-exec".into()),
                 });
             }
         }
@@ -360,7 +360,7 @@ fn scan_insecure_python(node: &tree_sitter::Node, source: &str, findings: &mut V
                     grounding_status: None,
                     grounding_confidence: None,
                 model_agreement: None,
-                rule_id: None,
+                rule_id: Some("local-ast:python/debug-true".into()),
                 });
             }
             if args_text.contains("host=\"0.0.0.0\"") || args_text.contains("host='0.0.0.0'") {
@@ -386,7 +386,7 @@ fn scan_insecure_python(node: &tree_sitter::Node, source: &str, findings: &mut V
                     grounding_status: None,
                     grounding_confidence: None,
                 model_agreement: None,
-                rule_id: None,
+                rule_id: Some("local-ast:python/bind-all-interfaces".into()),
                 });
             }
         }
@@ -426,7 +426,7 @@ fn scan_insecure_python(node: &tree_sitter::Node, source: &str, findings: &mut V
                     grounding_status: None,
                     grounding_confidence: None,
                             model_agreement: None,
-                            rule_id: None,
+                            rule_id: Some("local-ast:python/sql-injection".into()),
                             });
                     } else if arg_text.contains(".format(") {
                         findings.push(Finding {
@@ -451,7 +451,7 @@ fn scan_insecure_python(node: &tree_sitter::Node, source: &str, findings: &mut V
                     grounding_status: None,
                     grounding_confidence: None,
                             model_agreement: None,
-                            rule_id: None,
+                            rule_id: Some("local-ast:python/sql-injection".into()),
                             });
                     }
                 }
@@ -496,7 +496,7 @@ fn scan_insecure_python(node: &tree_sitter::Node, source: &str, findings: &mut V
                     grounding_status: None,
                     grounding_confidence: None,
                         model_agreement: None,
-                        rule_id: None,
+                        rule_id: Some("local-ast:python/open-no-encoding".into()),
                         });
                 }
             }
@@ -558,7 +558,7 @@ fn scan_insecure_python(node: &tree_sitter::Node, source: &str, findings: &mut V
                     grounding_status: None,
                     grounding_confidence: None,
                     model_agreement: None,
-                    rule_id: None,
+                    rule_id: Some("local-ast:python/bare-except-pass".into()),
                     });
             }
         }
@@ -636,7 +636,7 @@ fn scan_insecure_python(node: &tree_sitter::Node, source: &str, findings: &mut V
                     grounding_status: None,
                     grounding_confidence: None,
                         model_agreement: None,
-                        rule_id: None,
+                        rule_id: Some("local-ast:python/hardcoded-secret".into()),
                         });
             }
         }
@@ -675,7 +675,7 @@ fn scan_insecure_python(node: &tree_sitter::Node, source: &str, findings: &mut V
                     grounding_status: None,
                     grounding_confidence: None,
                         model_agreement: None,
-                        rule_id: None,
+                        rule_id: Some("local-ast:python/mutation-during-iteration".into()),
                         });
                 }
             }
@@ -732,7 +732,7 @@ fn scan_insecure_python(node: &tree_sitter::Node, source: &str, findings: &mut V
                     grounding_status: None,
                     grounding_confidence: None,
                 model_agreement: None,
-                rule_id: None,
+                rule_id: Some("local-ast:python/exception-disclosure".into()),
                 });
             }
         }
@@ -767,7 +767,7 @@ fn scan_insecure_python(node: &tree_sitter::Node, source: &str, findings: &mut V
                     grounding_status: None,
                     grounding_confidence: None,
                 model_agreement: None,
-                rule_id: None,
+                rule_id: Some("local-ast:python/blocking-in-async".into()),
                 });
         }
     }
@@ -804,7 +804,7 @@ fn scan_insecure_python(node: &tree_sitter::Node, source: &str, findings: &mut V
                     grounding_status: None,
                     grounding_confidence: None,
                 model_agreement: None,
-                rule_id: None,
+                rule_id: Some("local-ast:python/mutable-default-arg".into()),
                 });
         }
     }
@@ -1170,7 +1170,7 @@ fn scan_insecure_yaml(node: &tree_sitter::Node, source: &str, findings: &mut Vec
                     grounding_status: None,
                     grounding_confidence: None,
                             model_agreement: None,
-                            rule_id: None,
+                            rule_id: Some("local-ast:yaml/duplicate-key".into()),
                             });
                 } else {
                     seen_keys.push((key_text, key_line));
@@ -1209,7 +1209,7 @@ fn scan_insecure_yaml(node: &tree_sitter::Node, source: &str, findings: &mut Vec
                     grounding_status: None,
                     grounding_confidence: None,
                     model_agreement: None,
-                    rule_id: None,
+                    rule_id: Some("local-ast:yaml/ha-no-id".into()),
                 });
             }
 
@@ -1237,7 +1237,7 @@ fn scan_insecure_yaml(node: &tree_sitter::Node, source: &str, findings: &mut Vec
                     grounding_status: None,
                     grounding_confidence: None,
                     model_agreement: None,
-                    rule_id: None,
+                    rule_id: Some("local-ast:yaml/ha-no-mode".into()),
                 });
             }
 
@@ -1274,7 +1274,7 @@ fn scan_insecure_yaml(node: &tree_sitter::Node, source: &str, findings: &mut Vec
                     grounding_status: None,
                     grounding_confidence: None,
                     model_agreement: None,
-                    rule_id: None,
+                    rule_id: Some("local-ast:yaml/ha-deprecated-singular".into()),
                     });
                 }
             }
@@ -1314,7 +1314,7 @@ fn scan_insecure_yaml(node: &tree_sitter::Node, source: &str, findings: &mut Vec
                     grounding_status: None,
                     grounding_confidence: None,
                                 model_agreement: None,
-                                rule_id: None,
+                                rule_id: Some("local-ast:yaml/ha-empty-section".into()),
                                 });
                     }
                 }
@@ -1358,7 +1358,7 @@ fn scan_insecure_yaml(node: &tree_sitter::Node, source: &str, findings: &mut Vec
                     grounding_status: None,
                     grounding_confidence: None,
                         model_agreement: None,
-                        rule_id: None,
+                        rule_id: Some("local-ast:yaml/esphome-ota-no-password".into()),
                         });
                     }
                 }
@@ -1395,7 +1395,7 @@ fn scan_insecure_yaml(node: &tree_sitter::Node, source: &str, findings: &mut Vec
                     grounding_status: None,
                     grounding_confidence: None,
                         model_agreement: None,
-                        rule_id: None,
+                        rule_id: Some("local-ast:yaml/esphome-api-no-encryption".into()),
                         });
                     }
                 }
@@ -1466,7 +1466,7 @@ fn scan_insecure_yaml(node: &tree_sitter::Node, source: &str, findings: &mut Vec
                     grounding_status: None,
                     grounding_confidence: None,
                                         model_agreement: None,
-                                        rule_id: None,
+                                        rule_id: Some("local-ast:yaml/compose-no-new-privileges".into()),
                                         });
                             }
 
@@ -1494,7 +1494,7 @@ fn scan_insecure_yaml(node: &tree_sitter::Node, source: &str, findings: &mut Vec
                     grounding_status: None,
                     grounding_confidence: None,
                                         model_agreement: None,
-                                        rule_id: None,
+                                        rule_id: Some("local-ast:yaml/compose-writable-rootfs".into()),
                                         });
                             }
                         }
@@ -1541,7 +1541,7 @@ fn scan_insecure_yaml(node: &tree_sitter::Node, source: &str, findings: &mut Vec
                     grounding_status: None,
                     grounding_confidence: None,
                     model_agreement: None,
-                    rule_id: None,
+                    rule_id: Some("local-ast:yaml/hardcoded-secret".into()),
                 });
             }
         }
@@ -1591,7 +1591,7 @@ fn scan_insecure_yaml(node: &tree_sitter::Node, source: &str, findings: &mut Vec
                                     grounding_status: None,
                                     grounding_confidence: None,
                                     model_agreement: None,
-                                    rule_id: None,
+                                    rule_id: Some("local-ast:yaml/entity-id-no-domain".into()),
                                 });
                             }
                         }
@@ -1625,7 +1625,7 @@ fn scan_insecure_yaml(node: &tree_sitter::Node, source: &str, findings: &mut Vec
                     grounding_status: None,
                     grounding_confidence: None,
                     model_agreement: None,
-                    rule_id: None,
+                    rule_id: Some("local-ast:yaml/entity-id-no-domain".into()),
                 });
             }
         }
@@ -1661,7 +1661,7 @@ fn scan_insecure_yaml(node: &tree_sitter::Node, source: &str, findings: &mut Vec
                     grounding_status: None,
                     grounding_confidence: None,
                     model_agreement: None,
-                    rule_id: None,
+                    rule_id: Some("local-ast:yaml/service-no-domain".into()),
                 });
             }
         }
@@ -1694,7 +1694,7 @@ fn scan_insecure_yaml(node: &tree_sitter::Node, source: &str, findings: &mut Vec
                     grounding_status: None,
                     grounding_confidence: None,
                         model_agreement: None,
-                        rule_id: None,
+                        rule_id: Some("local-ast:yaml/bind-all-interfaces".into()),
                         });
             }
         }
@@ -1729,7 +1729,7 @@ fn scan_insecure_yaml(node: &tree_sitter::Node, source: &str, findings: &mut Vec
                     grounding_status: None,
                     grounding_confidence: None,
                         model_agreement: None,
-                        rule_id: None,
+                        rule_id: Some("local-ast:yaml/url-credentials".into()),
                         });
             }
         }
@@ -1771,7 +1771,7 @@ fn scan_insecure_yaml(node: &tree_sitter::Node, source: &str, findings: &mut Vec
                     grounding_status: None,
                     grounding_confidence: None,
                     model_agreement: None,
-                    rule_id: None,
+                    rule_id: Some("local-ast:yaml/states-no-availability-check".into()),
                     });
                 }
             }
@@ -1833,7 +1833,7 @@ fn scan_insecure_yaml(node: &tree_sitter::Node, source: &str, findings: &mut Vec
                     grounding_status: None,
                     grounding_confidence: None,
                     model_agreement: None,
-                    rule_id: None,
+                    rule_id: Some("local-ast:yaml/deprecated-dot-state".into()),
                 });
             }
         }
@@ -1873,7 +1873,7 @@ fn scan_insecure_typescript(node: &tree_sitter::Node, source: &str, findings: &m
                 grounding_status: None,
                 grounding_confidence: None,
                 model_agreement: None,
-                rule_id: None,
+                rule_id: Some("local-ast:typescript/eval".into()),
             });
         }
 
@@ -1901,7 +1901,7 @@ fn scan_insecure_typescript(node: &tree_sitter::Node, source: &str, findings: &m
                     grounding_status: None,
                     grounding_confidence: None,
                 model_agreement: None,
-                rule_id: None,
+                rule_id: Some("local-ast:typescript/document-write-xss".into()),
                 });
         }
 
@@ -1929,7 +1929,7 @@ fn scan_insecure_typescript(node: &tree_sitter::Node, source: &str, findings: &m
                     grounding_status: None,
                     grounding_confidence: None,
                 model_agreement: None,
-                rule_id: None,
+                rule_id: Some("local-ast:typescript/console-log-artifact".into()),
                 });
         }
     }
@@ -1986,7 +1986,7 @@ fn scan_insecure_typescript(node: &tree_sitter::Node, source: &str, findings: &m
                     grounding_status: None,
                     grounding_confidence: None,
                             model_agreement: None,
-                            rule_id: None,
+                            rule_id: Some("local-ast:typescript/hardcoded-secret".into()),
                             });
                 }
             }
@@ -2026,7 +2026,7 @@ fn scan_insecure_typescript(node: &tree_sitter::Node, source: &str, findings: &m
                     grounding_status: None,
                     grounding_confidence: None,
                 model_agreement: None,
-                rule_id: None,
+                rule_id: Some("local-ast:typescript/innerhtml-xss".into()),
                 });
         }
     }
@@ -2058,7 +2058,7 @@ fn scan_insecure_typescript(node: &tree_sitter::Node, source: &str, findings: &m
                 grounding_status: None,
                 grounding_confidence: None,
                 model_agreement: None,
-                rule_id: None,
+                rule_id: Some("local-ast:typescript/any-type".into()),
             });
         }
     }
@@ -2097,7 +2097,7 @@ fn scan_insecure_typescript(node: &tree_sitter::Node, source: &str, findings: &m
                 grounding_status: None,
                 grounding_confidence: None,
                 model_agreement: None,
-                rule_id: None,
+                rule_id: Some("local-ast:typescript/empty-catch".into()),
             });
         }
     }
@@ -2147,7 +2147,7 @@ fn scan_insecure_typescript(node: &tree_sitter::Node, source: &str, findings: &m
                     grounding_status: None,
                     grounding_confidence: None,
                         model_agreement: None,
-                        rule_id: None,
+                        rule_id: Some("local-ast:typescript/sync-in-async".into()),
                         });
                 break;
             }
@@ -2192,7 +2192,7 @@ fn scan_insecure_typescript(node: &tree_sitter::Node, source: &str, findings: &m
                     grounding_status: None,
                     grounding_confidence: None,
                             model_agreement: None,
-                            rule_id: None,
+                            rule_id: Some("local-ast:typescript/tautological-length".into()),
                             });
             }
         }
@@ -2222,7 +2222,7 @@ fn scan_insecure_typescript(node: &tree_sitter::Node, source: &str, findings: &m
                     grounding_status: None,
                     grounding_confidence: None,
         model_agreement: None,
-        rule_id: None,
+        rule_id: Some("local-ast:typescript/non-null-assertion".into()),
         });
     }
 }
@@ -2256,7 +2256,7 @@ fn scan_insecure_bash(node: &tree_sitter::Node, source: &str, findings: &mut Vec
                     grounding_status: None,
                 grounding_confidence: None,
             model_agreement: None,
-            rule_id: None,
+            rule_id: Some("local-ast:bash/no-shebang".into()),
             });
     }
 
@@ -2299,7 +2299,7 @@ fn scan_insecure_bash(node: &tree_sitter::Node, source: &str, findings: &mut Vec
                 grounding_status: None,
                 grounding_confidence: None,
                 model_agreement: None,
-                rule_id: None,
+                rule_id: Some("local-ast:bash/no-set-e".into()),
             });
         }
     }
@@ -2333,7 +2333,7 @@ fn scan_insecure_bash(node: &tree_sitter::Node, source: &str, findings: &mut Vec
                 grounding_status: None,
                 grounding_confidence: None,
                 model_agreement: None,
-                rule_id: None,
+                rule_id: Some("local-ast:bash/eval".into()),
             });
         }
 
@@ -2366,7 +2366,7 @@ fn scan_insecure_bash(node: &tree_sitter::Node, source: &str, findings: &mut Vec
                             grounding_status: None,
                             grounding_confidence: None,
                             model_agreement: None,
-                            rule_id: None,
+                            rule_id: Some("local-ast:bash/chmod-777".into()),
                         });
                         break;
                     }
@@ -2409,7 +2409,7 @@ fn scan_insecure_bash(node: &tree_sitter::Node, source: &str, findings: &mut Vec
                         grounding_status: None,
                         grounding_confidence: None,
                         model_agreement: None,
-                        rule_id: None,
+                        rule_id: Some("local-ast:bash/curl-pipe-bash".into()),
                     });
                     break;
                 }
@@ -2461,7 +2461,7 @@ fn scan_insecure_bash(node: &tree_sitter::Node, source: &str, findings: &mut Vec
                     grounding_status: None,
                     grounding_confidence: None,
                             model_agreement: None,
-                            rule_id: None,
+                            rule_id: Some("local-ast:bash/hardcoded-secret".into()),
                             });
                 }
             }
@@ -2499,7 +2499,7 @@ fn scan_insecure_dockerfile(node: &tree_sitter::Node, source: &str, findings: &m
                     grounding_status: None,
                     grounding_confidence: None,
                 model_agreement: None,
-                rule_id: None,
+                rule_id: Some("local-ast:dockerfile/add-vs-copy".into()),
                 });
             }
         }
@@ -2548,7 +2548,7 @@ fn scan_insecure_dockerfile(node: &tree_sitter::Node, source: &str, findings: &m
                     grounding_status: None,
                     grounding_confidence: None,
                             model_agreement: None,
-                            rule_id: None,
+                            rule_id: Some("local-ast:dockerfile/hardcoded-secret".into()),
                             });
                             break;
                         }
@@ -2586,7 +2586,7 @@ fn scan_insecure_dockerfile(node: &tree_sitter::Node, source: &str, findings: &m
                     grounding_status: None,
                     grounding_confidence: None,
                 model_agreement: None,
-                rule_id: None,
+                rule_id: Some("local-ast:dockerfile/curl-pipe-bash".into()),
                 });
             }
         }
@@ -2693,7 +2693,7 @@ fn scan_insecure_terraform(node: &tree_sitter::Node, source: &str, findings: &mu
                     grounding_status: None,
                     grounding_confidence: None,
                                 model_agreement: None,
-                                rule_id: None,
+                                rule_id: Some("local-ast:terraform/hardcoded-secret".into()),
                                 });
             }
         }
@@ -2737,7 +2737,7 @@ fn scan_insecure_terraform(node: &tree_sitter::Node, source: &str, findings: &mu
                     grounding_status: None,
                     grounding_confidence: None,
                                 model_agreement: None,
-                                rule_id: None,
+                                rule_id: Some("local-ast:terraform/wildcard-iam".into()),
                                 });
                     }
                 }
@@ -2809,7 +2809,7 @@ fn scan_insecure_terraform(node: &tree_sitter::Node, source: &str, findings: &mu
                     grounding_status: None,
                     grounding_confidence: None,
                     model_agreement: None,
-                    rule_id: None,
+                    rule_id: Some("local-ast:terraform/open-security-group".into()),
                     });
         }
     }
@@ -2906,7 +2906,7 @@ fn analyze_terraform_structure(tree: &tree_sitter::Tree, source: &str) -> Vec<Fi
                     grounding_status: None,
                     grounding_confidence: None,
         model_agreement: None,
-        rule_id: None,
+        rule_id: Some("local-ast:terraform/no-version-pin".into()),
         });
     }
 
@@ -3004,7 +3004,7 @@ fn check_required_providers(rp_body: tree_sitter::Node, source: &str, findings: 
                 grounding_status: None,
                 grounding_confidence: None,
                 model_agreement: None,
-                rule_id: None,
+                rule_id: Some("local-ast:terraform/no-provider-version".into()),
             });
         }
     }
@@ -3107,7 +3107,7 @@ fn analyze_dockerfile_structure(tree: &tree_sitter::Tree, source: &str) -> Vec<F
                     grounding_status: None,
                     grounding_confidence: None,
                         model_agreement: None,
-                        rule_id: None,
+                        rule_id: Some("local-ast:dockerfile/from-latest".into()),
                         });
                     }
                 }
@@ -3145,7 +3145,7 @@ fn analyze_dockerfile_structure(tree: &tree_sitter::Tree, source: &str) -> Vec<F
             grounding_status: None,
             grounding_confidence: None,
             model_agreement: None,
-            rule_id: None,
+            rule_id: Some("local-ast:dockerfile/no-user".into()),
         });
     }
 
@@ -3173,7 +3173,7 @@ fn analyze_dockerfile_structure(tree: &tree_sitter::Tree, source: &str) -> Vec<F
                     grounding_status: None,
                     grounding_confidence: None,
         model_agreement: None,
-        rule_id: None,
+        rule_id: Some("local-ast:dockerfile/no-healthcheck".into()),
         });
     }
 
@@ -3204,7 +3204,7 @@ fn analyze_dockerfile_structure(tree: &tree_sitter::Tree, source: &str) -> Vec<F
             grounding_status: None,
             grounding_confidence: None,
             model_agreement: None,
-            rule_id: None,
+            rule_id: Some("local-ast:dockerfile/multiple-cmd".into()),
         });
     }
     if entrypoint_count > 1 {
@@ -3233,7 +3233,7 @@ fn analyze_dockerfile_structure(tree: &tree_sitter::Tree, source: &str) -> Vec<F
             grounding_status: None,
             grounding_confidence: None,
             model_agreement: None,
-            rule_id: None,
+            rule_id: Some("local-ast:dockerfile/multiple-entrypoint".into()),
         });
     }
 
@@ -5184,6 +5184,41 @@ resource "aws_instance" "web" {
                 .any(|f| f.title.contains("version constraint")),
             "Should not warn when provider has version constraint: {:?}",
             findings
+        );
+    }
+
+    #[test]
+    fn complexity_finding_has_rule_id() {
+        // Reuse the proven source from analyze_flags_complex_function which is known
+        // to exceed threshold=5 (CC=8).
+        let source = "fn complex(a: bool, b: bool, c: bool, d: bool) {\n    if a {\n        if b {\n            if c {\n                if d {\n                    return;\n                }\n            }\n        }\n    }\n    if a && b {\n        return;\n    }\n    for x in 0..10 {\n        if x > 5 {\n            break;\n        }\n    }\n}\n";
+        let tree = parse(source, Language::Rust).unwrap();
+        let findings = analyze_complexity(&tree, source, Language::Rust, 5);
+        assert!(
+            !findings.is_empty(),
+            "complex function should produce a complexity finding"
+        );
+        assert_eq!(findings[0].rule_id.as_deref(), Some("local-ast:complexity"));
+    }
+
+    #[test]
+    fn insecure_pattern_has_language_prefixed_rule_id() {
+        let source = "def run(code):\n    result = eval(code)\n    return result\n";
+        let tree = parse(source, Language::Python).unwrap();
+        let findings = analyze_insecure_patterns(&tree, source, Language::Python);
+        let eval_finding = findings.iter().find(|f| f.title.contains("eval"));
+        assert!(
+            eval_finding.is_some(),
+            "should detect eval() call in Python"
+        );
+        let f = eval_finding.unwrap();
+        assert!(
+            f.rule_id
+                .as_ref()
+                .unwrap()
+                .starts_with("local-ast:python/"),
+            "rule_id should start with local-ast:python/, got {:?}",
+            f.rule_id
         );
     }
 }

--- a/src/analysis.rs
+++ b/src/analysis.rs
@@ -5396,10 +5396,7 @@ resource "aws_instance" "web" {
         );
         let f = eval_finding.unwrap();
         assert!(
-            f.rule_id
-                .as_ref()
-                .unwrap()
-                .starts_with("local-ast:python/"),
+            f.rule_id.as_ref().unwrap().starts_with("local-ast:python/"),
             "rule_id should start with local-ast:python/, got {:?}",
             f.rule_id
         );

--- a/src/analysis.rs
+++ b/src/analysis.rs
@@ -68,6 +68,7 @@ pub fn analyze_complexity(
                     grounding_status: None,
                     grounding_confidence: None,
                 model_agreement: None,
+                rule_id: None,
                 });
             }
         }
@@ -251,6 +252,7 @@ fn scan_insecure_rust(node: &tree_sitter::Node, source: &str, findings: &mut Vec
                     grounding_status: None,
                     grounding_confidence: None,
         model_agreement: None,
+        rule_id: None,
         });
     }
 
@@ -287,6 +289,7 @@ fn scan_insecure_rust(node: &tree_sitter::Node, source: &str, findings: &mut Vec
                 grounding_status: None,
                 grounding_confidence: None,
                 model_agreement: None,
+                rule_id: None,
             });
         }
     }
@@ -326,6 +329,7 @@ fn scan_insecure_python(node: &tree_sitter::Node, source: &str, findings: &mut V
                     grounding_status: None,
                     grounding_confidence: None,
                     model_agreement: None,
+                    rule_id: None,
                 });
             }
         }
@@ -356,6 +360,7 @@ fn scan_insecure_python(node: &tree_sitter::Node, source: &str, findings: &mut V
                     grounding_status: None,
                     grounding_confidence: None,
                 model_agreement: None,
+                rule_id: None,
                 });
             }
             if args_text.contains("host=\"0.0.0.0\"") || args_text.contains("host='0.0.0.0'") {
@@ -381,6 +386,7 @@ fn scan_insecure_python(node: &tree_sitter::Node, source: &str, findings: &mut V
                     grounding_status: None,
                     grounding_confidence: None,
                 model_agreement: None,
+                rule_id: None,
                 });
             }
         }
@@ -420,6 +426,7 @@ fn scan_insecure_python(node: &tree_sitter::Node, source: &str, findings: &mut V
                     grounding_status: None,
                     grounding_confidence: None,
                             model_agreement: None,
+                            rule_id: None,
                             });
                     } else if arg_text.contains(".format(") {
                         findings.push(Finding {
@@ -444,6 +451,7 @@ fn scan_insecure_python(node: &tree_sitter::Node, source: &str, findings: &mut V
                     grounding_status: None,
                     grounding_confidence: None,
                             model_agreement: None,
+                            rule_id: None,
                             });
                     }
                 }
@@ -488,6 +496,7 @@ fn scan_insecure_python(node: &tree_sitter::Node, source: &str, findings: &mut V
                     grounding_status: None,
                     grounding_confidence: None,
                         model_agreement: None,
+                        rule_id: None,
                         });
                 }
             }
@@ -549,6 +558,7 @@ fn scan_insecure_python(node: &tree_sitter::Node, source: &str, findings: &mut V
                     grounding_status: None,
                     grounding_confidence: None,
                     model_agreement: None,
+                    rule_id: None,
                     });
             }
         }
@@ -626,6 +636,7 @@ fn scan_insecure_python(node: &tree_sitter::Node, source: &str, findings: &mut V
                     grounding_status: None,
                     grounding_confidence: None,
                         model_agreement: None,
+                        rule_id: None,
                         });
             }
         }
@@ -664,6 +675,7 @@ fn scan_insecure_python(node: &tree_sitter::Node, source: &str, findings: &mut V
                     grounding_status: None,
                     grounding_confidence: None,
                         model_agreement: None,
+                        rule_id: None,
                         });
                 }
             }
@@ -720,6 +732,7 @@ fn scan_insecure_python(node: &tree_sitter::Node, source: &str, findings: &mut V
                     grounding_status: None,
                     grounding_confidence: None,
                 model_agreement: None,
+                rule_id: None,
                 });
             }
         }
@@ -754,6 +767,7 @@ fn scan_insecure_python(node: &tree_sitter::Node, source: &str, findings: &mut V
                     grounding_status: None,
                     grounding_confidence: None,
                 model_agreement: None,
+                rule_id: None,
                 });
         }
     }
@@ -790,6 +804,7 @@ fn scan_insecure_python(node: &tree_sitter::Node, source: &str, findings: &mut V
                     grounding_status: None,
                     grounding_confidence: None,
                 model_agreement: None,
+                rule_id: None,
                 });
         }
     }
@@ -1155,6 +1170,7 @@ fn scan_insecure_yaml(node: &tree_sitter::Node, source: &str, findings: &mut Vec
                     grounding_status: None,
                     grounding_confidence: None,
                             model_agreement: None,
+                            rule_id: None,
                             });
                 } else {
                     seen_keys.push((key_text, key_line));
@@ -1193,6 +1209,7 @@ fn scan_insecure_yaml(node: &tree_sitter::Node, source: &str, findings: &mut Vec
                     grounding_status: None,
                     grounding_confidence: None,
                     model_agreement: None,
+                    rule_id: None,
                 });
             }
 
@@ -1220,6 +1237,7 @@ fn scan_insecure_yaml(node: &tree_sitter::Node, source: &str, findings: &mut Vec
                     grounding_status: None,
                     grounding_confidence: None,
                     model_agreement: None,
+                    rule_id: None,
                 });
             }
 
@@ -1256,6 +1274,7 @@ fn scan_insecure_yaml(node: &tree_sitter::Node, source: &str, findings: &mut Vec
                     grounding_status: None,
                     grounding_confidence: None,
                     model_agreement: None,
+                    rule_id: None,
                     });
                 }
             }
@@ -1295,6 +1314,7 @@ fn scan_insecure_yaml(node: &tree_sitter::Node, source: &str, findings: &mut Vec
                     grounding_status: None,
                     grounding_confidence: None,
                                 model_agreement: None,
+                                rule_id: None,
                                 });
                     }
                 }
@@ -1338,6 +1358,7 @@ fn scan_insecure_yaml(node: &tree_sitter::Node, source: &str, findings: &mut Vec
                     grounding_status: None,
                     grounding_confidence: None,
                         model_agreement: None,
+                        rule_id: None,
                         });
                     }
                 }
@@ -1374,6 +1395,7 @@ fn scan_insecure_yaml(node: &tree_sitter::Node, source: &str, findings: &mut Vec
                     grounding_status: None,
                     grounding_confidence: None,
                         model_agreement: None,
+                        rule_id: None,
                         });
                     }
                 }
@@ -1444,6 +1466,7 @@ fn scan_insecure_yaml(node: &tree_sitter::Node, source: &str, findings: &mut Vec
                     grounding_status: None,
                     grounding_confidence: None,
                                         model_agreement: None,
+                                        rule_id: None,
                                         });
                             }
 
@@ -1471,6 +1494,7 @@ fn scan_insecure_yaml(node: &tree_sitter::Node, source: &str, findings: &mut Vec
                     grounding_status: None,
                     grounding_confidence: None,
                                         model_agreement: None,
+                                        rule_id: None,
                                         });
                             }
                         }
@@ -1517,6 +1541,7 @@ fn scan_insecure_yaml(node: &tree_sitter::Node, source: &str, findings: &mut Vec
                     grounding_status: None,
                     grounding_confidence: None,
                     model_agreement: None,
+                    rule_id: None,
                 });
             }
         }
@@ -1566,6 +1591,7 @@ fn scan_insecure_yaml(node: &tree_sitter::Node, source: &str, findings: &mut Vec
                                     grounding_status: None,
                                     grounding_confidence: None,
                                     model_agreement: None,
+                                    rule_id: None,
                                 });
                             }
                         }
@@ -1599,6 +1625,7 @@ fn scan_insecure_yaml(node: &tree_sitter::Node, source: &str, findings: &mut Vec
                     grounding_status: None,
                     grounding_confidence: None,
                     model_agreement: None,
+                    rule_id: None,
                 });
             }
         }
@@ -1634,6 +1661,7 @@ fn scan_insecure_yaml(node: &tree_sitter::Node, source: &str, findings: &mut Vec
                     grounding_status: None,
                     grounding_confidence: None,
                     model_agreement: None,
+                    rule_id: None,
                 });
             }
         }
@@ -1666,6 +1694,7 @@ fn scan_insecure_yaml(node: &tree_sitter::Node, source: &str, findings: &mut Vec
                     grounding_status: None,
                     grounding_confidence: None,
                         model_agreement: None,
+                        rule_id: None,
                         });
             }
         }
@@ -1700,6 +1729,7 @@ fn scan_insecure_yaml(node: &tree_sitter::Node, source: &str, findings: &mut Vec
                     grounding_status: None,
                     grounding_confidence: None,
                         model_agreement: None,
+                        rule_id: None,
                         });
             }
         }
@@ -1741,6 +1771,7 @@ fn scan_insecure_yaml(node: &tree_sitter::Node, source: &str, findings: &mut Vec
                     grounding_status: None,
                     grounding_confidence: None,
                     model_agreement: None,
+                    rule_id: None,
                     });
                 }
             }
@@ -1802,6 +1833,7 @@ fn scan_insecure_yaml(node: &tree_sitter::Node, source: &str, findings: &mut Vec
                     grounding_status: None,
                     grounding_confidence: None,
                     model_agreement: None,
+                    rule_id: None,
                 });
             }
         }
@@ -1841,6 +1873,7 @@ fn scan_insecure_typescript(node: &tree_sitter::Node, source: &str, findings: &m
                 grounding_status: None,
                 grounding_confidence: None,
                 model_agreement: None,
+                rule_id: None,
             });
         }
 
@@ -1868,6 +1901,7 @@ fn scan_insecure_typescript(node: &tree_sitter::Node, source: &str, findings: &m
                     grounding_status: None,
                     grounding_confidence: None,
                 model_agreement: None,
+                rule_id: None,
                 });
         }
 
@@ -1895,6 +1929,7 @@ fn scan_insecure_typescript(node: &tree_sitter::Node, source: &str, findings: &m
                     grounding_status: None,
                     grounding_confidence: None,
                 model_agreement: None,
+                rule_id: None,
                 });
         }
     }
@@ -1951,6 +1986,7 @@ fn scan_insecure_typescript(node: &tree_sitter::Node, source: &str, findings: &m
                     grounding_status: None,
                     grounding_confidence: None,
                             model_agreement: None,
+                            rule_id: None,
                             });
                 }
             }
@@ -1990,6 +2026,7 @@ fn scan_insecure_typescript(node: &tree_sitter::Node, source: &str, findings: &m
                     grounding_status: None,
                     grounding_confidence: None,
                 model_agreement: None,
+                rule_id: None,
                 });
         }
     }
@@ -2021,6 +2058,7 @@ fn scan_insecure_typescript(node: &tree_sitter::Node, source: &str, findings: &m
                 grounding_status: None,
                 grounding_confidence: None,
                 model_agreement: None,
+                rule_id: None,
             });
         }
     }
@@ -2059,6 +2097,7 @@ fn scan_insecure_typescript(node: &tree_sitter::Node, source: &str, findings: &m
                 grounding_status: None,
                 grounding_confidence: None,
                 model_agreement: None,
+                rule_id: None,
             });
         }
     }
@@ -2108,6 +2147,7 @@ fn scan_insecure_typescript(node: &tree_sitter::Node, source: &str, findings: &m
                     grounding_status: None,
                     grounding_confidence: None,
                         model_agreement: None,
+                        rule_id: None,
                         });
                 break;
             }
@@ -2152,6 +2192,7 @@ fn scan_insecure_typescript(node: &tree_sitter::Node, source: &str, findings: &m
                     grounding_status: None,
                     grounding_confidence: None,
                             model_agreement: None,
+                            rule_id: None,
                             });
             }
         }
@@ -2181,6 +2222,7 @@ fn scan_insecure_typescript(node: &tree_sitter::Node, source: &str, findings: &m
                     grounding_status: None,
                     grounding_confidence: None,
         model_agreement: None,
+        rule_id: None,
         });
     }
 }
@@ -2214,6 +2256,7 @@ fn scan_insecure_bash(node: &tree_sitter::Node, source: &str, findings: &mut Vec
                     grounding_status: None,
                 grounding_confidence: None,
             model_agreement: None,
+            rule_id: None,
             });
     }
 
@@ -2256,6 +2299,7 @@ fn scan_insecure_bash(node: &tree_sitter::Node, source: &str, findings: &mut Vec
                 grounding_status: None,
                 grounding_confidence: None,
                 model_agreement: None,
+                rule_id: None,
             });
         }
     }
@@ -2289,6 +2333,7 @@ fn scan_insecure_bash(node: &tree_sitter::Node, source: &str, findings: &mut Vec
                 grounding_status: None,
                 grounding_confidence: None,
                 model_agreement: None,
+                rule_id: None,
             });
         }
 
@@ -2321,6 +2366,7 @@ fn scan_insecure_bash(node: &tree_sitter::Node, source: &str, findings: &mut Vec
                             grounding_status: None,
                             grounding_confidence: None,
                             model_agreement: None,
+                            rule_id: None,
                         });
                         break;
                     }
@@ -2363,6 +2409,7 @@ fn scan_insecure_bash(node: &tree_sitter::Node, source: &str, findings: &mut Vec
                         grounding_status: None,
                         grounding_confidence: None,
                         model_agreement: None,
+                        rule_id: None,
                     });
                     break;
                 }
@@ -2414,6 +2461,7 @@ fn scan_insecure_bash(node: &tree_sitter::Node, source: &str, findings: &mut Vec
                     grounding_status: None,
                     grounding_confidence: None,
                             model_agreement: None,
+                            rule_id: None,
                             });
                 }
             }
@@ -2451,6 +2499,7 @@ fn scan_insecure_dockerfile(node: &tree_sitter::Node, source: &str, findings: &m
                     grounding_status: None,
                     grounding_confidence: None,
                 model_agreement: None,
+                rule_id: None,
                 });
             }
         }
@@ -2499,6 +2548,7 @@ fn scan_insecure_dockerfile(node: &tree_sitter::Node, source: &str, findings: &m
                     grounding_status: None,
                     grounding_confidence: None,
                             model_agreement: None,
+                            rule_id: None,
                             });
                             break;
                         }
@@ -2536,6 +2586,7 @@ fn scan_insecure_dockerfile(node: &tree_sitter::Node, source: &str, findings: &m
                     grounding_status: None,
                     grounding_confidence: None,
                 model_agreement: None,
+                rule_id: None,
                 });
             }
         }
@@ -2642,6 +2693,7 @@ fn scan_insecure_terraform(node: &tree_sitter::Node, source: &str, findings: &mu
                     grounding_status: None,
                     grounding_confidence: None,
                                 model_agreement: None,
+                                rule_id: None,
                                 });
             }
         }
@@ -2685,6 +2737,7 @@ fn scan_insecure_terraform(node: &tree_sitter::Node, source: &str, findings: &mu
                     grounding_status: None,
                     grounding_confidence: None,
                                 model_agreement: None,
+                                rule_id: None,
                                 });
                     }
                 }
@@ -2756,6 +2809,7 @@ fn scan_insecure_terraform(node: &tree_sitter::Node, source: &str, findings: &mu
                     grounding_status: None,
                     grounding_confidence: None,
                     model_agreement: None,
+                    rule_id: None,
                     });
         }
     }
@@ -2852,6 +2906,7 @@ fn analyze_terraform_structure(tree: &tree_sitter::Tree, source: &str) -> Vec<Fi
                     grounding_status: None,
                     grounding_confidence: None,
         model_agreement: None,
+        rule_id: None,
         });
     }
 
@@ -2949,6 +3004,7 @@ fn check_required_providers(rp_body: tree_sitter::Node, source: &str, findings: 
                 grounding_status: None,
                 grounding_confidence: None,
                 model_agreement: None,
+                rule_id: None,
             });
         }
     }
@@ -3051,6 +3107,7 @@ fn analyze_dockerfile_structure(tree: &tree_sitter::Tree, source: &str) -> Vec<F
                     grounding_status: None,
                     grounding_confidence: None,
                         model_agreement: None,
+                        rule_id: None,
                         });
                     }
                 }
@@ -3088,6 +3145,7 @@ fn analyze_dockerfile_structure(tree: &tree_sitter::Tree, source: &str) -> Vec<F
             grounding_status: None,
             grounding_confidence: None,
             model_agreement: None,
+            rule_id: None,
         });
     }
 
@@ -3115,6 +3173,7 @@ fn analyze_dockerfile_structure(tree: &tree_sitter::Tree, source: &str) -> Vec<F
                     grounding_status: None,
                     grounding_confidence: None,
         model_agreement: None,
+        rule_id: None,
         });
     }
 
@@ -3145,6 +3204,7 @@ fn analyze_dockerfile_structure(tree: &tree_sitter::Tree, source: &str) -> Vec<F
             grounding_status: None,
             grounding_confidence: None,
             model_agreement: None,
+            rule_id: None,
         });
     }
     if entrypoint_count > 1 {
@@ -3173,6 +3233,7 @@ fn analyze_dockerfile_structure(tree: &tree_sitter::Tree, source: &str) -> Vec<F
             grounding_status: None,
             grounding_confidence: None,
             model_agreement: None,
+            rule_id: None,
         });
     }
 

--- a/src/analysis.rs
+++ b/src/analysis.rs
@@ -69,6 +69,9 @@ pub fn analyze_complexity(
                     grounding_confidence: None,
                 model_agreement: None,
                 rule_id: Some("local-ast:complexity".into()),
+                judge_verdict: None,
+                judge_confidence: None,
+                precision_tier: None,
                 });
             }
         }
@@ -253,6 +256,9 @@ fn scan_insecure_rust(node: &tree_sitter::Node, source: &str, findings: &mut Vec
                     grounding_confidence: None,
         model_agreement: None,
         rule_id: Some("local-ast:rust/unsafe-block".into()),
+        judge_verdict: None,
+        judge_confidence: None,
+        precision_tier: None,
         });
     }
 
@@ -290,6 +296,9 @@ fn scan_insecure_rust(node: &tree_sitter::Node, source: &str, findings: &mut Vec
                 grounding_confidence: None,
                 model_agreement: None,
                 rule_id: Some("local-ast:rust/unwrap-in-non-test".into()),
+                judge_verdict: None,
+                judge_confidence: None,
+                precision_tier: None,
             });
         }
     }
@@ -330,6 +339,9 @@ fn scan_insecure_python(node: &tree_sitter::Node, source: &str, findings: &mut V
                     grounding_confidence: None,
                     model_agreement: None,
                     rule_id: Some("local-ast:python/eval-exec".into()),
+                    judge_verdict: None,
+                    judge_confidence: None,
+                    precision_tier: None,
                 });
             }
         }
@@ -361,6 +373,9 @@ fn scan_insecure_python(node: &tree_sitter::Node, source: &str, findings: &mut V
                     grounding_confidence: None,
                 model_agreement: None,
                 rule_id: Some("local-ast:python/debug-true".into()),
+                judge_verdict: None,
+                judge_confidence: None,
+                precision_tier: None,
                 });
             }
             if args_text.contains("host=\"0.0.0.0\"") || args_text.contains("host='0.0.0.0'") {
@@ -387,6 +402,9 @@ fn scan_insecure_python(node: &tree_sitter::Node, source: &str, findings: &mut V
                     grounding_confidence: None,
                 model_agreement: None,
                 rule_id: Some("local-ast:python/bind-all-interfaces".into()),
+                judge_verdict: None,
+                judge_confidence: None,
+                precision_tier: None,
                 });
             }
         }
@@ -427,6 +445,9 @@ fn scan_insecure_python(node: &tree_sitter::Node, source: &str, findings: &mut V
                     grounding_confidence: None,
                             model_agreement: None,
                             rule_id: Some("local-ast:python/sql-injection".into()),
+                            judge_verdict: None,
+                            judge_confidence: None,
+                            precision_tier: None,
                             });
                     } else if arg_text.contains(".format(") {
                         findings.push(Finding {
@@ -452,6 +473,9 @@ fn scan_insecure_python(node: &tree_sitter::Node, source: &str, findings: &mut V
                     grounding_confidence: None,
                             model_agreement: None,
                             rule_id: Some("local-ast:python/sql-injection".into()),
+                            judge_verdict: None,
+                            judge_confidence: None,
+                            precision_tier: None,
                             });
                     }
                 }
@@ -497,6 +521,9 @@ fn scan_insecure_python(node: &tree_sitter::Node, source: &str, findings: &mut V
                     grounding_confidence: None,
                         model_agreement: None,
                         rule_id: Some("local-ast:python/open-no-encoding".into()),
+                        judge_verdict: None,
+                        judge_confidence: None,
+                        precision_tier: None,
                         });
                 }
             }
@@ -559,6 +586,9 @@ fn scan_insecure_python(node: &tree_sitter::Node, source: &str, findings: &mut V
                     grounding_confidence: None,
                     model_agreement: None,
                     rule_id: Some("local-ast:python/bare-except-pass".into()),
+                    judge_verdict: None,
+                    judge_confidence: None,
+                    precision_tier: None,
                     });
             }
         }
@@ -637,6 +667,9 @@ fn scan_insecure_python(node: &tree_sitter::Node, source: &str, findings: &mut V
                     grounding_confidence: None,
                         model_agreement: None,
                         rule_id: Some("local-ast:python/hardcoded-secret".into()),
+                        judge_verdict: None,
+                        judge_confidence: None,
+                        precision_tier: None,
                         });
             }
         }
@@ -676,6 +709,9 @@ fn scan_insecure_python(node: &tree_sitter::Node, source: &str, findings: &mut V
                     grounding_confidence: None,
                         model_agreement: None,
                         rule_id: Some("local-ast:python/mutation-during-iteration".into()),
+                        judge_verdict: None,
+                        judge_confidence: None,
+                        precision_tier: None,
                         });
                 }
             }
@@ -733,6 +769,9 @@ fn scan_insecure_python(node: &tree_sitter::Node, source: &str, findings: &mut V
                     grounding_confidence: None,
                 model_agreement: None,
                 rule_id: Some("local-ast:python/exception-disclosure".into()),
+                judge_verdict: None,
+                judge_confidence: None,
+                precision_tier: None,
                 });
             }
         }
@@ -768,6 +807,9 @@ fn scan_insecure_python(node: &tree_sitter::Node, source: &str, findings: &mut V
                     grounding_confidence: None,
                 model_agreement: None,
                 rule_id: Some("local-ast:python/blocking-in-async".into()),
+                judge_verdict: None,
+                judge_confidence: None,
+                precision_tier: None,
                 });
         }
     }
@@ -805,6 +847,9 @@ fn scan_insecure_python(node: &tree_sitter::Node, source: &str, findings: &mut V
                     grounding_confidence: None,
                 model_agreement: None,
                 rule_id: Some("local-ast:python/mutable-default-arg".into()),
+                judge_verdict: None,
+                judge_confidence: None,
+                precision_tier: None,
                 });
         }
     }
@@ -1171,6 +1216,9 @@ fn scan_insecure_yaml(node: &tree_sitter::Node, source: &str, findings: &mut Vec
                     grounding_confidence: None,
                             model_agreement: None,
                             rule_id: Some("local-ast:yaml/duplicate-key".into()),
+                            judge_verdict: None,
+                            judge_confidence: None,
+                            precision_tier: None,
                             });
                 } else {
                     seen_keys.push((key_text, key_line));
@@ -1210,6 +1258,9 @@ fn scan_insecure_yaml(node: &tree_sitter::Node, source: &str, findings: &mut Vec
                     grounding_confidence: None,
                     model_agreement: None,
                     rule_id: Some("local-ast:yaml/ha-no-id".into()),
+                    judge_verdict: None,
+                    judge_confidence: None,
+                    precision_tier: None,
                 });
             }
 
@@ -1238,6 +1289,9 @@ fn scan_insecure_yaml(node: &tree_sitter::Node, source: &str, findings: &mut Vec
                     grounding_confidence: None,
                     model_agreement: None,
                     rule_id: Some("local-ast:yaml/ha-no-mode".into()),
+                    judge_verdict: None,
+                    judge_confidence: None,
+                    precision_tier: None,
                 });
             }
 
@@ -1275,6 +1329,9 @@ fn scan_insecure_yaml(node: &tree_sitter::Node, source: &str, findings: &mut Vec
                     grounding_confidence: None,
                     model_agreement: None,
                     rule_id: Some("local-ast:yaml/ha-deprecated-singular".into()),
+                    judge_verdict: None,
+                    judge_confidence: None,
+                    precision_tier: None,
                     });
                 }
             }
@@ -1315,6 +1372,9 @@ fn scan_insecure_yaml(node: &tree_sitter::Node, source: &str, findings: &mut Vec
                     grounding_confidence: None,
                                 model_agreement: None,
                                 rule_id: Some("local-ast:yaml/ha-empty-section".into()),
+                                judge_verdict: None,
+                                judge_confidence: None,
+                                precision_tier: None,
                                 });
                     }
                 }
@@ -1359,6 +1419,9 @@ fn scan_insecure_yaml(node: &tree_sitter::Node, source: &str, findings: &mut Vec
                     grounding_confidence: None,
                         model_agreement: None,
                         rule_id: Some("local-ast:yaml/esphome-ota-no-password".into()),
+                        judge_verdict: None,
+                        judge_confidence: None,
+                        precision_tier: None,
                         });
                     }
                 }
@@ -1396,6 +1459,9 @@ fn scan_insecure_yaml(node: &tree_sitter::Node, source: &str, findings: &mut Vec
                     grounding_confidence: None,
                         model_agreement: None,
                         rule_id: Some("local-ast:yaml/esphome-api-no-encryption".into()),
+                        judge_verdict: None,
+                        judge_confidence: None,
+                        precision_tier: None,
                         });
                     }
                 }
@@ -1467,6 +1533,9 @@ fn scan_insecure_yaml(node: &tree_sitter::Node, source: &str, findings: &mut Vec
                     grounding_confidence: None,
                                         model_agreement: None,
                                         rule_id: Some("local-ast:yaml/compose-no-new-privileges".into()),
+                                        judge_verdict: None,
+                                        judge_confidence: None,
+                                        precision_tier: None,
                                         });
                             }
 
@@ -1495,6 +1564,9 @@ fn scan_insecure_yaml(node: &tree_sitter::Node, source: &str, findings: &mut Vec
                     grounding_confidence: None,
                                         model_agreement: None,
                                         rule_id: Some("local-ast:yaml/compose-writable-rootfs".into()),
+                                        judge_verdict: None,
+                                        judge_confidence: None,
+                                        precision_tier: None,
                                         });
                             }
                         }
@@ -1542,6 +1614,9 @@ fn scan_insecure_yaml(node: &tree_sitter::Node, source: &str, findings: &mut Vec
                     grounding_confidence: None,
                     model_agreement: None,
                     rule_id: Some("local-ast:yaml/hardcoded-secret".into()),
+                    judge_verdict: None,
+                    judge_confidence: None,
+                    precision_tier: None,
                 });
             }
         }
@@ -1592,6 +1667,9 @@ fn scan_insecure_yaml(node: &tree_sitter::Node, source: &str, findings: &mut Vec
                                     grounding_confidence: None,
                                     model_agreement: None,
                                     rule_id: Some("local-ast:yaml/entity-id-no-domain".into()),
+                                    judge_verdict: None,
+                                    judge_confidence: None,
+                                    precision_tier: None,
                                 });
                             }
                         }
@@ -1626,6 +1704,9 @@ fn scan_insecure_yaml(node: &tree_sitter::Node, source: &str, findings: &mut Vec
                     grounding_confidence: None,
                     model_agreement: None,
                     rule_id: Some("local-ast:yaml/entity-id-no-domain".into()),
+                    judge_verdict: None,
+                    judge_confidence: None,
+                    precision_tier: None,
                 });
             }
         }
@@ -1662,6 +1743,9 @@ fn scan_insecure_yaml(node: &tree_sitter::Node, source: &str, findings: &mut Vec
                     grounding_confidence: None,
                     model_agreement: None,
                     rule_id: Some("local-ast:yaml/service-no-domain".into()),
+                    judge_verdict: None,
+                    judge_confidence: None,
+                    precision_tier: None,
                 });
             }
         }
@@ -1695,6 +1779,9 @@ fn scan_insecure_yaml(node: &tree_sitter::Node, source: &str, findings: &mut Vec
                     grounding_confidence: None,
                         model_agreement: None,
                         rule_id: Some("local-ast:yaml/bind-all-interfaces".into()),
+                        judge_verdict: None,
+                        judge_confidence: None,
+                        precision_tier: None,
                         });
             }
         }
@@ -1730,6 +1817,9 @@ fn scan_insecure_yaml(node: &tree_sitter::Node, source: &str, findings: &mut Vec
                     grounding_confidence: None,
                         model_agreement: None,
                         rule_id: Some("local-ast:yaml/url-credentials".into()),
+                        judge_verdict: None,
+                        judge_confidence: None,
+                        precision_tier: None,
                         });
             }
         }
@@ -1772,6 +1862,9 @@ fn scan_insecure_yaml(node: &tree_sitter::Node, source: &str, findings: &mut Vec
                     grounding_confidence: None,
                     model_agreement: None,
                     rule_id: Some("local-ast:yaml/states-no-availability-check".into()),
+                    judge_verdict: None,
+                    judge_confidence: None,
+                    precision_tier: None,
                     });
                 }
             }
@@ -1834,6 +1927,9 @@ fn scan_insecure_yaml(node: &tree_sitter::Node, source: &str, findings: &mut Vec
                     grounding_confidence: None,
                     model_agreement: None,
                     rule_id: Some("local-ast:yaml/deprecated-dot-state".into()),
+                    judge_verdict: None,
+                    judge_confidence: None,
+                    precision_tier: None,
                 });
             }
         }
@@ -1874,6 +1970,9 @@ fn scan_insecure_typescript(node: &tree_sitter::Node, source: &str, findings: &m
                 grounding_confidence: None,
                 model_agreement: None,
                 rule_id: Some("local-ast:typescript/eval".into()),
+                judge_verdict: None,
+                judge_confidence: None,
+                precision_tier: None,
             });
         }
 
@@ -1902,6 +2001,9 @@ fn scan_insecure_typescript(node: &tree_sitter::Node, source: &str, findings: &m
                     grounding_confidence: None,
                 model_agreement: None,
                 rule_id: Some("local-ast:typescript/document-write-xss".into()),
+                judge_verdict: None,
+                judge_confidence: None,
+                precision_tier: None,
                 });
         }
 
@@ -1930,6 +2032,9 @@ fn scan_insecure_typescript(node: &tree_sitter::Node, source: &str, findings: &m
                     grounding_confidence: None,
                 model_agreement: None,
                 rule_id: Some("local-ast:typescript/console-log-artifact".into()),
+                judge_verdict: None,
+                judge_confidence: None,
+                precision_tier: None,
                 });
         }
     }
@@ -1987,6 +2092,9 @@ fn scan_insecure_typescript(node: &tree_sitter::Node, source: &str, findings: &m
                     grounding_confidence: None,
                             model_agreement: None,
                             rule_id: Some("local-ast:typescript/hardcoded-secret".into()),
+                            judge_verdict: None,
+                            judge_confidence: None,
+                            precision_tier: None,
                             });
                 }
             }
@@ -2027,6 +2135,9 @@ fn scan_insecure_typescript(node: &tree_sitter::Node, source: &str, findings: &m
                     grounding_confidence: None,
                 model_agreement: None,
                 rule_id: Some("local-ast:typescript/innerhtml-xss".into()),
+                judge_verdict: None,
+                judge_confidence: None,
+                precision_tier: None,
                 });
         }
     }
@@ -2059,6 +2170,9 @@ fn scan_insecure_typescript(node: &tree_sitter::Node, source: &str, findings: &m
                 grounding_confidence: None,
                 model_agreement: None,
                 rule_id: Some("local-ast:typescript/any-type".into()),
+                judge_verdict: None,
+                judge_confidence: None,
+                precision_tier: None,
             });
         }
     }
@@ -2098,6 +2212,9 @@ fn scan_insecure_typescript(node: &tree_sitter::Node, source: &str, findings: &m
                 grounding_confidence: None,
                 model_agreement: None,
                 rule_id: Some("local-ast:typescript/empty-catch".into()),
+                judge_verdict: None,
+                judge_confidence: None,
+                precision_tier: None,
             });
         }
     }
@@ -2148,6 +2265,9 @@ fn scan_insecure_typescript(node: &tree_sitter::Node, source: &str, findings: &m
                     grounding_confidence: None,
                         model_agreement: None,
                         rule_id: Some("local-ast:typescript/sync-in-async".into()),
+                        judge_verdict: None,
+                        judge_confidence: None,
+                        precision_tier: None,
                         });
                 break;
             }
@@ -2193,6 +2313,9 @@ fn scan_insecure_typescript(node: &tree_sitter::Node, source: &str, findings: &m
                     grounding_confidence: None,
                             model_agreement: None,
                             rule_id: Some("local-ast:typescript/tautological-length".into()),
+                            judge_verdict: None,
+                            judge_confidence: None,
+                            precision_tier: None,
                             });
             }
         }
@@ -2223,6 +2346,9 @@ fn scan_insecure_typescript(node: &tree_sitter::Node, source: &str, findings: &m
                     grounding_confidence: None,
         model_agreement: None,
         rule_id: Some("local-ast:typescript/non-null-assertion".into()),
+        judge_verdict: None,
+        judge_confidence: None,
+        precision_tier: None,
         });
     }
 }
@@ -2257,6 +2383,9 @@ fn scan_insecure_bash(node: &tree_sitter::Node, source: &str, findings: &mut Vec
                 grounding_confidence: None,
             model_agreement: None,
             rule_id: Some("local-ast:bash/no-shebang".into()),
+            judge_verdict: None,
+            judge_confidence: None,
+            precision_tier: None,
             });
     }
 
@@ -2300,6 +2429,9 @@ fn scan_insecure_bash(node: &tree_sitter::Node, source: &str, findings: &mut Vec
                 grounding_confidence: None,
                 model_agreement: None,
                 rule_id: Some("local-ast:bash/no-set-e".into()),
+                judge_verdict: None,
+                judge_confidence: None,
+                precision_tier: None,
             });
         }
     }
@@ -2334,6 +2466,9 @@ fn scan_insecure_bash(node: &tree_sitter::Node, source: &str, findings: &mut Vec
                 grounding_confidence: None,
                 model_agreement: None,
                 rule_id: Some("local-ast:bash/eval".into()),
+                judge_verdict: None,
+                judge_confidence: None,
+                precision_tier: None,
             });
         }
 
@@ -2367,6 +2502,9 @@ fn scan_insecure_bash(node: &tree_sitter::Node, source: &str, findings: &mut Vec
                             grounding_confidence: None,
                             model_agreement: None,
                             rule_id: Some("local-ast:bash/chmod-777".into()),
+                            judge_verdict: None,
+                            judge_confidence: None,
+                            precision_tier: None,
                         });
                         break;
                     }
@@ -2410,6 +2548,9 @@ fn scan_insecure_bash(node: &tree_sitter::Node, source: &str, findings: &mut Vec
                         grounding_confidence: None,
                         model_agreement: None,
                         rule_id: Some("local-ast:bash/curl-pipe-bash".into()),
+                        judge_verdict: None,
+                        judge_confidence: None,
+                        precision_tier: None,
                     });
                     break;
                 }
@@ -2462,6 +2603,9 @@ fn scan_insecure_bash(node: &tree_sitter::Node, source: &str, findings: &mut Vec
                     grounding_confidence: None,
                             model_agreement: None,
                             rule_id: Some("local-ast:bash/hardcoded-secret".into()),
+                            judge_verdict: None,
+                            judge_confidence: None,
+                            precision_tier: None,
                             });
                 }
             }
@@ -2500,6 +2644,9 @@ fn scan_insecure_dockerfile(node: &tree_sitter::Node, source: &str, findings: &m
                     grounding_confidence: None,
                 model_agreement: None,
                 rule_id: Some("local-ast:dockerfile/add-vs-copy".into()),
+                judge_verdict: None,
+                judge_confidence: None,
+                precision_tier: None,
                 });
             }
         }
@@ -2549,6 +2696,9 @@ fn scan_insecure_dockerfile(node: &tree_sitter::Node, source: &str, findings: &m
                     grounding_confidence: None,
                             model_agreement: None,
                             rule_id: Some("local-ast:dockerfile/hardcoded-secret".into()),
+                            judge_verdict: None,
+                            judge_confidence: None,
+                            precision_tier: None,
                             });
                             break;
                         }
@@ -2587,6 +2737,9 @@ fn scan_insecure_dockerfile(node: &tree_sitter::Node, source: &str, findings: &m
                     grounding_confidence: None,
                 model_agreement: None,
                 rule_id: Some("local-ast:dockerfile/curl-pipe-bash".into()),
+                judge_verdict: None,
+                judge_confidence: None,
+                precision_tier: None,
                 });
             }
         }
@@ -2694,6 +2847,9 @@ fn scan_insecure_terraform(node: &tree_sitter::Node, source: &str, findings: &mu
                     grounding_confidence: None,
                                 model_agreement: None,
                                 rule_id: Some("local-ast:terraform/hardcoded-secret".into()),
+                                judge_verdict: None,
+                                judge_confidence: None,
+                                precision_tier: None,
                                 });
             }
         }
@@ -2738,6 +2894,9 @@ fn scan_insecure_terraform(node: &tree_sitter::Node, source: &str, findings: &mu
                     grounding_confidence: None,
                                 model_agreement: None,
                                 rule_id: Some("local-ast:terraform/wildcard-iam".into()),
+                                judge_verdict: None,
+                                judge_confidence: None,
+                                precision_tier: None,
                                 });
                     }
                 }
@@ -2810,6 +2969,9 @@ fn scan_insecure_terraform(node: &tree_sitter::Node, source: &str, findings: &mu
                     grounding_confidence: None,
                     model_agreement: None,
                     rule_id: Some("local-ast:terraform/open-security-group".into()),
+                    judge_verdict: None,
+                    judge_confidence: None,
+                    precision_tier: None,
                     });
         }
     }
@@ -2907,6 +3069,9 @@ fn analyze_terraform_structure(tree: &tree_sitter::Tree, source: &str) -> Vec<Fi
                     grounding_confidence: None,
         model_agreement: None,
         rule_id: Some("local-ast:terraform/no-version-pin".into()),
+        judge_verdict: None,
+        judge_confidence: None,
+        precision_tier: None,
         });
     }
 
@@ -3005,6 +3170,9 @@ fn check_required_providers(rp_body: tree_sitter::Node, source: &str, findings: 
                 grounding_confidence: None,
                 model_agreement: None,
                 rule_id: Some("local-ast:terraform/no-provider-version".into()),
+                judge_verdict: None,
+                judge_confidence: None,
+                precision_tier: None,
             });
         }
     }
@@ -3108,6 +3276,9 @@ fn analyze_dockerfile_structure(tree: &tree_sitter::Tree, source: &str) -> Vec<F
                     grounding_confidence: None,
                         model_agreement: None,
                         rule_id: Some("local-ast:dockerfile/from-latest".into()),
+                        judge_verdict: None,
+                        judge_confidence: None,
+                        precision_tier: None,
                         });
                     }
                 }
@@ -3146,6 +3317,9 @@ fn analyze_dockerfile_structure(tree: &tree_sitter::Tree, source: &str) -> Vec<F
             grounding_confidence: None,
             model_agreement: None,
             rule_id: Some("local-ast:dockerfile/no-user".into()),
+            judge_verdict: None,
+            judge_confidence: None,
+            precision_tier: None,
         });
     }
 
@@ -3174,6 +3348,9 @@ fn analyze_dockerfile_structure(tree: &tree_sitter::Tree, source: &str) -> Vec<F
                     grounding_confidence: None,
         model_agreement: None,
         rule_id: Some("local-ast:dockerfile/no-healthcheck".into()),
+        judge_verdict: None,
+        judge_confidence: None,
+        precision_tier: None,
         });
     }
 
@@ -3205,6 +3382,9 @@ fn analyze_dockerfile_structure(tree: &tree_sitter::Tree, source: &str) -> Vec<F
             grounding_confidence: None,
             model_agreement: None,
             rule_id: Some("local-ast:dockerfile/multiple-cmd".into()),
+            judge_verdict: None,
+            judge_confidence: None,
+            precision_tier: None,
         });
     }
     if entrypoint_count > 1 {
@@ -3234,6 +3414,9 @@ fn analyze_dockerfile_structure(tree: &tree_sitter::Tree, source: &str) -> Vec<F
             grounding_confidence: None,
             model_agreement: None,
             rule_id: Some("local-ast:dockerfile/multiple-entrypoint".into()),
+            judge_verdict: None,
+            judge_confidence: None,
+            precision_tier: None,
         });
     }
 

--- a/src/ast_grep.rs
+++ b/src/ast_grep.rs
@@ -296,6 +296,7 @@ pub fn scan_file(source: &str, ext: &str, rules: &[RuleConfig<SupportLang>]) -> 
                     grounding_status: None,
                     grounding_confidence: None,
                     model_agreement: None,
+                    rule_id: None,
                 });
             }
         }

--- a/src/ast_grep.rs
+++ b/src/ast_grep.rs
@@ -1,11 +1,44 @@
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::io::Read;
 use std::path::Path;
 
 use ast_grep_config::{GlobalRules, RuleConfig, Severity as AstSeverity, from_yaml_string};
 use ast_grep_language::{LanguageExt, SupportLang};
 
-use crate::finding::{Finding, Severity, Source};
+use crate::finding::{Finding, JudgeRequirement, PrecisionTier, Severity, Source};
+
+/// Optional metadata block that rule authors can embed in ast-grep YAML rules
+/// to declare precision tier and judge requirements. Example:
+///
+/// ```yaml
+/// metadata:
+///   precision: speculative
+///   judge: required
+/// ```
+///
+/// Rules without a `metadata` block default to `precision: high, judge: skip`.
+#[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
+pub struct RuleMetadata {
+    #[serde(default)]
+    pub precision: PrecisionTier,
+    #[serde(default)]
+    pub judge: JudgeRequirement,
+}
+
+#[derive(serde::Deserialize)]
+struct YamlWithMetadata {
+    #[serde(default)]
+    metadata: Option<RuleMetadata>,
+}
+
+/// Parse the optional `metadata` block from an ast-grep YAML rule string.
+/// Returns `RuleMetadata::default()` when the block is absent or unparseable.
+pub fn parse_rule_metadata(yaml_str: &str) -> RuleMetadata {
+    serde_yaml::from_str::<YamlWithMetadata>(yaml_str)
+        .ok()
+        .and_then(|y| y.metadata)
+        .unwrap_or_default()
+}
 
 /// Maximum size for a single ast-grep YAML rule file. Files exceeding this
 /// are skipped with a warning instead of being read into memory. Intended
@@ -96,8 +129,12 @@ pub fn ext_to_language(ext: &str) -> Option<SupportLang> {
 
 /// Load ast-grep rules from bundled `rules/<lang>/` and user `~/.quorum/rules/<lang>/` directories.
 /// Skips malformed rules with a warning. Returns sorted rule list for deterministic ordering.
-pub fn load_rules(project_dir: &Path, home_dir: &Path) -> Vec<RuleConfig<SupportLang>> {
+pub fn load_rules(
+    project_dir: &Path,
+    home_dir: &Path,
+) -> (Vec<RuleConfig<SupportLang>>, HashMap<String, RuleMetadata>) {
     let mut rules = Vec::new();
+    let mut metadata_map: HashMap<String, RuleMetadata> = HashMap::new();
     // Dedup key is `(language, id)` — bundled rules legitimately reuse ids
     // across grammars (e.g. `bind-all-interfaces` in both python and
     // javascript). Within a single grammar, a duplicate id is the bug:
@@ -184,6 +221,7 @@ pub fn load_rules(project_dir: &Path, home_dir: &Path) -> Vec<RuleConfig<Support
                         continue;
                     }
                 };
+                let meta = parse_rule_metadata(&yaml);
                 match from_yaml_string::<SupportLang>(&yaml, &globals) {
                     Ok(parsed) => {
                         for rule in parsed {
@@ -202,6 +240,7 @@ pub fn load_rules(project_dir: &Path, home_dir: &Path) -> Vec<RuleConfig<Support
                                 );
                                 continue;
                             }
+                            metadata_map.insert(rule.id.clone(), meta.clone());
                             rules.push(rule);
                         }
                     }
@@ -218,7 +257,7 @@ pub fn load_rules(project_dir: &Path, home_dir: &Path) -> Vec<RuleConfig<Support
     }
 
     rules.sort_by(|a, b| a.id.cmp(&b.id));
-    rules
+    (rules, metadata_map)
 }
 
 /// Returns the set of ast-grep languages compatible with a file extension.
@@ -254,7 +293,12 @@ fn lang_name(lang: &SupportLang) -> &'static str {
 
 /// Scan source code with the given rules. Per-rule isolation: one bad rule doesn't block others.
 /// Returns findings with normalized line numbers (1-indexed) and Source::Linter("ast-grep").
-pub fn scan_file(source: &str, ext: &str, rules: &[RuleConfig<SupportLang>]) -> Vec<Finding> {
+pub fn scan_file(
+    source: &str,
+    ext: &str,
+    rules: &[RuleConfig<SupportLang>],
+    metadata: &HashMap<String, RuleMetadata>,
+) -> Vec<Finding> {
     if source.is_empty() {
         return Vec::new();
     }
@@ -289,6 +333,7 @@ pub fn scan_file(source: &str, ext: &str, rules: &[RuleConfig<SupportLang>]) -> 
                     AstSeverity::Off => Severity::Low,
                 };
 
+                let meta = metadata.get(rule.id.as_str()).cloned().unwrap_or_default();
                 findings.push(Finding {
                     id: crate::finding::new_finding_ulid(),
                     title: format!("{}: {}", rule.id, message),
@@ -314,7 +359,7 @@ pub fn scan_file(source: &str, ext: &str, rules: &[RuleConfig<SupportLang>]) -> 
                     rule_id: Some(format!("ast-grep:{}/{}", lang_name(lang), rule.id)),
                     judge_verdict: None,
                     judge_confidence: None,
-                    precision_tier: None,
+                    precision_tier: Some(meta.precision),
                 });
             }
         }
@@ -427,7 +472,7 @@ mod tests {
     fn load_rules_from_bundled_dir() {
         let project_dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
         let fake_home = tempfile::tempdir().unwrap();
-        let rules = load_rules(&project_dir, fake_home.path());
+        let (rules, _metadata) = load_rules(&project_dir, fake_home.path());
         assert!(!rules.is_empty(), "should load bundled rules from rules/");
     }
 
@@ -445,7 +490,7 @@ rule:
   pattern: console.log($$$ARGS)
 "#;
         std::fs::write(user_rules_dir.join("user-test.yml"), rule_yaml).unwrap();
-        let rules = load_rules(empty_project.path(), home.path());
+        let (rules, _metadata) = load_rules(empty_project.path(), home.path());
         assert_eq!(rules.len(), 1);
         assert_eq!(rules[0].id, "user-test-rule");
     }
@@ -464,7 +509,7 @@ rule:
   pattern: console.log($$$ARGS)
 "#;
         std::fs::write(user_rules_dir.join("extra.yml"), rule_yaml).unwrap();
-        let rules = load_rules(&project_dir, home.path());
+        let (rules, _metadata) = load_rules(&project_dir, home.path());
         let ids: Vec<&str> = rules.iter().map(|r| r.id.as_str()).collect();
         assert!(ids.contains(&"as-any-cast"), "should include bundled rule");
         assert!(ids.contains(&"user-extra-rule"), "should include user rule");
@@ -487,7 +532,7 @@ rule:
 "#;
         std::fs::write(rules_dir.join("good.yml"), good_yaml).unwrap();
         let fake_home = tempfile::tempdir().unwrap();
-        let rules = load_rules(project.path(), fake_home.path());
+        let (rules, _metadata) = load_rules(project.path(), fake_home.path());
         assert_eq!(rules.len(), 1, "should skip bad rule, keep good one");
         assert_eq!(rules[0].id, "good-rule");
     }
@@ -496,7 +541,7 @@ rule:
     fn load_rules_missing_rules_dir_returns_empty() {
         let empty = tempfile::tempdir().unwrap();
         let fake_home = tempfile::tempdir().unwrap();
-        let rules = load_rules(empty.path(), fake_home.path());
+        let (rules, _metadata) = load_rules(empty.path(), fake_home.path());
         assert!(rules.is_empty());
     }
 
@@ -504,8 +549,8 @@ rule:
     fn load_rules_deterministic_order() {
         let project_dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
         let fake_home = tempfile::tempdir().unwrap();
-        let rules1 = load_rules(&project_dir, fake_home.path());
-        let rules2 = load_rules(&project_dir, fake_home.path());
+        let (rules1, _meta1) = load_rules(&project_dir, fake_home.path());
+        let (rules2, _meta2) = load_rules(&project_dir, fake_home.path());
         let ids1: Vec<&str> = rules1.iter().map(|r| r.id.as_str()).collect();
         let ids2: Vec<&str> = rules2.iter().map(|r| r.id.as_str()).collect();
         assert_eq!(ids1, ids2, "rule ordering should be deterministic");
@@ -517,8 +562,8 @@ rule:
     fn scan_file_finds_match() {
         let project_dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
         let fake_home = tempfile::tempdir().unwrap();
-        let rules = load_rules(&project_dir, fake_home.path());
-        let findings = scan_file("const x = 1 as any;", "ts", &rules);
+        let (rules, metadata) = load_rules(&project_dir, fake_home.path());
+        let findings = scan_file("const x = 1 as any;", "ts", &rules, &metadata);
         assert!(!findings.is_empty(), "should find as-any-cast");
         let f = &findings[0];
         assert!(f.title.contains("as-any-cast"));
@@ -537,7 +582,7 @@ rule:
 "#;
         let rules: Vec<RuleConfig<SupportLang>> =
             from_yaml_string(yaml, &GlobalRules::default()).unwrap();
-        let findings = scan_file("console.log('hello');", "ts", &rules);
+        let findings = scan_file("console.log('hello');", "ts", &rules, &HashMap::new());
         assert_eq!(findings[0].severity, Severity::Low);
     }
 
@@ -552,7 +597,7 @@ rule:
 "#;
         let rules: Vec<RuleConfig<SupportLang>> =
             from_yaml_string(yaml, &GlobalRules::default()).unwrap();
-        let findings = scan_file("eval('code');", "ts", &rules);
+        let findings = scan_file("eval('code');", "ts", &rules, &HashMap::new());
         assert_eq!(findings[0].severity, Severity::High);
     }
 
@@ -568,7 +613,7 @@ rule:
         let rules: Vec<RuleConfig<SupportLang>> =
             from_yaml_string(yaml, &GlobalRules::default()).unwrap();
         let source = "const a = 1;\nconst b = 2;\neval('code');\n";
-        let findings = scan_file(source, "ts", &rules);
+        let findings = scan_file(source, "ts", &rules, &HashMap::new());
         assert_eq!(
             findings[0].line_start, 3,
             "line numbers should be 1-indexed"
@@ -578,7 +623,7 @@ rule:
     #[test]
     fn scan_file_unsupported_extension_returns_empty() {
         let rules = vec![];
-        let findings = scan_file("some code", "go", &rules);
+        let findings = scan_file("some code", "go", &rules, &HashMap::new());
         assert!(findings.is_empty());
     }
 
@@ -586,8 +631,8 @@ rule:
     fn scan_file_empty_source_returns_empty() {
         let project_dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
         let fake_home = tempfile::tempdir().unwrap();
-        let rules = load_rules(&project_dir, fake_home.path());
-        let findings = scan_file("", "ts", &rules);
+        let (rules, metadata) = load_rules(&project_dir, fake_home.path());
+        let findings = scan_file("", "ts", &rules, &metadata);
         assert!(findings.is_empty());
     }
 
@@ -595,8 +640,8 @@ rule:
     fn scan_file_finding_has_evidence() {
         let project_dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
         let fake_home = tempfile::tempdir().unwrap();
-        let rules = load_rules(&project_dir, fake_home.path());
-        let findings = scan_file("const x = 1 as any;", "ts", &rules);
+        let (rules, metadata) = load_rules(&project_dir, fake_home.path());
+        let findings = scan_file("const x = 1 as any;", "ts", &rules, &metadata);
         assert!(!findings.is_empty());
         assert!(
             !findings[0].evidence.is_empty(),
@@ -608,8 +653,8 @@ rule:
     fn scan_file_source_is_ast_grep_linter() {
         let project_dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
         let fake_home = tempfile::tempdir().unwrap();
-        let rules = load_rules(&project_dir, fake_home.path());
-        let findings = scan_file("const x = 1 as any;", "ts", &rules);
+        let (rules, metadata) = load_rules(&project_dir, fake_home.path());
+        let findings = scan_file("const x = 1 as any;", "ts", &rules, &metadata);
         for f in &findings {
             assert_eq!(f.source, Source::Linter("ast-grep".into()));
         }
@@ -685,6 +730,7 @@ rule:
             "async fn run() { runtime.block_on(async { 1 }); }",
             "rs",
             &rules,
+            &HashMap::new(),
         );
         assert!(!findings.is_empty(), "should flag block_on inside async fn");
     }
@@ -698,7 +744,12 @@ rule:
         let yaml = std::fs::read_to_string(path).unwrap();
         let rules: Vec<RuleConfig<SupportLang>> =
             from_yaml_string(&yaml, &GlobalRules::default()).unwrap();
-        let findings = scan_file("fn run() { runtime.block_on(async { 1 }); }", "rs", &rules);
+        let findings = scan_file(
+            "fn run() { runtime.block_on(async { 1 }); }",
+            "rs",
+            &rules,
+            &HashMap::new(),
+        );
         assert!(findings.is_empty(), "must NOT flag in sync fn");
     }
 
@@ -862,7 +913,7 @@ rule:
         let project_dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
         let rules_dir = project_dir.join("rules");
         let fake_home = tempfile::tempdir().unwrap();
-        let rules = load_rules(&project_dir, fake_home.path());
+        let (rules, metadata) = load_rules(&project_dir, fake_home.path());
 
         let mut tested = 0;
         for lang_entry in std::fs::read_dir(&rules_dir).unwrap() {
@@ -892,7 +943,7 @@ rule:
                     continue;
                 }
                 let source = std::fs::read_to_string(&fixture_path).unwrap();
-                let findings = scan_file(&source, ext, &rules);
+                let findings = scan_file(&source, ext, &rules, &metadata);
                 assert!(
                     !findings.is_empty(),
                     "bundled rule should match fixture: {}",
@@ -934,7 +985,7 @@ rule:
             from_yaml_string(&yaml, &GlobalRules::default()).unwrap();
 
         let setheader = "res.setHeader('Access-Control-Allow-Origin', '*');";
-        let findings = scan_file(setheader, "ts", &rules);
+        let findings = scan_file(setheader, "ts", &rules, &HashMap::new());
         assert!(
             !findings.is_empty(),
             "should flag setHeader('Access-Control-Allow-Origin', '*')"
@@ -945,7 +996,7 @@ rule:
         );
 
         let header_fn = "res.header('Access-Control-Allow-Origin', '*');";
-        let findings2 = scan_file(header_fn, "ts", &rules);
+        let findings2 = scan_file(header_fn, "ts", &rules, &HashMap::new());
         assert!(
             !findings2.is_empty(),
             "should flag res.header('Access-Control-Allow-Origin', '*')"
@@ -965,7 +1016,7 @@ rule:
             from_yaml_string(&yaml, &GlobalRules::default()).unwrap();
 
         let unrelated = "res.setHeader('X-Custom-Flag', '*');";
-        let findings = scan_file(unrelated, "ts", &rules);
+        let findings = scan_file(unrelated, "ts", &rules, &HashMap::new());
         assert!(
             findings.is_empty(),
             "should NOT flag unrelated header with '*' value"
@@ -989,7 +1040,7 @@ rule:
             "res.setHeader(\"ACCESS-CONTROL-ALLOW-ORIGIN\", \"*\");",
             "res.setHeader('Access-control-allow-Origin', '*');",
         ] {
-            let findings = scan_file(lowered, "ts", &rules);
+            let findings = scan_file(lowered, "ts", &rules, &HashMap::new());
             assert!(
                 !findings.is_empty(),
                 "should flag case variant: {}",
@@ -1011,7 +1062,7 @@ rule:
             from_yaml_string(&yaml, &GlobalRules::default()).unwrap();
 
         let next_style = "response.headers.set('Access-Control-Allow-Origin', '*');";
-        let findings = scan_file(next_style, "ts", &rules);
+        let findings = scan_file(next_style, "ts", &rules, &HashMap::new());
         assert!(
             !findings.is_empty(),
             "should flag Next.js/Fetch-style headers.set(..., '*')"
@@ -1026,7 +1077,7 @@ rule:
     fn mining_2026_04_rules_scan_correctly() {
         let project_dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
         let fake_home = tempfile::tempdir().unwrap();
-        let rules = load_rules(&project_dir, fake_home.path());
+        let (rules, metadata) = load_rules(&project_dir, fake_home.path());
 
         let cases: &[(&str, &str, &str, usize)] = &[
             (
@@ -1199,7 +1250,7 @@ rule:
             let src_path = project_dir.join(path);
             let source = std::fs::read_to_string(&src_path)
                 .unwrap_or_else(|e| panic!("read {}: {e}", src_path.display()));
-            let findings = scan_file(&source, ext, &rules);
+            let findings = scan_file(&source, ext, &rules, &metadata);
             let matches = findings
                 .iter()
                 .filter(|f| f.title.contains(rule_id))
@@ -1228,7 +1279,7 @@ rule:
         // rule loads.
         let project_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR"));
         let empty_home = tempfile::tempdir().expect("empty home for test");
-        let rules = load_rules(project_dir, empty_home.path());
+        let (rules, _metadata) = load_rules(project_dir, empty_home.path());
         assert!(
             !rules.is_empty(),
             "bundled rules must still load after #120 hardening"
@@ -1271,7 +1322,7 @@ rule:
         ).unwrap();
         symlink(&evil_target, user_rules.join("python")).expect("symlink");
 
-        let rules = load_rules(project.path(), home.path());
+        let (rules, _metadata) = load_rules(project.path(), home.path());
         let ids: Vec<_> = rules.iter().map(|r| r.id.clone()).collect();
         assert!(
             ids.contains(&"safe-rule".to_string()),
@@ -1312,7 +1363,7 @@ rule:
         ).unwrap();
         symlink(&outside, user_python.join("smuggled.yml")).expect("symlink");
 
-        let rules = load_rules(project.path(), home.path());
+        let (rules, _metadata) = load_rules(project.path(), home.path());
         let ids: Vec<_> = rules.iter().map(|r| r.id.clone()).collect();
         assert!(
             ids.contains(&"real-rule".to_string()),
@@ -1359,7 +1410,7 @@ rule:
 
         // load_rules must complete (no hang on open) AND not load any
         // rule from the socket file.
-        let rules = load_rules(project.path(), home.path());
+        let (rules, _metadata) = load_rules(project.path(), home.path());
         let ids: Vec<_> = rules.iter().map(|r| r.id.clone()).collect();
         assert!(
             ids.contains(&"real-rule".to_string()),
@@ -1400,7 +1451,7 @@ rule:
         let oversized = format!("{prefix}  {padding}\n");
         std::fs::write(user_python.join("oversized.yml"), oversized).unwrap();
 
-        let rules = load_rules(project.path(), home.path());
+        let (rules, _metadata) = load_rules(project.path(), home.path());
         let ids: Vec<_> = rules.iter().map(|r| r.id.clone()).collect();
         assert!(
             ids.contains(&"small-rule".to_string()),
@@ -1446,7 +1497,7 @@ rule:
 "#;
         std::fs::write(user_ts.join("shared.yml"), user_yaml).unwrap();
 
-        let rules = load_rules(project.path(), home.path());
+        let (rules, _metadata) = load_rules(project.path(), home.path());
         let count = rules.iter().filter(|r| r.id == "shared-id").count();
         assert_eq!(
             count,
@@ -1477,8 +1528,8 @@ rule:
         std::fs::create_dir_all(&user_ts).unwrap();
         std::fs::write(user_ts.join("b.yml"), yaml).unwrap();
 
-        let rules = load_rules(project.path(), home.path());
-        let findings = scan_file("eval('x');", "ts", &rules);
+        let (rules, metadata) = load_rules(project.path(), home.path());
+        let findings = scan_file("eval('x');", "ts", &rules, &metadata);
         let dup_findings = findings
             .iter()
             .filter(|f| f.title.contains("dup-rule"))
@@ -1495,9 +1546,9 @@ rule:
     fn scan_file_populates_rule_id_with_language_and_rule_name() {
         let project_dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
         let fake_home = tempfile::tempdir().unwrap();
-        let rules = load_rules(&project_dir, fake_home.path());
+        let (rules, metadata) = load_rules(&project_dir, fake_home.path());
         let source = "const x = foo as any;";
-        let findings = scan_file(source, "ts", &rules);
+        let findings = scan_file(source, "ts", &rules, &metadata);
         assert!(!findings.is_empty());
         assert_eq!(
             findings[0].rule_id.as_deref(),
@@ -1509,11 +1560,13 @@ rule:
     fn scan_file_python_rule_id_uses_python_prefix() {
         let project_dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
         let fake_home = tempfile::tempdir().unwrap();
-        let rules = load_rules(&project_dir, fake_home.path());
+        let (rules, metadata) = load_rules(&project_dir, fake_home.path());
         let source = "try:\n    x()\nexcept:\n    pass\n";
-        let findings = scan_file(source, "py", &rules);
+        let findings = scan_file(source, "py", &rules, &metadata);
         // Should find bare-except-pass rule
-        let bep = findings.iter().find(|f| f.title.contains("bare-except-pass"));
+        let bep = findings
+            .iter()
+            .find(|f| f.title.contains("bare-except-pass"));
         assert!(bep.is_some(), "should find bare-except-pass rule");
         assert_eq!(
             bep.unwrap().rule_id.as_deref(),
@@ -1555,7 +1608,7 @@ rule:
         std::fs::create_dir_all(&user_quorum).unwrap();
         symlink(&evil_root, user_quorum.join("rules")).expect("symlink");
 
-        let rules = load_rules(project.path(), home.path());
+        let (rules, _metadata) = load_rules(project.path(), home.path());
         let ids: Vec<_> = rules.iter().map(|r| r.id.clone()).collect();
         assert!(
             ids.contains(&"safe-rule".to_string()),
@@ -1565,5 +1618,84 @@ rule:
             !ids.contains(&"evil-toplevel".to_string()),
             "rule loaded via symlinked top-level ~/.quorum/rules must be rejected; ids={ids:?}"
         );
+    }
+
+    // ── Rule metadata parsing tests ──
+
+    #[test]
+    fn parse_metadata_from_yaml_with_metadata_block() {
+        let yaml = r#"
+id: test-rule
+language: Python
+severity: warning
+message: "test"
+rule:
+  pattern: "eval($X)"
+metadata:
+  precision: speculative
+  judge: required
+"#;
+        let meta = parse_rule_metadata(yaml);
+        assert_eq!(meta.precision, PrecisionTier::Speculative);
+        assert_eq!(meta.judge, JudgeRequirement::Required);
+    }
+
+    #[test]
+    fn parse_metadata_defaults_when_no_metadata_block() {
+        let yaml = r#"
+id: test-rule
+language: Python
+severity: warning
+message: "test"
+rule:
+  pattern: "eval($X)"
+"#;
+        let meta = parse_rule_metadata(yaml);
+        assert_eq!(meta.precision, PrecisionTier::High);
+        assert_eq!(meta.judge, JudgeRequirement::Skip);
+    }
+
+    #[test]
+    fn parse_metadata_partial_fields_default() {
+        let yaml = r#"
+id: test-rule
+language: Python
+severity: warning
+message: "test"
+rule:
+  pattern: "eval($X)"
+metadata:
+  precision: medium
+"#;
+        let meta = parse_rule_metadata(yaml);
+        assert_eq!(meta.precision, PrecisionTier::Medium);
+        assert_eq!(meta.judge, JudgeRequirement::Skip);
+    }
+
+    #[test]
+    fn scan_file_sets_precision_tier_from_metadata() {
+        let project_dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        let fake_home = tempfile::tempdir().unwrap();
+        let (rules, metadata) = load_rules(&project_dir, fake_home.path());
+        let source = "const x = foo as any;";
+        let findings = scan_file(source, "ts", &rules, &metadata);
+        assert!(!findings.is_empty());
+        // Default rules (no metadata block) should have precision High
+        assert_eq!(findings[0].precision_tier, Some(PrecisionTier::High));
+    }
+
+    #[test]
+    fn load_rules_populates_metadata_map() {
+        let project_dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        let fake_home = tempfile::tempdir().unwrap();
+        let (rules, metadata) = load_rules(&project_dir, fake_home.path());
+        // Every loaded rule should have a metadata entry
+        for rule in &rules {
+            assert!(
+                metadata.contains_key(&rule.id),
+                "metadata map missing entry for rule id: {}",
+                rule.id
+            );
+        }
     }
 }

--- a/src/ast_grep.rs
+++ b/src/ast_grep.rs
@@ -237,6 +237,21 @@ fn compatible_languages(ext: &str) -> Vec<SupportLang> {
     }
 }
 
+/// Map `SupportLang` to a stable lowercase string for rule_id construction.
+fn lang_name(lang: &SupportLang) -> &'static str {
+    match lang {
+        SupportLang::Python => "python",
+        SupportLang::TypeScript => "typescript",
+        SupportLang::Tsx => "tsx",
+        SupportLang::JavaScript => "javascript",
+        SupportLang::Rust => "rust",
+        SupportLang::Bash => "bash",
+        SupportLang::Yaml => "yaml",
+        SupportLang::Hcl => "hcl",
+        _ => "unknown",
+    }
+}
+
 /// Scan source code with the given rules. Per-rule isolation: one bad rule doesn't block others.
 /// Returns findings with normalized line numbers (1-indexed) and Source::Linter("ast-grep").
 pub fn scan_file(source: &str, ext: &str, rules: &[RuleConfig<SupportLang>]) -> Vec<Finding> {
@@ -296,7 +311,7 @@ pub fn scan_file(source: &str, ext: &str, rules: &[RuleConfig<SupportLang>]) -> 
                     grounding_status: None,
                     grounding_confidence: None,
                     model_agreement: None,
-                    rule_id: None,
+                    rule_id: Some(format!("ast-grep:{}/{}", lang_name(lang), rule.id)),
                 });
             }
         }
@@ -1468,6 +1483,38 @@ rule:
         assert_eq!(
             dup_findings, 1,
             "duplicate rule id must not double-fire on the same match; got {dup_findings}"
+        );
+    }
+
+    // ── rule_id population tests ──
+
+    #[test]
+    fn scan_file_populates_rule_id_with_language_and_rule_name() {
+        let project_dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        let fake_home = tempfile::tempdir().unwrap();
+        let rules = load_rules(&project_dir, fake_home.path());
+        let source = "const x = foo as any;";
+        let findings = scan_file(source, "ts", &rules);
+        assert!(!findings.is_empty());
+        assert_eq!(
+            findings[0].rule_id.as_deref(),
+            Some("ast-grep:typescript/as-any-cast")
+        );
+    }
+
+    #[test]
+    fn scan_file_python_rule_id_uses_python_prefix() {
+        let project_dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        let fake_home = tempfile::tempdir().unwrap();
+        let rules = load_rules(&project_dir, fake_home.path());
+        let source = "try:\n    x()\nexcept:\n    pass\n";
+        let findings = scan_file(source, "py", &rules);
+        // Should find bare-except-pass rule
+        let bep = findings.iter().find(|f| f.title.contains("bare-except-pass"));
+        assert!(bep.is_some(), "should find bare-except-pass rule");
+        assert_eq!(
+            bep.unwrap().rule_id.as_deref(),
+            Some("ast-grep:python/bare-except-pass")
         );
     }
 

--- a/src/ast_grep.rs
+++ b/src/ast_grep.rs
@@ -312,6 +312,9 @@ pub fn scan_file(source: &str, ext: &str, rules: &[RuleConfig<SupportLang>]) -> 
                     grounding_confidence: None,
                     model_agreement: None,
                     rule_id: Some(format!("ast-grep:{}/{}", lang_name(lang), rule.id)),
+                    judge_verdict: None,
+                    judge_confidence: None,
+                    precision_tier: None,
                 });
             }
         }

--- a/src/ast_grep.rs
+++ b/src/ast_grep.rs
@@ -34,10 +34,13 @@ struct YamlWithMetadata {
 /// Parse the optional `metadata` block from an ast-grep YAML rule string.
 /// Returns `RuleMetadata::default()` when the block is absent or unparseable.
 pub fn parse_rule_metadata(yaml_str: &str) -> RuleMetadata {
-    serde_yaml::from_str::<YamlWithMetadata>(yaml_str)
-        .ok()
-        .and_then(|y| y.metadata)
-        .unwrap_or_default()
+    match serde_yaml::from_str::<YamlWithMetadata>(yaml_str) {
+        Ok(y) => y.metadata.unwrap_or_default(),
+        Err(e) => {
+            tracing::warn!(error = %e, "ast-grep: failed to parse rule metadata block");
+            RuleMetadata::default()
+        }
+    }
 }
 
 /// Maximum size for a single ast-grep YAML rule file. Files exceeding this
@@ -240,7 +243,9 @@ pub fn load_rules(
                                 );
                                 continue;
                             }
-                            metadata_map.insert(rule.id.clone(), meta.clone());
+                            let meta_key =
+                                format!("ast-grep:{}/{}", lang_name(&rule.language), rule.id);
+                            metadata_map.insert(meta_key, meta.clone());
                             rules.push(rule);
                         }
                     }
@@ -321,6 +326,8 @@ pub fn scan_file(
         }
         let root = lang.ast_grep(source);
         for rule in lang_rules {
+            let meta_key = format!("ast-grep:{}/{}", lang_name(lang), rule.id);
+            let meta = metadata.get(meta_key.as_str()).cloned().unwrap_or_default();
             let matches: Vec<_> = root.root().find_all(&rule.matcher).collect();
             for m in matches {
                 let start_line = m.start_pos().line() as u32 + 1;
@@ -332,8 +339,6 @@ pub fn scan_file(
                     AstSeverity::Info | AstSeverity::Hint => Severity::Low,
                     AstSeverity::Off => Severity::Low,
                 };
-
-                let meta = metadata.get(rule.id.as_str()).cloned().unwrap_or_default();
                 findings.push(Finding {
                     id: crate::finding::new_finding_ulid(),
                     title: format!("{}: {}", rule.id, message),
@@ -356,10 +361,10 @@ pub fn scan_file(
                     grounding_status: None,
                     grounding_confidence: None,
                     model_agreement: None,
-                    rule_id: Some(format!("ast-grep:{}/{}", lang_name(lang), rule.id)),
+                    rule_id: Some(meta_key.clone()),
                     judge_verdict: None,
                     judge_confidence: None,
-                    precision_tier: Some(meta.precision),
+                    precision_tier: Some(meta.precision.clone()),
                 });
             }
         }

--- a/src/ast_grep.rs
+++ b/src/ast_grep.rs
@@ -1696,10 +1696,11 @@ metadata:
         let (rules, metadata) = load_rules(&project_dir, fake_home.path());
         // Every loaded rule should have a metadata entry
         for rule in &rules {
+            let key = format!("ast-grep:{}/{}", lang_name(&rule.language), rule.id);
             assert!(
-                metadata.contains_key(&rule.id),
-                "metadata map missing entry for rule id: {}",
-                rule.id
+                metadata.contains_key(&key),
+                "metadata map missing entry for rule key: {}",
+                key
             );
         }
     }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -497,6 +497,14 @@ pub struct ReviewOpts {
     /// Review mode: code (default), plan, docs
     #[arg(long, default_value = "code")]
     pub mode: crate::review_mode::ReviewMode,
+
+    /// Enable LLM micro-judge for speculative AST rules (also: QUORUM_JUDGE=1)
+    #[arg(long)]
+    pub judge: bool,
+
+    /// Model for judge calls (default: gpt-5-nano, also: QUORUM_JUDGE_MODEL)
+    #[arg(long)]
+    pub judge_model: Option<String>,
 }
 
 /// CLI surface for `--fp-kind` (#123 Layer 1). Variants map onto

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -337,8 +337,16 @@ pub struct StatsOpts {
     pub misleading: bool,
 
     /// Rank files by finding frequency from feedback (hotspot detection)
-    #[arg(long, conflicts_with_all = ["by_repo", "by_caller", "rolling", "by_source", "by_reviewed_repo", "misleading"])]
+    #[arg(long, conflicts_with_all = ["by_repo", "by_caller", "rolling", "by_source", "by_reviewed_repo", "misleading", "by_rule"])]
     pub by_file: bool,
+
+    /// Per-rule TP/FP/precision breakdown from feedback
+    #[arg(long, conflicts_with_all = ["by_repo", "by_caller", "rolling", "by_source", "by_reviewed_repo", "misleading", "by_file"])]
+    pub by_rule: bool,
+
+    /// Filter rules by glob pattern (e.g. "ast-grep:python/*")
+    #[arg(long, requires = "by_rule")]
+    pub rule: Option<String>,
 
     /// Limit output rows for --by-file (default: show all)
     #[arg(long, requires = "by_file", value_parser = parse_top_n)]
@@ -1609,6 +1617,56 @@ mod tests {
         use clap::Parser;
         let res = Args::try_parse_from(["quorum", "stats", "--top", "5"]);
         assert!(res.is_err(), "--top requires --by-file");
+    }
+
+    #[test]
+    fn stats_by_rule_flag_parses() {
+        use clap::Parser;
+        let args = Args::parse_from(["quorum", "stats", "--by-rule"]);
+        match args.command {
+            Command::Stats(opts) => assert!(opts.by_rule),
+            _ => panic!("expected Stats"),
+        }
+    }
+
+    #[test]
+    fn stats_by_rule_with_filter() {
+        use clap::Parser;
+        let args = Args::parse_from([
+            "quorum",
+            "stats",
+            "--by-rule",
+            "--rule",
+            "ast-grep:python/*",
+        ]);
+        match args.command {
+            Command::Stats(opts) => {
+                assert!(opts.by_rule);
+                assert_eq!(opts.rule.as_deref(), Some("ast-grep:python/*"));
+            }
+            _ => panic!("expected Stats"),
+        }
+    }
+
+    #[test]
+    fn stats_by_rule_conflicts_with_by_file() {
+        use clap::Parser;
+        let res = Args::try_parse_from(["quorum", "stats", "--by-rule", "--by-file"]);
+        assert!(res.is_err(), "--by-rule and --by-file should conflict");
+    }
+
+    #[test]
+    fn stats_by_rule_conflicts_with_by_repo() {
+        use clap::Parser;
+        let res = Args::try_parse_from(["quorum", "stats", "--by-rule", "--by-repo"]);
+        assert!(res.is_err(), "--by-rule and --by-repo should conflict");
+    }
+
+    #[test]
+    fn stats_rule_without_by_rule_is_rejected() {
+        use clap::Parser;
+        let res = Args::try_parse_from(["quorum", "stats", "--rule", "foo*"]);
+        assert!(res.is_err(), "--rule requires --by-rule");
     }
 
     #[test]

--- a/src/dimensions.rs
+++ b/src/dimensions.rs
@@ -506,6 +506,81 @@ pub fn group_by_file(entries: &[FeedbackEntry], top_n: Option<usize>) -> Vec<Fil
     rows
 }
 
+/// Per-rule precision row aggregated from feedback verdicts.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct RuleDimensionSlice {
+    pub key: String,
+    pub tp: u32,
+    pub fp: u32,
+    pub partial: u32,
+    pub wontfix: u32,
+    pub total: u32,
+    pub precision: f64,
+    pub low_sample: bool,
+}
+
+pub fn group_by_rule(
+    entries: &[FeedbackEntry],
+    glob_filter: Option<&str>,
+) -> Vec<RuleDimensionSlice> {
+    let mut buckets: HashMap<String, (u32, u32, u32, u32)> = HashMap::new();
+
+    for entry in entries {
+        let rule_id = match &entry.rule_id {
+            Some(r) if !r.is_empty() => r,
+            _ => continue,
+        };
+
+        if let Some(pattern) = glob_filter {
+            if !glob_match(pattern, rule_id) {
+                continue;
+            }
+        }
+
+        let counts = buckets.entry(rule_id.clone()).or_default();
+        match &entry.verdict {
+            Verdict::Tp => counts.0 += 1,
+            Verdict::Fp => counts.1 += 1,
+            Verdict::Partial => counts.2 += 1,
+            Verdict::Wontfix => counts.3 += 1,
+            Verdict::ContextMisleading { .. } => {}
+        }
+    }
+
+    let mut slices: Vec<RuleDimensionSlice> = buckets
+        .into_iter()
+        .map(|(key, (tp, fp, partial, wontfix))| {
+            let total = tp + fp + partial + wontfix;
+            let precision = if tp + fp > 0 {
+                tp as f64 / (tp + fp) as f64
+            } else {
+                0.0
+            };
+            RuleDimensionSlice {
+                key,
+                tp,
+                fp,
+                partial,
+                wontfix,
+                total,
+                precision,
+                low_sample: total < MIN_SAMPLE,
+            }
+        })
+        .collect();
+
+    slices.sort_by(|a, b| b.total.cmp(&a.total).then_with(|| a.key.cmp(&b.key)));
+    slices
+}
+
+fn glob_match(pattern: &str, value: &str) -> bool {
+    if let Some(prefix) = pattern.strip_suffix('*') {
+        value.starts_with(prefix)
+    } else {
+        value == pattern
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1170,6 +1245,70 @@ mod tests {
         assert_eq!(rows[1].file_path, "noisy.rs");
         assert_eq!(rows[1].tp_count, 0);
         assert_eq!(rows[1].fp_count, 2);
+    }
+
+    // ── group_by_rule tests ──
+
+    fn feedback_entry_with_rule(rule_id: Option<&str>, verdict: Verdict) -> FeedbackEntry {
+        FeedbackEntry {
+            file_path: "test.py".into(),
+            finding_title: "test".into(),
+            finding_category: "security".into(),
+            verdict,
+            reason: "".into(),
+            model: None,
+            timestamp: Utc::now(),
+            provenance: Provenance::Human,
+            fp_kind: None,
+            finding_id: None,
+            rule_id: rule_id.map(String::from),
+        }
+    }
+
+    #[test]
+    fn group_by_rule_buckets_by_rule_id() {
+        let entries = vec![
+            feedback_entry_with_rule(Some("local-ast:python/eval-exec"), Verdict::Tp),
+            feedback_entry_with_rule(Some("local-ast:python/eval-exec"), Verdict::Fp),
+            feedback_entry_with_rule(Some("ast-grep:python/bare-except-pass"), Verdict::Tp),
+            feedback_entry_with_rule(None, Verdict::Tp),
+        ];
+        let slices = group_by_rule(&entries, None);
+        assert_eq!(slices.len(), 2, "None entries should be excluded");
+        let eval_slice = slices
+            .iter()
+            .find(|s| s.key == "local-ast:python/eval-exec")
+            .unwrap();
+        assert_eq!(eval_slice.tp, 1);
+        assert_eq!(eval_slice.fp, 1);
+        assert!((eval_slice.precision - 0.5).abs() < 0.01);
+    }
+
+    #[test]
+    fn group_by_rule_filters_by_glob() {
+        let entries = vec![
+            feedback_entry_with_rule(Some("local-ast:python/eval-exec"), Verdict::Tp),
+            feedback_entry_with_rule(Some("ast-grep:typescript/as-any-cast"), Verdict::Tp),
+        ];
+        let slices = group_by_rule(&entries, Some("local-ast:python/*"));
+        assert_eq!(slices.len(), 1);
+        assert_eq!(slices[0].key, "local-ast:python/eval-exec");
+    }
+
+    #[test]
+    fn group_by_rule_empty_input() {
+        let slices = group_by_rule(&[], None);
+        assert!(slices.is_empty());
+    }
+
+    #[test]
+    fn group_by_rule_low_sample_flag() {
+        let entries = vec![feedback_entry_with_rule(Some("rule-a"), Verdict::Tp)];
+        let slices = group_by_rule(&entries, None);
+        assert!(
+            slices[0].low_sample,
+            "1 entry < MIN_SAMPLE should be flagged"
+        );
     }
 
     #[test]

--- a/src/dimensions.rs
+++ b/src/dimensions.rs
@@ -531,10 +531,10 @@ pub fn group_by_rule(
             _ => continue,
         };
 
-        if let Some(pattern) = glob_filter {
-            if !glob_match(pattern, rule_id) {
-                continue;
-            }
+        if let Some(pattern) = glob_filter
+            && !glob_match(pattern, rule_id)
+        {
+            continue;
         }
 
         let counts = buckets.entry(rule_id.clone()).or_default();

--- a/src/finding.rs
+++ b/src/finding.rs
@@ -1017,7 +1017,10 @@ mod tests {
         let f = FindingBuilder::new()
             .rule_id("ast-grep:python/bare-except-pass")
             .build();
-        assert_eq!(f.rule_id.as_deref(), Some("ast-grep:python/bare-except-pass"));
+        assert_eq!(
+            f.rule_id.as_deref(),
+            Some("ast-grep:python/bare-except-pass")
+        );
     }
 
     #[test]

--- a/src/finding.rs
+++ b/src/finding.rs
@@ -156,15 +156,24 @@ impl Finding {
     }
 
     pub fn compute_confidence(&mut self) {
-        let base = match &self.source {
-            Source::LocalAst => 0.95,
-            Source::Linter(_) => 0.90,
-            Source::Llm(_) => self
+        let base = match (&self.source, &self.precision_tier) {
+            (Source::LocalAst, Some(PrecisionTier::High)) | (Source::LocalAst, None) => 0.95,
+            (Source::LocalAst, Some(PrecisionTier::Medium)) => 0.80,
+            (Source::LocalAst, Some(PrecisionTier::Speculative)) => 0.50,
+            (Source::Linter(_), Some(PrecisionTier::High)) | (Source::Linter(_), None) => 0.90,
+            (Source::Linter(_), Some(PrecisionTier::Medium)) => 0.75,
+            (Source::Linter(_), Some(PrecisionTier::Speculative)) => 0.45,
+            (Source::Llm(_), _) => self
                 .grounding_confidence
                 .filter(|c| c.is_finite())
                 .map(|c| c.clamp(0.0, 1.0))
                 .unwrap_or(0.5),
         };
+        let base = self
+            .judge_confidence
+            .filter(|c| c.is_finite())
+            .map(|c| c.clamp(0.0, 1.0))
+            .unwrap_or(base);
         let cal_factor = match self.calibrator_action {
             Some(CalibratorAction::Confirmed) => 1.1,
             Some(CalibratorAction::Disputed) => 0.6,
@@ -1095,5 +1104,68 @@ mod tests {
         assert!(!json.contains("judge_verdict"));
         assert!(!json.contains("judge_confidence"));
         assert!(!json.contains("precision_tier"));
+    }
+
+    // -- Tier-aware confidence --
+
+    #[test]
+    fn confidence_speculative_local_ast_is_050() {
+        let mut f = FindingBuilder::new().source(Source::LocalAst).build();
+        f.precision_tier = Some(PrecisionTier::Speculative);
+        f.compute_confidence();
+        assert!((f.confidence.unwrap() - 0.50).abs() < 0.01);
+    }
+
+    #[test]
+    fn confidence_medium_local_ast_is_080() {
+        let mut f = FindingBuilder::new().source(Source::LocalAst).build();
+        f.precision_tier = Some(PrecisionTier::Medium);
+        f.compute_confidence();
+        assert!((f.confidence.unwrap() - 0.80).abs() < 0.01);
+    }
+
+    #[test]
+    fn confidence_medium_linter_is_075() {
+        let mut f = FindingBuilder::new()
+            .source(Source::Linter("ast-grep".into()))
+            .build();
+        f.precision_tier = Some(PrecisionTier::Medium);
+        f.compute_confidence();
+        assert!((f.confidence.unwrap() - 0.75).abs() < 0.01);
+    }
+
+    #[test]
+    fn confidence_speculative_linter_is_045() {
+        let mut f = FindingBuilder::new()
+            .source(Source::Linter("ast-grep".into()))
+            .build();
+        f.precision_tier = Some(PrecisionTier::Speculative);
+        f.compute_confidence();
+        assert!((f.confidence.unwrap() - 0.45).abs() < 0.01);
+    }
+
+    #[test]
+    fn confidence_judge_overrides_base() {
+        let mut f = FindingBuilder::new().source(Source::LocalAst).build();
+        f.precision_tier = Some(PrecisionTier::Speculative);
+        f.judge_confidence = Some(0.85);
+        f.compute_confidence();
+        assert!((f.confidence.unwrap() - 0.85).abs() < 0.01);
+    }
+
+    #[test]
+    fn confidence_no_tier_matches_legacy_behavior() {
+        let mut f = FindingBuilder::new().source(Source::LocalAst).build();
+        f.precision_tier = None;
+        f.compute_confidence();
+        assert!((f.confidence.unwrap() - 0.95).abs() < 0.01);
+    }
+
+    #[test]
+    fn confidence_judge_nan_falls_back_to_base() {
+        let mut f = FindingBuilder::new().source(Source::LocalAst).build();
+        f.judge_confidence = Some(f32::NAN);
+        f.compute_confidence();
+        assert!((f.confidence.unwrap() - 0.95).abs() < 0.01);
     }
 }

--- a/src/finding.rs
+++ b/src/finding.rs
@@ -39,6 +39,33 @@ pub enum CalibratorAction {
     Added,
 }
 
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum PrecisionTier {
+    #[default]
+    High,
+    Medium,
+    Speculative,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum JudgeRequirement {
+    Required,
+    Optional,
+    #[default]
+    Skip,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum JudgeVerdict {
+    Approved,
+    Rejected,
+    Uncertain,
+    Skipped,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub enum Source {
@@ -115,6 +142,12 @@ pub struct Finding {
     pub model_agreement: Option<f32>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub rule_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub judge_verdict: Option<JudgeVerdict>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub judge_confidence: Option<f32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub precision_tier: Option<PrecisionTier>,
 }
 
 impl Finding {
@@ -205,6 +238,9 @@ impl FindingBuilder {
                 grounding_confidence: None,
                 model_agreement: None,
                 rule_id: None,
+                judge_verdict: None,
+                judge_confidence: None,
+                precision_tier: None,
             },
         }
     }
@@ -408,6 +444,9 @@ mod tests {
             grounding_confidence: None,
             model_agreement: None,
             rule_id: None,
+            judge_verdict: None,
+            judge_confidence: None,
+            precision_tier: None,
         };
         let json = serde_json::to_value(&f).unwrap();
         assert_eq!(json["title"], "Unvalidated input");
@@ -446,6 +485,9 @@ mod tests {
             grounding_confidence: None,
             model_agreement: None,
             rule_id: None,
+            judge_verdict: None,
+            judge_confidence: None,
+            precision_tier: None,
         };
         let json_str = serde_json::to_string(&original).unwrap();
         let deserialized: Finding = serde_json::from_str(&json_str).unwrap();
@@ -477,6 +519,9 @@ mod tests {
             grounding_confidence: None,
             model_agreement: None,
             rule_id: None,
+            judge_verdict: None,
+            judge_confidence: None,
+            precision_tier: None,
         };
         let json = serde_json::to_value(&f).unwrap();
         assert!(json["calibrator_action"].is_null());
@@ -510,6 +555,9 @@ mod tests {
             grounding_confidence: None,
             model_agreement: None,
             rule_id: None,
+            judge_verdict: None,
+            judge_confidence: None,
+            precision_tier: None,
         };
         assert!(f.is_valid());
     }
@@ -539,6 +587,9 @@ mod tests {
             grounding_confidence: None,
             model_agreement: None,
             rule_id: None,
+            judge_verdict: None,
+            judge_confidence: None,
+            precision_tier: None,
         };
         assert!(f.is_valid());
     }
@@ -568,6 +619,9 @@ mod tests {
             grounding_confidence: None,
             model_agreement: None,
             rule_id: None,
+            judge_verdict: None,
+            judge_confidence: None,
+            precision_tier: None,
         };
         assert!(!f.is_valid());
     }
@@ -597,6 +651,9 @@ mod tests {
             grounding_confidence: None,
             model_agreement: None,
             rule_id: None,
+            judge_verdict: None,
+            judge_confidence: None,
+            precision_tier: None,
         };
         assert!(!f.is_valid());
     }
@@ -976,5 +1033,67 @@ mod tests {
         let json = r#"{"title":"t","description":"d","severity":"info","category":"maintainability","source":"local-ast","line_start":1,"line_end":1,"evidence":[],"similar_precedent":[]}"#;
         let f: Finding = serde_json::from_str(json).unwrap();
         assert_eq!(f.rule_id, None);
+    }
+
+    // -- PrecisionTier / JudgeRequirement / JudgeVerdict --
+
+    #[test]
+    fn precision_tier_default_is_high() {
+        let tier: PrecisionTier = Default::default();
+        assert_eq!(tier, PrecisionTier::High);
+    }
+
+    #[test]
+    fn precision_tier_serde_roundtrip() {
+        let tier = PrecisionTier::Speculative;
+        let json = serde_json::to_string(&tier).unwrap();
+        assert_eq!(json, "\"speculative\"");
+        let parsed: PrecisionTier = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed, PrecisionTier::Speculative);
+    }
+
+    #[test]
+    fn judge_requirement_default_is_skip() {
+        let req: JudgeRequirement = Default::default();
+        assert_eq!(req, JudgeRequirement::Skip);
+    }
+
+    #[test]
+    fn judge_verdict_serde_roundtrip() {
+        let v = JudgeVerdict::Approved;
+        let json = serde_json::to_string(&v).unwrap();
+        assert_eq!(json, "\"approved\"");
+        let parsed: JudgeVerdict = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed, JudgeVerdict::Approved);
+    }
+
+    #[test]
+    fn finding_judge_fields_default_to_none() {
+        let f = FindingBuilder::new().build();
+        assert_eq!(f.judge_verdict, None);
+        assert_eq!(f.judge_confidence, None);
+        assert_eq!(f.precision_tier, None);
+    }
+
+    #[test]
+    fn finding_with_judge_fields_survives_roundtrip() {
+        let mut f = FindingBuilder::new().build();
+        f.judge_verdict = Some(JudgeVerdict::Approved);
+        f.judge_confidence = Some(0.85);
+        f.precision_tier = Some(PrecisionTier::Speculative);
+        let json = serde_json::to_string(&f).unwrap();
+        let parsed: Finding = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed.judge_verdict, Some(JudgeVerdict::Approved));
+        assert_eq!(parsed.judge_confidence, Some(0.85));
+        assert_eq!(parsed.precision_tier, Some(PrecisionTier::Speculative));
+    }
+
+    #[test]
+    fn finding_without_judge_fields_omits_from_json() {
+        let f = FindingBuilder::new().build();
+        let json = serde_json::to_string(&f).unwrap();
+        assert!(!json.contains("judge_verdict"));
+        assert!(!json.contains("judge_confidence"));
+        assert!(!json.contains("precision_tier"));
     }
 }

--- a/src/finding.rs
+++ b/src/finding.rs
@@ -113,6 +113,8 @@ pub struct Finding {
     pub grounding_confidence: Option<f32>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub model_agreement: Option<f32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub rule_id: Option<String>,
 }
 
 impl Finding {
@@ -202,6 +204,7 @@ impl FindingBuilder {
                 grounding_status: None,
                 grounding_confidence: None,
                 model_agreement: None,
+                rule_id: None,
             },
         }
     }
@@ -314,6 +317,11 @@ impl FindingBuilder {
         self
     }
 
+    pub fn rule_id(mut self, r: &str) -> Self {
+        self.inner.rule_id = Some(r.into());
+        self
+    }
+
     pub fn build(self) -> Finding {
         self.inner
     }
@@ -399,6 +407,7 @@ mod tests {
             grounding_status: None,
             grounding_confidence: None,
             model_agreement: None,
+            rule_id: None,
         };
         let json = serde_json::to_value(&f).unwrap();
         assert_eq!(json["title"], "Unvalidated input");
@@ -436,6 +445,7 @@ mod tests {
             grounding_status: None,
             grounding_confidence: None,
             model_agreement: None,
+            rule_id: None,
         };
         let json_str = serde_json::to_string(&original).unwrap();
         let deserialized: Finding = serde_json::from_str(&json_str).unwrap();
@@ -466,6 +476,7 @@ mod tests {
             grounding_status: None,
             grounding_confidence: None,
             model_agreement: None,
+            rule_id: None,
         };
         let json = serde_json::to_value(&f).unwrap();
         assert!(json["calibrator_action"].is_null());
@@ -498,6 +509,7 @@ mod tests {
             grounding_status: None,
             grounding_confidence: None,
             model_agreement: None,
+            rule_id: None,
         };
         assert!(f.is_valid());
     }
@@ -526,6 +538,7 @@ mod tests {
             grounding_status: None,
             grounding_confidence: None,
             model_agreement: None,
+            rule_id: None,
         };
         assert!(f.is_valid());
     }
@@ -554,6 +567,7 @@ mod tests {
             grounding_status: None,
             grounding_confidence: None,
             model_agreement: None,
+            rule_id: None,
         };
         assert!(!f.is_valid());
     }
@@ -582,6 +596,7 @@ mod tests {
             grounding_status: None,
             grounding_confidence: None,
             model_agreement: None,
+            rule_id: None,
         };
         assert!(!f.is_valid());
     }
@@ -921,5 +936,45 @@ mod tests {
             f.confidence.unwrap() <= 1.0,
             "grounding > 1.0 must be clamped"
         );
+    }
+
+    // -- rule_id field --
+
+    #[test]
+    fn finding_rule_id_defaults_to_none() {
+        let f = FindingBuilder::new().build();
+        assert_eq!(f.rule_id, None);
+    }
+
+    #[test]
+    fn finding_rule_id_set_via_builder() {
+        let f = FindingBuilder::new()
+            .rule_id("ast-grep:python/bare-except-pass")
+            .build();
+        assert_eq!(f.rule_id.as_deref(), Some("ast-grep:python/bare-except-pass"));
+    }
+
+    #[test]
+    fn finding_rule_id_survives_json_roundtrip() {
+        let f = FindingBuilder::new()
+            .rule_id("local-ast:complexity")
+            .build();
+        let json = serde_json::to_string(&f).unwrap();
+        let parsed: Finding = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed.rule_id.as_deref(), Some("local-ast:complexity"));
+    }
+
+    #[test]
+    fn finding_without_rule_id_omits_from_json() {
+        let f = FindingBuilder::new().build();
+        let json = serde_json::to_string(&f).unwrap();
+        assert!(!json.contains("rule_id"));
+    }
+
+    #[test]
+    fn legacy_json_without_rule_id_deserializes_as_none() {
+        let json = r#"{"title":"t","description":"d","severity":"info","category":"maintainability","source":"local-ast","line_start":1,"line_end":1,"evidence":[],"similar_precedent":[]}"#;
+        let f: Finding = serde_json::from_str(json).unwrap();
+        assert_eq!(f.rule_id, None);
     }
 }

--- a/src/judge.rs
+++ b/src/judge.rs
@@ -223,10 +223,11 @@ pub fn judge_findings(
                 && let Ok(verdicts) = serde_json::from_str::<Vec<JudgeResponseItem>>(&response)
             {
                 for v in &verdicts {
-                    if let Some(&i) = to_judge
+                    if let Some(pos) = to_judge
                         .iter()
-                        .find(|&&i| findings[i].rule_id.as_deref() == Some(&v.rule_id))
+                        .position(|&i| findings[i].rule_id.as_deref() == Some(&v.rule_id))
                     {
+                        let i = to_judge.swap_remove(pos);
                         let verdict = parse_verdict(&v.verdict);
                         let confidence = v.confidence.clamp(0.0, 1.0);
                         findings[i].judge_verdict = Some(verdict.clone());
@@ -275,7 +276,22 @@ pub fn judge_findings(
         }
     }
 
-    // Phase 3: Apply rejection policy
+    // Phase 3: Clamp confidence for Optional+Rejected, then drop Required+Rejected
+    for f in findings.iter_mut() {
+        let meta = f
+            .rule_id
+            .as_ref()
+            .and_then(|rid| metadata.get(rid.as_str()))
+            .cloned()
+            .unwrap_or_default();
+
+        if meta.judge == JudgeRequirement::Optional
+            && f.judge_verdict == Some(JudgeVerdict::Rejected)
+        {
+            f.judge_confidence = Some(0.05);
+        }
+    }
+
     findings.retain(|f| {
         let meta = f
             .rule_id
@@ -284,18 +300,8 @@ pub fn judge_findings(
             .cloned()
             .unwrap_or_default();
 
-        // Required + Rejected: drop finding entirely
-        if meta.judge == JudgeRequirement::Required
-            && f.judge_verdict == Some(JudgeVerdict::Rejected)
-        {
-            return false;
-        }
-
-        // Optional + Rejected: finding survives but confidence is clamped.
-        // judge_confidence is already set; compute_confidence will pick it up
-        // via the judge_confidence arm, pushing it to bottom of rankings.
-
-        true
+        !(meta.judge == JudgeRequirement::Required
+            && f.judge_verdict == Some(JudgeVerdict::Rejected))
     });
 
     result.latency_ms = start.elapsed().as_millis() as u64;

--- a/src/judge.rs
+++ b/src/judge.rs
@@ -1,7 +1,7 @@
 use crate::ast_grep::RuleMetadata;
-use crate::finding::{Finding, JudgeRequirement, JudgeVerdict};
 #[cfg(test)]
 use crate::finding::PrecisionTier;
+use crate::finding::{Finding, JudgeRequirement, JudgeVerdict};
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
@@ -220,8 +220,7 @@ pub fn judge_findings(
             result.calls += 1;
 
             if let Some(response) = llm(&prompt)
-                && let Ok(verdicts) =
-                    serde_json::from_str::<Vec<JudgeResponseItem>>(&response)
+                && let Ok(verdicts) = serde_json::from_str::<Vec<JudgeResponseItem>>(&response)
             {
                 for v in &verdicts {
                     if let Some(&i) = to_judge
@@ -233,8 +232,11 @@ pub fn judge_findings(
                         findings[i].judge_verdict = Some(verdict.clone());
                         findings[i].judge_confidence = Some(confidence);
 
-                        let evidence =
-                            findings[i].evidence.first().map(|s| s.as_str()).unwrap_or("");
+                        let evidence = findings[i]
+                            .evidence
+                            .first()
+                            .map(|s| s.as_str())
+                            .unwrap_or("");
                         let key = verdict_cache_key(&v.rule_id, evidence);
                         let _ = write_cache_entry(
                             cache_path,

--- a/src/judge.rs
+++ b/src/judge.rs
@@ -1,0 +1,547 @@
+use crate::ast_grep::RuleMetadata;
+use crate::finding::{Finding, JudgeRequirement, JudgeVerdict};
+#[cfg(test)]
+use crate::finding::PrecisionTier;
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use std::collections::HashMap;
+use std::path::Path;
+
+const CACHE_TTL_DAYS: i64 = 7;
+
+/// Compute a deterministic cache key from a rule ID and its evidence snippet.
+/// The null byte separator prevents prefix collisions between rule and evidence.
+pub fn verdict_cache_key(rule_id: &str, evidence: &str) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(rule_id.as_bytes());
+    hasher.update(b"\0");
+    hasher.update(evidence.as_bytes());
+    let hash = hasher.finalize();
+    let mut hex = String::with_capacity(hash.len() * 2);
+    for byte in hash {
+        use std::fmt::Write;
+        let _ = write!(hex, "{byte:02x}");
+    }
+    hex
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CacheEntry {
+    pub cache_key: String,
+    pub rule_id: String,
+    pub verdict: JudgeVerdict,
+    pub confidence: f32,
+    pub reason: String,
+    pub timestamp: DateTime<Utc>,
+}
+
+/// Load the verdict cache from a JSONL file, discarding entries older than
+/// `CACHE_TTL_DAYS`. Returns an empty map if the file does not exist.
+pub fn load_cache(path: &Path) -> std::io::Result<HashMap<String, CacheEntry>> {
+    let mut map = HashMap::new();
+    let content = match std::fs::read_to_string(path) {
+        Ok(c) => c,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(map),
+        Err(e) => return Err(e),
+    };
+    let cutoff = Utc::now() - chrono::Duration::days(CACHE_TTL_DAYS);
+    for line in content.lines() {
+        if let Ok(entry) = serde_json::from_str::<CacheEntry>(line)
+            && entry.timestamp > cutoff
+        {
+            map.insert(entry.cache_key.clone(), entry);
+        }
+    }
+    Ok(map)
+}
+
+/// Append a single verdict cache entry to the JSONL file, creating parent
+/// directories as needed.
+pub fn write_cache_entry(path: &Path, entry: &CacheEntry) -> std::io::Result<()> {
+    use std::io::Write;
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let mut file = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(path)?;
+    let json = serde_json::to_string(entry)
+        .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
+    writeln!(file, "{json}")
+}
+
+// ---------------------------------------------------------------------------
+// LLM judge client
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Deserialize)]
+pub struct JudgeResponseItem {
+    pub rule_id: String,
+    pub verdict: String,
+    pub confidence: f32,
+    pub reason: String,
+}
+
+/// Map wire-format verdict strings to the `JudgeVerdict` enum.
+pub fn parse_verdict(s: &str) -> JudgeVerdict {
+    match s {
+        "tp" => JudgeVerdict::Approved,
+        "fp" => JudgeVerdict::Rejected,
+        "uncertain" => JudgeVerdict::Uncertain,
+        _ => JudgeVerdict::Uncertain,
+    }
+}
+
+/// Build the LLM prompt for judging a batch of AST-detected findings.
+///
+/// Each finding tuple is `(rule_id, title, line_start, line_end, evidence)`.
+pub fn build_judge_prompt(
+    source_code: &str,
+    findings: &[(String, String, u32, u32, String)],
+) -> String {
+    let mut prompt = String::from(
+        "You are a code review judge. For each AST-detected finding below, \
+         determine if it is a true positive (tp), false positive (fp), or \
+         uncertain based on the surrounding code context.\n\n",
+    );
+    prompt.push_str("Source code:\n```\n");
+    prompt.push_str(source_code);
+    prompt.push_str("\n```\n\nFindings to judge:\n");
+
+    for (i, (rule_id, title, start, end, evidence)) in findings.iter().enumerate() {
+        prompt.push_str(&format!(
+            "{}. rule_id=\"{}\", title=\"{}\", lines {}-{}, evidence=\"{}\"\n",
+            i + 1,
+            rule_id,
+            title,
+            start,
+            end,
+            evidence
+        ));
+    }
+
+    prompt.push_str(
+        "\nRespond with ONLY a JSON array. Each element: \
+         {\"rule_id\": \"...\", \"verdict\": \"tp\"|\"fp\"|\"uncertain\", \
+         \"confidence\": 0.0-1.0, \"reason\": \"...\"}\n",
+    );
+    prompt
+}
+
+// ---------------------------------------------------------------------------
+// Judge orchestrator
+// ---------------------------------------------------------------------------
+
+/// Aggregate counters for a single `judge_findings` invocation.
+#[derive(Debug, Default)]
+pub struct JudgeResult {
+    pub approved: u32,
+    pub rejected: u32,
+    pub uncertain: u32,
+    pub skipped: u32,
+    pub cache_hits: u32,
+    pub calls: u32,
+    pub latency_ms: u64,
+}
+
+/// Judge AST findings against their rule metadata.
+///
+/// - Findings with `judge: Skip` pass through unchanged.
+/// - Findings with `judge: Required` that are rejected get dropped.
+/// - Findings with `judge: Optional` that are rejected get confidence
+///   clamped to 0.05.
+#[allow(clippy::too_many_arguments, clippy::type_complexity)]
+pub fn judge_findings(
+    findings: &mut Vec<Finding>,
+    source_code: &str,
+    metadata: &HashMap<String, RuleMetadata>,
+    cache: &HashMap<String, CacheEntry>,
+    cache_path: &Path,
+    llm_call: Option<&dyn Fn(&str) -> Option<String>>,
+) -> JudgeResult {
+    let start = std::time::Instant::now();
+    let mut result = JudgeResult::default();
+
+    // Phase 1: Check cache and categorize
+    let mut to_judge: Vec<usize> = Vec::new();
+    for (i, f) in findings.iter_mut().enumerate() {
+        let meta = f
+            .rule_id
+            .as_ref()
+            .and_then(|rid| metadata.get(rid.as_str()))
+            .cloned()
+            .unwrap_or_default();
+
+        if meta.judge == JudgeRequirement::Skip {
+            f.judge_verdict = Some(JudgeVerdict::Skipped);
+            result.skipped += 1;
+            continue;
+        }
+
+        let evidence = f.evidence.first().map(|s| s.as_str()).unwrap_or("");
+        let rule_id = f.rule_id.as_deref().unwrap_or("");
+        let key = verdict_cache_key(rule_id, evidence);
+
+        if let Some(cached) = cache.get(&key) {
+            f.judge_verdict = Some(cached.verdict.clone());
+            f.judge_confidence = Some(cached.confidence);
+            result.cache_hits += 1;
+            match &cached.verdict {
+                JudgeVerdict::Approved => result.approved += 1,
+                JudgeVerdict::Rejected => result.rejected += 1,
+                JudgeVerdict::Uncertain => result.uncertain += 1,
+                JudgeVerdict::Skipped => result.skipped += 1,
+            }
+            continue;
+        }
+        to_judge.push(i);
+    }
+
+    // Phase 2: Batch LLM call for uncached findings
+    if !to_judge.is_empty() {
+        if let Some(llm) = llm_call {
+            let items: Vec<_> = to_judge
+                .iter()
+                .map(|&i| {
+                    let f = &findings[i];
+                    (
+                        f.rule_id.clone().unwrap_or_default(),
+                        f.title.clone(),
+                        f.line_start,
+                        f.line_end,
+                        f.evidence.first().cloned().unwrap_or_default(),
+                    )
+                })
+                .collect();
+
+            let prompt = build_judge_prompt(source_code, &items);
+            result.calls += 1;
+
+            if let Some(response) = llm(&prompt)
+                && let Ok(verdicts) =
+                    serde_json::from_str::<Vec<JudgeResponseItem>>(&response)
+            {
+                for v in &verdicts {
+                    if let Some(&i) = to_judge
+                        .iter()
+                        .find(|&&i| findings[i].rule_id.as_deref() == Some(&v.rule_id))
+                    {
+                        let verdict = parse_verdict(&v.verdict);
+                        let confidence = v.confidence.clamp(0.0, 1.0);
+                        findings[i].judge_verdict = Some(verdict.clone());
+                        findings[i].judge_confidence = Some(confidence);
+
+                        let evidence =
+                            findings[i].evidence.first().map(|s| s.as_str()).unwrap_or("");
+                        let key = verdict_cache_key(&v.rule_id, evidence);
+                        let _ = write_cache_entry(
+                            cache_path,
+                            &CacheEntry {
+                                cache_key: key,
+                                rule_id: v.rule_id.clone(),
+                                verdict: verdict.clone(),
+                                confidence,
+                                reason: v.reason.clone(),
+                                timestamp: Utc::now(),
+                            },
+                        );
+
+                        match verdict {
+                            JudgeVerdict::Approved => result.approved += 1,
+                            JudgeVerdict::Rejected => result.rejected += 1,
+                            _ => result.uncertain += 1,
+                        }
+                    }
+                }
+            }
+
+            // Any remaining unjudged findings (LLM didn't return verdict): mark uncertain
+            for &i in &to_judge {
+                if findings[i].judge_verdict.is_none() {
+                    findings[i].judge_verdict = Some(JudgeVerdict::Uncertain);
+                    result.uncertain += 1;
+                }
+            }
+        } else {
+            // No LLM available: mark all as uncertain
+            for &i in &to_judge {
+                findings[i].judge_verdict = Some(JudgeVerdict::Uncertain);
+                result.uncertain += 1;
+            }
+        }
+    }
+
+    // Phase 3: Apply rejection policy
+    findings.retain(|f| {
+        let meta = f
+            .rule_id
+            .as_ref()
+            .and_then(|rid| metadata.get(rid.as_str()))
+            .cloned()
+            .unwrap_or_default();
+
+        // Required + Rejected: drop finding entirely
+        if meta.judge == JudgeRequirement::Required
+            && f.judge_verdict == Some(JudgeVerdict::Rejected)
+        {
+            return false;
+        }
+
+        // Optional + Rejected: finding survives but confidence is clamped.
+        // judge_confidence is already set; compute_confidence will pick it up
+        // via the judge_confidence arm, pushing it to bottom of rankings.
+
+        true
+    });
+
+    result.latency_ms = start.elapsed().as_millis() as u64;
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::finding::{FindingBuilder, Source};
+
+    #[test]
+    fn cache_key_deterministic() {
+        let k1 = verdict_cache_key("ast-grep:python/bare-except-pass", "except:\n    pass");
+        let k2 = verdict_cache_key("ast-grep:python/bare-except-pass", "except:\n    pass");
+        assert_eq!(k1, k2);
+    }
+
+    #[test]
+    fn cache_key_differs_for_different_evidence() {
+        let k1 = verdict_cache_key("rule-a", "code1");
+        let k2 = verdict_cache_key("rule-a", "code2");
+        assert_ne!(k1, k2);
+    }
+
+    #[test]
+    fn cache_key_differs_for_different_rules() {
+        let k1 = verdict_cache_key("rule-a", "code");
+        let k2 = verdict_cache_key("rule-b", "code");
+        assert_ne!(k1, k2);
+    }
+
+    #[test]
+    fn cache_roundtrip() {
+        let dir = tempfile::tempdir().unwrap();
+        let cache_path = dir.path().join("judge_cache.jsonl");
+        let entry = CacheEntry {
+            cache_key: "abc123".into(),
+            rule_id: "ast-grep:python/test".into(),
+            verdict: JudgeVerdict::Approved,
+            confidence: 0.85,
+            reason: "looks good".into(),
+            timestamp: Utc::now(),
+        };
+        write_cache_entry(&cache_path, &entry).unwrap();
+        let loaded = load_cache(&cache_path).unwrap();
+        assert_eq!(loaded.len(), 1);
+        assert_eq!(loaded["abc123"].verdict, JudgeVerdict::Approved);
+    }
+
+    #[test]
+    fn cache_ttl_expires_old_entries() {
+        let dir = tempfile::tempdir().unwrap();
+        let cache_path = dir.path().join("judge_cache.jsonl");
+        let old_entry = CacheEntry {
+            cache_key: "old".into(),
+            rule_id: "rule".into(),
+            verdict: JudgeVerdict::Approved,
+            confidence: 0.9,
+            reason: String::new(),
+            timestamp: Utc::now() - chrono::Duration::days(8),
+        };
+        write_cache_entry(&cache_path, &old_entry).unwrap();
+        let loaded = load_cache(&cache_path).unwrap();
+        assert!(loaded.is_empty());
+    }
+
+    #[test]
+    fn parse_verdict_mapping() {
+        assert_eq!(parse_verdict("tp"), JudgeVerdict::Approved);
+        assert_eq!(parse_verdict("fp"), JudgeVerdict::Rejected);
+        assert_eq!(parse_verdict("uncertain"), JudgeVerdict::Uncertain);
+        assert_eq!(parse_verdict("garbage"), JudgeVerdict::Uncertain);
+    }
+
+    #[test]
+    fn judge_response_deserializes() {
+        let json = r#"[
+            {"rule_id": "ast-grep:python/test", "verdict": "tp", "confidence": 0.85, "reason": "valid"},
+            {"rule_id": "ast-grep:python/other", "verdict": "fp", "confidence": 0.92, "reason": "safe"}
+        ]"#;
+        let verdicts: Vec<JudgeResponseItem> = serde_json::from_str(json).unwrap();
+        assert_eq!(verdicts.len(), 2);
+        assert_eq!(verdicts[0].verdict, "tp");
+        assert_eq!(verdicts[1].verdict, "fp");
+    }
+
+    #[test]
+    fn judge_skips_high_precision_rules() {
+        let mut findings = vec![{
+            let mut f = FindingBuilder::new()
+                .source(Source::Linter("ast-grep".into()))
+                .rule_id("ast-grep:typescript/as-any-cast")
+                .build();
+            f.precision_tier = Some(PrecisionTier::High);
+            f
+        }];
+        let mut metadata = HashMap::new();
+        metadata.insert(
+            "ast-grep:typescript/as-any-cast".into(),
+            RuleMetadata {
+                precision: PrecisionTier::High,
+                judge: JudgeRequirement::Skip,
+            },
+        );
+        let dir = tempfile::tempdir().unwrap();
+        let cache_path = dir.path().join("cache.jsonl");
+        let result = judge_findings(
+            &mut findings,
+            "code",
+            &metadata,
+            &HashMap::new(),
+            &cache_path,
+            None,
+        );
+        assert_eq!(result.skipped, 1);
+        assert_eq!(findings[0].judge_verdict, Some(JudgeVerdict::Skipped));
+    }
+
+    #[test]
+    fn judge_approves_with_mock_llm() {
+        let mut findings = vec![{
+            let mut f = FindingBuilder::new()
+                .source(Source::Linter("ast-grep".into()))
+                .rule_id("ast-grep:python/broad-exception-catch")
+                .evidence("except Exception as e:")
+                .build();
+            f.precision_tier = Some(PrecisionTier::Speculative);
+            f
+        }];
+        let mut metadata = HashMap::new();
+        metadata.insert(
+            "ast-grep:python/broad-exception-catch".into(),
+            RuleMetadata {
+                precision: PrecisionTier::Speculative,
+                judge: JudgeRequirement::Required,
+            },
+        );
+        let dir = tempfile::tempdir().unwrap();
+        let cache_path = dir.path().join("cache.jsonl");
+        let mock_llm = |_prompt: &str| -> Option<String> {
+            Some(
+                r#"[{"rule_id":"ast-grep:python/broad-exception-catch","verdict":"tp","confidence":0.85,"reason":"valid"}]"#.into(),
+            )
+        };
+        let result = judge_findings(
+            &mut findings,
+            "source",
+            &metadata,
+            &HashMap::new(),
+            &cache_path,
+            Some(&mock_llm),
+        );
+        assert_eq!(result.approved, 1);
+        assert_eq!(result.calls, 1);
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].judge_verdict, Some(JudgeVerdict::Approved));
+        assert_eq!(findings[0].judge_confidence, Some(0.85));
+        // Verify cache was written
+        let loaded = load_cache(&cache_path).unwrap();
+        assert_eq!(loaded.len(), 1);
+    }
+
+    #[test]
+    fn judge_drops_required_rejected() {
+        let mut findings = vec![{
+            let mut f = FindingBuilder::new()
+                .source(Source::Linter("ast-grep".into()))
+                .rule_id("ast-grep:python/broad-exception-catch")
+                .evidence("except Exception:")
+                .build();
+            f.precision_tier = Some(PrecisionTier::Speculative);
+            f
+        }];
+        let mut metadata = HashMap::new();
+        metadata.insert(
+            "ast-grep:python/broad-exception-catch".into(),
+            RuleMetadata {
+                precision: PrecisionTier::Speculative,
+                judge: JudgeRequirement::Required,
+            },
+        );
+        let dir = tempfile::tempdir().unwrap();
+        let cache_path = dir.path().join("cache.jsonl");
+        let mock_llm = |_prompt: &str| -> Option<String> {
+            Some(
+                r#"[{"rule_id":"ast-grep:python/broad-exception-catch","verdict":"fp","confidence":0.92,"reason":"intentional top-level handler"}]"#.into(),
+            )
+        };
+        let result = judge_findings(
+            &mut findings,
+            "source",
+            &metadata,
+            &HashMap::new(),
+            &cache_path,
+            Some(&mock_llm),
+        );
+        assert_eq!(result.rejected, 1);
+        assert!(
+            findings.is_empty(),
+            "Required+Rejected finding should be dropped"
+        );
+    }
+
+    #[test]
+    fn judge_uses_cache_hit() {
+        let mut findings = vec![{
+            let mut f = FindingBuilder::new()
+                .source(Source::Linter("ast-grep".into()))
+                .rule_id("ast-grep:python/test")
+                .evidence("test code")
+                .build();
+            f.precision_tier = Some(PrecisionTier::Speculative);
+            f
+        }];
+        let mut metadata = HashMap::new();
+        metadata.insert(
+            "ast-grep:python/test".into(),
+            RuleMetadata {
+                precision: PrecisionTier::Speculative,
+                judge: JudgeRequirement::Required,
+            },
+        );
+        let key = verdict_cache_key("ast-grep:python/test", "test code");
+        let mut cache = HashMap::new();
+        cache.insert(
+            key,
+            CacheEntry {
+                cache_key: String::new(),
+                rule_id: "ast-grep:python/test".into(),
+                verdict: JudgeVerdict::Approved,
+                confidence: 0.9,
+                reason: "cached".into(),
+                timestamp: Utc::now(),
+            },
+        );
+        let dir = tempfile::tempdir().unwrap();
+        let cache_path = dir.path().join("cache.jsonl");
+        let result = judge_findings(
+            &mut findings,
+            "source",
+            &metadata,
+            &cache,
+            &cache_path,
+            None,
+        );
+        assert_eq!(result.cache_hits, 1);
+        assert_eq!(result.approved, 1);
+        assert_eq!(result.calls, 0);
+    }
+}

--- a/src/judge.rs
+++ b/src/judge.rs
@@ -544,4 +544,140 @@ mod tests {
         assert_eq!(result.approved, 1);
         assert_eq!(result.calls, 0);
     }
+
+    #[test]
+    fn judge_flow_end_to_end_with_cache() {
+        let mut findings = vec![
+            {
+                let mut f = FindingBuilder::new()
+                    .title("broad-exception-catch: Catching broad Exception")
+                    .source(Source::Linter("ast-grep".into()))
+                    .rule_id("ast-grep:python/broad-exception-catch")
+                    .evidence("except Exception as e:")
+                    .build();
+                f.precision_tier = Some(PrecisionTier::Speculative);
+                f
+            },
+            {
+                let mut f = FindingBuilder::new()
+                    .title("as-any-cast: as any cast")
+                    .source(Source::Linter("ast-grep".into()))
+                    .rule_id("ast-grep:typescript/as-any-cast")
+                    .evidence("foo as any")
+                    .build();
+                f.precision_tier = Some(PrecisionTier::High);
+                f
+            },
+        ];
+
+        let mut metadata = HashMap::new();
+        metadata.insert(
+            "ast-grep:python/broad-exception-catch".into(),
+            RuleMetadata {
+                precision: PrecisionTier::Speculative,
+                judge: JudgeRequirement::Required,
+            },
+        );
+        metadata.insert(
+            "ast-grep:typescript/as-any-cast".into(),
+            RuleMetadata {
+                precision: PrecisionTier::High,
+                judge: JudgeRequirement::Skip,
+            },
+        );
+
+        let dir = tempfile::tempdir().unwrap();
+        let cache_path = dir.path().join("cache.jsonl");
+        let cache = HashMap::new();
+
+        // Mock LLM: always approve
+        let mock_llm = |_prompt: &str| -> Option<String> {
+            Some(r#"[{"rule_id":"ast-grep:python/broad-exception-catch","verdict":"tp","confidence":0.85,"reason":"valid"}]"#.into())
+        };
+
+        let result = judge_findings(
+            &mut findings,
+            "source code here",
+            &metadata,
+            &cache,
+            &cache_path,
+            Some(&mock_llm),
+        );
+
+        assert_eq!(result.approved, 1);
+        assert_eq!(result.skipped, 1);
+        assert_eq!(findings.len(), 2); // none dropped (approved)
+        assert_eq!(findings[0].judge_verdict, Some(JudgeVerdict::Approved));
+        assert_eq!(findings[0].judge_confidence, Some(0.85));
+        assert_eq!(findings[1].judge_verdict, Some(JudgeVerdict::Skipped)); // skipped
+
+        // Verify cache was written
+        let loaded_cache = load_cache(&cache_path).unwrap();
+        assert_eq!(loaded_cache.len(), 1);
+    }
+
+    #[test]
+    fn judge_drops_required_rejected_findings() {
+        let mut findings = vec![
+            {
+                let mut f = FindingBuilder::new()
+                    .title("broad-exception-catch: Catching broad Exception")
+                    .source(Source::Linter("ast-grep".into()))
+                    .rule_id("ast-grep:python/broad-exception-catch")
+                    .evidence("except Exception as e:")
+                    .build();
+                f.precision_tier = Some(PrecisionTier::Speculative);
+                f
+            },
+            {
+                let mut f = FindingBuilder::new()
+                    .title("as-any-cast: as any cast")
+                    .source(Source::Linter("ast-grep".into()))
+                    .rule_id("ast-grep:typescript/as-any-cast")
+                    .evidence("foo as any")
+                    .build();
+                f.precision_tier = Some(PrecisionTier::High);
+                f
+            },
+        ];
+
+        let mut metadata = HashMap::new();
+        metadata.insert(
+            "ast-grep:python/broad-exception-catch".into(),
+            RuleMetadata {
+                precision: PrecisionTier::Speculative,
+                judge: JudgeRequirement::Required,
+            },
+        );
+        metadata.insert(
+            "ast-grep:typescript/as-any-cast".into(),
+            RuleMetadata {
+                precision: PrecisionTier::High,
+                judge: JudgeRequirement::Skip,
+            },
+        );
+
+        let dir = tempfile::tempdir().unwrap();
+        let cache_path = dir.path().join("cache.jsonl");
+        let cache = HashMap::new();
+
+        // Mock LLM: rejects the speculative finding
+        let mock_llm = |_prompt: &str| -> Option<String> {
+            Some(r#"[{"rule_id":"ast-grep:python/broad-exception-catch","verdict":"fp","confidence":0.92,"reason":"intentional"}]"#.into())
+        };
+
+        let result = judge_findings(
+            &mut findings,
+            "code",
+            &metadata,
+            &cache,
+            &cache_path,
+            Some(&mock_llm),
+        );
+
+        assert_eq!(result.rejected, 1);
+        assert_eq!(result.skipped, 1);
+        assert_eq!(findings.len(), 1); // speculative finding was DROPPED
+        assert_eq!(findings[0].title, "as-any-cast: as any cast"); // only the high-precision one remains
+    }
 }

--- a/src/linter.rs
+++ b/src/linter.rs
@@ -296,6 +296,9 @@ pub fn normalize_ruff_output(json_output: &str) -> anyhow::Result<Vec<Finding>> 
             grounding_confidence: None,
             model_agreement: None,
             rule_id: None,
+            judge_verdict: None,
+            judge_confidence: None,
+            precision_tier: None,
         });
     }
 
@@ -360,6 +363,9 @@ pub fn normalize_clippy_output(json_output: &str) -> anyhow::Result<Vec<Finding>
             grounding_confidence: None,
             model_agreement: None,
             rule_id: None,
+            judge_verdict: None,
+            judge_confidence: None,
+            precision_tier: None,
         });
     }
 
@@ -412,6 +418,9 @@ pub fn normalize_eslint_output(json_output: &str) -> anyhow::Result<Vec<Finding>
                 grounding_confidence: None,
                 model_agreement: None,
                 rule_id: None,
+                judge_verdict: None,
+                judge_confidence: None,
+                precision_tier: None,
             });
         }
     }
@@ -478,6 +487,9 @@ pub fn normalize_yamllint_output(output: &str) -> anyhow::Result<Vec<Finding>> {
             grounding_confidence: None,
             model_agreement: None,
             rule_id: None,
+            judge_verdict: None,
+            judge_confidence: None,
+            precision_tier: None,
         });
     }
     Ok(findings)
@@ -527,6 +539,9 @@ pub fn normalize_shellcheck_output(json_output: &str) -> anyhow::Result<Vec<Find
                 grounding_confidence: None,
                 model_agreement: None,
                 rule_id: None,
+                judge_verdict: None,
+                judge_confidence: None,
+                precision_tier: None,
             });
         }
     }
@@ -593,6 +608,9 @@ pub fn normalize_hadolint_output(output: &str) -> anyhow::Result<Vec<Finding>> {
             grounding_confidence: None,
             model_agreement: None,
             rule_id: None,
+            judge_verdict: None,
+            judge_confidence: None,
+            precision_tier: None,
         });
     }
     Ok(findings)
@@ -643,6 +661,9 @@ pub fn normalize_tflint_output(json_output: &str) -> anyhow::Result<Vec<Finding>
                 grounding_confidence: None,
                 model_agreement: None,
                 rule_id: None,
+                judge_verdict: None,
+                judge_confidence: None,
+                precision_tier: None,
             });
         }
     }

--- a/src/linter.rs
+++ b/src/linter.rs
@@ -295,6 +295,7 @@ pub fn normalize_ruff_output(json_output: &str) -> anyhow::Result<Vec<Finding>> 
             grounding_status: None,
             grounding_confidence: None,
             model_agreement: None,
+            rule_id: None,
         });
     }
 
@@ -358,6 +359,7 @@ pub fn normalize_clippy_output(json_output: &str) -> anyhow::Result<Vec<Finding>
             grounding_status: None,
             grounding_confidence: None,
             model_agreement: None,
+            rule_id: None,
         });
     }
 
@@ -409,6 +411,7 @@ pub fn normalize_eslint_output(json_output: &str) -> anyhow::Result<Vec<Finding>
                 grounding_status: None,
                 grounding_confidence: None,
                 model_agreement: None,
+                rule_id: None,
             });
         }
     }
@@ -474,6 +477,7 @@ pub fn normalize_yamllint_output(output: &str) -> anyhow::Result<Vec<Finding>> {
             grounding_status: None,
             grounding_confidence: None,
             model_agreement: None,
+            rule_id: None,
         });
     }
     Ok(findings)
@@ -522,6 +526,7 @@ pub fn normalize_shellcheck_output(json_output: &str) -> anyhow::Result<Vec<Find
                 grounding_status: None,
                 grounding_confidence: None,
                 model_agreement: None,
+                rule_id: None,
             });
         }
     }
@@ -587,6 +592,7 @@ pub fn normalize_hadolint_output(output: &str) -> anyhow::Result<Vec<Finding>> {
             grounding_status: None,
             grounding_confidence: None,
             model_agreement: None,
+            rule_id: None,
         });
     }
     Ok(findings)
@@ -636,6 +642,7 @@ pub fn normalize_tflint_output(json_output: &str) -> anyhow::Result<Vec<Finding>
                 grounding_status: None,
                 grounding_confidence: None,
                 model_agreement: None,
+                rule_id: None,
             });
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -200,10 +200,7 @@ async fn main() -> anyhow::Result<()> {
                         );
                     }
                     if slices.iter().any(|s| s.low_sample) {
-                        println!(
-                            "\n* = low sample (<{} entries)",
-                            dimensions::MIN_SAMPLE
-                        );
+                        println!("\n* = low sample (<{} entries)", dimensions::MIN_SAMPLE);
                     }
                 }
                 std::process::exit(0);

--- a/src/main.rs
+++ b/src/main.rs
@@ -40,6 +40,7 @@ mod enrichment_policy;
 mod formatting;
 mod glyphs;
 mod http_server;
+mod judge;
 mod linter;
 mod llm_client;
 mod mcp;

--- a/src/main.rs
+++ b/src/main.rs
@@ -155,6 +155,60 @@ async fn main() -> anyhow::Result<()> {
             // Context dims (Task 6.3): --by-source/--by-reviewed-repo/--misleading.
             // Context dims compose with --rolling by restricting aggregation to
             // the chronologically-last N records.
+            if opts.by_rule {
+                let fb_store = feedback::FeedbackStore::new(quorum_home.join("feedback.jsonl"));
+                let entries = match fb_store.load_all() {
+                    Ok(e) => e,
+                    Err(e) => {
+                        eprintln!("error: cannot read feedback store: {e}");
+                        std::process::exit(3);
+                    }
+                };
+                let slices = dimensions::group_by_rule(&entries, opts.rule.as_deref());
+
+                let is_pipe = !std::io::IsTerminal::is_terminal(&std::io::stdout());
+                let use_compact = output::should_use_compact(opts.compact);
+                let use_json = opts.json || (is_pipe && !use_compact);
+
+                if use_json {
+                    let payload = serde_json::json!({
+                        "mode": "by-rule",
+                        "rows": slices,
+                        "meta": {
+                            "total_feedback_entries": entries.len(),
+                            "filter": opts.rule,
+                        },
+                    });
+                    println!("{}", serde_json::to_string_pretty(&payload).unwrap());
+                } else {
+                    println!(
+                        "{:<55} {:>4} {:>4} {:>4} {:>4} {:>6} {:>5}",
+                        "Rule", "TP", "FP", "Part", "Won't", "Prec%", "Total"
+                    );
+                    println!("{}", "-".repeat(85));
+                    for s in &slices {
+                        println!(
+                            "{:<55} {:>4} {:>4} {:>4} {:>4} {:>5.1}% {:>5}{}",
+                            s.key,
+                            s.tp,
+                            s.fp,
+                            s.partial,
+                            s.wontfix,
+                            s.precision * 100.0,
+                            s.total,
+                            if s.low_sample { " *" } else { "" }
+                        );
+                    }
+                    if slices.iter().any(|s| s.low_sample) {
+                        println!(
+                            "\n* = low sample (<{} entries)",
+                            dimensions::MIN_SAMPLE
+                        );
+                    }
+                }
+                std::process::exit(0);
+            }
+
             if opts.by_file {
                 let fb_store = feedback::FeedbackStore::new(quorum_home.join("feedback.jsonl"));
                 let entries = match fb_store.load_all() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -180,7 +180,13 @@ async fn main() -> anyhow::Result<()> {
                             "filter": opts.rule,
                         },
                     });
-                    println!("{}", serde_json::to_string_pretty(&payload).unwrap());
+                    match serde_json::to_string_pretty(&payload) {
+                        Ok(json) => println!("{json}"),
+                        Err(e) => {
+                            eprintln!("error: failed to serialize --by-rule output: {e}");
+                            std::process::exit(3);
+                        }
+                    }
                 } else {
                     println!(
                         "{:<55} {:>4} {:>4} {:>4} {:>4} {:>6} {:>5}",
@@ -1100,7 +1106,11 @@ async fn run_review(opts: cli::ReviewOpts) -> i32 {
         judge_model: opts
             .judge_model
             .clone()
-            .or_else(|| std::env::var("QUORUM_JUDGE_MODEL").ok())
+            .or_else(|| {
+                std::env::var("QUORUM_JUDGE_MODEL")
+                    .ok()
+                    .filter(|s| !s.is_empty())
+            })
             .unwrap_or_else(|| "gpt-5-nano".into()),
         ..Default::default()
     };

--- a/src/main.rs
+++ b/src/main.rs
@@ -1093,6 +1093,15 @@ async fn run_review(opts: cli::ReviewOpts) -> i32 {
         calibrator_config,
         mode: opts.mode,
         registry_client,
+        judge_enabled: opts.judge
+            || std::env::var("QUORUM_JUDGE")
+                .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+                .unwrap_or(false),
+        judge_model: opts
+            .judge_model
+            .clone()
+            .or_else(|| std::env::var("QUORUM_JUDGE_MODEL").ok())
+            .unwrap_or_else(|| "gpt-5-nano".into()),
         ..Default::default()
     };
 
@@ -1389,6 +1398,7 @@ async fn run_review(opts: cli::ReviewOpts) -> i32 {
                                 suppressed: sup_result.suppressed.len(),
                                 context_telemetry: None,
                                 enrichment_metrics: Default::default(),
+                                judge_metrics: Default::default(),
                             };
                             return (idx, Ok((result, sup_result.suppressed)));
                         }
@@ -1588,6 +1598,13 @@ async fn run_review(opts: cli::ReviewOpts) -> i32 {
             fp_kind_utilization_rate: feedback::compute_fp_kind_utilization_rate(
                 &pipeline_cfg.feedback,
             ),
+            judge_calls: file_results.iter().map(|r| r.judge_metrics.calls).sum(),
+            judge_approved: file_results.iter().map(|r| r.judge_metrics.approved).sum(),
+            judge_rejected: file_results.iter().map(|r| r.judge_metrics.rejected).sum(),
+            judge_uncertain: file_results.iter().map(|r| r.judge_metrics.uncertain).sum(),
+            judge_skipped: file_results.iter().map(|r| r.judge_metrics.skipped).sum(),
+            judge_cache_hits: file_results.iter().map(|r| r.judge_metrics.cache_hits).sum(),
+            judge_latency_ms: file_results.iter().map(|r| r.judge_metrics.latency_ms).sum(),
         };
         let _ = telem_store.record(&telem_entry);
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1603,8 +1603,14 @@ async fn run_review(opts: cli::ReviewOpts) -> i32 {
             judge_rejected: file_results.iter().map(|r| r.judge_metrics.rejected).sum(),
             judge_uncertain: file_results.iter().map(|r| r.judge_metrics.uncertain).sum(),
             judge_skipped: file_results.iter().map(|r| r.judge_metrics.skipped).sum(),
-            judge_cache_hits: file_results.iter().map(|r| r.judge_metrics.cache_hits).sum(),
-            judge_latency_ms: file_results.iter().map(|r| r.judge_metrics.latency_ms).sum(),
+            judge_cache_hits: file_results
+                .iter()
+                .map(|r| r.judge_metrics.cache_hits)
+                .sum(),
+            judge_latency_ms: file_results
+                .iter()
+                .map(|r| r.judge_metrics.latency_ms)
+                .sum(),
         };
         let _ = telem_store.record(&telem_entry);
 

--- a/src/merge.rs
+++ b/src/merge.rs
@@ -28,6 +28,22 @@ pub fn merge_findings(
                         existing.evidence.push(e.clone());
                     }
                 }
+                // Mixed-source confidence: take max of judge/grounding confidence
+                if let Some(jc) = finding.judge_confidence {
+                    match existing.judge_confidence {
+                        Some(ec) => existing.judge_confidence = Some(ec.max(jc)),
+                        None => existing.judge_confidence = Some(jc),
+                    }
+                }
+                if finding.judge_verdict.is_some() && existing.judge_verdict.is_none() {
+                    existing.judge_verdict = finding.judge_verdict.clone();
+                }
+                if let Some(gc) = finding.grounding_confidence {
+                    match existing.grounding_confidence {
+                        Some(ec) => existing.grounding_confidence = Some(ec.max(gc)),
+                        None => existing.grounding_confidence = Some(gc),
+                    }
+                }
                 if let Source::Llm(ref model) = finding.source {
                     llm_model_names[idx].insert(model.clone());
                 }

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -121,6 +121,20 @@ pub struct FileReviewResult {
     /// Per-file Context7 enrichment counters (resolved/resolve_failed/query_failed).
     /// Aggregated into TelemetryEntry by main.rs.
     pub enrichment_metrics: crate::context_enrichment::EnrichmentMetrics,
+    /// Per-file judge telemetry counters. Aggregated into TelemetryEntry by main.rs.
+    pub judge_metrics: JudgeMetrics,
+}
+
+/// Per-file judge result counters, propagated from pipeline to TelemetryEntry.
+#[derive(Clone, Debug, Default)]
+pub struct JudgeMetrics {
+    pub approved: u32,
+    pub rejected: u32,
+    pub uncertain: u32,
+    pub skipped: u32,
+    pub cache_hits: u32,
+    pub calls: u32,
+    pub latency_ms: u64,
 }
 
 pub struct PipelineConfig {
@@ -180,6 +194,10 @@ pub struct PipelineConfig {
     /// When `None` (default / Phase 1), the policy relies on the skip-list
     /// and quality gate only — no network calls to crates.io / npm / PyPI.
     pub registry_client: Option<std::sync::Arc<dyn crate::enrichment_policy::RegistryClient>>,
+    /// Enable LLM micro-judge for speculative AST rules (--judge / QUORUM_JUDGE=1)
+    pub judge_enabled: bool,
+    /// Model for judge calls (--judge-model / QUORUM_JUDGE_MODEL / default gpt-5-nano)
+    pub judge_model: String,
 }
 
 impl Default for PipelineConfig {
@@ -205,6 +223,8 @@ impl Default for PipelineConfig {
             calibrator_config: CalibratorConfig::default(),
             mode: crate::review_mode::ReviewMode::Code,
             registry_client: None,
+            judge_enabled: false,
+            judge_model: "gpt-5-nano".into(),
         }
     }
 }
@@ -670,6 +690,8 @@ pub async fn review_file(
 
     // Source 2: ast-grep library rules (skipped for prose reviews)
     let ext = file_path.extension().and_then(|e| e.to_str()).unwrap_or("");
+    let mut rule_metadata: std::collections::HashMap<String, crate::ast_grep::RuleMetadata> =
+        std::collections::HashMap::new();
     if !pipeline_config.mode.is_prose() && ast_grep::ext_to_language(ext).is_some() {
         let _span = tracing::info_span!("phase.ast_grep", file = %file_str).entered();
         let t0 = std::time::Instant::now();
@@ -678,7 +700,8 @@ pub async fn review_file(
             .or_else(|_| std::env::var("USERPROFILE"))
             .map(std::path::PathBuf::from)
             .unwrap_or_default();
-        let (rules, rule_metadata) = ast_grep::load_rules(&project_root, &home_dir);
+        let (rules, loaded_metadata) = ast_grep::load_rules(&project_root, &home_dir);
+        rule_metadata = loaded_metadata;
         let mut ag_count = 0;
         if !rules.is_empty() {
             let ag_findings = ast_grep::scan_file(source, ext, &rules, &rule_metadata);
@@ -692,6 +715,45 @@ pub async fn review_file(
             duration_ms = t0.elapsed().as_millis() as u64,
             rules = rules.len(),
             findings = ag_count,
+            "phase complete"
+        );
+    }
+
+    // Source 2b: Judge speculative AST findings (if enabled).
+    // Only runs on ast-grep findings (index 1+), not local AST (index 0).
+    let mut judge_metrics = JudgeMetrics::default();
+    if pipeline_config.judge_enabled && !rule_metadata.is_empty() {
+        let _span = tracing::info_span!("phase.judge", file = %file_str).entered();
+        let home_dir = std::env::var("HOME")
+            .or_else(|_| std::env::var("USERPROFILE"))
+            .map(std::path::PathBuf::from)
+            .unwrap_or_default();
+        let cache_path = home_dir.join(".quorum").join("judge_cache.jsonl");
+        let cache = crate::judge::load_cache(&cache_path).unwrap_or_default();
+
+        for source_findings in all_sources.iter_mut().skip(1) {
+            let result = crate::judge::judge_findings(
+                source_findings,
+                source,
+                &rule_metadata,
+                &cache,
+                &cache_path,
+                None, // LLM client not wired yet -- cache-only + skip for now
+            );
+            judge_metrics.approved += result.approved;
+            judge_metrics.rejected += result.rejected;
+            judge_metrics.uncertain += result.uncertain;
+            judge_metrics.skipped += result.skipped;
+            judge_metrics.cache_hits += result.cache_hits;
+            judge_metrics.calls += result.calls;
+            judge_metrics.latency_ms += result.latency_ms;
+        }
+        tracing::info!(
+            phase = "judge",
+            approved = judge_metrics.approved,
+            rejected = judge_metrics.rejected,
+            skipped = judge_metrics.skipped,
+            cache_hits = judge_metrics.cache_hits,
             "phase complete"
         );
     }
@@ -1095,6 +1157,7 @@ pub async fn review_file(
         suppressed: suppressed_count,
         context_telemetry,
         enrichment_metrics,
+        judge_metrics,
     })
 }
 
@@ -1514,6 +1577,7 @@ pub async fn review_file_llm_only(
         suppressed: suppressed_count,
         context_telemetry: None,
         enrichment_metrics,
+        judge_metrics: JudgeMetrics::default(),
     })
 }
 

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -752,8 +752,11 @@ pub async fn review_file(
             phase = "judge",
             approved = judge_metrics.approved,
             rejected = judge_metrics.rejected,
+            uncertain = judge_metrics.uncertain,
             skipped = judge_metrics.skipped,
             cache_hits = judge_metrics.cache_hits,
+            calls = judge_metrics.calls,
+            latency_ms = judge_metrics.latency_ms,
             "phase complete"
         );
     }

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -678,10 +678,10 @@ pub async fn review_file(
             .or_else(|_| std::env::var("USERPROFILE"))
             .map(std::path::PathBuf::from)
             .unwrap_or_default();
-        let rules = ast_grep::load_rules(&project_root, &home_dir);
+        let (rules, rule_metadata) = ast_grep::load_rules(&project_root, &home_dir);
         let mut ag_count = 0;
         if !rules.is_empty() {
-            let ag_findings = ast_grep::scan_file(source, ext, &rules);
+            let ag_findings = ast_grep::scan_file(source, ext, &rules, &rule_metadata);
             ag_count = ag_findings.len();
             if !ag_findings.is_empty() {
                 all_sources.push(ag_findings);

--- a/src/review.rs
+++ b/src/review.rs
@@ -157,6 +157,9 @@ impl LlmFinding {
             grounding_confidence: None,
             model_agreement: None,
             rule_id: None,
+            judge_verdict: None,
+            judge_confidence: None,
+            precision_tier: None,
         }
     }
 }

--- a/src/review.rs
+++ b/src/review.rs
@@ -156,6 +156,7 @@ impl LlmFinding {
             grounding_status: None,
             grounding_confidence: None,
             model_agreement: None,
+            rule_id: None,
         }
     }
 }

--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -338,6 +338,13 @@ mod tests {
         assert_eq!(entry.context7_query_failed, 0);
         assert_eq!(entry.context7_skipped_popular, 0);
         assert_eq!(entry.context7_budget_reduced, 0);
+        assert_eq!(entry.judge_calls, 0);
+        assert_eq!(entry.judge_approved, 0);
+        assert_eq!(entry.judge_rejected, 0);
+        assert_eq!(entry.judge_uncertain, 0);
+        assert_eq!(entry.judge_skipped, 0);
+        assert_eq!(entry.judge_cache_hits, 0);
+        assert_eq!(entry.judge_latency_ms, 0);
     }
 
     #[test]

--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -32,6 +32,20 @@ pub struct TelemetryEntry {
     /// with pre-bump rows.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub fp_kind_utilization_rate: Option<f32>,
+    #[serde(default)]
+    pub judge_calls: u32,
+    #[serde(default)]
+    pub judge_approved: u32,
+    #[serde(default)]
+    pub judge_rejected: u32,
+    #[serde(default)]
+    pub judge_uncertain: u32,
+    #[serde(default)]
+    pub judge_skipped: u32,
+    #[serde(default)]
+    pub judge_cache_hits: u32,
+    #[serde(default)]
+    pub judge_latency_ms: u64,
 }
 
 /// Structured per-line parse failure surfaced by `load_all_with_stats`.
@@ -284,6 +298,13 @@ mod tests {
             context7_skipped_popular: 0,
             context7_budget_reduced: 0,
             fp_kind_utilization_rate: None,
+            judge_calls: 0,
+            judge_approved: 0,
+            judge_rejected: 0,
+            judge_uncertain: 0,
+            judge_skipped: 0,
+            judge_cache_hits: 0,
+            judge_latency_ms: 0,
         }
     }
 

--- a/tests/finding_schema_test.rs
+++ b/tests/finding_schema_test.rs
@@ -25,6 +25,7 @@ fn finding_with_new_fields_roundtrips() {
         grounding_status: None,
         grounding_confidence: None,
         model_agreement: None,
+        rule_id: None,
     };
 
     let json = serde_json::to_string(&finding).unwrap();
@@ -79,6 +80,7 @@ fn new_fields_omitted_from_json_when_none() {
         grounding_status: None,
         grounding_confidence: None,
         model_agreement: None,
+        rule_id: None,
     };
 
     let json = serde_json::to_string(&finding).unwrap();
@@ -113,6 +115,7 @@ fn category_serializes_as_kebab_case_in_finding() {
         grounding_status: None,
         grounding_confidence: None,
         model_agreement: None,
+        rule_id: None,
     };
 
     let json = serde_json::to_string(&finding).unwrap();

--- a/tests/finding_schema_test.rs
+++ b/tests/finding_schema_test.rs
@@ -26,6 +26,9 @@ fn finding_with_new_fields_roundtrips() {
         grounding_confidence: None,
         model_agreement: None,
         rule_id: None,
+        judge_verdict: None,
+        judge_confidence: None,
+        precision_tier: None,
     };
 
     let json = serde_json::to_string(&finding).unwrap();
@@ -81,6 +84,9 @@ fn new_fields_omitted_from_json_when_none() {
         grounding_confidence: None,
         model_agreement: None,
         rule_id: None,
+        judge_verdict: None,
+        judge_confidence: None,
+        precision_tier: None,
     };
 
     let json = serde_json::to_string(&finding).unwrap();
@@ -116,6 +122,9 @@ fn category_serializes_as_kebab_case_in_finding() {
         grounding_confidence: None,
         model_agreement: None,
         rule_id: None,
+        judge_verdict: None,
+        judge_confidence: None,
+        precision_tier: None,
     };
 
     let json = serde_json::to_string(&finding).unwrap();

--- a/tests/finding_schema_test.rs
+++ b/tests/finding_schema_test.rs
@@ -95,6 +95,10 @@ fn new_fields_omitted_from_json_when_none() {
     assert!(!json.contains("cited_lines"));
     assert!(!json.contains("grounding_confidence"));
     assert!(!json.contains("model_agreement"));
+    assert!(!json.contains("rule_id"));
+    assert!(!json.contains("judge_verdict"));
+    assert!(!json.contains("judge_confidence"));
+    assert!(!json.contains("precision_tier"));
 }
 
 #[test]

--- a/tests/lib_integration_smoke.rs
+++ b/tests/lib_integration_smoke.rs
@@ -41,6 +41,7 @@ fn lib_exports_are_reachable_from_integration_tests() {
         grounding_status: None,
         grounding_confidence: None,
         model_agreement: None,
+        rule_id: None,
     };
 
     // calibrate(...) must be callable with no precedents — exercises the

--- a/tests/lib_integration_smoke.rs
+++ b/tests/lib_integration_smoke.rs
@@ -42,6 +42,9 @@ fn lib_exports_are_reachable_from_integration_tests() {
         grounding_confidence: None,
         model_agreement: None,
         rule_id: None,
+        judge_verdict: None,
+        judge_confidence: None,
+        precision_tier: None,
     };
 
     // calibrate(...) must be callable with no precedents — exercises the


### PR DESCRIPTION
## Summary

Two-phase implementation of the AST Finding Judge system:

**Phase 1 — Rule Identity & Per-Rule Stats**
- Added `rule_id: Option<String>` to `Finding` struct, populated at all 61 LocalAst construction sites and all ast-grep scan sites
- Format: `ast-grep:{lang}/{rule.id}` for ast-grep rules, `local-ast:{lang}/{pattern}` for built-in patterns
- New `stats --by-rule` CLI dimension with glob filtering (`--rule "ast-grep:python/*"`)

**Phase 2 — Judge Infrastructure**
- `PrecisionTier` (High/Medium/Speculative), `JudgeRequirement` (Required/Optional/Skip), `JudgeVerdict` (Approved/Rejected/Uncertain/Skipped) enums
- Tier-aware `compute_confidence`: speculative rules get 0.45-0.50 base (vs 0.90-0.95 for high-precision)
- Rule metadata parsing from ast-grep YAML `metadata:` blocks (precision + judge fields)
- `src/judge.rs` module: SHA-256 keyed verdict cache (7-day TTL), LLM judge client with batched prompts, rejection policy (Required+Rejected = drop, Optional+Rejected = clamp 0.05)
- Pipeline integration: judge stage between AST collection and merge, gated by `--judge` / `QUORUM_JUDGE=1`
- `JudgeMetrics` flow from pipeline → `FileReviewResult` → `TelemetryEntry`
- Mixed-source confidence precedence in merge (`max()` of judge_confidence and grounding_confidence)
- 7 pilot speculative rules (2 Python, 2 TypeScript, 2 Rust, 1 YAML) with `precision: speculative, judge: required`
- End-to-end integration tests for approve and reject flows

## Key design decisions

- Judge runs **before** merge, parallel with LLM reviewer (they are independent)
- Existing 53 high-precision rules are **unchanged** — precision defaults to High, judge defaults to Skip
- LLM judge client slot is wired but passes `None` (cache-only for now) — the pipeline plumbing is complete, model integration is a follow-up
- `judge_verdict` is separate from `calibrator_action` to distinguish machine vs human feedback

## Test plan

- [x] 1391 unit tests pass (28 new tests across finding, ast_grep, dimensions, judge, cli, telemetry)
- [x] Clippy clean (1 pre-existing warning)
- [x] Smoke test: `QUORUM_JUDGE=1 cargo run -- review /tmp/test.py --json` shows speculative findings with `precision_tier: "speculative"` and `judge_verdict: "skipped"`
- [x] `cargo run -- stats --by-rule` returns empty rows (expected — legacy feedback lacks rule_id)
- [x] Backward compat: all new fields use `serde(default, skip_serializing_if)`, old JSON deserializes correctly

Addresses #11, #17, #281

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Seven new lint rules across Python, Rust, TypeScript, and YAML (e.g., logging debug leaks, missing-await, discarded Result, string/byte-slice, nullish-coalescing, SQL-in-templates, Jinja scoping).
  * Per-rule aggregation and stats (--by-rule) with optional rule filtering and low-sample marking.
  * Optional LLM-backed micro-judge (--judge / --judge-model) with local verdict cache and judge metrics surfaced.

* **Documentation**
  * Added rollout plan and detailed design for per-rule IDs and the AST Finding Judge.

* **Chores**
  * Added YAML serialization dependency.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jsnyder/quorum/pull/311)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->