### PR TITLE
feat: in-diff classification for findings (#310)

### DIFF
--- a/docs/superpowers/plans/2026-05-12-in-diff-classification.md
+++ b/docs/superpowers/plans/2026-05-12-in-diff-classification.md
@@ -1,0 +1,1223 @@
+# In-Diff Classification Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Tag findings as in-diff vs pre-existing when `--diff-file` is active, propagate through calibrator/output/feedback, and apply a 0.7x confidence discount for out-of-diff verdicts.
+
+**Architecture:** A post-collection stamp pass classifies findings by range overlap against parsed diff hunks. The `in_diff: Option<bool>` field flows through Finding, CalibratorTraceEntry, and FeedbackEntry. Output groups findings into "In this change" vs "Pre-existing" sections. Exit codes only count in-diff findings.
+
+**Tech Stack:** Rust, serde, existing pipeline/calibrator infrastructure.
+
+---
+
+## File Map
+
+| File | Responsibility | Change |
+|------|---------------|--------|
+| `src/finding.rs` | Finding data model | Add `in_diff: Option<bool>`, update FindingBuilder |
+| `src/calibrator_trace.rs` | Trace observability | Add `in_diff: Option<bool>` |
+| `src/feedback.rs` | Feedback data model | Add `in_diff` to FeedbackEntry + ExternalVerdictInput |
+| `src/pipeline.rs` | Review pipeline | `classify_in_diff()` function + call site |
+| `src/calibrator.rs` | Calibration logic | `OUT_OF_DIFF_WEIGHT`, discount in `verdict_weight()`, trace passthrough |
+| `src/calibrate.rs` | Model building | Apply `in_diff_factor` in `compute_calibrator_model()` |
+| `src/output/mod.rs` | Output formatting | Grouped human/compact output, exit code scoping |
+| `src/cli/mod.rs` | CLI args | `--in-diff` / `--no-in-diff` flags |
+| `src/mcp/tools.rs` | MCP interface | `inDiff` field on FeedbackTool |
+| `src/main.rs` | Wiring | Pass `in_diff` through feedback recording, pass `has_diff` to exit code |
+
+---
+
+### Task 1: Add `in_diff` to Finding struct
+
+**Files:**
+- Modify: `src/finding.rs:78-116` (Finding struct)
+- Modify: `src/finding.rs:180-206` (FindingBuilder)
+
+- [ ] **Step 1: Write failing test for in_diff serde round-trip**
+
+Add to the existing `#[cfg(test)] mod tests` in `src/finding.rs`:
+
+```rust
+#[test]
+fn in_diff_serde_round_trip() {
+    let mut f = FindingBuilder::new().build();
+    assert_eq!(f.in_diff, None);
+
+    f.in_diff = Some(true);
+    let json = serde_json::to_string(&f).unwrap();
+    assert!(json.contains("\"in_diff\":true"));
+    let parsed: Finding = serde_json::from_str(&json).unwrap();
+    assert_eq!(parsed.in_diff, Some(true));
+
+    f.in_diff = Some(false);
+    let json = serde_json::to_string(&f).unwrap();
+    assert!(json.contains("\"in_diff\":false"));
+    let parsed: Finding = serde_json::from_str(&json).unwrap();
+    assert_eq!(parsed.in_diff, Some(false));
+}
+
+#[test]
+fn in_diff_omitted_deserializes_as_none() {
+    let json = r#"{"title":"t","description":"d","severity":"info","category":"maintainability","source":"local-ast","line_start":1,"line_end":1,"evidence":[],"similar_precedent":[]}"#;
+    let f: Finding = serde_json::from_str(json).unwrap();
+    assert_eq!(f.in_diff, None);
+}
+
+#[test]
+fn in_diff_none_not_serialized() {
+    let f = FindingBuilder::new().build();
+    let json = serde_json::to_string(&f).unwrap();
+    assert!(!json.contains("in_diff"));
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cargo test --bin quorum in_diff_serde_round_trip in_diff_omitted in_diff_none_not -- --nocapture`
+Expected: compile error — `in_diff` field doesn't exist on Finding.
+
+- [ ] **Step 3: Add `in_diff` field to Finding and FindingBuilder**
+
+In `src/finding.rs`, after the `model_agreement` field (line 115), add:
+
+```rust
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub in_diff: Option<bool>,
+```
+
+In `FindingBuilder::new()` (inside the `Finding` literal starting at line 183), after `model_agreement: None,` add:
+
+```rust
+                in_diff: None,
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cargo test --bin quorum in_diff_serde -- --nocapture`
+Expected: 3 tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/finding.rs
+git commit -m "feat(finding): add in_diff field for diff classification (#310)"
+```
+
+---
+
+### Task 2: Add `in_diff` to CalibratorTraceEntry
+
+**Files:**
+- Modify: `src/calibrator_trace.rs:63-90` (struct)
+- Modify: `src/calibrator_trace.rs:92+` (test module)
+
+- [ ] **Step 1: Write failing test**
+
+Add to the test module in `src/calibrator_trace.rs`:
+
+```rust
+#[test]
+fn trace_entry_in_diff_serde_round_trip() {
+    let mut trace = CalibratorTraceEntry {
+        finding_title: "test".into(),
+        finding_category: "security".into(),
+        tp_weight: 1.0,
+        fp_weight: 0.0,
+        wontfix_weight: 0.0,
+        full_suppress_weight: 0.0,
+        soft_fp_weight: 0.0,
+        matched_precedents: vec![],
+        action: None,
+        input_severity: Severity::Info,
+        output_severity: Severity::Info,
+        severity_change_reason: None,
+        file_path: None,
+        provenance: None,
+        same_file_precedent_count: None,
+        composite_score: None,
+        in_diff: Some(false),
+    };
+    let json = serde_json::to_string(&trace).unwrap();
+    assert!(json.contains("\"in_diff\":false"));
+    let parsed: CalibratorTraceEntry = serde_json::from_str(&json).unwrap();
+    assert_eq!(parsed.in_diff, Some(false));
+
+    trace.in_diff = None;
+    let json = serde_json::to_string(&trace).unwrap();
+    assert!(!json.contains("in_diff"));
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test --bin quorum trace_entry_in_diff_serde -- --nocapture`
+Expected: compile error — `in_diff` field doesn't exist.
+
+- [ ] **Step 3: Add `in_diff` field to CalibratorTraceEntry**
+
+In `src/calibrator_trace.rs`, after `composite_score` field (line 89), add:
+
+```rust
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub in_diff: Option<bool>,
+```
+
+Then fix all construction sites. In `src/calibrator.rs`, function `make_trace_entry` (line 142), add `in_diff: None,` after `composite_score: None,`. Similarly in `make_no_match_trace` (around line 100), add `in_diff: None,`. Also fix any test construction sites in `src/calibrator_trace.rs` tests.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cargo test --bin quorum trace_entry_in_diff -- --nocapture`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/calibrator_trace.rs src/calibrator.rs
+git commit -m "feat(trace): add in_diff to CalibratorTraceEntry (#310)"
+```
+
+---
+
+### Task 3: Add `in_diff` to FeedbackEntry and ExternalVerdictInput
+
+**Files:**
+- Modify: `src/feedback.rs:90-120` (FeedbackEntry)
+- Modify: `src/feedback.rs:128-140` (ExternalVerdictInput)
+- Modify: `src/feedback.rs:766+` (record_external)
+- Modify: `src/feedback.rs:815+` (record_context_misleading)
+
+- [ ] **Step 1: Write failing test**
+
+Add to the test module in `src/feedback.rs`:
+
+```rust
+#[test]
+fn feedback_in_diff_serde_round_trip() {
+    let entry = FeedbackEntry {
+        file_path: "test.rs".into(),
+        finding_title: "test".into(),
+        finding_category: "security".into(),
+        verdict: Verdict::Tp,
+        reason: "real bug".into(),
+        model: None,
+        timestamp: chrono::Utc::now(),
+        provenance: Provenance::Human,
+        fp_kind: None,
+        finding_id: None,
+        rule_id: None,
+        in_diff: Some(true),
+    };
+    let json = serde_json::to_string(&entry).unwrap();
+    assert!(json.contains("\"in_diff\":true"));
+    let parsed: FeedbackEntry = serde_json::from_str(&json).unwrap();
+    assert_eq!(parsed.in_diff, Some(true));
+}
+
+#[test]
+fn feedback_in_diff_omitted_is_none() {
+    let json = r#"{"file_path":"t.rs","finding_title":"t","finding_category":"c","verdict":"tp","reason":"r","timestamp":"2026-01-01T00:00:00Z","provenance":"human"}"#;
+    let parsed: FeedbackEntry = serde_json::from_str(json).unwrap();
+    assert_eq!(parsed.in_diff, None);
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cargo test --bin quorum feedback_in_diff -- --nocapture`
+Expected: compile error — `in_diff` field doesn't exist.
+
+- [ ] **Step 3: Add `in_diff` to FeedbackEntry and ExternalVerdictInput**
+
+In `src/feedback.rs`, FeedbackEntry struct (after `rule_id` field, line 119), add:
+
+```rust
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub in_diff: Option<bool>,
+```
+
+In ExternalVerdictInput (after `confidence` field, around line 137), add:
+
+```rust
+    pub in_diff: Option<bool>,
+```
+
+In `record_external()` (around line 785), add `in_diff: input.in_diff,` to the FeedbackEntry construction.
+
+In `record_context_misleading()` (around line 830), add `in_diff: None,` to the FeedbackEntry construction.
+
+Fix all other FeedbackEntry construction sites (search for `FeedbackEntry {` — there are several in tests and in `run_feedback_inner` in `src/main.rs`).
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cargo test --bin quorum feedback_in_diff -- --nocapture`
+Expected: PASS. Also run `cargo check` to find any remaining construction sites.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/feedback.rs src/main.rs
+git commit -m "feat(feedback): add in_diff to FeedbackEntry and ExternalVerdictInput (#310)"
+```
+
+---
+
+### Task 4: Implement `classify_in_diff` function
+
+**Files:**
+- Modify: `src/pipeline.rs` (add function + tests)
+
+- [ ] **Step 1: Write failing tests**
+
+Add to the test module in `src/pipeline.rs`:
+
+```rust
+#[test]
+fn classify_in_diff_tags_overlapping_findings() {
+    use crate::finding::FindingBuilder;
+    let mut findings = vec![
+        FindingBuilder::new().line_start(10).line_end(20).build(),
+        FindingBuilder::new().line_start(50).line_end(60).build(),
+        FindingBuilder::new().line_start(100).line_end(100).build(),
+    ];
+    let changed = vec![(15, 25)]; // overlaps first, not second or third
+    classify_in_diff(&mut findings, &changed);
+    assert_eq!(findings[0].in_diff, Some(true));
+    assert_eq!(findings[1].in_diff, Some(false));
+    assert_eq!(findings[2].in_diff, Some(false));
+}
+
+#[test]
+fn classify_in_diff_boundary_overlap() {
+    use crate::finding::FindingBuilder;
+    let mut findings = vec![
+        FindingBuilder::new().line_start(10).line_end(20).build(), // end touches hunk start
+        FindingBuilder::new().line_start(30).line_end(40).build(), // start touches hunk end
+    ];
+    let changed = vec![(20, 30)];
+    classify_in_diff(&mut findings, &changed);
+    assert_eq!(findings[0].in_diff, Some(true)); // line_end == hunk start
+    assert_eq!(findings[1].in_diff, Some(true)); // line_start == hunk end
+}
+
+#[test]
+fn classify_in_diff_empty_changed_lines_is_noop() {
+    use crate::finding::FindingBuilder;
+    let mut findings = vec![FindingBuilder::new().build()];
+    classify_in_diff(&mut findings, &[]);
+    assert_eq!(findings[0].in_diff, None); // unchanged
+}
+
+#[test]
+fn classify_in_diff_skips_invalid_findings() {
+    use crate::finding::FindingBuilder;
+    let mut findings = vec![
+        FindingBuilder::new().line_start(0).line_end(0).build(), // invalid
+    ];
+    let changed = vec![(1, 100)];
+    classify_in_diff(&mut findings, &changed);
+    assert_eq!(findings[0].in_diff, None); // skipped
+}
+
+#[test]
+fn classify_in_diff_large_span_finding() {
+    use crate::finding::FindingBuilder;
+    let mut findings = vec![
+        FindingBuilder::new().line_start(1).line_end(500).build(),
+    ];
+    let changed = vec![(250, 260)];
+    classify_in_diff(&mut findings, &changed);
+    assert_eq!(findings[0].in_diff, Some(true)); // any overlap counts
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cargo test --bin quorum classify_in_diff -- --nocapture`
+Expected: compile error — `classify_in_diff` doesn't exist.
+
+- [ ] **Step 3: Implement `classify_in_diff`**
+
+Add to `src/pipeline.rs` (above the test module, after the existing helper functions):
+
+```rust
+/// Stamp each finding with `in_diff` based on line-range overlap with changed hunks.
+///
+/// Only called when `--diff-file` was explicitly provided. Invalid findings
+/// (malformed line ranges) are skipped.
+fn classify_in_diff(findings: &mut [Finding], changed_lines: &[(u32, u32)]) {
+    if changed_lines.is_empty() {
+        return;
+    }
+    for finding in findings {
+        if !finding.is_valid() {
+            continue;
+        }
+        let overlaps = changed_lines
+            .iter()
+            .any(|(start, end)| finding.line_start <= *end && finding.line_end >= *start);
+        finding.in_diff = Some(overlaps);
+    }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cargo test --bin quorum classify_in_diff -- --nocapture`
+Expected: 5 tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/pipeline.rs
+git commit -m "feat(pipeline): implement classify_in_diff function (#310)"
+```
+
+---
+
+### Task 5: Wire `classify_in_diff` into the review pipeline
+
+**Files:**
+- Modify: `src/pipeline.rs:1034-1040` (between grounding and calibration)
+
+- [ ] **Step 1: Write failing integration test**
+
+Add to the test module in `src/pipeline.rs`:
+
+```rust
+#[test]
+fn review_file_stamps_in_diff_when_diff_ranges_provided() {
+    use crate::finding::FindingBuilder;
+
+    // Simulate: findings at lines 10 and 50, diff hunk covers 8-15
+    let mut findings = vec![
+        FindingBuilder::new().line_start(10).line_end(12).build(),
+        FindingBuilder::new().line_start(50).line_end(55).build(),
+    ];
+    let diff_lines = vec![(8u32, 15u32)];
+    classify_in_diff(&mut findings, &diff_lines);
+
+    assert_eq!(findings[0].in_diff, Some(true));
+    assert_eq!(findings[1].in_diff, Some(false));
+}
+
+#[test]
+fn classify_not_called_without_diff_ranges() {
+    use crate::finding::FindingBuilder;
+    let findings = vec![FindingBuilder::new().build()];
+    // No diff_ranges means classify_in_diff is never called
+    // Findings should have in_diff == None
+    assert_eq!(findings[0].in_diff, None);
+}
+```
+
+- [ ] **Step 2: Run tests to verify they pass** (these test the function directly, not the wiring)
+
+Run: `cargo test --bin quorum review_file_stamps_in_diff classify_not_called -- --nocapture`
+Expected: PASS.
+
+- [ ] **Step 3: Wire into pipeline**
+
+In `src/pipeline.rs`, after the grounding block (after line 1034 `grounded`), before calibration (line 1036), insert:
+
+```rust
+    // Classify findings as in-diff or pre-existing when --diff-file is active.
+    // Gate on diff_ranges presence, not changed_lines emptiness (the hydration
+    // path falls back to full-file ranges, which would incorrectly tag everything
+    // as in-diff).
+    let mut merged = merged;
+    if pipeline_config.diff_ranges.is_some() {
+        let repo_root = find_project_root(file_path);
+        let resolver = ReviewPathResolver::new(&file_str, &repo_root);
+        let diff_lines: Vec<(u32, u32)> = pipeline_config
+            .diff_ranges
+            .as_ref()
+            .unwrap()
+            .iter()
+            .filter(|(path, _)| resolver.matches(path))
+            .flat_map(|(_, ranges)| ranges.clone())
+            .collect();
+        classify_in_diff(&mut merged, &diff_lines);
+    }
+```
+
+- [ ] **Step 4: Run full test suite**
+
+Run: `cargo test --bin quorum`
+Expected: all tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/pipeline.rs
+git commit -m "feat(pipeline): wire classify_in_diff after grounding (#310)"
+```
+
+---
+
+### Task 6: Add `OUT_OF_DIFF_WEIGHT` and discount in `verdict_weight`
+
+**Files:**
+- Modify: `src/calibrator.rs:412-461` (verdict_weight function)
+
+- [ ] **Step 1: Write failing tests**
+
+Add to the test module in `src/calibrator.rs`:
+
+```rust
+#[test]
+fn verdict_weight_in_diff_none_is_full_weight() {
+    let entry = crate::feedback::FeedbackEntry {
+        file_path: "test.rs".into(),
+        finding_title: "test".into(),
+        finding_category: "security".into(),
+        verdict: crate::feedback::Verdict::Tp,
+        reason: "real".into(),
+        model: None,
+        timestamp: chrono::Utc::now(),
+        provenance: crate::feedback::Provenance::Human,
+        fp_kind: None,
+        finding_id: None,
+        rule_id: None,
+        in_diff: None,
+    };
+    let w = verdict_weight(&entry, chrono::Utc::now());
+    // Human(1.0) * recency(~1.0) * in_diff(1.0) = ~1.0
+    assert!((w - 1.0).abs() < 0.01);
+}
+
+#[test]
+fn verdict_weight_in_diff_true_is_full_weight() {
+    let entry = crate::feedback::FeedbackEntry {
+        file_path: "test.rs".into(),
+        finding_title: "test".into(),
+        finding_category: "security".into(),
+        verdict: crate::feedback::Verdict::Tp,
+        reason: "real".into(),
+        model: None,
+        timestamp: chrono::Utc::now(),
+        provenance: crate::feedback::Provenance::Human,
+        fp_kind: None,
+        finding_id: None,
+        rule_id: None,
+        in_diff: Some(true),
+    };
+    let w = verdict_weight(&entry, chrono::Utc::now());
+    assert!((w - 1.0).abs() < 0.01);
+}
+
+#[test]
+fn verdict_weight_out_of_diff_applies_discount() {
+    let entry = crate::feedback::FeedbackEntry {
+        file_path: "test.rs".into(),
+        finding_title: "test".into(),
+        finding_category: "security".into(),
+        verdict: crate::feedback::Verdict::Tp,
+        reason: "real".into(),
+        model: None,
+        timestamp: chrono::Utc::now(),
+        provenance: crate::feedback::Provenance::Human,
+        fp_kind: None,
+        finding_id: None,
+        rule_id: None,
+        in_diff: Some(false),
+    };
+    let w = verdict_weight(&entry, chrono::Utc::now());
+    // Human(1.0) * recency(~1.0) * out_of_diff(0.7) = ~0.7
+    assert!((w - 0.7).abs() < 0.01);
+}
+
+#[test]
+fn verdict_weight_external_out_of_diff_compounds() {
+    let entry = crate::feedback::FeedbackEntry {
+        file_path: "test.rs".into(),
+        finding_title: "test".into(),
+        finding_category: "security".into(),
+        verdict: crate::feedback::Verdict::Fp,
+        reason: "nah".into(),
+        model: None,
+        timestamp: chrono::Utc::now(),
+        provenance: crate::feedback::Provenance::External {
+            agent: "pal".into(),
+            agent_model: None,
+            confidence: None,
+        },
+        fp_kind: None,
+        finding_id: None,
+        rule_id: None,
+        in_diff: Some(false),
+    };
+    let w = verdict_weight(&entry, chrono::Utc::now());
+    // External(0.7) * recency(~1.0) * out_of_diff(0.7) = ~0.49
+    assert!((w - 0.49).abs() < 0.02);
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cargo test --bin quorum verdict_weight_in_diff verdict_weight_out_of_diff verdict_weight_external_out -- --nocapture`
+Expected: compile errors or assertion failures.
+
+- [ ] **Step 3: Add constant and discount logic**
+
+In `src/calibrator.rs`, add the constant near the top (around line 15, with other constants):
+
+```rust
+const OUT_OF_DIFF_WEIGHT: f64 = 0.7;
+```
+
+In `verdict_weight()` (line 460), change the return from:
+
+```rust
+    provenance_weight * recency_weight
+```
+
+to:
+
+```rust
+    let in_diff_factor = match entry.in_diff {
+        Some(false) => OUT_OF_DIFF_WEIGHT,
+        _ => 1.0,
+    };
+
+    provenance_weight * recency_weight * in_diff_factor
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cargo test --bin quorum verdict_weight -- --nocapture`
+Expected: all verdict_weight tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/calibrator.rs
+git commit -m "feat(calibrator): 0.7x confidence discount for out-of-diff verdicts (#310)"
+```
+
+---
+
+### Task 7: Pass `in_diff` through `make_trace_entry`
+
+**Files:**
+- Modify: `src/calibrator.rs:130-150` (make_trace_entry)
+- Modify: `src/calibrator.rs` (all call sites of make_trace_entry)
+
+- [ ] **Step 1: Write failing test**
+
+Add to the test module in `src/calibrator.rs`:
+
+```rust
+#[test]
+fn trace_entry_carries_in_diff_from_finding() {
+    let mut finding = crate::finding::FindingBuilder::new()
+        .severity(crate::finding::Severity::Medium)
+        .build();
+    finding.in_diff = Some(true);
+    let trace = make_trace_entry(
+        &finding, 1.0, 0.0, 0.0, 0.0, 0.0, vec![], None,
+        crate::finding::Severity::Medium, None, "test.rs",
+    );
+    assert_eq!(trace.in_diff, Some(true));
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test --bin quorum trace_entry_carries_in_diff -- --nocapture`
+Expected: assertion failure — `trace.in_diff` is `None`.
+
+- [ ] **Step 3: Pass `in_diff` from finding to trace entry**
+
+In `make_trace_entry()` (around line 142), change the `CalibratorTraceEntry` construction. After `composite_score: None,` add:
+
+```rust
+        in_diff: finding.in_diff,
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cargo test --bin quorum trace_entry_carries_in_diff -- --nocapture`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/calibrator.rs
+git commit -m "feat(calibrator): propagate in_diff to trace entries (#310)"
+```
+
+---
+
+### Task 8: Output grouping — human mode
+
+**Files:**
+- Modify: `src/output/mod.rs:141-186` (format_review function)
+
+- [ ] **Step 1: Write failing tests**
+
+Add to the test module in `src/output/mod.rs`:
+
+```rust
+#[test]
+fn format_review_groups_in_diff_and_pre_existing() {
+    use crate::finding::{FindingBuilder, Severity};
+    let mut in_diff_finding = FindingBuilder::new()
+        .title("SQL injection")
+        .severity(Severity::Critical)
+        .build();
+    in_diff_finding.in_diff = Some(true);
+
+    let mut pre_existing = FindingBuilder::new()
+        .title("Unused import")
+        .severity(Severity::Info)
+        .build();
+    pre_existing.in_diff = Some(false);
+
+    let style = Style::plain();
+    let output = format_review("src/main.rs", &[in_diff_finding, pre_existing], &style);
+    assert!(output.contains("SQL injection"));
+    assert!(output.contains("Pre-existing"));
+    assert!(output.contains("Unused import"));
+    // In-diff finding should appear before Pre-existing header
+    let sql_pos = output.find("SQL injection").unwrap();
+    let pre_pos = output.find("Pre-existing").unwrap();
+    assert!(sql_pos < pre_pos);
+}
+
+#[test]
+fn format_review_no_pre_existing_header_when_all_in_diff() {
+    use crate::finding::{FindingBuilder, Severity};
+    let mut f = FindingBuilder::new()
+        .severity(Severity::Medium)
+        .build();
+    f.in_diff = Some(true);
+    let style = Style::plain();
+    let output = format_review("test.rs", &[f], &style);
+    assert!(!output.contains("Pre-existing"));
+}
+
+#[test]
+fn format_review_summary_shows_diff_breakdown() {
+    use crate::finding::{FindingBuilder, Severity};
+    let mut f1 = FindingBuilder::new().severity(Severity::Medium).build();
+    f1.in_diff = Some(true);
+    let mut f2 = FindingBuilder::new().severity(Severity::Info).build();
+    f2.in_diff = Some(false);
+    let style = Style::plain();
+    let output = format_review("test.rs", &[f1, f2], &style);
+    assert!(output.contains("in this change"));
+    assert!(output.contains("pre-existing"));
+}
+
+#[test]
+fn format_review_no_diff_context_renders_normally() {
+    use crate::finding::FindingBuilder;
+    let f = FindingBuilder::new().build(); // in_diff = None
+    let style = Style::plain();
+    let output = format_review("test.rs", &[f], &style);
+    assert!(!output.contains("Pre-existing"));
+    assert!(!output.contains("in this change"));
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cargo test --bin quorum format_review_groups format_review_no_pre format_review_summary format_review_no_diff -- --nocapture`
+Expected: assertion failures.
+
+- [ ] **Step 3: Implement grouped output**
+
+Replace the `format_review` function body in `src/output/mod.rs`:
+
+```rust
+pub fn format_review(file_path: &str, findings: &[Finding], style: &Style) -> String {
+    let mut out = format!(
+        "{bold}~ Review: {file}{reset}\n\n",
+        bold = style.bold,
+        file = file_path,
+        reset = style.reset,
+    );
+
+    if findings.is_empty() {
+        out.push_str(&format!(
+            "  {green}= No findings.{reset}\n",
+            green = style.green,
+            reset = style.reset,
+        ));
+        return out;
+    }
+
+    let has_diff_context = findings.iter().any(|f| f.in_diff.is_some());
+    let (in_diff, pre_existing): (Vec<_>, Vec<_>) = if has_diff_context {
+        findings
+            .iter()
+            .partition(|f| f.in_diff != Some(false))
+    } else {
+        (findings.iter().collect(), vec![])
+    };
+
+    for f in &in_diff {
+        out.push_str(&format_finding(f, style));
+        out.push('\n');
+    }
+
+    if !pre_existing.is_empty() {
+        out.push_str(&format!(
+            "\n  {dim}-- Pre-existing ({count} finding{s}) --{reset}\n\n",
+            dim = style.dim,
+            count = pre_existing.len(),
+            s = if pre_existing.len() == 1 { "" } else { "s" },
+            reset = style.reset,
+        ));
+        for f in &pre_existing {
+            out.push_str(&format_finding(f, style));
+            out.push('\n');
+        }
+    }
+
+    // Summary line
+    let critical = findings
+        .iter()
+        .filter(|f| matches!(f.severity, Severity::Critical | Severity::High))
+        .count();
+    let warning = findings
+        .iter()
+        .filter(|f| f.severity == Severity::Medium)
+        .count();
+    let info = findings.len() - critical - warning;
+
+    if has_diff_context && !pre_existing.is_empty() {
+        out.push_str(&format!(
+            "  {dim}{count} finding{s} ({in_diff} in this change, {pre} pre-existing) ({critical} critical, {warning} warning, {info} info){reset}\n",
+            dim = style.dim,
+            count = findings.len(),
+            s = if findings.len() == 1 { "" } else { "s" },
+            in_diff = in_diff.len(),
+            pre = pre_existing.len(),
+            critical = critical,
+            warning = warning,
+            info = info,
+            reset = style.reset,
+        ));
+    } else {
+        out.push_str(&format!(
+            "  {dim}{count} finding{s} ({critical} critical, {warning} warning, {info} info){reset}\n",
+            dim = style.dim,
+            count = findings.len(),
+            s = if findings.len() == 1 { "" } else { "s" },
+            critical = critical,
+            warning = warning,
+            info = info,
+            reset = style.reset,
+        ));
+    }
+
+    out
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cargo test --bin quorum format_review -- --nocapture`
+Expected: all format_review tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/output/mod.rs
+git commit -m "feat(output): group findings by in-diff/pre-existing in human mode (#310)"
+```
+
+---
+
+### Task 9: Output grouping — compact mode
+
+**Files:**
+- Modify: `src/output/mod.rs:298-324` (format_compact_finding)
+- Modify: `src/output/mod.rs:326-350` (format_compact_review)
+
+- [ ] **Step 1: Write failing tests**
+
+Add to the test module in `src/output/mod.rs`:
+
+```rust
+#[test]
+fn compact_finding_pre_existing_gets_prefix() {
+    use crate::finding::FindingBuilder;
+    let mut f = FindingBuilder::new().title("Unused import").build();
+    f.in_diff = Some(false);
+    let line = format_compact_finding(&f);
+    assert!(line.starts_with("[pre] "));
+}
+
+#[test]
+fn compact_finding_in_diff_no_prefix() {
+    use crate::finding::FindingBuilder;
+    let mut f = FindingBuilder::new().title("SQL injection").build();
+    f.in_diff = Some(true);
+    let line = format_compact_finding(&f);
+    assert!(!line.starts_with("[pre]"));
+}
+
+#[test]
+fn compact_finding_no_diff_context_no_prefix() {
+    use crate::finding::FindingBuilder;
+    let f = FindingBuilder::new().build(); // in_diff = None
+    let line = format_compact_finding(&f);
+    assert!(!line.starts_with("[pre]"));
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cargo test --bin quorum compact_finding_pre compact_finding_in_diff compact_finding_no_diff -- --nocapture`
+Expected: assertion failure on `[pre]` prefix.
+
+- [ ] **Step 3: Add `[pre]` prefix to compact output**
+
+In `format_compact_finding()` (around line 313), change the result construction. After building `result`, add the prefix:
+
+```rust
+    if f.in_diff == Some(false) {
+        format!("[pre] {}", result)
+    } else {
+        result
+    }
+```
+
+Specifically, replace the end of `format_compact_finding` from:
+
+```rust
+    if f.based_on_excerpt.is_some() {
+        result.push_str(" [excerpt]");
+    }
+    result
+```
+
+to:
+
+```rust
+    if f.based_on_excerpt.is_some() {
+        result.push_str(" [excerpt]");
+    }
+    if f.in_diff == Some(false) {
+        format!("[pre] {}", result)
+    } else {
+        result
+    }
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cargo test --bin quorum compact_finding -- --nocapture`
+Expected: all compact_finding tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/output/mod.rs
+git commit -m "feat(output): add [pre] prefix for pre-existing findings in compact mode (#310)"
+```
+
+---
+
+### Task 10: Exit code scoping
+
+**Files:**
+- Modify: `src/output/mod.rs:357-368` (compute_exit_code)
+- Modify: `src/main.rs:1721,1866` (call sites)
+
+- [ ] **Step 1: Write failing tests**
+
+Add to the test module in `src/output/mod.rs`:
+
+```rust
+#[test]
+fn exit_code_ignores_pre_existing_critical() {
+    use crate::finding::{FindingBuilder, Severity};
+    let mut f = FindingBuilder::new()
+        .severity(Severity::Critical)
+        .build();
+    f.in_diff = Some(false); // pre-existing
+    assert_eq!(compute_exit_code(&[f]), 0);
+}
+
+#[test]
+fn exit_code_counts_in_diff_critical() {
+    use crate::finding::{FindingBuilder, Severity};
+    let mut f = FindingBuilder::new()
+        .severity(Severity::Critical)
+        .build();
+    f.in_diff = Some(true);
+    assert_eq!(compute_exit_code(&[f]), 2);
+}
+
+#[test]
+fn exit_code_counts_none_diff_context_normally() {
+    use crate::finding::{FindingBuilder, Severity};
+    let f = FindingBuilder::new()
+        .severity(Severity::Critical)
+        .build(); // in_diff = None
+    assert_eq!(compute_exit_code(&[f]), 2);
+}
+
+#[test]
+fn exit_code_mixed_in_diff_and_pre_existing() {
+    use crate::finding::{FindingBuilder, Severity};
+    let mut in_diff = FindingBuilder::new()
+        .severity(Severity::Medium)
+        .build();
+    in_diff.in_diff = Some(true);
+    let mut pre = FindingBuilder::new()
+        .severity(Severity::Critical)
+        .build();
+    pre.in_diff = Some(false);
+    // Only the medium in-diff counts -> exit 1, not 2
+    assert_eq!(compute_exit_code(&[in_diff, pre]), 1);
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cargo test --bin quorum exit_code_ignores_pre exit_code_counts_in_diff exit_code_counts_none exit_code_mixed -- --nocapture`
+Expected: assertion failures.
+
+- [ ] **Step 3: Update `compute_exit_code` to scope by in_diff**
+
+Replace the `compute_exit_code` function in `src/output/mod.rs`:
+
+```rust
+pub fn compute_exit_code(findings: &[Finding]) -> i32 {
+    let dominated = |f: &&Finding| f.in_diff != Some(false);
+    if findings
+        .iter()
+        .filter(dominated)
+        .any(|f| matches!(f.severity, Severity::Critical | Severity::High))
+    {
+        2
+    } else if findings.iter().filter(dominated).any(|f| f.severity == Severity::Medium) {
+        1
+    } else {
+        0
+    }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cargo test --bin quorum exit_code -- --nocapture`
+Expected: all exit_code tests PASS (including existing ones — they use `in_diff: None` which contributes normally).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/output/mod.rs
+git commit -m "feat(output): scope exit codes to in-diff findings only (#310)"
+```
+
+---
+
+### Task 11: CLI and MCP feedback `in_diff` fields
+
+**Files:**
+- Modify: `src/cli/mod.rs:515-575` (FeedbackOpts)
+- Modify: `src/mcp/tools.rs:45-95` (FeedbackTool)
+- Modify: `src/main.rs:1968-2000` (run_feedback)
+
+- [ ] **Step 1: Write failing test**
+
+Add to the test module in `src/main.rs` (in the feedback tests section):
+
+```rust
+#[test]
+fn feedback_in_diff_flag_sets_field() {
+    let opts = cli::FeedbackOpts {
+        file: "test.rs".into(),
+        finding: "test finding".into(),
+        verdict: "tp".into(),
+        reason: "real bug".into(),
+        model: None,
+        blamed_chunks: None,
+        category: None,
+        json: false,
+        from_agent: None,
+        agent_model: None,
+        confidence: None,
+        fp_kind: None,
+        fp_discriminator: None,
+        fp_reference: None,
+        fp_tracked_in: None,
+        in_diff: Some(true),
+    };
+    assert_eq!(opts.in_diff, Some(true));
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test --bin quorum feedback_in_diff_flag -- --nocapture`
+Expected: compile error — `in_diff` field doesn't exist on FeedbackOpts.
+
+- [ ] **Step 3: Add CLI and MCP fields**
+
+In `src/cli/mod.rs`, add to FeedbackOpts (after the `fp_tracked_in` field):
+
+```rust
+    /// Whether the finding was in the diff (true) or pre-existing (false).
+    /// Omit when unknown. Propagated to the feedback entry for calibrator weighting.
+    #[arg(long)]
+    pub in_diff: Option<bool>,
+```
+
+In `src/mcp/tools.rs`, add to FeedbackTool (after `fp_kind` field):
+
+```rust
+    /// Whether the finding was in the diff (true) or pre-existing (false).
+    #[serde(default, rename = "inDiff", skip_serializing_if = "Option::is_none")]
+    pub in_diff: Option<bool>,
+```
+
+In `src/main.rs`, `run_feedback()` (around line 1984), add `in_diff: opts.in_diff,` to the `ExternalVerdictInput` construction. In the Human path (further down in `run_feedback_inner`), add `in_diff: opts.in_diff,` to the `FeedbackEntry` construction.
+
+In the MCP feedback handler (wherever `FeedbackTool` is converted to a `FeedbackEntry` or `ExternalVerdictInput`), pass `tool.in_diff` through.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cargo test --bin quorum feedback_in_diff_flag -- --nocapture`
+Expected: PASS. Also run `cargo check` to verify no remaining compile errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/cli/mod.rs src/mcp/tools.rs src/main.rs
+git commit -m "feat(feedback): add --in-diff CLI flag and inDiff MCP field (#310)"
+```
+
+---
+
+### Task 12: Apply `in_diff_factor` in calibrator model building
+
+**Files:**
+- Modify: `src/calibrate.rs` (compute_calibrator_model and rescore_samples_with_model)
+
+- [ ] **Step 1: Write failing test**
+
+Add to the test module in `src/calibrate.rs`:
+
+```rust
+#[test]
+fn out_of_diff_entries_down_weighted_in_model() {
+    use crate::feedback::{FeedbackEntry, Provenance, Verdict};
+
+    let now = chrono::Utc::now();
+    let make_entry = |verdict: Verdict, in_diff: Option<bool>| FeedbackEntry {
+        file_path: "test.rs".into(),
+        finding_title: "hardcoded secret".into(),
+        finding_category: "security".into(),
+        verdict,
+        reason: "test".into(),
+        model: None,
+        timestamp: now,
+        provenance: Provenance::Human,
+        fp_kind: None,
+        finding_id: None,
+        rule_id: None,
+        in_diff,
+    };
+
+    let in_diff_entry = make_entry(Verdict::Fp, Some(true));
+    let out_of_diff_entry = make_entry(Verdict::Fp, Some(false));
+
+    // Both should contribute to word_lor, but out-of-diff with 0.7x weight.
+    // We verify this indirectly by checking that the model builds without error
+    // and the entries are counted.
+    let entries = vec![
+        make_entry(Verdict::Tp, Some(true)),
+        in_diff_entry,
+        out_of_diff_entry,
+    ];
+    // This test mainly verifies the code compiles and runs with in_diff set.
+    // The actual weight difference is tested in verdict_weight tests.
+    assert_eq!(entries[2].in_diff, Some(false));
+}
+```
+
+- [ ] **Step 2: Run test**
+
+Run: `cargo test --bin quorum out_of_diff_entries_down_weighted -- --nocapture`
+Expected: PASS (this is a compilation/smoke test since verdict_weight already handles the discount).
+
+- [ ] **Step 3: Verify verdict_weight is already applied**
+
+The `verdict_weight()` function in `src/calibrator.rs` is already called from `compute_calibrator_model()` in `src/calibrate.rs` (at multiple call sites: lines 562, 568, 575, 592, 832, 844, 857, 877). Since Task 6 already added the `in_diff_factor` to `verdict_weight`, the discount automatically applies during model building. No additional code changes needed in `src/calibrate.rs`.
+
+Verify: `grep -n "verdict_weight" src/calibrate.rs` to confirm all call sites go through the same function.
+
+- [ ] **Step 4: Run full test suite**
+
+Run: `cargo test --bin quorum`
+Expected: all tests PASS.
+
+- [ ] **Step 5: Commit** (only if any changes were made)
+
+```bash
+git add src/calibrate.rs
+git commit -m "test(calibrate): verify out-of-diff entries use discounted weight (#310)"
+```
+
+---
+
+### Task 13: Final verification
+
+- [ ] **Step 1: Run full test suite**
+
+```bash
+cargo test --bin quorum
+```
+
+Expected: all tests PASS.
+
+- [ ] **Step 2: Run clippy**
+
+```bash
+cargo clippy --bin quorum -- -D warnings
+```
+
+Expected: no warnings.
+
+- [ ] **Step 3: Run rustfmt**
+
+```bash
+cargo fmt -- --check
+```
+
+Expected: no formatting issues.
+
+- [ ] **Step 4: Release build**
+
+```bash
+cargo build --release
+```
+
+Expected: clean build.
+
+- [ ] **Step 5: Smoke test with a diff file**
+
+```bash
+git diff HEAD~3 > /tmp/test.patch
+cargo run -- review src/pipeline.rs --diff-file /tmp/test.patch
+```
+
+Expected: findings are grouped into in-diff and pre-existing sections (if applicable). Exit code reflects only in-diff findings.
+
+---
+
+## Deferred: Stats Dimension
+
+The spec (section 5) mentions that existing `--by-file` and `--by-repo` views should include an in-diff/out-of-diff breakdown column when feedback data has `in_diff` set. This is deferred from this plan because:
+
+1. The core classification, calibrator, output, and feedback infrastructure must land first
+2. The stats enhancement is purely additive (no breaking changes)
+3. It requires feedback data with `in_diff` populated to be meaningful
+
+File a follow-up task or include in a future stats enhancement PR.

--- a/docs/superpowers/specs/2026-05-12-in-diff-classification-design.md
+++ b/docs/superpowers/specs/2026-05-12-in-diff-classification-design.md
@@ -43,6 +43,9 @@ fn classify_in_diff(findings: &mut [Finding], changed_lines: &[(u32, u32)]) {
         return;
     }
     for finding in findings {
+        if !finding.is_valid() {
+            continue;
+        }
         let overlaps = changed_lines.iter().any(|(start, end)| {
             finding.line_start <= *end && finding.line_end >= *start
         });
@@ -51,7 +54,9 @@ fn classify_in_diff(findings: &mut [Finding], changed_lines: &[(u32, u32)]) {
 }
 ```
 
-Any overlap between the finding's line range and a changed hunk counts as in-diff (inclusive approach).
+Any overlap between the finding's line range and a changed hunk counts as in-diff (inclusive approach). Invalid findings (malformed line ranges) are skipped via `Finding::is_valid()` to avoid classifying nonsensical coordinates.
+
+Note: this is line-range based, not semantic ownership. A function spanning lines 1-500 where only line 250 changed will be tagged `in_diff: true`. This is deliberate -- the finding touches changed code and is relevant to the PR.
 
 ### Pipeline placement
 
@@ -93,6 +98,8 @@ The same `in_diff_factor` applies when building lookup tables (word LOR, family 
 
 After calibration, only findings where `in_diff != Some(false)` contribute to severity-based exit codes (0/1/2). Pre-existing findings are informational. `in_diff: None` (full-file review, no diff context) contributes normally.
 
+This is an intentional semantic change when `--diff-file` is active: a project with only pre-existing critical findings exits 0 ("nothing wrong with your change") instead of 2. This matches the expected CI behavior -- `--diff-file` means "judge only what I changed."
+
 ## 4. Output Formatting
 
 ### Human mode (`src/output/mod.rs`)
@@ -116,6 +123,7 @@ Findings are split into two groups per file:
 
 - "Pre-existing" header only appears when out-of-diff findings exist
 - In-diff findings render first, pre-existing after a visual separator
+- Within each group, preserve the existing sort order (don't re-sort)
 - No severity downgrade -- grouping does the work
 - Summary line: `"3 findings (2 in this change, 1 pre-existing)"`
 
@@ -145,7 +153,7 @@ Pre-existing findings get a `[pre]` prefix:
 
 For feedback on findings from the current review session, callers should propagate the finding's `in_diff` value. For historical/manual feedback where the diff context is unknown, `in_diff` stays `None`.
 
-Both `record_human()` and `record_external()` in `FeedbackStore` pass through `in_diff`.
+Both `record_human()` and `record_external()` in `FeedbackStore` pass through `in_diff`. `ExternalVerdictInput` also gains `in_diff: Option<bool>` for field parity (unlike `fp_kind`, which is dropped on the External path, `in_diff` is a simple informational field with no validation concerns).
 
 ### Stats
 
@@ -173,3 +181,15 @@ Existing `--by-file` and `--by-repo` views include an in-diff/out-of-diff breakd
 5. **Stamp-after-collection.** One function, zero constructor changes, follows existing pipeline patterns (calibrator actions are also stamped post-collection).
 6. **Gate on --diff-file flag, not changed_lines emptiness.** Avoids false `in_diff: true` when full-file fallback ranges are used.
 7. **inferust/statsmodels deferred to #312.** No regression fitting needed for a constant multiplier.
+
+## 8. Test Requirements (from review)
+
+- Round-trip serde tests for all three structs with `in_diff` present, absent, and `None`
+- Boundary overlap: `finding.line_end == hunk.start` and `finding.line_start == hunk.end`
+- Large-span findings (line 1-500, hunk at line 250) tagged `in_diff: true`
+- Invalid findings (`line_start=0`) skipped by classifier
+- Full-file fallback (`changed_lines = [(1, total)]`) does not stamp `in_diff`
+- Compound discount threshold tests: External + out-of-diff = 0.49x, AutoCalibrate + out-of-diff = 0.35x
+- Both calibrate join paths (`join_feedback_and_traces_with_options` and `rescore_samples_with_model`) apply identical `in_diff` weighting
+- Exit code: only in-diff findings contribute when `--diff-file` is active
+- Output grouping preserves sort order within each group

--- a/docs/superpowers/specs/2026-05-12-in-diff-classification-design.md
+++ b/docs/superpowers/specs/2026-05-12-in-diff-classification-design.md
@@ -106,7 +106,7 @@ This is an intentional semantic change when `--diff-file` is active: a project w
 
 Findings are split into two groups per file:
 
-```
+```text
 -- src/main.rs (3 findings) ----------------------------------------
 
   ! [critical] SQL injection in query builder (line 42)
@@ -131,7 +131,7 @@ Findings are split into two groups per file:
 
 Pre-existing findings get a `[pre]` prefix:
 
-```
+```text
 !|critical|42|SQL injection in query builder
 ~|medium|88|Missing error handling
 [pre] -|low|3|Unused import

--- a/docs/superpowers/specs/2026-05-12-in-diff-classification-design.md
+++ b/docs/superpowers/specs/2026-05-12-in-diff-classification-design.md
@@ -1,0 +1,175 @@
+# In-Diff Classification for Findings
+
+> Issue: #310
+> Related: #308 (composite calibrator), #309 (join refactor), #312 (learned weights)
+
+**Goal:** Tag each finding as in-diff or pre-existing when `--diff-file` is active, propagate through calibrator and output, and down-weight out-of-diff verdicts in feedback.
+
+**Architecture:** A post-collection stamp pass classifies findings by range overlap against parsed diff hunks. The classification flows into calibrator trace entries, feedback records, output grouping, and exit code scoping. A 0.7x confidence discount on out-of-diff verdicts mirrors the existing provenance weighting system.
+
+**Tech Stack:** Rust, serde (backward-compat optional fields), existing pipeline infrastructure.
+
+---
+
+## 1. Data Model Changes
+
+### Finding (`src/finding.rs`)
+
+Add `in_diff: Option<bool>` to the `Finding` struct:
+
+- `Some(true)` -- finding's line range overlaps at least one changed hunk
+- `Some(false)` -- finding is in unchanged code (pre-existing)
+- `None` -- no diff context available (full-file review)
+
+Serde attributes: `#[serde(default, skip_serializing_if = "Option::is_none")]` for backward compatibility with existing JSON output consumers.
+
+### FeedbackEntry (`src/feedback.rs`)
+
+Add `in_diff: Option<bool>` with the same serde attributes. Value is copied from the finding at feedback recording time. Old feedback rows deserialize as `None`.
+
+### CalibratorTraceEntry (`src/calibrator_trace.rs`)
+
+Add `in_diff: Option<bool>` with the same serde attributes. Copied from the finding before `calibrate_core_decision()` runs, so traces show the classification alongside any applied confidence discount.
+
+## 2. Classification Logic
+
+### Core function
+
+A single pure function in `src/pipeline.rs`:
+
+```rust
+fn classify_in_diff(findings: &mut [Finding], changed_lines: &[(u32, u32)]) {
+    if changed_lines.is_empty() {
+        return;
+    }
+    for finding in findings {
+        let overlaps = changed_lines.iter().any(|(start, end)| {
+            finding.line_start <= *end && finding.line_end >= *start
+        });
+        finding.in_diff = Some(overlaps);
+    }
+}
+```
+
+Any overlap between the finding's line range and a changed hunk counts as in-diff (inclusive approach).
+
+### Pipeline placement
+
+Called after findings are collected and before calibration, in the per-file review flow. Only called when `--diff-file` was explicitly provided -- when `changed_lines` falls back to `[(1, total_lines)]` (no diff file), the function is not called and `in_diff` remains `None`.
+
+### Gating
+
+The pipeline already tracks whether `--diff-file` was provided. The stamp pass is gated on that flag, not on the emptiness of `changed_lines`.
+
+## 3. Calibrator Integration
+
+### verdict_weight() (`src/calibrator.rs`)
+
+`in_diff` acts as a multiplicative discount on the existing `provenance * recency` weight:
+
+```rust
+const OUT_OF_DIFF_WEIGHT: f64 = 0.7;
+
+let in_diff_factor = match entry.in_diff {
+    Some(false) => OUT_OF_DIFF_WEIGHT,
+    _ => 1.0,  // in-diff or no diff context
+};
+// final = provenance_weight * recency_decay * in_diff_factor
+```
+
+Stacking examples:
+- Human + in-diff: `1.0 * recency * 1.0`
+- Human + out-of-diff: `1.0 * recency * 0.7`
+- External + out-of-diff: `0.7 * recency * 0.7 = 0.49`
+- AutoCalibrate + out-of-diff: `0.5 * recency * 0.7 = 0.35`
+
+The 0.7x constant is defined as `OUT_OF_DIFF_WEIGHT` in `src/calibrator.rs`. Issue #312 may later tune this via learned weights.
+
+### compute_calibrator_model() (`src/calibrate.rs`)
+
+The same `in_diff_factor` applies when building lookup tables (word LOR, family FP rates, language FP rates). Out-of-diff entries contribute 0.7x weight to learned distributions since those verdicts are noisier.
+
+### Exit codes
+
+After calibration, only findings where `in_diff != Some(false)` contribute to severity-based exit codes (0/1/2). Pre-existing findings are informational. `in_diff: None` (full-file review, no diff context) contributes normally.
+
+## 4. Output Formatting
+
+### Human mode (`src/output/mod.rs`)
+
+Findings are split into two groups per file:
+
+```
+-- src/main.rs (3 findings) ----------------------------------------
+
+  ! [critical] SQL injection in query builder (line 42)
+    ...
+
+  ~ [medium] Missing error handling (line 88)
+    ...
+
+  -- Pre-existing (1 finding) ----------------------------------------
+
+  - [low] Unused import (line 3)
+    ...
+```
+
+- "Pre-existing" header only appears when out-of-diff findings exist
+- In-diff findings render first, pre-existing after a visual separator
+- No severity downgrade -- grouping does the work
+- Summary line: `"3 findings (2 in this change, 1 pre-existing)"`
+
+### Compact mode
+
+Pre-existing findings get a `[pre]` prefix:
+
+```
+!|critical|42|SQL injection in query builder
+~|medium|88|Missing error handling
+[pre] -|low|3|Unused import
+```
+
+### JSON mode
+
+`in_diff` field serializes via serde. No structural change to JSON shape.
+
+## 5. Feedback & Stats
+
+### Feedback recording
+
+`in_diff` is captured from the finding being judged at recording time:
+
+- **MCP path:** the `feedback` tool gains an optional `inDiff` field. Callers (Claude Code, dev:start workflow) propagate the finding's `in_diff` value.
+- **CLI path:** `quorum feedback` gains optional `--in-diff` / `--no-in-diff` flags. When omitted, `in_diff` is `None`.
+- **Programmatic path:** `FeedbackStore::record_human()` and `record_external()` accept `in_diff: Option<bool>`.
+
+For feedback on findings from the current review session, callers should propagate the finding's `in_diff` value. For historical/manual feedback where the diff context is unknown, `in_diff` stays `None`.
+
+Both `record_human()` and `record_external()` in `FeedbackStore` pass through `in_diff`.
+
+### Stats
+
+Existing `--by-file` and `--by-repo` views include an in-diff/out-of-diff breakdown column when any feedback has `in_diff` set. No new `--by-diff-scope` flag in this PR. Precision/action-rate can be sliced by `in_diff` in the rolling window display.
+
+## 6. Files to Modify
+
+| File | Change | Complexity |
+|------|--------|-----------|
+| `src/finding.rs` | Add `in_diff: Option<bool>` | trivial |
+| `src/pipeline.rs` | `classify_in_diff()` + call site | low |
+| `src/feedback.rs` | Add `in_diff: Option<bool>` to FeedbackEntry | trivial |
+| `src/calibrator_trace.rs` | Add `in_diff: Option<bool>` to CalibratorTraceEntry | trivial |
+| `src/calibrator.rs` | `OUT_OF_DIFF_WEIGHT` constant, discount in `verdict_weight()` | low |
+| `src/calibrate.rs` | Down-weight out-of-diff in model building | low |
+| `src/output/mod.rs` | Grouped human output, `[pre]` compact prefix, summary line | medium |
+| `src/main.rs` | Exit code scoping to in-diff findings | low |
+
+## 7. Design Decisions
+
+1. **Any overlap = in-diff.** A finding touching changed code is relevant even if part of its range is pre-existing.
+2. **0.7x out-of-diff discount.** Conservative enough to meaningfully down-weight without discarding signal. Matches External provenance weight. Tunable via #312.
+3. **No severity downgrade.** Grouping communicates priority without losing information.
+4. **Option<bool> everywhere.** Backward compatible, zero-cost for full-file reviews, simple to reason about.
+5. **Stamp-after-collection.** One function, zero constructor changes, follows existing pipeline patterns (calibrator actions are also stamped post-collection).
+6. **Gate on --diff-file flag, not changed_lines emptiness.** Avoids false `in_diff: true` when full-file fallback ranges are used.
+7. **inferust/statsmodels deferred to #312.** No regression fitting needed for a constant multiplier.

--- a/src/analysis.rs
+++ b/src/analysis.rs
@@ -301,7 +301,7 @@ fn scan_insecure_rust(node: &tree_sitter::Node, source: &str, findings: &mut Vec
                 judge_verdict: None,
                 judge_confidence: None,
                 precision_tier: None,
-                    in_diff: None,
+                in_diff: None,
             });
         }
     }
@@ -1695,7 +1695,7 @@ fn scan_insecure_yaml(node: &tree_sitter::Node, source: &str, findings: &mut Vec
                                     judge_verdict: None,
                                     judge_confidence: None,
                                     precision_tier: None,
-                    in_diff: None,
+                                    in_diff: None,
                                 });
                             }
                         }
@@ -2005,7 +2005,7 @@ fn scan_insecure_typescript(node: &tree_sitter::Node, source: &str, findings: &m
                 judge_verdict: None,
                 judge_confidence: None,
                 precision_tier: None,
-                    in_diff: None,
+                in_diff: None,
             });
         }
 
@@ -2210,7 +2210,7 @@ fn scan_insecure_typescript(node: &tree_sitter::Node, source: &str, findings: &m
                 judge_verdict: None,
                 judge_confidence: None,
                 precision_tier: None,
-                    in_diff: None,
+                in_diff: None,
             });
         }
     }
@@ -2253,7 +2253,7 @@ fn scan_insecure_typescript(node: &tree_sitter::Node, source: &str, findings: &m
                 judge_verdict: None,
                 judge_confidence: None,
                 precision_tier: None,
-                    in_diff: None,
+                in_diff: None,
             });
         }
     }
@@ -2475,7 +2475,7 @@ fn scan_insecure_bash(node: &tree_sitter::Node, source: &str, findings: &mut Vec
                 judge_verdict: None,
                 judge_confidence: None,
                 precision_tier: None,
-                    in_diff: None,
+                in_diff: None,
             });
         }
     }
@@ -2513,7 +2513,7 @@ fn scan_insecure_bash(node: &tree_sitter::Node, source: &str, findings: &mut Vec
                 judge_verdict: None,
                 judge_confidence: None,
                 precision_tier: None,
-                    in_diff: None,
+                in_diff: None,
             });
         }
 
@@ -2550,7 +2550,7 @@ fn scan_insecure_bash(node: &tree_sitter::Node, source: &str, findings: &mut Vec
                             judge_verdict: None,
                             judge_confidence: None,
                             precision_tier: None,
-                    in_diff: None,
+                            in_diff: None,
                         });
                         break;
                     }
@@ -2597,7 +2597,7 @@ fn scan_insecure_bash(node: &tree_sitter::Node, source: &str, findings: &mut Vec
                         judge_verdict: None,
                         judge_confidence: None,
                         precision_tier: None,
-                    in_diff: None,
+                        in_diff: None,
                     });
                     break;
                 }
@@ -3228,7 +3228,7 @@ fn check_required_providers(rp_body: tree_sitter::Node, source: &str, findings: 
                 judge_verdict: None,
                 judge_confidence: None,
                 precision_tier: None,
-                    in_diff: None,
+                in_diff: None,
             });
         }
     }
@@ -3377,7 +3377,7 @@ fn analyze_dockerfile_structure(tree: &tree_sitter::Tree, source: &str) -> Vec<F
             judge_verdict: None,
             judge_confidence: None,
             precision_tier: None,
-                    in_diff: None,
+            in_diff: None,
         });
     }
 
@@ -3444,7 +3444,7 @@ fn analyze_dockerfile_structure(tree: &tree_sitter::Tree, source: &str) -> Vec<F
             judge_verdict: None,
             judge_confidence: None,
             precision_tier: None,
-                    in_diff: None,
+            in_diff: None,
         });
     }
     if entrypoint_count > 1 {
@@ -3477,7 +3477,7 @@ fn analyze_dockerfile_structure(tree: &tree_sitter::Tree, source: &str) -> Vec<F
             judge_verdict: None,
             judge_confidence: None,
             precision_tier: None,
-                    in_diff: None,
+            in_diff: None,
         });
     }
 

--- a/src/analysis.rs
+++ b/src/analysis.rs
@@ -72,6 +72,7 @@ pub fn analyze_complexity(
                 judge_verdict: None,
                 judge_confidence: None,
                 precision_tier: None,
+                    in_diff: None,
                 });
             }
         }
@@ -259,6 +260,7 @@ fn scan_insecure_rust(node: &tree_sitter::Node, source: &str, findings: &mut Vec
         judge_verdict: None,
         judge_confidence: None,
         precision_tier: None,
+                    in_diff: None,
         });
     }
 
@@ -299,6 +301,7 @@ fn scan_insecure_rust(node: &tree_sitter::Node, source: &str, findings: &mut Vec
                 judge_verdict: None,
                 judge_confidence: None,
                 precision_tier: None,
+                    in_diff: None,
             });
         }
     }
@@ -342,6 +345,7 @@ fn scan_insecure_python(node: &tree_sitter::Node, source: &str, findings: &mut V
                     judge_verdict: None,
                     judge_confidence: None,
                     precision_tier: None,
+                    in_diff: None,
                 });
             }
         }
@@ -376,6 +380,7 @@ fn scan_insecure_python(node: &tree_sitter::Node, source: &str, findings: &mut V
                 judge_verdict: None,
                 judge_confidence: None,
                 precision_tier: None,
+                    in_diff: None,
                 });
             }
             if args_text.contains("host=\"0.0.0.0\"") || args_text.contains("host='0.0.0.0'") {
@@ -405,6 +410,7 @@ fn scan_insecure_python(node: &tree_sitter::Node, source: &str, findings: &mut V
                 judge_verdict: None,
                 judge_confidence: None,
                 precision_tier: None,
+                    in_diff: None,
                 });
             }
         }
@@ -448,6 +454,7 @@ fn scan_insecure_python(node: &tree_sitter::Node, source: &str, findings: &mut V
                             judge_verdict: None,
                             judge_confidence: None,
                             precision_tier: None,
+                    in_diff: None,
                             });
                     } else if arg_text.contains(".format(") {
                         findings.push(Finding {
@@ -476,6 +483,7 @@ fn scan_insecure_python(node: &tree_sitter::Node, source: &str, findings: &mut V
                             judge_verdict: None,
                             judge_confidence: None,
                             precision_tier: None,
+                    in_diff: None,
                             });
                     }
                 }
@@ -524,6 +532,7 @@ fn scan_insecure_python(node: &tree_sitter::Node, source: &str, findings: &mut V
                         judge_verdict: None,
                         judge_confidence: None,
                         precision_tier: None,
+                    in_diff: None,
                         });
                 }
             }
@@ -589,6 +598,7 @@ fn scan_insecure_python(node: &tree_sitter::Node, source: &str, findings: &mut V
                     judge_verdict: None,
                     judge_confidence: None,
                     precision_tier: None,
+                    in_diff: None,
                     });
             }
         }
@@ -670,6 +680,7 @@ fn scan_insecure_python(node: &tree_sitter::Node, source: &str, findings: &mut V
                         judge_verdict: None,
                         judge_confidence: None,
                         precision_tier: None,
+                    in_diff: None,
                         });
             }
         }
@@ -712,6 +723,7 @@ fn scan_insecure_python(node: &tree_sitter::Node, source: &str, findings: &mut V
                         judge_verdict: None,
                         judge_confidence: None,
                         precision_tier: None,
+                    in_diff: None,
                         });
                 }
             }
@@ -772,6 +784,7 @@ fn scan_insecure_python(node: &tree_sitter::Node, source: &str, findings: &mut V
                 judge_verdict: None,
                 judge_confidence: None,
                 precision_tier: None,
+                    in_diff: None,
                 });
             }
         }
@@ -810,6 +823,7 @@ fn scan_insecure_python(node: &tree_sitter::Node, source: &str, findings: &mut V
                 judge_verdict: None,
                 judge_confidence: None,
                 precision_tier: None,
+                    in_diff: None,
                 });
         }
     }
@@ -850,6 +864,7 @@ fn scan_insecure_python(node: &tree_sitter::Node, source: &str, findings: &mut V
                 judge_verdict: None,
                 judge_confidence: None,
                 precision_tier: None,
+                    in_diff: None,
                 });
         }
     }
@@ -1219,6 +1234,7 @@ fn scan_insecure_yaml(node: &tree_sitter::Node, source: &str, findings: &mut Vec
                             judge_verdict: None,
                             judge_confidence: None,
                             precision_tier: None,
+                    in_diff: None,
                             });
                 } else {
                     seen_keys.push((key_text, key_line));
@@ -1261,6 +1277,7 @@ fn scan_insecure_yaml(node: &tree_sitter::Node, source: &str, findings: &mut Vec
                     judge_verdict: None,
                     judge_confidence: None,
                     precision_tier: None,
+                    in_diff: None,
                 });
             }
 
@@ -1292,6 +1309,7 @@ fn scan_insecure_yaml(node: &tree_sitter::Node, source: &str, findings: &mut Vec
                     judge_verdict: None,
                     judge_confidence: None,
                     precision_tier: None,
+                    in_diff: None,
                 });
             }
 
@@ -1332,6 +1350,7 @@ fn scan_insecure_yaml(node: &tree_sitter::Node, source: &str, findings: &mut Vec
                     judge_verdict: None,
                     judge_confidence: None,
                     precision_tier: None,
+                    in_diff: None,
                     });
                 }
             }
@@ -1375,6 +1394,7 @@ fn scan_insecure_yaml(node: &tree_sitter::Node, source: &str, findings: &mut Vec
                                 judge_verdict: None,
                                 judge_confidence: None,
                                 precision_tier: None,
+                    in_diff: None,
                                 });
                     }
                 }
@@ -1422,6 +1442,7 @@ fn scan_insecure_yaml(node: &tree_sitter::Node, source: &str, findings: &mut Vec
                         judge_verdict: None,
                         judge_confidence: None,
                         precision_tier: None,
+                    in_diff: None,
                         });
                     }
                 }
@@ -1462,6 +1483,7 @@ fn scan_insecure_yaml(node: &tree_sitter::Node, source: &str, findings: &mut Vec
                         judge_verdict: None,
                         judge_confidence: None,
                         precision_tier: None,
+                    in_diff: None,
                         });
                     }
                 }
@@ -1536,6 +1558,7 @@ fn scan_insecure_yaml(node: &tree_sitter::Node, source: &str, findings: &mut Vec
                                         judge_verdict: None,
                                         judge_confidence: None,
                                         precision_tier: None,
+                    in_diff: None,
                                         });
                             }
 
@@ -1567,6 +1590,7 @@ fn scan_insecure_yaml(node: &tree_sitter::Node, source: &str, findings: &mut Vec
                                         judge_verdict: None,
                                         judge_confidence: None,
                                         precision_tier: None,
+                    in_diff: None,
                                         });
                             }
                         }
@@ -1617,6 +1641,7 @@ fn scan_insecure_yaml(node: &tree_sitter::Node, source: &str, findings: &mut Vec
                     judge_verdict: None,
                     judge_confidence: None,
                     precision_tier: None,
+                    in_diff: None,
                 });
             }
         }
@@ -1670,6 +1695,7 @@ fn scan_insecure_yaml(node: &tree_sitter::Node, source: &str, findings: &mut Vec
                                     judge_verdict: None,
                                     judge_confidence: None,
                                     precision_tier: None,
+                    in_diff: None,
                                 });
                             }
                         }
@@ -1707,6 +1733,7 @@ fn scan_insecure_yaml(node: &tree_sitter::Node, source: &str, findings: &mut Vec
                     judge_verdict: None,
                     judge_confidence: None,
                     precision_tier: None,
+                    in_diff: None,
                 });
             }
         }
@@ -1746,6 +1773,7 @@ fn scan_insecure_yaml(node: &tree_sitter::Node, source: &str, findings: &mut Vec
                     judge_verdict: None,
                     judge_confidence: None,
                     precision_tier: None,
+                    in_diff: None,
                 });
             }
         }
@@ -1782,6 +1810,7 @@ fn scan_insecure_yaml(node: &tree_sitter::Node, source: &str, findings: &mut Vec
                         judge_verdict: None,
                         judge_confidence: None,
                         precision_tier: None,
+                    in_diff: None,
                         });
             }
         }
@@ -1820,6 +1849,7 @@ fn scan_insecure_yaml(node: &tree_sitter::Node, source: &str, findings: &mut Vec
                         judge_verdict: None,
                         judge_confidence: None,
                         precision_tier: None,
+                    in_diff: None,
                         });
             }
         }
@@ -1865,6 +1895,7 @@ fn scan_insecure_yaml(node: &tree_sitter::Node, source: &str, findings: &mut Vec
                     judge_verdict: None,
                     judge_confidence: None,
                     precision_tier: None,
+                    in_diff: None,
                     });
                 }
             }
@@ -1930,6 +1961,7 @@ fn scan_insecure_yaml(node: &tree_sitter::Node, source: &str, findings: &mut Vec
                     judge_verdict: None,
                     judge_confidence: None,
                     precision_tier: None,
+                    in_diff: None,
                 });
             }
         }
@@ -1973,6 +2005,7 @@ fn scan_insecure_typescript(node: &tree_sitter::Node, source: &str, findings: &m
                 judge_verdict: None,
                 judge_confidence: None,
                 precision_tier: None,
+                    in_diff: None,
             });
         }
 
@@ -2004,6 +2037,7 @@ fn scan_insecure_typescript(node: &tree_sitter::Node, source: &str, findings: &m
                 judge_verdict: None,
                 judge_confidence: None,
                 precision_tier: None,
+                    in_diff: None,
                 });
         }
 
@@ -2035,6 +2069,7 @@ fn scan_insecure_typescript(node: &tree_sitter::Node, source: &str, findings: &m
                 judge_verdict: None,
                 judge_confidence: None,
                 precision_tier: None,
+                    in_diff: None,
                 });
         }
     }
@@ -2095,6 +2130,7 @@ fn scan_insecure_typescript(node: &tree_sitter::Node, source: &str, findings: &m
                             judge_verdict: None,
                             judge_confidence: None,
                             precision_tier: None,
+                    in_diff: None,
                             });
                 }
             }
@@ -2138,6 +2174,7 @@ fn scan_insecure_typescript(node: &tree_sitter::Node, source: &str, findings: &m
                 judge_verdict: None,
                 judge_confidence: None,
                 precision_tier: None,
+                    in_diff: None,
                 });
         }
     }
@@ -2173,6 +2210,7 @@ fn scan_insecure_typescript(node: &tree_sitter::Node, source: &str, findings: &m
                 judge_verdict: None,
                 judge_confidence: None,
                 precision_tier: None,
+                    in_diff: None,
             });
         }
     }
@@ -2215,6 +2253,7 @@ fn scan_insecure_typescript(node: &tree_sitter::Node, source: &str, findings: &m
                 judge_verdict: None,
                 judge_confidence: None,
                 precision_tier: None,
+                    in_diff: None,
             });
         }
     }
@@ -2268,6 +2307,7 @@ fn scan_insecure_typescript(node: &tree_sitter::Node, source: &str, findings: &m
                         judge_verdict: None,
                         judge_confidence: None,
                         precision_tier: None,
+                    in_diff: None,
                         });
                 break;
             }
@@ -2316,6 +2356,7 @@ fn scan_insecure_typescript(node: &tree_sitter::Node, source: &str, findings: &m
                             judge_verdict: None,
                             judge_confidence: None,
                             precision_tier: None,
+                    in_diff: None,
                             });
             }
         }
@@ -2349,6 +2390,7 @@ fn scan_insecure_typescript(node: &tree_sitter::Node, source: &str, findings: &m
         judge_verdict: None,
         judge_confidence: None,
         precision_tier: None,
+                    in_diff: None,
         });
     }
 }
@@ -2386,6 +2428,7 @@ fn scan_insecure_bash(node: &tree_sitter::Node, source: &str, findings: &mut Vec
             judge_verdict: None,
             judge_confidence: None,
             precision_tier: None,
+                    in_diff: None,
             });
     }
 
@@ -2432,6 +2475,7 @@ fn scan_insecure_bash(node: &tree_sitter::Node, source: &str, findings: &mut Vec
                 judge_verdict: None,
                 judge_confidence: None,
                 precision_tier: None,
+                    in_diff: None,
             });
         }
     }
@@ -2469,6 +2513,7 @@ fn scan_insecure_bash(node: &tree_sitter::Node, source: &str, findings: &mut Vec
                 judge_verdict: None,
                 judge_confidence: None,
                 precision_tier: None,
+                    in_diff: None,
             });
         }
 
@@ -2505,6 +2550,7 @@ fn scan_insecure_bash(node: &tree_sitter::Node, source: &str, findings: &mut Vec
                             judge_verdict: None,
                             judge_confidence: None,
                             precision_tier: None,
+                    in_diff: None,
                         });
                         break;
                     }
@@ -2551,6 +2597,7 @@ fn scan_insecure_bash(node: &tree_sitter::Node, source: &str, findings: &mut Vec
                         judge_verdict: None,
                         judge_confidence: None,
                         precision_tier: None,
+                    in_diff: None,
                     });
                     break;
                 }
@@ -2606,6 +2653,7 @@ fn scan_insecure_bash(node: &tree_sitter::Node, source: &str, findings: &mut Vec
                             judge_verdict: None,
                             judge_confidence: None,
                             precision_tier: None,
+                    in_diff: None,
                             });
                 }
             }
@@ -2647,6 +2695,7 @@ fn scan_insecure_dockerfile(node: &tree_sitter::Node, source: &str, findings: &m
                 judge_verdict: None,
                 judge_confidence: None,
                 precision_tier: None,
+                    in_diff: None,
                 });
             }
         }
@@ -2699,6 +2748,7 @@ fn scan_insecure_dockerfile(node: &tree_sitter::Node, source: &str, findings: &m
                             judge_verdict: None,
                             judge_confidence: None,
                             precision_tier: None,
+                    in_diff: None,
                             });
                             break;
                         }
@@ -2740,6 +2790,7 @@ fn scan_insecure_dockerfile(node: &tree_sitter::Node, source: &str, findings: &m
                 judge_verdict: None,
                 judge_confidence: None,
                 precision_tier: None,
+                    in_diff: None,
                 });
             }
         }
@@ -2850,6 +2901,7 @@ fn scan_insecure_terraform(node: &tree_sitter::Node, source: &str, findings: &mu
                                 judge_verdict: None,
                                 judge_confidence: None,
                                 precision_tier: None,
+                    in_diff: None,
                                 });
             }
         }
@@ -2897,6 +2949,7 @@ fn scan_insecure_terraform(node: &tree_sitter::Node, source: &str, findings: &mu
                                 judge_verdict: None,
                                 judge_confidence: None,
                                 precision_tier: None,
+                    in_diff: None,
                                 });
                     }
                 }
@@ -2972,6 +3025,7 @@ fn scan_insecure_terraform(node: &tree_sitter::Node, source: &str, findings: &mu
                     judge_verdict: None,
                     judge_confidence: None,
                     precision_tier: None,
+                    in_diff: None,
                     });
         }
     }
@@ -3072,6 +3126,7 @@ fn analyze_terraform_structure(tree: &tree_sitter::Tree, source: &str) -> Vec<Fi
         judge_verdict: None,
         judge_confidence: None,
         precision_tier: None,
+                    in_diff: None,
         });
     }
 
@@ -3173,6 +3228,7 @@ fn check_required_providers(rp_body: tree_sitter::Node, source: &str, findings: 
                 judge_verdict: None,
                 judge_confidence: None,
                 precision_tier: None,
+                    in_diff: None,
             });
         }
     }
@@ -3279,6 +3335,7 @@ fn analyze_dockerfile_structure(tree: &tree_sitter::Tree, source: &str) -> Vec<F
                         judge_verdict: None,
                         judge_confidence: None,
                         precision_tier: None,
+                    in_diff: None,
                         });
                     }
                 }
@@ -3320,6 +3377,7 @@ fn analyze_dockerfile_structure(tree: &tree_sitter::Tree, source: &str) -> Vec<F
             judge_verdict: None,
             judge_confidence: None,
             precision_tier: None,
+                    in_diff: None,
         });
     }
 
@@ -3351,6 +3409,7 @@ fn analyze_dockerfile_structure(tree: &tree_sitter::Tree, source: &str) -> Vec<F
         judge_verdict: None,
         judge_confidence: None,
         precision_tier: None,
+                    in_diff: None,
         });
     }
 
@@ -3385,6 +3444,7 @@ fn analyze_dockerfile_structure(tree: &tree_sitter::Tree, source: &str) -> Vec<F
             judge_verdict: None,
             judge_confidence: None,
             precision_tier: None,
+                    in_diff: None,
         });
     }
     if entrypoint_count > 1 {
@@ -3417,6 +3477,7 @@ fn analyze_dockerfile_structure(tree: &tree_sitter::Tree, source: &str) -> Vec<F
             judge_verdict: None,
             judge_confidence: None,
             precision_tier: None,
+                    in_diff: None,
         });
     }
 

--- a/src/analytics.rs
+++ b/src/analytics.rs
@@ -546,6 +546,7 @@ mod tests {
             fp_kind: None,
             finding_id: None,
             rule_id: None,
+            in_diff: None,
         }
     }
 
@@ -562,6 +563,7 @@ mod tests {
             fp_kind: None,
             finding_id: None,
             rule_id: None,
+            in_diff: None,
         }
     }
 

--- a/src/ast_grep.rs
+++ b/src/ast_grep.rs
@@ -365,6 +365,7 @@ pub fn scan_file(
                     judge_verdict: None,
                     judge_confidence: None,
                     precision_tier: Some(meta.precision.clone()),
+                    in_diff: None,
                 });
             }
         }

--- a/src/calibrator.rs
+++ b/src/calibrator.rs
@@ -114,6 +114,7 @@ fn make_no_match_trace(
         },
         provenance: None,
         same_file_precedent_count: None,
+        in_diff: None,
     }
 }
 
@@ -154,6 +155,7 @@ fn make_trace_entry(
         },
         provenance: None,
         same_file_precedent_count: None,
+        in_diff: None,
     }
 }
 

--- a/src/calibrator.rs
+++ b/src/calibrator.rs
@@ -6,6 +6,11 @@ use crate::category::Category;
 use crate::feedback::{FeedbackEntry, Verdict};
 use crate::finding::{CalibratorAction, Finding, Severity};
 
+/// Weight multiplier applied to verdicts where `in_diff = Some(false)`.
+/// Verdicts on findings that were outside the reviewed diff carry less signal
+/// (the reviewer may not have had full context), so we discount them by 30%.
+const OUT_OF_DIFF_WEIGHT: f64 = 0.7;
+
 #[derive(Debug, Clone)]
 pub struct CalibrationResult {
     pub findings: Vec<Finding>,
@@ -439,7 +444,12 @@ fn verdict_weight(entry: &FeedbackEntry, now: chrono::DateTime<chrono::Utc>) -> 
     let age_days = (now - entry.timestamp).num_days().unsigned_abs() as f64;
     let recency_weight = (-age_days / recency_tau_days).exp();
 
-    provenance_weight * recency_weight
+    let in_diff_factor = match entry.in_diff {
+        Some(false) => OUT_OF_DIFF_WEIGHT,
+        _ => 1.0,
+    };
+
+    provenance_weight * recency_weight * in_diff_factor
 }
 
 /// Calibrate findings using feedback precedent.
@@ -4870,5 +4880,93 @@ mod tests {
             decision.suppressed,
             "NaN threshold should fall back to legacy which suppresses at fp=2.0"
         );
+    }
+
+    // -------------------------------------------------------------------
+    // Task 6: OUT_OF_DIFF_WEIGHT discount in verdict_weight (#310)
+    // -------------------------------------------------------------------
+
+    #[test]
+    fn verdict_weight_in_diff_none_is_full_weight() {
+        let entry = crate::feedback::FeedbackEntry {
+            file_path: "test.rs".into(),
+            finding_title: "test".into(),
+            finding_category: "security".into(),
+            verdict: crate::feedback::Verdict::Tp,
+            reason: "real".into(),
+            model: None,
+            timestamp: chrono::Utc::now(),
+            provenance: crate::feedback::Provenance::Human,
+            fp_kind: None,
+            finding_id: None,
+            rule_id: None,
+            in_diff: None,
+        };
+        let w = verdict_weight(&entry, chrono::Utc::now());
+        assert!((w - 1.0).abs() < 0.01);
+    }
+
+    #[test]
+    fn verdict_weight_in_diff_true_is_full_weight() {
+        let entry = crate::feedback::FeedbackEntry {
+            file_path: "test.rs".into(),
+            finding_title: "test".into(),
+            finding_category: "security".into(),
+            verdict: crate::feedback::Verdict::Tp,
+            reason: "real".into(),
+            model: None,
+            timestamp: chrono::Utc::now(),
+            provenance: crate::feedback::Provenance::Human,
+            fp_kind: None,
+            finding_id: None,
+            rule_id: None,
+            in_diff: Some(true),
+        };
+        let w = verdict_weight(&entry, chrono::Utc::now());
+        assert!((w - 1.0).abs() < 0.01);
+    }
+
+    #[test]
+    fn verdict_weight_out_of_diff_applies_discount() {
+        let entry = crate::feedback::FeedbackEntry {
+            file_path: "test.rs".into(),
+            finding_title: "test".into(),
+            finding_category: "security".into(),
+            verdict: crate::feedback::Verdict::Tp,
+            reason: "real".into(),
+            model: None,
+            timestamp: chrono::Utc::now(),
+            provenance: crate::feedback::Provenance::Human,
+            fp_kind: None,
+            finding_id: None,
+            rule_id: None,
+            in_diff: Some(false),
+        };
+        let w = verdict_weight(&entry, chrono::Utc::now());
+        assert!((w - 0.7).abs() < 0.01);
+    }
+
+    #[test]
+    fn verdict_weight_external_out_of_diff_compounds() {
+        let entry = crate::feedback::FeedbackEntry {
+            file_path: "test.rs".into(),
+            finding_title: "test".into(),
+            finding_category: "security".into(),
+            verdict: crate::feedback::Verdict::Fp,
+            reason: "nah".into(),
+            model: None,
+            timestamp: chrono::Utc::now(),
+            provenance: crate::feedback::Provenance::External {
+                agent: "pal".into(),
+                model: None,
+                confidence: None,
+            },
+            fp_kind: None,
+            finding_id: None,
+            rule_id: None,
+            in_diff: Some(false),
+        };
+        let w = verdict_weight(&entry, chrono::Utc::now());
+        assert!((w - 0.49).abs() < 0.02);
     }
 }

--- a/src/calibrator.rs
+++ b/src/calibrator.rs
@@ -4893,8 +4893,17 @@ mod tests {
             .build();
         finding.in_diff = Some(true);
         let trace = make_trace_entry(
-            &finding, 1.0, 0.0, 0.0, 0.0, 0.0, vec![], None,
-            crate::finding::Severity::Medium, None, "test.rs",
+            &finding,
+            1.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            vec![],
+            None,
+            crate::finding::Severity::Medium,
+            None,
+            "test.rs",
         );
         assert_eq!(trace.in_diff, Some(true));
     }

--- a/src/calibrator.rs
+++ b/src/calibrator.rs
@@ -119,7 +119,7 @@ fn make_no_match_trace(
         },
         provenance: None,
         same_file_precedent_count: None,
-        in_diff: None,
+        in_diff: finding.in_diff,
     }
 }
 
@@ -4906,6 +4906,16 @@ mod tests {
             "test.rs",
         );
         assert_eq!(trace.in_diff, Some(true));
+    }
+
+    #[test]
+    fn no_match_trace_carries_in_diff_from_finding() {
+        let mut finding = crate::finding::FindingBuilder::new()
+            .severity(crate::finding::Severity::Medium)
+            .build();
+        finding.in_diff = Some(false);
+        let trace = make_no_match_trace(&finding, "test.rs");
+        assert_eq!(trace.in_diff, Some(false));
     }
 
     // -------------------------------------------------------------------

--- a/src/calibrator.rs
+++ b/src/calibrator.rs
@@ -160,7 +160,7 @@ fn make_trace_entry(
         },
         provenance: None,
         same_file_precedent_count: None,
-        in_diff: None,
+        in_diff: finding.in_diff,
     }
 }
 
@@ -4880,6 +4880,23 @@ mod tests {
             decision.suppressed,
             "NaN threshold should fall back to legacy which suppresses at fp=2.0"
         );
+    }
+
+    // -------------------------------------------------------------------
+    // Task 7: make_trace_entry propagates in_diff from finding (#310)
+    // -------------------------------------------------------------------
+
+    #[test]
+    fn trace_entry_carries_in_diff_from_finding() {
+        let mut finding = crate::finding::FindingBuilder::new()
+            .severity(crate::finding::Severity::Medium)
+            .build();
+        finding.in_diff = Some(true);
+        let trace = make_trace_entry(
+            &finding, 1.0, 0.0, 0.0, 0.0, 0.0, vec![], None,
+            crate::finding::Severity::Medium, None, "test.rs",
+        );
+        assert_eq!(trace.in_diff, Some(true));
     }
 
     // -------------------------------------------------------------------

--- a/src/calibrator.rs
+++ b/src/calibrator.rs
@@ -1213,6 +1213,7 @@ mod tests {
             fp_kind: None,
             finding_id: None,
             rule_id: None,
+            in_diff: None,
         }
     }
 
@@ -1554,6 +1555,7 @@ mod tests {
             fp_kind: Some(crate::feedback::FpKind::TrustModelAssumption),
             finding_id: None,
             rule_id: None,
+            in_diff: None,
         };
         let halluc_120d = FeedbackEntry {
             timestamp: now - chrono::Duration::days(120),
@@ -1611,6 +1613,7 @@ mod tests {
             fp_kind: Some(crate::feedback::FpKind::Hallucination),
             finding_id: None,
             rule_id: None,
+            in_diff: None,
         };
         let w = verdict_weight(&entry, now);
         // 1.0 (Human) * e^-1 ≈ 0.36788 — tight tolerance kills 120→119 mutant.
@@ -1634,6 +1637,7 @@ mod tests {
             }),
             finding_id: None,
             rule_id: None,
+            in_diff: None,
         };
         let w = verdict_weight(&entry, now);
         assert!(
@@ -1661,6 +1665,7 @@ mod tests {
             fp_kind: None,
             finding_id: None,
             rule_id: None,
+            in_diff: None,
         };
         let trust_entry = FeedbackEntry {
             fp_kind: Some(crate::feedback::FpKind::TrustModelAssumption),
@@ -1708,6 +1713,7 @@ mod tests {
             fp_kind: Some(crate::feedback::FpKind::TrustModelAssumption),
             finding_id: None,
             rule_id: None,
+            in_diff: None,
         };
         let w = verdict_weight(&entry, now);
         // 1.0 (Human) * e^(-40/120) ≈ 0.7165 — uses 120d default branch.
@@ -1739,6 +1745,7 @@ mod tests {
             }),
             finding_id: None,
             rule_id: None,
+            in_diff: None,
         };
         let feedback = vec![make_oos(1), make_oos(2), make_oos(3)];
         let findings = vec![
@@ -1775,6 +1782,7 @@ mod tests {
             fp_kind: Some(crate::feedback::FpKind::Hallucination),
             finding_id: None,
             rule_id: None,
+            in_diff: None,
         };
         let feedback = vec![make_halluc(1), make_halluc(2), make_halluc(3)];
         let findings = vec![
@@ -1820,6 +1828,7 @@ mod tests {
             }),
             finding_id: None,
             rule_id: None,
+            in_diff: None,
         };
         let entries = vec![make_oos(1), make_oos(2), make_oos(3)];
         for e in &entries {
@@ -2159,6 +2168,7 @@ mod tests {
             fp_kind: None,
             finding_id: None,
             rule_id: None,
+            in_diff: None,
         };
         let feedback = vec![auto_fb.clone(), auto_fb];
         let config = CalibratorConfig {
@@ -2192,6 +2202,7 @@ mod tests {
             fp_kind: None,
             finding_id: None,
             rule_id: None,
+            in_diff: None,
         };
         let human_fb = FeedbackEntry {
             provenance: crate::feedback::Provenance::Human,
@@ -2247,6 +2258,7 @@ mod tests {
             fp_kind: None,
             finding_id: None,
             rule_id: None,
+            in_diff: None,
         };
         let auto_fp = FeedbackEntry {
             file_path: "test.py".into(),
@@ -2260,6 +2272,7 @@ mod tests {
             fp_kind: None,
             finding_id: None,
             rule_id: None,
+            in_diff: None,
         };
 
         // Human (1.0) + auto (0.5) = 1.5 >= threshold -> suppress
@@ -2300,6 +2313,7 @@ mod tests {
             fp_kind: None,
             finding_id: None,
             rule_id: None,
+            in_diff: None,
         };
         let recent_fp = FeedbackEntry {
             file_path: "test.rs".into(),
@@ -2313,6 +2327,7 @@ mod tests {
             fp_kind: None,
             finding_id: None,
             rule_id: None,
+            in_diff: None,
         };
 
         let config = CalibratorConfig::default();
@@ -2350,6 +2365,7 @@ mod tests {
             fp_kind: None,
             finding_id: None,
             rule_id: None,
+            in_diff: None,
         };
 
         let config = CalibratorConfig::default();
@@ -2375,6 +2391,7 @@ mod tests {
             fp_kind: None,
             finding_id: None,
             rule_id: None,
+            in_diff: None,
         };
         let weight = verdict_weight(&old_entry, Utc::now());
         assert!(
@@ -2405,6 +2422,7 @@ mod tests {
             fp_kind: None,
             finding_id: None,
             rule_id: None,
+            in_diff: None,
         };
 
         let config = CalibratorConfig::default();
@@ -2438,6 +2456,7 @@ mod tests {
             fp_kind: None,
             finding_id: None,
             rule_id: None,
+            in_diff: None,
         };
         let feedback = vec![auto_fb.clone(), auto_fb.clone(), auto_fb.clone(), auto_fb];
         let config = CalibratorConfig::default();
@@ -2469,6 +2488,7 @@ mod tests {
             fp_kind: None,
             finding_id: None,
             rule_id: None,
+            in_diff: None,
         };
         let human_fb = FeedbackEntry {
             provenance: crate::feedback::Provenance::Human,
@@ -2634,6 +2654,7 @@ mod tests {
             fp_kind: None,
             finding_id: None,
             rule_id: None,
+            in_diff: None,
         };
 
         let config = CalibratorConfig::default();
@@ -3240,6 +3261,7 @@ mod tests {
             fp_kind: None,
             finding_id: None,
             rule_id: None,
+            in_diff: None,
         }
     }
 
@@ -3351,6 +3373,7 @@ mod tests {
             fp_kind: None,
             finding_id: None,
             rule_id: None,
+            in_diff: None,
         };
         let w = verdict_weight(&entry, Utc::now());
         assert!((w - 0.7).abs() < 0.01, "expected ~0.7, got {w}");
@@ -3377,6 +3400,7 @@ mod tests {
             fp_kind: None,
             finding_id: None,
             rule_id: None,
+            in_diff: None,
         };
         let cases: &[(&str, Option<f32>)] = &[
             ("None", None),
@@ -3411,6 +3435,7 @@ mod tests {
             fp_kind: None,
             finding_id: None,
             rule_id: None,
+            in_diff: None,
         };
         let w = verdict_weight(&entry, Utc::now());
         assert!((w - 0.3).abs() < 0.01, "Unknown must stay at 0.3, got {w}");
@@ -3436,6 +3461,7 @@ mod tests {
             fp_kind: None,
             finding_id: None,
             rule_id: None,
+            in_diff: None,
         }
     }
 
@@ -3544,6 +3570,7 @@ mod tests {
             fp_kind: None,
             finding_id: None,
             rule_id: None,
+            in_diff: None,
         }
     }
 
@@ -4258,6 +4285,7 @@ mod tests {
             fp_kind: None,
             finding_id: None,
             rule_id: None,
+            in_diff: None,
         }
     }
 

--- a/src/calibrator_fingerprint.rs
+++ b/src/calibrator_fingerprint.rs
@@ -180,6 +180,7 @@ mod tests {
             file_path: None,
             provenance: None,
             same_file_precedent_count: None,
+            in_diff: None,
         }
     }
 

--- a/src/calibrator_trace.rs
+++ b/src/calibrator_trace.rs
@@ -462,6 +462,9 @@ mod tests {
         // Old trace JSON without in_diff deserializes to None
         let old_json = r#"{"finding_title":"SQL injection","finding_category":"security","tp_weight":1.0,"fp_weight":0.0,"wontfix_weight":0.0,"full_suppress_weight":0.0,"soft_fp_weight":0.0,"matched_precedents":[],"action":null,"input_severity":"medium","output_severity":"medium"}"#;
         let old: CalibratorTraceEntry = serde_json::from_str(old_json).unwrap();
-        assert_eq!(old.in_diff, None, "old trace lines must deserialize in_diff as None");
+        assert_eq!(
+            old.in_diff, None,
+            "old trace lines must deserialize in_diff as None"
+        );
     }
 }

--- a/src/calibrator_trace.rs
+++ b/src/calibrator_trace.rs
@@ -85,6 +85,10 @@ pub struct CalibratorTraceEntry {
     pub provenance: Option<TraceProvenance>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub same_file_precedent_count: Option<usize>,
+    /// Whether the finding was inside the reviewed diff. `None` for backward-compat
+    /// with pre-#310 trace lines and when no diff context is available.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub in_diff: Option<bool>,
 }
 
 #[cfg(test)]
@@ -118,6 +122,7 @@ mod tests {
             file_path: None,
             provenance: None,
             same_file_precedent_count: None,
+            in_diff: None,
         };
         let json = serde_json::to_string(&trace).unwrap();
         assert!(json.contains("\"tp_weight\":2.5"));
@@ -142,6 +147,7 @@ mod tests {
             file_path: None,
             provenance: None,
             same_file_precedent_count: None,
+            in_diff: None,
         };
         let json = serde_json::to_string(&trace).unwrap();
         assert!(json.contains("\"matched_precedents\":[]"));
@@ -185,6 +191,7 @@ mod tests {
             file_path: None,
             provenance: None,
             same_file_precedent_count: None,
+            in_diff: None,
         };
         let json = serde_json::to_string(&trace).unwrap();
         assert!(
@@ -226,6 +233,7 @@ mod tests {
             file_path: Some("src/main.rs".to_string()),
             provenance: None,
             same_file_precedent_count: None,
+            in_diff: None,
         };
         let json = serde_json::to_string(&trace).unwrap();
         assert!(json.contains("\"file_path\":\"src/main.rs\""));
@@ -301,6 +309,7 @@ mod tests {
             file_path: None,
             provenance: None,
             same_file_precedent_count: Some(2),
+            in_diff: None,
         };
         let json = serde_json::to_string(&trace).unwrap();
         assert!(json.contains("\"same_file_precedent_count\":2"));
@@ -361,6 +370,7 @@ mod tests {
                 ..Default::default()
             }),
             same_file_precedent_count: None,
+            in_diff: None,
         };
         let json = serde_json::to_string(&trace).unwrap();
         assert!(
@@ -401,11 +411,57 @@ mod tests {
             file_path: None,
             provenance: None,
             same_file_precedent_count: None,
+            in_diff: None,
         };
         let json = serde_json::to_string(&trace).unwrap();
         assert!(
             !json.contains("provenance"),
             "None provenance must be omitted from JSON"
         );
+    }
+
+    #[test]
+    fn trace_entry_in_diff_serde_round_trip() {
+        let trace = CalibratorTraceEntry {
+            finding_title: "SQL injection".into(),
+            finding_category: "security".into(),
+            tp_weight: 1.0,
+            fp_weight: 0.0,
+            wontfix_weight: 0.0,
+            full_suppress_weight: 0.0,
+            soft_fp_weight: 0.0,
+            matched_precedents: vec![],
+            action: None,
+            input_severity: Severity::Medium,
+            output_severity: Severity::Medium,
+            severity_change_reason: None,
+            file_path: None,
+            provenance: None,
+            same_file_precedent_count: None,
+            in_diff: Some(false),
+        };
+        let json = serde_json::to_string(&trace).unwrap();
+        assert!(
+            json.contains("\"in_diff\":false"),
+            "in_diff:false must be present in JSON, got: {json}"
+        );
+        let parsed: CalibratorTraceEntry = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed.in_diff, Some(false));
+
+        // None is omitted
+        let trace_none = CalibratorTraceEntry {
+            in_diff: None,
+            ..trace.clone()
+        };
+        let json_none = serde_json::to_string(&trace_none).unwrap();
+        assert!(
+            !json_none.contains("in_diff"),
+            "None in_diff must be omitted from JSON"
+        );
+
+        // Old trace JSON without in_diff deserializes to None
+        let old_json = r#"{"finding_title":"SQL injection","finding_category":"security","tp_weight":1.0,"fp_weight":0.0,"wontfix_weight":0.0,"full_suppress_weight":0.0,"soft_fp_weight":0.0,"matched_precedents":[],"action":null,"input_severity":"medium","output_severity":"medium"}"#;
+        let old: CalibratorTraceEntry = serde_json::from_str(old_json).unwrap();
+        assert_eq!(old.in_diff, None, "old trace lines must deserialize in_diff as None");
     }
 }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -611,6 +611,11 @@ pub struct FeedbackOpts {
     /// orphaned deferrals (still records the entry though).
     #[arg(long, requires = "fp_kind")]
     pub fp_tracked_in: Option<String>,
+
+    /// Whether the finding was inside the diff (true), outside (false), or
+    /// unknown (omitted). Flows through both Human and External paths.
+    #[arg(long)]
+    pub in_diff: Option<bool>,
 }
 
 impl FeedbackOpts {

--- a/src/dimensions.rs
+++ b/src/dimensions.rs
@@ -1136,6 +1136,7 @@ mod tests {
             fp_kind: None,
             finding_id: None,
             rule_id: None,
+            in_diff: None,
         }
     }
 
@@ -1262,6 +1263,7 @@ mod tests {
             fp_kind: None,
             finding_id: None,
             rule_id: rule_id.map(String::from),
+            in_diff: None,
         }
     }
 

--- a/src/feedback.rs
+++ b/src/feedback.rs
@@ -2498,7 +2498,10 @@ mod tests {
         // JSON without in_diff field deserializes as None (backward compat).
         let legacy = r#"{"file_path":"x.rs","finding_title":"t","finding_category":"security","verdict":"tp","reason":"r","model":null,"timestamp":"2026-01-01T00:00:00Z"}"#;
         let entry: FeedbackEntry = serde_json::from_str(legacy).expect("legacy load");
-        assert_eq!(entry.in_diff, None, "legacy entries must deserialize in_diff as None");
+        assert_eq!(
+            entry.in_diff, None,
+            "legacy entries must deserialize in_diff as None"
+        );
 
         // And re-serializing a None in_diff entry must not introduce the key.
         let resaved = serde_json::to_string(&entry).unwrap();

--- a/src/feedback.rs
+++ b/src/feedback.rs
@@ -117,6 +117,11 @@ pub struct FeedbackEntry {
     /// sources (LLM, linter, custom AST patterns).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub rule_id: Option<String>,
+
+    /// Whether the finding was inside the reviewed diff. `None` for backward-compat
+    /// with pre-#310 entries and when no diff context is available.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub in_diff: Option<bool>,
 }
 
 /// Input for recording a verdict from an external review agent.
@@ -134,6 +139,7 @@ pub struct ExternalVerdictInput {
     pub agent: String,
     pub agent_model: Option<String>,
     pub confidence: Option<f32>,
+    pub in_diff: Option<bool>,
 }
 
 /// #123 Layer 1 (Task 10): adoption telemetry for the FpKind taxonomy.
@@ -251,6 +257,7 @@ impl From<ExternalVerdictInputWire> for ExternalVerdictInput {
             agent: w.agent,
             agent_model: w.agent_model,
             confidence: w.confidence,
+            in_diff: None,
         }
     }
 }
@@ -805,6 +812,7 @@ impl FeedbackStore {
             fp_kind: None,
             finding_id: None,
             rule_id: None,
+            in_diff: input.in_diff,
         };
         self.record(&entry)
     }
@@ -832,6 +840,7 @@ impl FeedbackStore {
             fp_kind: None,
             finding_id: None,
             rule_id: None,
+            in_diff: None,
         };
         self.record(&entry)
     }
@@ -929,6 +938,7 @@ mod tests {
             fp_kind,
             finding_id: None,
             rule_id: None,
+            in_diff: None,
         }
     }
 
@@ -1080,6 +1090,7 @@ mod tests {
             fp_kind: None,
             finding_id: None,
             rule_id: None,
+            in_diff: None,
         }
     }
 
@@ -1155,6 +1166,7 @@ mod tests {
             fp_kind: None,
             finding_id: None,
             rule_id: None,
+            in_diff: None,
         };
         assert_eq!(entry.provenance, Provenance::Human);
     }
@@ -1329,6 +1341,7 @@ mod tests {
             fp_kind: None,
             finding_id: None,
             rule_id: None,
+            in_diff: None,
         };
         store.record(&entry).unwrap();
         let all = store.load_all().unwrap();
@@ -1436,6 +1449,7 @@ mod tests {
             agent: "pal".into(),
             agent_model: Some("gemini-3-pro-preview".into()),
             confidence: Some(0.85),
+            in_diff: None,
         };
         store.record_external(input).unwrap();
         let all = store.load_all().unwrap();
@@ -1471,6 +1485,7 @@ mod tests {
                 agent: "  PaL  ".into(),
                 agent_model: None,
                 confidence: None,
+                in_diff: None,
             })
             .unwrap();
         let all = store.load_all().unwrap();
@@ -1493,6 +1508,7 @@ mod tests {
                 agent: "   ".into(),
                 agent_model: None,
                 confidence: None,
+                in_diff: None,
             })
             .expect_err("empty agent must be rejected");
         assert!(
@@ -1514,6 +1530,7 @@ mod tests {
                 agent: "pal".into(),
                 agent_model: None,
                 confidence: None,
+                in_diff: None,
             })
             .unwrap();
         let all = store.load_all().unwrap();
@@ -1533,6 +1550,7 @@ mod tests {
                 agent: "pal".into(),
                 agent_model: None,
                 confidence: Some(1.5),
+                in_diff: None,
             })
             .unwrap();
         let all = store.load_all().unwrap();
@@ -1562,6 +1580,7 @@ mod tests {
                 agent: "pal".into(),
                 agent_model: None,
                 confidence: None,
+                in_diff: None,
             })
             .expect_err("ContextMisleading must be rejected for External provenance");
         assert!(
@@ -1637,6 +1656,7 @@ mod tests {
                 agent: "pal".into(),
                 agent_model: None,
                 confidence: None,
+                in_diff: None,
             })
             .expect_err("Wontfix must be rejected for External provenance");
         assert!(
@@ -2345,6 +2365,7 @@ mod tests {
             fp_kind: None,
             finding_id: None,
             rule_id: None,
+            in_diff: None,
         };
         let json = serde_json::to_string(&entry).expect("serialize");
         assert!(
@@ -2371,6 +2392,7 @@ mod tests {
             fp_kind: None,
             finding_id: Some("01HXYZ1234567890ABCDEFGHJK".into()),
             rule_id: Some("python/eval-non-literal".into()),
+            in_diff: None,
         };
         let json = serde_json::to_string(&entry).expect("serialize");
         let back: FeedbackEntry = serde_json::from_str(&json).expect("deserialize");
@@ -2397,6 +2419,7 @@ mod tests {
             fp_kind: None,
             finding_id: None,
             rule_id: Some("python/md5-usage".into()),
+            in_diff: None,
         };
         let json = serde_json::to_string(&entry).expect("serialize");
         assert!(
@@ -2442,6 +2465,46 @@ mod tests {
         assert!(
             !resaved.contains("\"rule_id\""),
             "resave must not introduce rule_id key: {resaved}"
+        );
+    }
+
+    #[test]
+    fn feedback_in_diff_serde_round_trip() {
+        let entry = FeedbackEntry {
+            file_path: "src/auth.rs".into(),
+            finding_title: "SQL injection".into(),
+            finding_category: "security".into(),
+            verdict: Verdict::Tp,
+            reason: "confirmed".into(),
+            model: None,
+            timestamp: Utc::now(),
+            provenance: Provenance::Human,
+            fp_kind: None,
+            finding_id: None,
+            rule_id: None,
+            in_diff: Some(true),
+        };
+        let json = serde_json::to_string(&entry).unwrap();
+        assert!(
+            json.contains("\"in_diff\":true"),
+            "in_diff:true must be present in JSON, got: {json}"
+        );
+        let back: FeedbackEntry = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.in_diff, Some(true));
+    }
+
+    #[test]
+    fn feedback_in_diff_omitted_is_none() {
+        // JSON without in_diff field deserializes as None (backward compat).
+        let legacy = r#"{"file_path":"x.rs","finding_title":"t","finding_category":"security","verdict":"tp","reason":"r","model":null,"timestamp":"2026-01-01T00:00:00Z"}"#;
+        let entry: FeedbackEntry = serde_json::from_str(legacy).expect("legacy load");
+        assert_eq!(entry.in_diff, None, "legacy entries must deserialize in_diff as None");
+
+        // And re-serializing a None in_diff entry must not introduce the key.
+        let resaved = serde_json::to_string(&entry).unwrap();
+        assert!(
+            !resaved.contains("\"in_diff\""),
+            "None in_diff must be omitted from JSON, got: {resaved}"
         );
     }
 }

--- a/src/feedback_index.rs
+++ b/src/feedback_index.rs
@@ -535,6 +535,7 @@ mod tests {
             fp_kind: None,
             finding_id: None,
             rule_id: None,
+            in_diff: None,
         }
     }
 
@@ -861,6 +862,7 @@ mod tests {
             fp_kind: None,
             finding_id: None,
             rule_id: None,
+            in_diff: None,
         };
         let e_fp = FeedbackEntry {
             verdict: Verdict::Fp,

--- a/src/finding.rs
+++ b/src/finding.rs
@@ -148,6 +148,8 @@ pub struct Finding {
     pub judge_confidence: Option<f32>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub precision_tier: Option<PrecisionTier>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub in_diff: Option<bool>,
 }
 
 impl Finding {
@@ -250,6 +252,7 @@ impl FindingBuilder {
                 judge_verdict: None,
                 judge_confidence: None,
                 precision_tier: None,
+                in_diff: None,
             },
         }
     }
@@ -456,6 +459,7 @@ mod tests {
             judge_verdict: None,
             judge_confidence: None,
             precision_tier: None,
+            in_diff: None,
         };
         let json = serde_json::to_value(&f).unwrap();
         assert_eq!(json["title"], "Unvalidated input");
@@ -497,6 +501,7 @@ mod tests {
             judge_verdict: None,
             judge_confidence: None,
             precision_tier: None,
+            in_diff: None,
         };
         let json_str = serde_json::to_string(&original).unwrap();
         let deserialized: Finding = serde_json::from_str(&json_str).unwrap();
@@ -531,6 +536,7 @@ mod tests {
             judge_verdict: None,
             judge_confidence: None,
             precision_tier: None,
+            in_diff: None,
         };
         let json = serde_json::to_value(&f).unwrap();
         assert!(json["calibrator_action"].is_null());
@@ -567,6 +573,7 @@ mod tests {
             judge_verdict: None,
             judge_confidence: None,
             precision_tier: None,
+            in_diff: None,
         };
         assert!(f.is_valid());
     }
@@ -599,6 +606,7 @@ mod tests {
             judge_verdict: None,
             judge_confidence: None,
             precision_tier: None,
+            in_diff: None,
         };
         assert!(f.is_valid());
     }
@@ -631,6 +639,7 @@ mod tests {
             judge_verdict: None,
             judge_confidence: None,
             precision_tier: None,
+            in_diff: None,
         };
         assert!(!f.is_valid());
     }
@@ -663,6 +672,7 @@ mod tests {
             judge_verdict: None,
             judge_confidence: None,
             precision_tier: None,
+            in_diff: None,
         };
         assert!(!f.is_valid());
     }
@@ -1170,5 +1180,39 @@ mod tests {
         f.judge_confidence = Some(f32::NAN);
         f.compute_confidence();
         assert!((f.confidence.unwrap() - 0.95).abs() < 0.01);
+    }
+
+    // -- in_diff field --
+
+    #[test]
+    fn in_diff_serde_round_trip() {
+        let mut f = FindingBuilder::new().build();
+        assert_eq!(f.in_diff, None);
+
+        f.in_diff = Some(true);
+        let json = serde_json::to_string(&f).unwrap();
+        assert!(json.contains("\"in_diff\":true"));
+        let parsed: Finding = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed.in_diff, Some(true));
+
+        f.in_diff = Some(false);
+        let json = serde_json::to_string(&f).unwrap();
+        assert!(json.contains("\"in_diff\":false"));
+        let parsed: Finding = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed.in_diff, Some(false));
+    }
+
+    #[test]
+    fn in_diff_omitted_deserializes_as_none() {
+        let json = r#"{"title":"t","description":"d","severity":"info","category":"maintainability","source":"local-ast","line_start":1,"line_end":1,"evidence":[],"similar_precedent":[]}"#;
+        let f: Finding = serde_json::from_str(json).unwrap();
+        assert_eq!(f.in_diff, None);
+    }
+
+    #[test]
+    fn in_diff_none_not_serialized() {
+        let f = FindingBuilder::new().build();
+        let json = serde_json::to_string(&f).unwrap();
+        assert!(!json.contains("in_diff"));
     }
 }

--- a/src/finding.rs
+++ b/src/finding.rs
@@ -320,6 +320,16 @@ impl FindingBuilder {
         self
     }
 
+    pub fn line_start(mut self, start: u32) -> Self {
+        self.inner.line_start = start;
+        self
+    }
+
+    pub fn line_end(mut self, end: u32) -> Self {
+        self.inner.line_end = end;
+        self
+    }
+
     pub fn evidence(mut self, e: &str) -> Self {
         self.inner.evidence.push(e.into());
         self

--- a/src/linter.rs
+++ b/src/linter.rs
@@ -299,6 +299,7 @@ pub fn normalize_ruff_output(json_output: &str) -> anyhow::Result<Vec<Finding>> 
             judge_verdict: None,
             judge_confidence: None,
             precision_tier: None,
+            in_diff: None,
         });
     }
 
@@ -366,6 +367,7 @@ pub fn normalize_clippy_output(json_output: &str) -> anyhow::Result<Vec<Finding>
             judge_verdict: None,
             judge_confidence: None,
             precision_tier: None,
+            in_diff: None,
         });
     }
 
@@ -421,6 +423,7 @@ pub fn normalize_eslint_output(json_output: &str) -> anyhow::Result<Vec<Finding>
                 judge_verdict: None,
                 judge_confidence: None,
                 precision_tier: None,
+                in_diff: None,
             });
         }
     }
@@ -490,6 +493,7 @@ pub fn normalize_yamllint_output(output: &str) -> anyhow::Result<Vec<Finding>> {
             judge_verdict: None,
             judge_confidence: None,
             precision_tier: None,
+            in_diff: None,
         });
     }
     Ok(findings)
@@ -542,6 +546,7 @@ pub fn normalize_shellcheck_output(json_output: &str) -> anyhow::Result<Vec<Find
                 judge_verdict: None,
                 judge_confidence: None,
                 precision_tier: None,
+                in_diff: None,
             });
         }
     }
@@ -611,6 +616,7 @@ pub fn normalize_hadolint_output(output: &str) -> anyhow::Result<Vec<Finding>> {
             judge_verdict: None,
             judge_confidence: None,
             precision_tier: None,
+            in_diff: None,
         });
     }
     Ok(findings)
@@ -664,6 +670,7 @@ pub fn normalize_tflint_output(json_output: &str) -> anyhow::Result<Vec<Finding>
                 judge_verdict: None,
                 judge_confidence: None,
                 precision_tier: None,
+                in_diff: None,
             });
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1932,6 +1932,7 @@ fn run_feedback_inner(
     blamed_chunks: Option<&str>,
     category: Option<&str>,
     fp_kind: Option<feedback::FpKind>,
+    in_diff: Option<bool>,
     json: bool,
     feedback_path: &std::path::Path,
 ) -> (i32, String) {
@@ -1973,7 +1974,7 @@ fn run_feedback_inner(
         fp_kind,
         finding_id: None,
         rule_id: None,
-        in_diff: None,
+        in_diff,
     };
 
     let store = feedback::FeedbackStore::new(feedback_path.to_path_buf());
@@ -2045,7 +2046,7 @@ fn run_feedback(opts: cli::FeedbackOpts) -> i32 {
             agent: agent.to_string(),
             agent_model: opts.agent_model.clone(),
             confidence: opts.confidence,
-            in_diff: None,
+            in_diff: opts.in_diff,
         };
         if let Some(parent) = feedback_path.parent() {
             let _ = std::fs::create_dir_all(parent);
@@ -2130,6 +2131,7 @@ fn run_feedback(opts: cli::FeedbackOpts) -> i32 {
             opts.blamed_chunks.as_deref(),
             opts.category.as_deref(),
             fp_kind,
+            opts.in_diff,
             opts.json,
             &feedback_path,
         );
@@ -2467,6 +2469,7 @@ mod feedback_tests {
             None,
             None,
             None,
+            None,
             false,
             &path,
         );
@@ -2490,6 +2493,7 @@ mod feedback_tests {
             None,
             None,
             None,
+            None,
             false,
             &path,
         );
@@ -2506,6 +2510,7 @@ mod feedback_tests {
             "SQL injection",
             "tp",
             "Real issue",
+            None,
             None,
             None,
             None,
@@ -2531,6 +2536,7 @@ mod feedback_tests {
             None,
             None,
             None,
+            None,
             false,
             &path,
         );
@@ -2552,6 +2558,7 @@ mod feedback_tests {
             None,
             None,
             None,
+            None,
             false,
             &path,
         );
@@ -2569,6 +2576,7 @@ mod feedback_tests {
             "SQL injection",
             "fp",
             "Not a real issue",
+            None,
             None,
             None,
             None,
@@ -2600,6 +2608,7 @@ mod feedback_tests {
             None,
             None,
             None,
+            None,
             false,
             &path,
         );
@@ -2621,6 +2630,7 @@ mod feedback_tests {
             Some("chunk-abc,chunk-def"),
             None,
             None, // fp_kind
+            None, // in_diff
             false,
             &path,
         );
@@ -2671,6 +2681,7 @@ mod feedback_tests {
             Some("a,,b"),
             None,
             None, // fp_kind
+            None, // in_diff
             false,
             &path,
         );
@@ -2697,6 +2708,7 @@ mod feedback_tests {
             None, // user omitted --blamed-chunks entirely
             None,
             None, // fp_kind
+            None, // in_diff
             false,
             &path,
         );

--- a/src/main.rs
+++ b/src/main.rs
@@ -1973,6 +1973,7 @@ fn run_feedback_inner(
         fp_kind,
         finding_id: None,
         rule_id: None,
+        in_diff: None,
     };
 
     let store = feedback::FeedbackStore::new(feedback_path.to_path_buf());
@@ -2044,6 +2045,7 @@ fn run_feedback(opts: cli::FeedbackOpts) -> i32 {
             agent: agent.to_string(),
             agent_model: opts.agent_model.clone(),
             confidence: opts.confidence,
+            in_diff: None,
         };
         if let Some(parent) = feedback_path.parent() {
             let _ = std::fs::create_dir_all(parent);

--- a/src/mcp/handler.rs
+++ b/src/mcp/handler.rs
@@ -176,7 +176,7 @@ impl QuorumHandler {
                 agent,
                 agent_model: params.agent_model,
                 confidence: params.confidence,
-                in_diff: None,
+                in_diff: params.in_diff,
             };
             self.feedback_store
                 .record_external(input)
@@ -204,7 +204,7 @@ impl QuorumHandler {
             fp_kind,
             finding_id: None,
             rule_id: None,
-            in_diff: None,
+            in_diff: params.in_diff,
         };
 
         self.feedback_store
@@ -576,6 +576,7 @@ mod tests {
             confidence: None,
             category: None,
             fp_kind: None,
+            in_diff: None,
         };
 
         let result = handler.handle_feedback(params).unwrap();
@@ -618,6 +619,7 @@ mod tests {
             confidence: None,
             category: None,
             fp_kind: None,
+            in_diff: None,
         };
 
         let result = handler.handle_feedback(params).unwrap();
@@ -665,6 +667,7 @@ mod tests {
             confidence: None,
             category: None,
             fp_kind: None,
+            in_diff: None,
         };
 
         let err = handler.handle_feedback(params).expect_err("must reject");
@@ -704,6 +707,7 @@ mod tests {
             confidence: Some(0.9),
             category: None,
             fp_kind: None,
+            in_diff: None,
         };
         handler.handle_feedback(params).unwrap();
 
@@ -751,6 +755,7 @@ mod tests {
             confidence: None,
             category: None,
             fp_kind: None,
+            in_diff: None,
         };
         handler.handle_feedback(params).unwrap();
 
@@ -1428,6 +1433,7 @@ mod tests {
                 confidence: None,
                 category: None,
                 fp_kind: Some(kind.clone()),
+                in_diff: None,
             };
             handler.handle_feedback(params).unwrap();
 
@@ -1496,6 +1502,7 @@ mod tests {
             confidence: None,
             category: None,
             fp_kind: Some(FpKind::Hallucination),
+            in_diff: None,
         };
         handler.handle_feedback(params).unwrap();
 

--- a/src/mcp/handler.rs
+++ b/src/mcp/handler.rs
@@ -176,6 +176,7 @@ impl QuorumHandler {
                 agent,
                 agent_model: params.agent_model,
                 confidence: params.confidence,
+                in_diff: None,
             };
             self.feedback_store
                 .record_external(input)
@@ -203,6 +204,7 @@ impl QuorumHandler {
             fp_kind,
             finding_id: None,
             rule_id: None,
+            in_diff: None,
         };
 
         self.feedback_store

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -92,6 +92,10 @@ pub struct FeedbackTool {
     /// without `reference`) is rejected by serde at deserialization.
     #[serde(default, rename = "fpKind", skip_serializing_if = "Option::is_none")]
     pub fp_kind: Option<crate::feedback::FpKind>,
+    /// Whether the finding was inside the diff (true), outside (false), or
+    /// unknown (omitted). Flows through both Human and External paths.
+    #[serde(default, rename = "inDiff", skip_serializing_if = "Option::is_none")]
+    pub in_diff: Option<bool>,
 }
 
 #[mcp_tool(

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -155,9 +155,32 @@ pub fn format_review(file_path: &str, findings: &[Finding], style: &Style) -> St
         return out;
     }
 
-    for f in findings {
+    let has_diff_context = findings.iter().any(|f| f.in_diff.is_some());
+    let (in_diff, pre_existing): (Vec<_>, Vec<_>) = if has_diff_context {
+        findings
+            .iter()
+            .partition(|f| f.in_diff != Some(false))
+    } else {
+        (findings.iter().collect(), vec![])
+    };
+
+    for f in &in_diff {
         out.push_str(&format_finding(f, style));
         out.push('\n');
+    }
+
+    if !pre_existing.is_empty() {
+        out.push_str(&format!(
+            "\n  {dim}-- Pre-existing ({count} finding{s}) --{reset}\n\n",
+            dim = style.dim,
+            count = pre_existing.len(),
+            s = if pre_existing.len() == 1 { "" } else { "s" },
+            reset = style.reset,
+        ));
+        for f in &pre_existing {
+            out.push_str(&format_finding(f, style));
+            out.push('\n');
+        }
     }
 
     // Summary line
@@ -171,16 +194,31 @@ pub fn format_review(file_path: &str, findings: &[Finding], style: &Style) -> St
         .count();
     let info = findings.len() - critical - warning;
 
-    out.push_str(&format!(
-        "  {dim}{count} finding{s} ({critical} critical, {warning} warning, {info} info){reset}\n",
-        dim = style.dim,
-        count = findings.len(),
-        s = if findings.len() == 1 { "" } else { "s" },
-        critical = critical,
-        warning = warning,
-        info = info,
-        reset = style.reset,
-    ));
+    if has_diff_context && !pre_existing.is_empty() {
+        out.push_str(&format!(
+            "  {dim}{count} finding{s} ({in_diff} in this change, {pre} pre-existing) ({critical} critical, {warning} warning, {info} info){reset}\n",
+            dim = style.dim,
+            count = findings.len(),
+            s = if findings.len() == 1 { "" } else { "s" },
+            in_diff = in_diff.len(),
+            pre = pre_existing.len(),
+            critical = critical,
+            warning = warning,
+            info = info,
+            reset = style.reset,
+        ));
+    } else {
+        out.push_str(&format!(
+            "  {dim}{count} finding{s} ({critical} critical, {warning} warning, {info} info){reset}\n",
+            dim = style.dim,
+            count = findings.len(),
+            s = if findings.len() == 1 { "" } else { "s" },
+            critical = critical,
+            warning = warning,
+            info = info,
+            reset = style.reset,
+        ));
+    }
 
     out
 }
@@ -1104,5 +1142,64 @@ mod tests {
     #[test]
     fn json_flag_wins_even_in_terminal() {
         assert_eq!(resolve_output_mode(true, false, true), OutputMode::Json,);
+    }
+
+    // -- in-diff grouping --
+
+    #[test]
+    fn format_review_groups_in_diff_and_pre_existing() {
+        let mut in_diff_finding = FindingBuilder::new()
+            .title("SQL injection")
+            .severity(Severity::Critical)
+            .build();
+        in_diff_finding.in_diff = Some(true);
+
+        let mut pre_existing = FindingBuilder::new()
+            .title("Unused import")
+            .severity(Severity::Info)
+            .build();
+        pre_existing.in_diff = Some(false);
+
+        let style = Style::plain();
+        let output = format_review("src/main.rs", &[in_diff_finding, pre_existing], &style);
+        assert!(output.contains("SQL injection"));
+        assert!(output.contains("Pre-existing"));
+        assert!(output.contains("Unused import"));
+        // In-diff finding should appear before Pre-existing header
+        let sql_pos = output.find("SQL injection").unwrap();
+        let pre_pos = output.find("Pre-existing").unwrap();
+        assert!(sql_pos < pre_pos);
+    }
+
+    #[test]
+    fn format_review_no_pre_existing_header_when_all_in_diff() {
+        let mut f = FindingBuilder::new()
+            .severity(Severity::Medium)
+            .build();
+        f.in_diff = Some(true);
+        let style = Style::plain();
+        let output = format_review("test.rs", &[f], &style);
+        assert!(!output.contains("Pre-existing"));
+    }
+
+    #[test]
+    fn format_review_summary_shows_diff_breakdown() {
+        let mut f1 = FindingBuilder::new().severity(Severity::Medium).build();
+        f1.in_diff = Some(true);
+        let mut f2 = FindingBuilder::new().severity(Severity::Info).build();
+        f2.in_diff = Some(false);
+        let style = Style::plain();
+        let output = format_review("test.rs", &[f1, f2], &style);
+        assert!(output.contains("in this change"));
+        assert!(output.contains("pre-existing"));
+    }
+
+    #[test]
+    fn format_review_no_diff_context_renders_normally() {
+        let f = FindingBuilder::new().build(); // in_diff = None
+        let style = Style::plain();
+        let output = format_review("test.rs", &[f], &style);
+        assert!(!output.contains("Pre-existing"));
+        assert!(!output.contains("in this change"));
     }
 }

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -397,12 +397,14 @@ pub fn format_compact_review(file_path: &str, findings: &[Finding]) -> String {
 }
 
 pub fn compute_exit_code(findings: &[Finding]) -> i32 {
+    let dominated = |f: &&Finding| f.in_diff != Some(false);
     if findings
         .iter()
+        .filter(dominated)
         .any(|f| matches!(f.severity, Severity::Critical | Severity::High))
     {
         2
-    } else if findings.iter().any(|f| f.severity == Severity::Medium) {
+    } else if findings.iter().filter(dominated).any(|f| f.severity == Severity::Medium) {
         1
     } else {
         0
@@ -1230,5 +1232,47 @@ mod tests {
         let f = FindingBuilder::new().build(); // in_diff = None
         let line = format_compact_finding(&f);
         assert!(!line.starts_with("[pre]"));
+    }
+
+    // -- exit code scoped to in-diff findings --
+
+    #[test]
+    fn exit_code_ignores_pre_existing_critical() {
+        let mut f = FindingBuilder::new()
+            .severity(Severity::Critical)
+            .build();
+        f.in_diff = Some(false); // pre-existing
+        assert_eq!(compute_exit_code(&[f]), 0);
+    }
+
+    #[test]
+    fn exit_code_counts_in_diff_critical() {
+        let mut f = FindingBuilder::new()
+            .severity(Severity::Critical)
+            .build();
+        f.in_diff = Some(true);
+        assert_eq!(compute_exit_code(&[f]), 2);
+    }
+
+    #[test]
+    fn exit_code_counts_none_diff_context_normally() {
+        let f = FindingBuilder::new()
+            .severity(Severity::Critical)
+            .build(); // in_diff = None
+        assert_eq!(compute_exit_code(&[f]), 2);
+    }
+
+    #[test]
+    fn exit_code_mixed_in_diff_and_pre_existing() {
+        let mut in_diff = FindingBuilder::new()
+            .severity(Severity::Medium)
+            .build();
+        in_diff.in_diff = Some(true);
+        let mut pre = FindingBuilder::new()
+            .severity(Severity::Critical)
+            .build();
+        pre.in_diff = Some(false);
+        // Only the medium in-diff counts -> exit 1, not 2
+        assert_eq!(compute_exit_code(&[in_diff, pre]), 1);
     }
 }

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -358,7 +358,11 @@ pub fn format_compact_finding(f: &Finding) -> String {
     if f.based_on_excerpt.is_some() {
         result.push_str(" [excerpt]");
     }
-    result
+    if f.in_diff == Some(false) {
+        format!("[pre] {}", result)
+    } else {
+        result
+    }
 }
 
 pub fn format_compact_review(file_path: &str, findings: &[Finding]) -> String {
@@ -1201,5 +1205,30 @@ mod tests {
         let output = format_review("test.rs", &[f], &style);
         assert!(!output.contains("Pre-existing"));
         assert!(!output.contains("in this change"));
+    }
+
+    // -- compact finding [pre] prefix --
+
+    #[test]
+    fn compact_finding_pre_existing_gets_prefix() {
+        let mut f = FindingBuilder::new().title("Unused import").build();
+        f.in_diff = Some(false);
+        let line = format_compact_finding(&f);
+        assert!(line.starts_with("[pre] "));
+    }
+
+    #[test]
+    fn compact_finding_in_diff_no_prefix() {
+        let mut f = FindingBuilder::new().title("SQL injection").build();
+        f.in_diff = Some(true);
+        let line = format_compact_finding(&f);
+        assert!(!line.starts_with("[pre]"));
+    }
+
+    #[test]
+    fn compact_finding_no_diff_context_no_prefix() {
+        let f = FindingBuilder::new().build(); // in_diff = None
+        let line = format_compact_finding(&f);
+        assert!(!line.starts_with("[pre]"));
     }
 }

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -1265,4 +1265,11 @@ mod tests {
         // Only the medium in-diff counts -> exit 1, not 2
         assert_eq!(compute_exit_code(&[in_diff, pre]), 1);
     }
+
+    #[test]
+    fn exit_code_ignores_pre_existing_medium() {
+        let mut f = FindingBuilder::new().severity(Severity::Medium).build();
+        f.in_diff = Some(false);
+        assert_eq!(compute_exit_code(&[f]), 0);
+    }
 }

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -157,9 +157,7 @@ pub fn format_review(file_path: &str, findings: &[Finding], style: &Style) -> St
 
     let has_diff_context = findings.iter().any(|f| f.in_diff.is_some());
     let (in_diff, pre_existing): (Vec<_>, Vec<_>) = if has_diff_context {
-        findings
-            .iter()
-            .partition(|f| f.in_diff != Some(false))
+        findings.iter().partition(|f| f.in_diff != Some(false))
     } else {
         (findings.iter().collect(), vec![])
     };
@@ -404,7 +402,11 @@ pub fn compute_exit_code(findings: &[Finding]) -> i32 {
         .any(|f| matches!(f.severity, Severity::Critical | Severity::High))
     {
         2
-    } else if findings.iter().filter(dominated).any(|f| f.severity == Severity::Medium) {
+    } else if findings
+        .iter()
+        .filter(dominated)
+        .any(|f| f.severity == Severity::Medium)
+    {
         1
     } else {
         0
@@ -1179,9 +1181,7 @@ mod tests {
 
     #[test]
     fn format_review_no_pre_existing_header_when_all_in_diff() {
-        let mut f = FindingBuilder::new()
-            .severity(Severity::Medium)
-            .build();
+        let mut f = FindingBuilder::new().severity(Severity::Medium).build();
         f.in_diff = Some(true);
         let style = Style::plain();
         let output = format_review("test.rs", &[f], &style);
@@ -1238,39 +1238,29 @@ mod tests {
 
     #[test]
     fn exit_code_ignores_pre_existing_critical() {
-        let mut f = FindingBuilder::new()
-            .severity(Severity::Critical)
-            .build();
+        let mut f = FindingBuilder::new().severity(Severity::Critical).build();
         f.in_diff = Some(false); // pre-existing
         assert_eq!(compute_exit_code(&[f]), 0);
     }
 
     #[test]
     fn exit_code_counts_in_diff_critical() {
-        let mut f = FindingBuilder::new()
-            .severity(Severity::Critical)
-            .build();
+        let mut f = FindingBuilder::new().severity(Severity::Critical).build();
         f.in_diff = Some(true);
         assert_eq!(compute_exit_code(&[f]), 2);
     }
 
     #[test]
     fn exit_code_counts_none_diff_context_normally() {
-        let f = FindingBuilder::new()
-            .severity(Severity::Critical)
-            .build(); // in_diff = None
+        let f = FindingBuilder::new().severity(Severity::Critical).build(); // in_diff = None
         assert_eq!(compute_exit_code(&[f]), 2);
     }
 
     #[test]
     fn exit_code_mixed_in_diff_and_pre_existing() {
-        let mut in_diff = FindingBuilder::new()
-            .severity(Severity::Medium)
-            .build();
+        let mut in_diff = FindingBuilder::new().severity(Severity::Medium).build();
         in_diff.in_diff = Some(true);
-        let mut pre = FindingBuilder::new()
-            .severity(Severity::Critical)
-            .build();
+        let mut pre = FindingBuilder::new().severity(Severity::Critical).build();
         pre.in_diff = Some(false);
         // Only the medium in-diff counts -> exit 1, not 2
         assert_eq!(compute_exit_code(&[in_diff, pre]), 1);

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -1532,6 +1532,18 @@ pub async fn review_file_llm_only(
         grounded
     };
 
+    let mut merged = merged;
+    if let Some(ref diff_ranges) = pipeline_config.diff_ranges {
+        let repo_root = find_project_root(file_path);
+        let resolver = ReviewPathResolver::new(&file_str, &repo_root);
+        let diff_lines: Vec<(u32, u32)> = diff_ranges
+            .iter()
+            .filter(|(path, _)| resolver.matches(path))
+            .flat_map(|(_, ranges)| ranges.clone())
+            .collect();
+        classify_in_diff(&mut merged, &diff_lines);
+    }
+
     // Calibrate
     let has_feedback =
         !pipeline_config.feedback.is_empty() || pipeline_config.feedback_store.is_some();

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -1610,6 +1610,7 @@ mod tests {
             fp_kind,
             finding_id: None,
             rule_id: None,
+            in_diff: None,
         }
     }
 
@@ -1711,6 +1712,7 @@ mod tests {
                 fp_kind: None,
                 finding_id: None,
                 rule_id: None,
+                in_diff: None,
             },
             similarity,
         }
@@ -1735,6 +1737,7 @@ mod tests {
                 fp_kind: None,
                 finding_id: None,
                 rule_id: None,
+                in_diff: None,
             },
             similarity,
         }
@@ -2975,6 +2978,7 @@ mod tests {
                     fp_kind: None,
                     finding_id: None,
                     rule_id: None,
+                    in_diff: None,
                 },
                 similarity: 0.90,
             },
@@ -2991,6 +2995,7 @@ mod tests {
                     fp_kind: None,
                     finding_id: None,
                     rule_id: None,
+                    in_diff: None,
                 },
                 similarity: 0.90,
             },

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -1584,6 +1584,25 @@ pub async fn review_file_llm_only(
     })
 }
 
+/// Stamp each finding with `in_diff` based on line-range overlap with changed hunks.
+///
+/// Only called when `--diff-file` was explicitly provided. Invalid findings
+/// (malformed line ranges) are skipped.
+fn classify_in_diff(findings: &mut [Finding], changed_lines: &[(u32, u32)]) {
+    if changed_lines.is_empty() {
+        return;
+    }
+    for finding in findings {
+        if !finding.is_valid() {
+            continue;
+        }
+        let overlaps = changed_lines
+            .iter()
+            .any(|(start, end)| finding.line_start <= *end && finding.line_end >= *start);
+        finding.in_diff = Some(overlaps);
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -3005,5 +3024,65 @@ mod tests {
             candidates[0].entry.finding_title, "newer",
             "newer timestamp wins ties"
         );
+    }
+
+    // -- classify_in_diff --
+
+    #[test]
+    fn classify_in_diff_tags_overlapping_findings() {
+        use crate::finding::FindingBuilder;
+        let mut findings = vec![
+            FindingBuilder::new().line_start(10).line_end(20).build(),
+            FindingBuilder::new().line_start(50).line_end(60).build(),
+            FindingBuilder::new().line_start(100).line_end(100).build(),
+        ];
+        let changed = vec![(15, 25)];
+        classify_in_diff(&mut findings, &changed);
+        assert_eq!(findings[0].in_diff, Some(true));
+        assert_eq!(findings[1].in_diff, Some(false));
+        assert_eq!(findings[2].in_diff, Some(false));
+    }
+
+    #[test]
+    fn classify_in_diff_boundary_overlap() {
+        use crate::finding::FindingBuilder;
+        let mut findings = vec![
+            FindingBuilder::new().line_start(10).line_end(20).build(),
+            FindingBuilder::new().line_start(30).line_end(40).build(),
+        ];
+        let changed = vec![(20, 30)];
+        classify_in_diff(&mut findings, &changed);
+        assert_eq!(findings[0].in_diff, Some(true));
+        assert_eq!(findings[1].in_diff, Some(true));
+    }
+
+    #[test]
+    fn classify_in_diff_empty_changed_lines_is_noop() {
+        use crate::finding::FindingBuilder;
+        let mut findings = vec![FindingBuilder::new().build()];
+        classify_in_diff(&mut findings, &[]);
+        assert_eq!(findings[0].in_diff, None);
+    }
+
+    #[test]
+    fn classify_in_diff_skips_invalid_findings() {
+        use crate::finding::FindingBuilder;
+        let mut findings = vec![
+            FindingBuilder::new().line_start(0).line_end(0).build(),
+        ];
+        let changed = vec![(1, 100)];
+        classify_in_diff(&mut findings, &changed);
+        assert_eq!(findings[0].in_diff, None);
+    }
+
+    #[test]
+    fn classify_in_diff_large_span_finding() {
+        use crate::finding::FindingBuilder;
+        let mut findings = vec![
+            FindingBuilder::new().line_start(1).line_end(500).build(),
+        ];
+        let changed = vec![(250, 260)];
+        classify_in_diff(&mut findings, &changed);
+        assert_eq!(findings[0].in_diff, Some(true));
     }
 }

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -1098,6 +1098,22 @@ pub async fn review_file(
         grounded
     };
 
+    // Classify findings as in-diff or pre-existing when --diff-file is active.
+    let mut merged = merged;
+    if pipeline_config.diff_ranges.is_some() {
+        let repo_root = find_project_root(file_path);
+        let resolver = ReviewPathResolver::new(&file_str, &repo_root);
+        let diff_lines: Vec<(u32, u32)> = pipeline_config
+            .diff_ranges
+            .as_ref()
+            .unwrap()
+            .iter()
+            .filter(|(path, _)| resolver.matches(path))
+            .flat_map(|(_, ranges)| ranges.clone())
+            .collect();
+        classify_in_diff(&mut merged, &diff_lines);
+    }
+
     // Calibrate using feedback precedent (prefer FeedbackIndex for semantic matching)
     let has_feedback =
         !pipeline_config.feedback.is_empty() || pipeline_config.feedback_store.is_some();

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -1098,15 +1098,11 @@ pub async fn review_file(
         grounded
     };
 
-    // Classify findings as in-diff or pre-existing when --diff-file is active.
     let mut merged = merged;
-    if pipeline_config.diff_ranges.is_some() {
+    if let Some(ref diff_ranges) = pipeline_config.diff_ranges {
         let repo_root = find_project_root(file_path);
         let resolver = ReviewPathResolver::new(&file_str, &repo_root);
-        let diff_lines: Vec<(u32, u32)> = pipeline_config
-            .diff_ranges
-            .as_ref()
-            .unwrap()
+        let diff_lines: Vec<(u32, u32)> = diff_ranges
             .iter()
             .filter(|(path, _)| resolver.matches(path))
             .flat_map(|(_, ranges)| ranges.clone())
@@ -3083,9 +3079,7 @@ mod tests {
     #[test]
     fn classify_in_diff_skips_invalid_findings() {
         use crate::finding::FindingBuilder;
-        let mut findings = vec![
-            FindingBuilder::new().line_start(0).line_end(0).build(),
-        ];
+        let mut findings = vec![FindingBuilder::new().line_start(0).line_end(0).build()];
         let changed = vec![(1, 100)];
         classify_in_diff(&mut findings, &changed);
         assert_eq!(findings[0].in_diff, None);
@@ -3094,9 +3088,7 @@ mod tests {
     #[test]
     fn classify_in_diff_large_span_finding() {
         use crate::finding::FindingBuilder;
-        let mut findings = vec![
-            FindingBuilder::new().line_start(1).line_end(500).build(),
-        ];
+        let mut findings = vec![FindingBuilder::new().line_start(1).line_end(500).build()];
         let changed = vec![(250, 260)];
         classify_in_diff(&mut findings, &changed);
         assert_eq!(findings[0].in_diff, Some(true));

--- a/src/review.rs
+++ b/src/review.rs
@@ -160,6 +160,7 @@ impl LlmFinding {
             judge_verdict: None,
             judge_confidence: None,
             precision_tier: None,
+            in_diff: None,
         }
     }
 }

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -1279,6 +1279,7 @@ mod tests {
                 fp_kind: None,
                 finding_id: Some(format!("FID-{i}")),
                 rule_id: None,
+                in_diff: None,
             })
             .unwrap();
         }
@@ -1295,6 +1296,7 @@ mod tests {
                 fp_kind: None,
                 finding_id: None,
                 rule_id: None,
+                in_diff: None,
             })
             .unwrap();
         }

--- a/tests/calibrator_pre_refactor_snapshot.rs
+++ b/tests/calibrator_pre_refactor_snapshot.rs
@@ -67,6 +67,7 @@ fn human_fb(title: &str, category: &str, verdict: Verdict) -> FeedbackEntry {
         fp_kind: None,
         finding_id: None,
         rule_id: None,
+        in_diff: None,
     }
 }
 

--- a/tests/finding_schema_test.rs
+++ b/tests/finding_schema_test.rs
@@ -29,6 +29,7 @@ fn finding_with_new_fields_roundtrips() {
         judge_verdict: None,
         judge_confidence: None,
         precision_tier: None,
+        in_diff: None,
     };
 
     let json = serde_json::to_string(&finding).unwrap();
@@ -87,6 +88,7 @@ fn new_fields_omitted_from_json_when_none() {
         judge_verdict: None,
         judge_confidence: None,
         precision_tier: None,
+        in_diff: None,
     };
 
     let json = serde_json::to_string(&finding).unwrap();
@@ -129,6 +131,7 @@ fn category_serializes_as_kebab_case_in_finding() {
         judge_verdict: None,
         judge_confidence: None,
         precision_tier: None,
+        in_diff: None,
     };
 
     let json = serde_json::to_string(&finding).unwrap();

--- a/tests/lib_integration_smoke.rs
+++ b/tests/lib_integration_smoke.rs
@@ -45,6 +45,7 @@ fn lib_exports_are_reachable_from_integration_tests() {
         judge_verdict: None,
         judge_confidence: None,
         precision_tier: None,
+        in_diff: None,
     };
 
     // calibrate(...) must be callable with no precedents — exercises the


### PR DESCRIPTION
## Summary

- Tag each finding as `in_diff: true` (overlaps changed hunk), `in_diff: false` (pre-existing), or `None` (no diff context) when `--diff-file` is active
- Apply 0.7x confidence discount (`OUT_OF_DIFF_WEIGHT`) on out-of-diff verdicts in calibrator, stacking multiplicatively with provenance and recency weights
- Group findings in human output: in-diff findings render first, pre-existing appear under a `-- Pre-existing --` separator with count
- Add `[pre]` prefix to pre-existing findings in compact output mode
- Scope exit codes to in-diff findings only — pre-existing criticals no longer trigger exit 2 when `--diff-file` is active
- Wire `--in-diff` CLI flag and `inDiff` MCP field through all feedback paths (Human + External)
- Propagate `in_diff` to calibrator trace entries (both `make_trace_entry` and `make_no_match_trace`)

## Design decisions

1. **Any overlap = in-diff** — a finding touching changed code is relevant even if part of its range is pre-existing
2. **Gate on `--diff-file` flag, not `changed_lines` emptiness** — avoids false tagging from full-file fallback ranges
3. **`Option<bool>` everywhere** — backward-compatible via `serde(default, skip_serializing_if)`, zero-cost for full-file reviews
4. **0.7x constant** — conservative discount matching External provenance weight; tunable via #312 (learned weights)
5. **No severity downgrade** — visual grouping communicates priority without losing information

## Files changed (24 files, +2150/-14)

| Area | Files | What |
|------|-------|------|
| Data model | finding.rs, feedback.rs, calibrator_trace.rs | `in_diff: Option<bool>` on Finding, FeedbackEntry, CalibratorTraceEntry, ExternalVerdictInput |
| Classification | pipeline.rs | `classify_in_diff()` function + wiring after grounding |
| Calibrator | calibrator.rs | `OUT_OF_DIFF_WEIGHT`, discount in `verdict_weight()`, trace propagation |
| Output | output/mod.rs | Grouped human output, `[pre]` compact prefix, exit code scoping |
| Feedback | cli/mod.rs, mcp/tools.rs, mcp/handler.rs, main.rs | `--in-diff` flag, `inDiff` MCP field |
| Construction sites | analysis.rs + 10 others | `in_diff: None` at all Finding/FeedbackEntry construction sites |

## Test plan

- [x] 1408 bin tests passing, 0 clippy warnings, clean rustfmt
- [x] Serde round-trip tests for Finding, FeedbackEntry, CalibratorTraceEntry with `in_diff` present/absent/None
- [x] Boundary overlap tests (finding.line_end == hunk.start, finding.line_start == hunk.end)
- [x] Large-span findings (1-500, hunk at 250) tagged in_diff: true
- [x] Invalid findings (line_start=0) skipped by classifier
- [x] Empty changed_lines is a no-op (in_diff stays None)
- [x] Compound discount: External+out-of-diff = 0.49x, Human+out-of-diff = 0.7x
- [x] Exit code: pre-existing criticals → exit 0; in-diff medium → exit 1; None → contributes normally
- [x] Output grouping preserves sort order; Pre-existing header only when out-of-diff findings exist
- [x] No diff context (in_diff=None) renders identically to before
- [x] make_no_match_trace propagates in_diff from finding (bug fix from review)
- [x] Release build clean

Closes #310

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Classify findings as "in this change" vs "pre-existing" when a diff is provided; human output groups in-change first with an optional "Pre-existing" section and compact output adds a `[pre]` prefix.
  * JSON output now includes an in-diff marker when present.
  * Feedback/CLI: added `--in-diff` flag and `inDiff` field for external feedback.
  * Exit codes and scoring now ignore pre-existing findings; out-of-diff feedback applies a 0.7 weight discount.

* **Tests**
  * Added unit and integration tests covering classification, serialization, output grouping, discounting, and exit-code behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jsnyder/quorum/pull/317)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->