### PR TITLE
feat: wire LLM client into judge stage for speculative finding verdicts

### DIFF
--- a/src/judge.rs
+++ b/src/judge.rs
@@ -98,6 +98,36 @@ pub trait JudgeLlm: Send + Sync {
     async fn call(&self, prompt: &str) -> Option<String>;
 }
 
+const JUDGE_SYSTEM_PROMPT: &str =
+    "You are a code review judge. Respond with ONLY a JSON array, no other text.";
+
+pub struct OpenAiJudge {
+    client: std::sync::Arc<crate::llm_client::OpenAiClient>,
+    model: String,
+}
+
+impl OpenAiJudge {
+    pub fn new(client: std::sync::Arc<crate::llm_client::OpenAiClient>, model: String) -> Self {
+        Self { client, model }
+    }
+}
+
+impl JudgeLlm for OpenAiJudge {
+    async fn call(&self, prompt: &str) -> Option<String> {
+        match self
+            .client
+            .judge_completion(&self.model, prompt, JUDGE_SYSTEM_PROMPT)
+            .await
+        {
+            Ok(response) => Some(response.content),
+            Err(e) => {
+                tracing::warn!(model = %self.model, error = %e, "judge LLM call failed");
+                None
+            }
+        }
+    }
+}
+
 /// Build the LLM prompt for judging a batch of AST-detected findings.
 ///
 /// Each finding tuple is `(rule_id, title, line_start, line_end, evidence)`.

--- a/src/judge.rs
+++ b/src/judge.rs
@@ -94,6 +94,10 @@ pub fn parse_verdict(s: &str) -> JudgeVerdict {
     }
 }
 
+pub trait JudgeLlm: Send + Sync {
+    async fn call(&self, prompt: &str) -> Option<String>;
+}
+
 /// Build the LLM prompt for judging a batch of AST-detected findings.
 ///
 /// Each finding tuple is `(rule_id, title, line_start, line_end, evidence)`.
@@ -312,6 +316,16 @@ pub fn judge_findings(
 mod tests {
     use super::*;
     use crate::finding::{FindingBuilder, Source};
+
+    struct MockJudge {
+        response: Option<String>,
+    }
+
+    impl JudgeLlm for MockJudge {
+        async fn call(&self, _prompt: &str) -> Option<String> {
+            self.response.clone()
+        }
+    }
 
     #[test]
     fn cache_key_deterministic() {

--- a/src/judge.rs
+++ b/src/judge.rs
@@ -276,7 +276,7 @@ pub async fn judge_findings<J: JudgeLlm>(
                             .map(|s| s.as_str())
                             .unwrap_or("");
                         let key = verdict_cache_key(&v.rule_id, evidence);
-                        let _ = write_cache_entry(
+                        if let Err(e) = write_cache_entry(
                             cache_path,
                             &CacheEntry {
                                 cache_key: key,
@@ -286,7 +286,13 @@ pub async fn judge_findings<J: JudgeLlm>(
                                 reason: v.reason.clone(),
                                 timestamp: Utc::now(),
                             },
-                        );
+                        ) {
+                            tracing::warn!(
+                                path = %cache_path.display(),
+                                error = %e,
+                                "failed to persist judge cache entry"
+                            );
+                        }
 
                         match verdict {
                             JudgeVerdict::Approved => result.approved += 1,

--- a/src/judge.rs
+++ b/src/judge.rs
@@ -186,14 +186,14 @@ pub struct JudgeResult {
 /// - Findings with `judge: Required` that are rejected get dropped.
 /// - Findings with `judge: Optional` that are rejected get confidence
 ///   clamped to 0.05.
-#[allow(clippy::too_many_arguments, clippy::type_complexity)]
-pub fn judge_findings(
+#[allow(clippy::too_many_arguments)]
+pub async fn judge_findings<J: JudgeLlm>(
     findings: &mut Vec<Finding>,
     source_code: &str,
     metadata: &HashMap<String, RuleMetadata>,
     cache: &HashMap<String, CacheEntry>,
     cache_path: &Path,
-    llm_call: Option<&dyn Fn(&str) -> Option<String>>,
+    llm: Option<&J>,
 ) -> JudgeResult {
     let start = std::time::Instant::now();
     let mut result = JudgeResult::default();
@@ -235,7 +235,10 @@ pub fn judge_findings(
 
     // Phase 2: Batch LLM call for uncached findings
     if !to_judge.is_empty() {
-        if let Some(llm) = llm_call {
+        if let Some(llm) = llm {
+            if to_judge.len() > 50 {
+                tracing::warn!(count = to_judge.len(), "large batch of speculative findings for judge");
+            }
             let items: Vec<_> = to_judge
                 .iter()
                 .map(|&i| {
@@ -253,7 +256,7 @@ pub fn judge_findings(
             let prompt = build_judge_prompt(source_code, &items);
             result.calls += 1;
 
-            if let Some(response) = llm(&prompt)
+            if let Some(response) = llm.call(&prompt).await
                 && let Ok(verdicts) = serde_json::from_str::<Vec<JudgeResponseItem>>(&response)
             {
                 for v in &verdicts {
@@ -292,6 +295,8 @@ pub fn judge_findings(
                         }
                     }
                 }
+            } else if to_judge.iter().any(|&i| findings[i].judge_verdict.is_none()) {
+                tracing::warn!("judge LLM returned no usable response");
             }
 
             // Any remaining unjudged findings (LLM didn't return verdict): mark uncertain
@@ -433,8 +438,8 @@ mod tests {
         assert_eq!(verdicts[1].verdict, "fp");
     }
 
-    #[test]
-    fn judge_skips_high_precision_rules() {
+    #[tokio::test]
+    async fn judge_skips_high_precision_rules() {
         let mut findings = vec![{
             let mut f = FindingBuilder::new()
                 .source(Source::Linter("ast-grep".into()))
@@ -459,14 +464,15 @@ mod tests {
             &metadata,
             &HashMap::new(),
             &cache_path,
-            None,
-        );
+            None::<&MockJudge>,
+        )
+        .await;
         assert_eq!(result.skipped, 1);
         assert_eq!(findings[0].judge_verdict, Some(JudgeVerdict::Skipped));
     }
 
-    #[test]
-    fn judge_approves_with_mock_llm() {
+    #[tokio::test]
+    async fn judge_approves_with_mock_llm() {
         let mut findings = vec![{
             let mut f = FindingBuilder::new()
                 .source(Source::Linter("ast-grep".into()))
@@ -486,10 +492,10 @@ mod tests {
         );
         let dir = tempfile::tempdir().unwrap();
         let cache_path = dir.path().join("cache.jsonl");
-        let mock_llm = |_prompt: &str| -> Option<String> {
-            Some(
+        let mock = MockJudge {
+            response: Some(
                 r#"[{"rule_id":"ast-grep:python/broad-exception-catch","verdict":"tp","confidence":0.85,"reason":"valid"}]"#.into(),
-            )
+            ),
         };
         let result = judge_findings(
             &mut findings,
@@ -497,8 +503,9 @@ mod tests {
             &metadata,
             &HashMap::new(),
             &cache_path,
-            Some(&mock_llm),
-        );
+            Some(&mock),
+        )
+        .await;
         assert_eq!(result.approved, 1);
         assert_eq!(result.calls, 1);
         assert_eq!(findings.len(), 1);
@@ -509,8 +516,8 @@ mod tests {
         assert_eq!(loaded.len(), 1);
     }
 
-    #[test]
-    fn judge_drops_required_rejected() {
+    #[tokio::test]
+    async fn judge_drops_required_rejected() {
         let mut findings = vec![{
             let mut f = FindingBuilder::new()
                 .source(Source::Linter("ast-grep".into()))
@@ -530,10 +537,10 @@ mod tests {
         );
         let dir = tempfile::tempdir().unwrap();
         let cache_path = dir.path().join("cache.jsonl");
-        let mock_llm = |_prompt: &str| -> Option<String> {
-            Some(
+        let mock = MockJudge {
+            response: Some(
                 r#"[{"rule_id":"ast-grep:python/broad-exception-catch","verdict":"fp","confidence":0.92,"reason":"intentional top-level handler"}]"#.into(),
-            )
+            ),
         };
         let result = judge_findings(
             &mut findings,
@@ -541,8 +548,9 @@ mod tests {
             &metadata,
             &HashMap::new(),
             &cache_path,
-            Some(&mock_llm),
-        );
+            Some(&mock),
+        )
+        .await;
         assert_eq!(result.rejected, 1);
         assert!(
             findings.is_empty(),
@@ -550,8 +558,8 @@ mod tests {
         );
     }
 
-    #[test]
-    fn judge_uses_cache_hit() {
+    #[tokio::test]
+    async fn judge_uses_cache_hit() {
         let mut findings = vec![{
             let mut f = FindingBuilder::new()
                 .source(Source::Linter("ast-grep".into()))
@@ -590,15 +598,16 @@ mod tests {
             &metadata,
             &cache,
             &cache_path,
-            None,
-        );
+            None::<&MockJudge>,
+        )
+        .await;
         assert_eq!(result.cache_hits, 1);
         assert_eq!(result.approved, 1);
         assert_eq!(result.calls, 0);
     }
 
-    #[test]
-    fn judge_flow_end_to_end_with_cache() {
+    #[tokio::test]
+    async fn judge_flow_end_to_end_with_cache() {
         let mut findings = vec![
             {
                 let mut f = FindingBuilder::new()
@@ -643,8 +652,8 @@ mod tests {
         let cache = HashMap::new();
 
         // Mock LLM: always approve
-        let mock_llm = |_prompt: &str| -> Option<String> {
-            Some(r#"[{"rule_id":"ast-grep:python/broad-exception-catch","verdict":"tp","confidence":0.85,"reason":"valid"}]"#.into())
+        let mock = MockJudge {
+            response: Some(r#"[{"rule_id":"ast-grep:python/broad-exception-catch","verdict":"tp","confidence":0.85,"reason":"valid"}]"#.into()),
         };
 
         let result = judge_findings(
@@ -653,8 +662,9 @@ mod tests {
             &metadata,
             &cache,
             &cache_path,
-            Some(&mock_llm),
-        );
+            Some(&mock),
+        )
+        .await;
 
         assert_eq!(result.approved, 1);
         assert_eq!(result.skipped, 1);
@@ -668,8 +678,8 @@ mod tests {
         assert_eq!(loaded_cache.len(), 1);
     }
 
-    #[test]
-    fn judge_drops_required_rejected_findings() {
+    #[tokio::test]
+    async fn judge_drops_required_rejected_findings() {
         let mut findings = vec![
             {
                 let mut f = FindingBuilder::new()
@@ -714,8 +724,8 @@ mod tests {
         let cache = HashMap::new();
 
         // Mock LLM: rejects the speculative finding
-        let mock_llm = |_prompt: &str| -> Option<String> {
-            Some(r#"[{"rule_id":"ast-grep:python/broad-exception-catch","verdict":"fp","confidence":0.92,"reason":"intentional"}]"#.into())
+        let mock = MockJudge {
+            response: Some(r#"[{"rule_id":"ast-grep:python/broad-exception-catch","verdict":"fp","confidence":0.92,"reason":"intentional"}]"#.into()),
         };
 
         let result = judge_findings(
@@ -724,8 +734,9 @@ mod tests {
             &metadata,
             &cache,
             &cache_path,
-            Some(&mock_llm),
-        );
+            Some(&mock),
+        )
+        .await;
 
         assert_eq!(result.rejected, 1);
         assert_eq!(result.skipped, 1);

--- a/src/judge.rs
+++ b/src/judge.rs
@@ -743,4 +743,145 @@ mod tests {
         assert_eq!(findings.len(), 1); // speculative finding was DROPPED
         assert_eq!(findings[0].title, "as-any-cast: as any cast"); // only the high-precision one remains
     }
+
+    #[tokio::test]
+    async fn judge_handles_llm_failure_gracefully() {
+        let judge = MockJudge { response: None };
+
+        let mut findings = vec![{
+            let mut f = FindingBuilder::new()
+                .source(Source::Linter("ast-grep".into()))
+                .rule_id("ast-grep:rust/discarded-result")
+                .evidence("let _ = foo()")
+                .build();
+            f.precision_tier = Some(PrecisionTier::Speculative);
+            f
+        }];
+        let mut metadata = HashMap::new();
+        metadata.insert(
+            "ast-grep:rust/discarded-result".into(),
+            RuleMetadata {
+                precision: PrecisionTier::Speculative,
+                judge: JudgeRequirement::Required,
+            },
+        );
+        let dir = tempfile::tempdir().unwrap();
+        let cache_path = dir.path().join("cache.jsonl");
+
+        let result = judge_findings(
+            &mut findings,
+            "fn main() { let _ = foo(); }",
+            &metadata,
+            &HashMap::new(),
+            &cache_path,
+            Some(&judge),
+        )
+        .await;
+
+        assert_eq!(result.uncertain, 1);
+        assert_eq!(result.calls, 1);
+        assert_eq!(findings[0].judge_verdict, Some(JudgeVerdict::Uncertain));
+    }
+
+    #[tokio::test]
+    async fn judge_handles_partial_llm_response() {
+        let judge = MockJudge {
+            response: Some(
+                r#"[{"rule_id":"ast-grep:python/missing-await","verdict":"tp","confidence":0.9,"reason":"ok"}]"#
+                    .into(),
+            ),
+        };
+
+        let mut findings = vec![
+            {
+                let mut f = FindingBuilder::new()
+                    .source(Source::Linter("ast-grep".into()))
+                    .rule_id("ast-grep:python/missing-await")
+                    .evidence("await missing")
+                    .build();
+                f.precision_tier = Some(PrecisionTier::Speculative);
+                f
+            },
+            {
+                let mut f = FindingBuilder::new()
+                    .source(Source::Linter("ast-grep".into()))
+                    .rule_id("ast-grep:python/logging-debug-leak")
+                    .evidence("logger.debug(secret)")
+                    .build();
+                f.precision_tier = Some(PrecisionTier::Speculative);
+                f
+            },
+        ];
+        let mut metadata = HashMap::new();
+        metadata.insert(
+            "ast-grep:python/missing-await".into(),
+            RuleMetadata {
+                precision: PrecisionTier::Speculative,
+                judge: JudgeRequirement::Required,
+            },
+        );
+        metadata.insert(
+            "ast-grep:python/logging-debug-leak".into(),
+            RuleMetadata {
+                precision: PrecisionTier::Speculative,
+                judge: JudgeRequirement::Required,
+            },
+        );
+        let dir = tempfile::tempdir().unwrap();
+        let cache_path = dir.path().join("cache.jsonl");
+
+        let result = judge_findings(
+            &mut findings,
+            "source",
+            &metadata,
+            &HashMap::new(),
+            &cache_path,
+            Some(&judge),
+        )
+        .await;
+
+        assert_eq!(result.approved, 1);
+        assert_eq!(result.uncertain, 1);
+    }
+
+    #[tokio::test]
+    async fn judge_handles_malformed_json_response() {
+        let judge = MockJudge {
+            response: Some("not valid json at all {{{".into()),
+        };
+
+        let mut findings = vec![{
+            let mut f = FindingBuilder::new()
+                .source(Source::Linter("ast-grep".into()))
+                .rule_id("ast-grep:python/missing-await")
+                .evidence("await missing")
+                .build();
+            f.precision_tier = Some(PrecisionTier::Speculative);
+            f
+        }];
+        let mut metadata = HashMap::new();
+        metadata.insert(
+            "ast-grep:python/missing-await".into(),
+            RuleMetadata {
+                precision: PrecisionTier::Speculative,
+                judge: JudgeRequirement::Required,
+            },
+        );
+        let dir = tempfile::tempdir().unwrap();
+        let cache_path = dir.path().join("cache.jsonl");
+
+        let result = judge_findings(
+            &mut findings,
+            "async def foo(): bar()",
+            &metadata,
+            &HashMap::new(),
+            &cache_path,
+            Some(&judge),
+        )
+        .await;
+
+        assert_eq!(result.uncertain, 1, "malformed JSON should degrade to Uncertain");
+        assert_eq!(result.calls, 1);
+        assert_eq!(findings[0].judge_verdict, Some(JudgeVerdict::Uncertain));
+    }
 }

--- a/src/llm_client.rs
+++ b/src/llm_client.rs
@@ -763,6 +763,53 @@ impl OpenAiClient {
         }
     }
 
+    pub async fn judge_completion(
+        &self,
+        model: &str,
+        prompt: &str,
+        system_prompt: &str,
+    ) -> anyhow::Result<LlmResponse> {
+        let body = serde_json::json!({
+            "model": model,
+            "messages": [
+                {"role": "system", "content": system_prompt},
+                {"role": "user", "content": prompt}
+            ],
+            "temperature": 0,
+            "max_tokens": 2048
+        });
+
+        let url = format!("{}/chat/completions", self.base_url);
+        let req = self
+            .http
+            .post(&url)
+            .header("Authorization", format!("Bearer {}", self.api_key))
+            .header("Content-Type", "application/json")
+            .json(&body);
+        let resp = self.send_with_retry(req).await?;
+
+        let status = resp.status();
+        if !status.is_success() {
+            let error_text = read_capped_error_body(resp).await;
+            let truncated = sanitize_error_body(&error_text);
+            anyhow::bail!("Judge API Error ({}): {}", status.as_u16(), truncated);
+        }
+
+        let json: serde_json::Value = resp.json().await?;
+        let usage = parse_usage(&json);
+
+        let content = json["choices"][0]["message"]["content"]
+            .as_str()
+            .ok_or_else(|| {
+                anyhow::anyhow!("Unexpected judge API response: no choices[0].message.content")
+            })?;
+
+        Ok(LlmResponse {
+            content: content.to_string(),
+            usage,
+        })
+    }
+
     /// #117: send a request with retry on transient 429/5xx + bounded by
     /// `overall_retry_deadline`. Honors `Retry-After` when supplied by
     /// upstream and the wait fits the remaining budget; otherwise uses
@@ -2920,5 +2967,27 @@ mod tests {
              Current length: {} chars",
             prompt.len()
         );
+    }
+
+    #[tokio::test]
+    async fn judge_completion_returns_content() {
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/chat/completions"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "choices": [{"message": {"content": "[{\"rule_id\":\"test\",\"verdict\":\"tp\",\"confidence\":0.9,\"reason\":\"ok\"}]"}, "finish_reason": "stop"}]
+            })))
+            .mount(&server)
+            .await;
+
+        let client = build_test_client(&server.uri());
+        let resp = client
+            .judge_completion("test-model", "test prompt", "system")
+            .await
+            .unwrap();
+        assert!(resp.content.contains("\"verdict\":\"tp\""));
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1112,6 +1112,7 @@ async fn run_review(opts: cli::ReviewOpts) -> i32 {
                     .filter(|s| !s.is_empty())
             })
             .unwrap_or_else(|| "gpt-5-nano".into()),
+        judge_client: llm_client.clone(),
         ..Default::default()
     };
 

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -198,6 +198,10 @@ pub struct PipelineConfig {
     pub judge_enabled: bool,
     /// Model for judge calls (--judge-model / QUORUM_JUDGE_MODEL / default gpt-5-nano)
     pub judge_model: String,
+    /// Shared OpenAI client for judge LLM calls. When `Some` and
+    /// `judge_enabled` is true, an `OpenAiJudge` is constructed per file.
+    /// When `None`, judge runs in cache-only mode (existing behavior).
+    pub judge_client: Option<std::sync::Arc<crate::llm_client::OpenAiClient>>,
 }
 
 impl Default for PipelineConfig {
@@ -225,6 +229,7 @@ impl Default for PipelineConfig {
             registry_client: None,
             judge_enabled: false,
             judge_model: "gpt-5-nano".into(),
+            judge_client: None,
         }
     }
 }
@@ -733,6 +738,13 @@ pub async fn review_file(
             let cache = crate::judge::load_cache(&cache_path).unwrap_or_default();
             drop(_span);
 
+            let judge = pipeline_config.judge_client.as_ref().map(|client| {
+                crate::judge::OpenAiJudge::new(
+                    std::sync::Arc::clone(client),
+                    pipeline_config.judge_model.clone(),
+                )
+            });
+
             for source_findings in all_sources.iter_mut().skip(1) {
                 let result = crate::judge::judge_findings(
                     source_findings,
@@ -740,7 +752,7 @@ pub async fn review_file(
                     &rule_metadata,
                     &cache,
                     &cache_path,
-                    None::<&crate::judge::OpenAiJudge>, // LLM client not wired yet -- cache-only + skip for now
+                    judge.as_ref(),
                 )
                 .await;
                 judge_metrics.approved += result.approved;

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -723,30 +723,34 @@ pub async fn review_file(
     // Only runs on ast-grep findings (index 1+), not local AST (index 0).
     let mut judge_metrics = JudgeMetrics::default();
     if pipeline_config.judge_enabled && !rule_metadata.is_empty() {
-        let _span = tracing::info_span!("phase.judge", file = %file_str).entered();
-        let home_dir = std::env::var("HOME")
-            .or_else(|_| std::env::var("USERPROFILE"))
-            .map(std::path::PathBuf::from)
-            .unwrap_or_default();
-        let cache_path = home_dir.join(".quorum").join("judge_cache.jsonl");
-        let cache = crate::judge::load_cache(&cache_path).unwrap_or_default();
+        {
+            let _span = tracing::info_span!("phase.judge", file = %file_str).entered();
+            let home_dir = std::env::var("HOME")
+                .or_else(|_| std::env::var("USERPROFILE"))
+                .map(std::path::PathBuf::from)
+                .unwrap_or_default();
+            let cache_path = home_dir.join(".quorum").join("judge_cache.jsonl");
+            let cache = crate::judge::load_cache(&cache_path).unwrap_or_default();
+            drop(_span);
 
-        for source_findings in all_sources.iter_mut().skip(1) {
-            let result = crate::judge::judge_findings(
-                source_findings,
-                source,
-                &rule_metadata,
-                &cache,
-                &cache_path,
-                None, // LLM client not wired yet -- cache-only + skip for now
-            );
-            judge_metrics.approved += result.approved;
-            judge_metrics.rejected += result.rejected;
-            judge_metrics.uncertain += result.uncertain;
-            judge_metrics.skipped += result.skipped;
-            judge_metrics.cache_hits += result.cache_hits;
-            judge_metrics.calls += result.calls;
-            judge_metrics.latency_ms += result.latency_ms;
+            for source_findings in all_sources.iter_mut().skip(1) {
+                let result = crate::judge::judge_findings(
+                    source_findings,
+                    source,
+                    &rule_metadata,
+                    &cache,
+                    &cache_path,
+                    None::<&crate::judge::OpenAiJudge>, // LLM client not wired yet -- cache-only + skip for now
+                )
+                .await;
+                judge_metrics.approved += result.approved;
+                judge_metrics.rejected += result.rejected;
+                judge_metrics.uncertain += result.uncertain;
+                judge_metrics.skipped += result.skipped;
+                judge_metrics.cache_hits += result.cache_hits;
+                judge_metrics.calls += result.calls;
+                judge_metrics.latency_ms += result.latency_ms;
+            }
         }
         tracing::info!(
             phase = "judge",


### PR DESCRIPTION
## Summary
- Adds `JudgeLlm` trait and `OpenAiJudge` implementation wrapping `OpenAiClient` for async LLM verdicts on speculative AST findings
- Adds `judge_completion` method on `OpenAiClient` with `temperature: 0`, `max_tokens: 2048`, no `reasoning_effort` — dedicated classification endpoint separate from the review path
- Wires `OpenAiJudge` into the pipeline's judge phase so speculative findings get real Approved/Rejected/Uncertain verdicts instead of always Uncertain
- Fixes silent cache write error by replacing `let _ =` with `tracing::warn` logging

## How it works
When `QUORUM_JUDGE=1` is set, the pipeline constructs an `OpenAiJudge` from the existing `OpenAiClient` and passes it into `judge_findings`. The judge batches all speculative findings for a file into a single LLM call, parses the JSON response, and applies verdicts. Rejected findings have confidence clamped to 0.05. LLM failures gracefully degrade to `Uncertain`.

## Benchmark
On quorum's own source files (3 files, 2 speculative findings):
- **Judge correctly rejected** a false positive (`&findings[i]` matched as string byte slicing — actually Vec indexing)
- **Judge correctly approved** a true positive (actual `&str` byte slicing in llm_client.rs)
- 17 findings → 16 findings (1 FP filtered)

## Test plan
- [x] 17 judge tests pass including 3 new behavioral tests (LLM failure, partial response, malformed JSON)
- [x] All 1396 tests pass
- [x] Clippy clean
- [x] Release build succeeds
- [x] Smoke tested with real LLM (gpt-4.1-mini) — confirmed Approved/Rejected verdicts
- [x] Verified cache hit path (68s → 2s on second run)
- [x] Verified graceful degradation on LLM unavailability

## Quorum review verdicts
- TP: judge_findings rule_id mismatch (pre-existing design limitation)
- TP+fixed: cache write failures silently ignored → now logged
- TP+fixed: discarded-result on cache write → now logged
- FP: string-byte-slice-broad on Vec indexing (pattern overgeneralization)
- Wontfix: judge_findings complexity 25 (inherent to pipeline logic)
- Pre-existing issues filed: #318, #319, #320

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Findings can now be judged using an LLM service for improved verdict accuracy.
  * Added caching layer for judgment verdicts to optimize repeated evaluations.
  * Enhanced handling of uncertain findings when LLM responses are unavailable.

* **Refactor**
  * Converted judgment system to async architecture for better performance and reliability.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jsnyder/quorum/pull/321)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->