### PR TITLE
feat(judge): wire LLM verdicts into speculative AST finding pipeline

### DIFF
--- a/eval/corpus/python/speculative_patterns.ground_truth.json
+++ b/eval/corpus/python/speculative_patterns.ground_truth.json
@@ -1,0 +1,98 @@
+[
+    {
+        "id": "sp-py-001",
+        "type": "planted",
+        "rule": "missing-await",
+        "expected_verdict": "approved",
+        "title": "Unawaited coroutine from aiohttp session.get",
+        "category": "correctness",
+        "severity": "high",
+        "line_start": 11,
+        "line_end": 11,
+        "description": "session.get(url) returns a coroutine that is never awaited. The HTTP request is silently dropped."
+    },
+    {
+        "id": "sp-py-002",
+        "type": "planted",
+        "rule": "missing-await",
+        "expected_verdict": "approved",
+        "title": "Async validate_item called without await in loop",
+        "category": "correctness",
+        "severity": "high",
+        "line_start": 22,
+        "line_end": 22,
+        "description": "validate_item is an async function called without await. Each iteration creates an unawaited coroutine, so no validation actually runs."
+    },
+    {
+        "id": "sp-py-003",
+        "type": "planted",
+        "rule": "missing-await",
+        "expected_verdict": "rejected",
+        "title": "Sync json.dumps call inside async function (false positive)",
+        "category": "correctness",
+        "severity": "high",
+        "line_start": 30,
+        "line_end": 30,
+        "description": "json.dumps is a synchronous function. Calling it without await inside an async function is correct."
+    },
+    {
+        "id": "sp-py-004",
+        "type": "planted",
+        "rule": "missing-await",
+        "expected_verdict": "rejected",
+        "title": "Sync list.append inside async function (false positive)",
+        "category": "correctness",
+        "severity": "high",
+        "line_start": 41,
+        "line_end": 41,
+        "description": "list.append is synchronous. The AST rule may fire because it sees a function call inside async without await, but this is correct."
+    },
+    {
+        "id": "sp-py-005",
+        "type": "planted",
+        "rule": "logging-debug-leak",
+        "expected_verdict": "approved",
+        "title": "Password logged at debug level",
+        "category": "security",
+        "severity": "high",
+        "line_start": 48,
+        "line_end": 48,
+        "description": "logging.debug includes the raw password string. If debug logging is enabled in production, credentials are written to log files."
+    },
+    {
+        "id": "sp-py-006",
+        "type": "planted",
+        "rule": "logging-debug-leak",
+        "expected_verdict": "approved",
+        "title": "API token logged at debug level",
+        "category": "security",
+        "severity": "high",
+        "line_start": 55,
+        "line_end": 55,
+        "description": "logging.debug exposes the API token. Tokens in log files can be harvested by anyone with log access."
+    },
+    {
+        "id": "sp-py-007",
+        "type": "planted",
+        "rule": "logging-debug-leak",
+        "expected_verdict": "rejected",
+        "title": "Non-sensitive request metadata in debug log (false positive)",
+        "category": "security",
+        "severity": "medium",
+        "line_start": 62,
+        "line_end": 62,
+        "description": "logging.debug logs request_id and HTTP method, which are non-sensitive operational data. This is a safe use of debug logging."
+    },
+    {
+        "id": "sp-py-008",
+        "type": "planted",
+        "rule": "logging-debug-leak",
+        "expected_verdict": "rejected",
+        "title": "Timing metrics in debug log (false positive)",
+        "category": "security",
+        "severity": "medium",
+        "line_start": 69,
+        "line_end": 69,
+        "description": "logging.debug logs operation name and elapsed time. No sensitive data is present."
+    }
+]

--- a/eval/corpus/python/speculative_patterns.py
+++ b/eval/corpus/python/speculative_patterns.py
@@ -1,0 +1,85 @@
+import logging
+import json
+import aiohttp
+
+
+# --- TRUE POSITIVE: missing-await ---
+# Unawaited coroutine from aiohttp session.get.
+async def fetch_status(session: aiohttp.ClientSession, url: str) -> dict:
+    response = {"status": "pending"}
+    # Bug: session.get() returns a coroutine, not the response
+    session.get(url)
+    return response
+
+
+# --- TRUE POSITIVE: missing-await ---
+# Async validate_item called without await in loop.
+async def validate_item(item: dict) -> bool:
+    return "id" in item and "name" in item
+
+async def process_batch(items: list[dict]) -> list[dict]:
+    for item in items:
+        validate_item(item)
+    return [item for item in items if "id" in item]
+
+
+# --- FALSE POSITIVE: missing-await ---
+# Sync json.dumps call inside async function (false positive).
+async def validate_json(data: dict) -> bool:
+    try:
+        json.dumps(data)
+        return True
+    except (TypeError, ValueError):
+        return False
+
+
+# --- FALSE POSITIVE: missing-await ---
+# Sync list.append inside async function (false positive).
+async def collect_names(items: list[dict]) -> list[str]:
+    results = []
+    for item in items:
+        results.append(item["name"])
+    return results
+
+
+# --- TRUE POSITIVE: logging-debug-leak ---
+# Password logged at debug level.
+def authenticate(username: str, password: str) -> bool:
+    logging.debug(f"Authenticating {username} with password={password}")
+    return username == "admin"
+
+
+# --- TRUE POSITIVE: logging-debug-leak ---
+# API token logged at debug level.
+def connect_api(endpoint: str, token: str) -> None:
+    logging.debug(f"Connecting to {endpoint} with token={token}")
+    pass
+
+
+# --- FALSE POSITIVE: logging-debug-leak ---
+# Non-sensitive request metadata in debug log.
+def log_request(request_id: str, method: str) -> None:
+    logging.debug(f"Processing request {request_id}: {method}")
+    pass
+
+
+# --- FALSE POSITIVE: logging-debug-leak ---
+# Timing metrics in debug log (not sensitive).
+def log_timing(operation: str, elapsed_ms: float) -> None:
+    logging.debug(f"Operation {operation} took {elapsed_ms}ms")
+    pass
+
+
+# --- Non-speculative code for context ---
+class DataProcessor:
+    def __init__(self, batch_size: int = 100):
+        self.batch_size = batch_size
+        self.processed = 0
+
+    def process(self, data: list) -> list:
+        results = []
+        for i in range(0, len(data), self.batch_size):
+            batch = data[i : i + self.batch_size]
+            results.extend(batch)
+            self.processed += len(batch)
+        return results

--- a/eval/corpus/rust/speculative_patterns.ground_truth.json
+++ b/eval/corpus/rust/speculative_patterns.ground_truth.json
@@ -1,0 +1,110 @@
+[
+    {
+        "id": "sp-rs-001",
+        "type": "planted",
+        "rule": "string-byte-slice-broad",
+        "expected_verdict": "approved",
+        "title": "Byte slice on user string panics on multi-byte characters",
+        "category": "correctness",
+        "severity": "medium",
+        "line_start": 8,
+        "line_end": 8,
+        "description": "&name[..16] panics if name contains multi-byte UTF-8 characters before byte 16. Should use name.get(..16) or char_indices."
+    },
+    {
+        "id": "sp-rs-002",
+        "type": "planted",
+        "rule": "string-byte-slice-broad",
+        "expected_verdict": "approved",
+        "title": "Byte slice with runtime length on arbitrary string",
+        "category": "correctness",
+        "severity": "medium",
+        "line_start": 14,
+        "line_end": 14,
+        "description": "&s[..len] panics if len falls on a non-ASCII character boundary. Should use s.get(..len)."
+    },
+    {
+        "id": "sp-rs-003",
+        "type": "planted",
+        "rule": "string-byte-slice-broad",
+        "expected_verdict": "rejected",
+        "title": "Byte slice on &[u8] not a string (false positive)",
+        "category": "correctness",
+        "severity": "medium",
+        "line_start": 20,
+        "line_end": 20,
+        "description": "&data[..4] is byte slicing on a byte array, not a string. No UTF-8 boundary risk. The rule fires syntactically but the type is &[u8]."
+    },
+    {
+        "id": "sp-rs-004",
+        "type": "planted",
+        "rule": "string-byte-slice-broad",
+        "expected_verdict": "rejected",
+        "title": "Byte slice after char_indices boundary validation (false positive)",
+        "category": "correctness",
+        "severity": "medium",
+        "line_start": 31,
+        "line_end": 31,
+        "description": "&s[..byte_pos] where byte_pos was computed from char_indices().nth(). The boundary is guaranteed valid by the char_indices API."
+    },
+    {
+        "id": "sp-rs-005",
+        "type": "planted",
+        "rule": "discarded-result",
+        "expected_verdict": "approved",
+        "title": "File write_all error silently discarded",
+        "category": "correctness",
+        "severity": "high",
+        "line_start": 38,
+        "line_end": 38,
+        "description": "let _ = file.write_all() discards the io::Result. Write failures (disk full, broken pipe) go undetected."
+    },
+    {
+        "id": "sp-rs-006",
+        "type": "planted",
+        "rule": "discarded-result",
+        "expected_verdict": "approved",
+        "title": "File flush error silently discarded",
+        "category": "correctness",
+        "severity": "high",
+        "line_start": 39,
+        "line_end": 39,
+        "description": "let _ = file.flush() discards the io::Result. Flush failures mean data may not reach disk."
+    },
+    {
+        "id": "sp-rs-007",
+        "type": "planted",
+        "rule": "discarded-result",
+        "expected_verdict": "approved",
+        "title": "HashMap try_reserve error silently dropped",
+        "category": "correctness",
+        "severity": "high",
+        "line_start": 45,
+        "line_end": 45,
+        "description": "let _ = cache.try_reserve() discards the allocation error. OOM condition goes undetected; subsequent inserts may panic."
+    },
+    {
+        "id": "sp-rs-008",
+        "type": "planted",
+        "rule": "discarded-result",
+        "expected_verdict": "rejected",
+        "title": "JoinHandle discard is intentional fire-and-forget (false positive)",
+        "category": "correctness",
+        "severity": "medium",
+        "line_start": 51,
+        "line_end": 53,
+        "description": "let _ = std::thread::spawn() discards the JoinHandle. This is the idiomatic fire-and-forget pattern — the background task runs independently."
+    },
+    {
+        "id": "sp-rs-009",
+        "type": "planted",
+        "rule": "discarded-result",
+        "expected_verdict": "rejected",
+        "title": "mpsc send discard after shutdown is expected (false positive)",
+        "category": "correctness",
+        "severity": "medium",
+        "line_start": 59,
+        "line_end": 59,
+        "description": "let _ = tx.send(()) discards the SendError. After shutdown the receiver may be dropped; send failure is the expected happy path."
+    }
+]

--- a/eval/corpus/rust/speculative_patterns.rs
+++ b/eval/corpus/rust/speculative_patterns.rs
@@ -1,0 +1,81 @@
+use std::collections::HashMap;
+use std::fs;
+use std::io::Write;
+
+// --- TRUE POSITIVE: string-byte-slice-broad ---
+// Byte slice on user-provided string can panic on multi-byte chars.
+pub fn truncate_username(name: &str) -> &str {
+    &name[..16]
+}
+
+// --- TRUE POSITIVE: string-byte-slice-broad ---
+// Byte range from runtime value on arbitrary string input.
+pub fn extract_prefix(s: &str, len: usize) -> &str {
+    &s[..len]
+}
+
+// --- FALSE POSITIVE: string-byte-slice-broad ---
+// Byte slice on a &[u8], not a string. No UTF-8 boundary risk.
+pub fn first_bytes(data: &[u8]) -> &[u8] {
+    &data[..4]
+}
+
+// --- FALSE POSITIVE: string-byte-slice-broad ---
+// Byte slice after char_indices validation ensures boundary safety.
+pub fn safe_truncate(s: &str, max_chars: usize) -> &str {
+    let byte_pos = s
+        .char_indices()
+        .nth(max_chars)
+        .map(|(i, _)| i)
+        .unwrap_or(s.len());
+    &s[..byte_pos]
+}
+
+// --- TRUE POSITIVE: discarded-result ---
+// File open/write/flush errors silently discarded.
+pub fn log_event(path: &str, event: &str) {
+    let mut file = fs::File::create(path).unwrap();
+    let _ = file.write_all(event.as_bytes());
+    let _ = file.flush();
+}
+
+// --- TRUE POSITIVE: discarded-result ---
+// HashMap::try_reserve error silently dropped; OOM can follow.
+pub fn prepare_cache(cache: &mut HashMap<String, String>, expected: usize) {
+    let _ = cache.try_reserve(expected);
+}
+
+// --- FALSE POSITIVE: discarded-result ---
+// Intentionally discarding JoinHandle; fire-and-forget background task.
+pub fn spawn_background(msg: String) {
+    let _ = std::thread::spawn(move || {
+        println!("background: {}", msg);
+    });
+}
+
+// --- FALSE POSITIVE: discarded-result ---
+// Discarding mpsc send after shutdown: receiver may be dropped.
+pub fn notify_shutdown(tx: std::sync::mpsc::Sender<()>) {
+    let _ = tx.send(());
+}
+
+// --- Non-speculative code for context ---
+pub struct MetricsCollector {
+    counts: HashMap<String, u64>,
+}
+
+impl MetricsCollector {
+    pub fn new() -> Self {
+        Self {
+            counts: HashMap::new(),
+        }
+    }
+
+    pub fn increment(&mut self, key: &str) {
+        *self.counts.entry(key.to_string()).or_insert(0) += 1;
+    }
+
+    pub fn get(&self, key: &str) -> u64 {
+        self.counts.get(key).copied().unwrap_or(0)
+    }
+}

--- a/eval/corpus/typescript/speculative_patterns.ground_truth.json
+++ b/eval/corpus/typescript/speculative_patterns.ground_truth.json
@@ -1,0 +1,98 @@
+[
+    {
+        "id": "sp-ts-001",
+        "type": "planted",
+        "rule": "string-format-sql",
+        "expected_verdict": "approved",
+        "title": "SQL injection via template literal in SELECT query",
+        "category": "security",
+        "severity": "critical",
+        "line_start": 6,
+        "line_end": 6,
+        "description": "User-supplied name is interpolated directly into a SQL SELECT query without parameterization, enabling SQL injection."
+    },
+    {
+        "id": "sp-ts-002",
+        "type": "planted",
+        "rule": "string-format-sql",
+        "expected_verdict": "approved",
+        "title": "Table name injection in DELETE query",
+        "category": "security",
+        "severity": "critical",
+        "line_start": 13,
+        "line_end": 13,
+        "description": "Table name and days parameter interpolated into DELETE query. The table name cannot be parameterized with $1, making this a real injection vector."
+    },
+    {
+        "id": "sp-ts-003",
+        "type": "planted",
+        "rule": "string-format-sql",
+        "expected_verdict": "rejected",
+        "title": "SQL keyword in error message, not a query (false positive)",
+        "category": "security",
+        "severity": "medium",
+        "line_start": 20,
+        "line_end": 20,
+        "description": "Template literal contains 'SELECT' but is a user-facing error message, not a database query. No injection risk."
+    },
+    {
+        "id": "sp-ts-004",
+        "type": "planted",
+        "rule": "string-format-sql",
+        "expected_verdict": "rejected",
+        "title": "SQL keywords in logging/documentation string (false positive)",
+        "category": "security",
+        "severity": "medium",
+        "line_start": 26,
+        "line_end": 26,
+        "description": "Template literal mentions UPDATE and INSERT but describes a migration, not an executed query."
+    },
+    {
+        "id": "sp-ts-005",
+        "type": "planted",
+        "rule": "nullish-coalescing-broad",
+        "expected_verdict": "approved",
+        "title": "|| on port number treats 0 as falsy",
+        "category": "correctness",
+        "severity": "medium",
+        "line_start": 32,
+        "line_end": 32,
+        "description": "config.port || 3000 treats port 0 as falsy, falling through to 3000. Port 0 is valid (OS-assigned) and should be preserved with ??."
+    },
+    {
+        "id": "sp-ts-006",
+        "type": "planted",
+        "rule": "nullish-coalescing-broad",
+        "expected_verdict": "approved",
+        "title": "|| on string treats empty string as falsy",
+        "category": "correctness",
+        "severity": "medium",
+        "line_start": 38,
+        "line_end": 38,
+        "description": "user.name || 'Anonymous' treats empty string as falsy. If a user explicitly sets name to '' it gets overwritten with 'Anonymous'."
+    },
+    {
+        "id": "sp-ts-007",
+        "type": "planted",
+        "rule": "nullish-coalescing-broad",
+        "expected_verdict": "rejected",
+        "title": "|| is correct when empty string should use default (false positive)",
+        "category": "correctness",
+        "severity": "medium",
+        "line_start": 44,
+        "line_end": 44,
+        "description": "label || 'Untitled' intentionally treats empty string as invalid input. The || behavior is the desired semantics."
+    },
+    {
+        "id": "sp-ts-008",
+        "type": "planted",
+        "rule": "nullish-coalescing-broad",
+        "expected_verdict": "rejected",
+        "title": "|| on booleans is idiomatic (false positive)",
+        "category": "correctness",
+        "severity": "medium",
+        "line_start": 50,
+        "line_end": 50,
+        "description": "flag || false is a standard boolean default pattern. Using ?? here would be semantically identical for boolean|undefined."
+    }
+]

--- a/eval/corpus/typescript/speculative_patterns.ts
+++ b/eval/corpus/typescript/speculative_patterns.ts
@@ -1,0 +1,74 @@
+import { Pool } from "pg";
+
+// --- TRUE POSITIVE: string-format-sql ---
+// User input directly interpolated into SQL query.
+export async function getUserByName(pool: Pool, name: string) {
+  const query = `SELECT * FROM users WHERE name = '${name}'`;  // TP: SQL injection
+  return pool.query(query);
+}
+
+// --- TRUE POSITIVE: string-format-sql ---
+// Template literal builds a DELETE statement with unescaped input.
+export async function deleteOldRecords(pool: Pool, table: string, days: number) {
+  const query = `DELETE FROM ${table} WHERE created_at < NOW() - INTERVAL '${days} days'`;  // TP: table name injection
+  return pool.query(query);
+}
+
+// --- FALSE POSITIVE: string-format-sql ---
+// SQL keyword appears in a user-facing message, not an actual query.
+export function formatError(operation: string): string {
+  return `Failed to SELECT data during ${operation}. Please retry.`;  // FP: not a real SQL query
+}
+
+// --- FALSE POSITIVE: string-format-sql ---
+// SQL keyword in a logging/documentation template string.
+export function logMigration(version: string): string {
+  return `Migration ${version}: will UPDATE schema and INSERT seed data`;  // FP: documentation text
+}
+
+// --- TRUE POSITIVE: nullish-coalescing-broad ---
+// || treats 0 as falsy, falling through to the default when 0 is valid.
+export function getPort(config: { port?: number }): number {
+  return config.port || 3000;  // TP: port=0 would fall through to 3000
+}
+
+// --- TRUE POSITIVE: nullish-coalescing-broad ---
+// || treats "" as falsy; empty string is a valid username override.
+export function getDisplayName(user: { name?: string }): string {
+  return user.name || "Anonymous";  // TP: empty string "" falls through
+}
+
+// --- FALSE POSITIVE: nullish-coalescing-broad ---
+// || is correct here: both null/undefined AND empty string should use default.
+export function getRequiredLabel(label?: string): string {
+  return label || "Untitled";  // FP: empty string SHOULD fall through to default
+}
+
+// --- FALSE POSITIVE: nullish-coalescing-broad ---
+// || on booleans is a standard pattern for default-true behavior.
+export function isEnabled(flag?: boolean): boolean {
+  return flag || false;  // FP: boolean || boolean is idiomatic
+}
+
+// --- Non-speculative code for context ---
+export interface DatabaseConfig {
+  host: string;
+  port: number;
+  database: string;
+  ssl: boolean;
+}
+
+export function buildConnectionString(config: DatabaseConfig): string {
+  const proto = config.ssl ? "postgresql+ssl" : "postgresql";
+  return `${proto}://${config.host}:${config.port}/${config.database}`;
+}
+
+export async function healthCheck(pool: Pool): Promise<boolean> {
+  const result = await pool.query("SELECT 1 as healthy");
+  return result.rows[0]?.healthy === 1;
+}
+
+// Proper parameterized query — not flagged.
+export async function getUserById(pool: Pool, id: number) {
+  return pool.query("SELECT * FROM users WHERE id = $1", [id]);
+}

--- a/eval/corpus/yaml/speculative_patterns.ground_truth.json
+++ b/eval/corpus/yaml/speculative_patterns.ground_truth.json
@@ -1,0 +1,50 @@
+[
+    {
+        "id": "sp-yaml-001",
+        "type": "planted",
+        "rule": "jinja-loop-variable-scoping",
+        "expected_verdict": "approved",
+        "title": "Counter variable set inside for-loop does not persist",
+        "category": "correctness",
+        "severity": "high",
+        "line_start": 15,
+        "line_end": 22,
+        "description": "count is set to 0 before the loop, then incremented with {% set count = count + 1 %} inside the loop. Due to Jinja2 scoping, the outer count stays 0 after the loop. The template always reports 0 lights."
+    },
+    {
+        "id": "sp-yaml-002",
+        "type": "planted",
+        "rule": "jinja-loop-variable-scoping",
+        "expected_verdict": "approved",
+        "title": "Max-tracking variables reset after loop exit",
+        "category": "correctness",
+        "severity": "high",
+        "line_start": 34,
+        "line_end": 43,
+        "description": "max_temp and hottest are set before the loop and reassigned inside it. The outer scope sees the original values (0 and 'none') after the loop ends."
+    },
+    {
+        "id": "sp-yaml-003",
+        "type": "planted",
+        "rule": "jinja-loop-variable-scoping",
+        "expected_verdict": "rejected",
+        "title": "Loop-local formatting variable (false positive)",
+        "category": "correctness",
+        "severity": "medium",
+        "line_start": 55,
+        "line_end": 59,
+        "description": "label is set inside the for loop but only used within the same iteration for formatting. The scoping issue does not apply since label does not need to persist outside the loop."
+    },
+    {
+        "id": "sp-yaml-004",
+        "type": "planted",
+        "rule": "jinja-loop-variable-scoping",
+        "expected_verdict": "rejected",
+        "title": "namespace() correctly persists loop state (false positive)",
+        "category": "correctness",
+        "severity": "medium",
+        "line_start": 71,
+        "line_end": 78,
+        "description": "Uses Jinja2 namespace() object which correctly persists attribute mutations across loop iterations. The set ns.count pattern is the recommended fix for the scoping issue."
+    }
+]

--- a/eval/corpus/yaml/speculative_patterns.yaml
+++ b/eval/corpus/yaml/speculative_patterns.yaml
@@ -1,0 +1,92 @@
+# Eval corpus file exercising speculative AST patterns for YAML/Jinja2.
+# Simulates Home Assistant automations with Jinja2 templates.
+
+# --- TRUE POSITIVE: jinja-loop-variable-scoping ---
+# Variable set inside for-loop does not persist outside the loop.
+automation:
+  - alias: "Summarize active lights"
+    trigger:
+      - platform: time_pattern
+        minutes: "/30"
+    action:
+      - service: notify.persistent_notification
+        data:
+          title: "Active Lights"
+          message: >
+            {% set count = 0 %}
+            {% for light in states.light %}
+              {% if light.state == 'on' %}
+                {% set count = count + 1 %}
+              {% endif %}
+            {% endfor %}
+            There are {{ count }} lights on.
+
+  # --- TRUE POSITIVE: jinja-loop-variable-scoping ---
+  # Variable reassigned in loop body; outer scope sees stale value.
+  - alias: "Find hottest sensor"
+    trigger:
+      - platform: time_pattern
+        hours: "/1"
+    action:
+      - service: notify.persistent_notification
+        data:
+          title: "Temperature Alert"
+          message: >
+            {% set max_temp = 0 %}
+            {% set hottest = 'none' %}
+            {% for sensor in states.sensor %}
+              {% if sensor.state | float > max_temp %}
+                {% set max_temp = sensor.state | float %}
+                {% set hottest = sensor.name %}
+              {% endif %}
+            {% endfor %}
+            Hottest: {{ hottest }} at {{ max_temp }}C
+
+  # --- FALSE POSITIVE: jinja-loop-variable-scoping ---
+  # Variable set inside loop is loop-local (only used within iteration).
+  - alias: "List formatted sensors"
+    trigger:
+      - platform: time_pattern
+        hours: "/6"
+    action:
+      - service: notify.persistent_notification
+        data:
+          title: "Sensor Report"
+          message: >
+            {% for sensor in states.sensor %}
+              {% set label = sensor.friendly_name | default(sensor.name) | title %}
+              - {{ label }}: {{ sensor.state }}
+            {% endfor %}
+
+  # --- FALSE POSITIVE: jinja-loop-variable-scoping ---
+  # Loop uses namespace() which correctly persists across iterations.
+  - alias: "Count open doors (namespace)"
+    trigger:
+      - platform: time_pattern
+        minutes: "/15"
+    action:
+      - service: notify.persistent_notification
+        data:
+          title: "Door Status"
+          message: >
+            {% set ns = namespace(count=0) %}
+            {% for door in states.binary_sensor %}
+              {% if door.state == 'on' %}
+                {% set ns.count = ns.count + 1 %}
+              {% endif %}
+            {% endfor %}
+            Open doors: {{ ns.count }}
+
+  # --- Non-speculative automation for context ---
+  - alias: "Turn off lights at midnight"
+    trigger:
+      - platform: time
+        at: "00:00:00"
+    condition:
+      - condition: state
+        entity_id: input_boolean.auto_lights
+        state: "on"
+    action:
+      - service: light.turn_off
+        target:
+          entity_id: all

--- a/rules/yaml/jinja-loop-variable-scoping.yml
+++ b/rules/yaml/jinja-loop-variable-scoping.yml
@@ -3,8 +3,16 @@ language: Yaml
 severity: warning
 message: "Variable set inside Jinja for-loop may not persist outside the loop scope due to Jinja2 scoping rules."
 rule:
-  kind: block_scalar
-  regex: "\\{%.*for\\s.*%\\}.*\\{%.*set\\s+\\w+.*%\\}"
+  any:
+    - all:
+        - kind: block_scalar
+        - regex: "\\{%\\s*for\\b[\\s\\S]*?\\{%\\s*set\\s+\\w+[\\s\\S]*?\\{%\\s*endfor"
+    - all:
+        - kind: plain_scalar
+        - regex: "\\{%\\s*for\\b[\\s\\S]*?\\{%\\s*set\\s+\\w+[\\s\\S]*?\\{%\\s*endfor"
+    - all:
+        - kind: double_quote_scalar
+        - regex: "\\{%\\s*for\\b[\\s\\S]*?\\{%\\s*set\\s+\\w+[\\s\\S]*?\\{%\\s*endfor"
 metadata:
   precision: speculative
   judge: required

--- a/rules/yaml/jinja-loop-variable-scoping.yml
+++ b/rules/yaml/jinja-loop-variable-scoping.yml
@@ -13,6 +13,9 @@ rule:
     - all:
         - kind: double_quote_scalar
         - regex: "\\{%\\s*for\\b[\\s\\S]*?\\{%\\s*set\\s+\\w+[\\s\\S]*?\\{%\\s*endfor"
+    - all:
+        - kind: single_quote_scalar
+        - regex: "\\{%\\s*for\\b[\\s\\S]*?\\{%\\s*set\\s+\\w+[\\s\\S]*?\\{%\\s*endfor"
 metadata:
   precision: speculative
   judge: required

--- a/src/ast_grep.rs
+++ b/src/ast_grep.rs
@@ -146,10 +146,12 @@ pub fn load_rules(
     let mut seen_ids: HashSet<(SupportLang, String)> = HashSet::new();
     let globals = GlobalRules::default();
 
-    let bundled_dir = project_dir.join("rules");
+    let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let bundled_dir = manifest_dir.join("rules");
+    let project_dir_rules = project_dir.join("rules");
     let user_dir = home_dir.join(".quorum").join("rules");
 
-    for rules_dir in [&bundled_dir, &user_dir] {
+    for rules_dir in [&bundled_dir, &project_dir_rules, &user_dir] {
         // #120: top-level rules-root check. symlink_metadata does NOT follow
         // symlinks, unlike is_dir(). Without this, a symlink at the rules
         // root itself (e.g. ~/.quorum/rules -> /etc/) bypasses every other

--- a/src/ast_grep.rs
+++ b/src/ast_grep.rs
@@ -499,8 +499,9 @@ rule:
 "#;
         std::fs::write(user_rules_dir.join("user-test.yml"), rule_yaml).unwrap();
         let (rules, _metadata) = load_rules(empty_project.path(), home.path());
-        assert_eq!(rules.len(), 1);
-        assert_eq!(rules[0].id, "user-test-rule");
+        let ids: Vec<&str> = rules.iter().map(|r| r.id.as_str()).collect();
+        assert!(ids.contains(&"user-test-rule"), "should include user rule");
+        assert!(rules.len() > 1, "should also include bundled rules");
     }
 
     #[test]
@@ -528,9 +529,7 @@ rule:
         let project = tempfile::tempdir().unwrap();
         let rules_dir = project.path().join("rules").join("typescript");
         std::fs::create_dir_all(&rules_dir).unwrap();
-        // Malformed rule (missing required fields)
         std::fs::write(rules_dir.join("bad.yml"), "not: valid: yaml: rule:").unwrap();
-        // Valid rule
         let good_yaml = r#"id: good-rule
 language: TypeScript
 severity: warning
@@ -541,16 +540,21 @@ rule:
         std::fs::write(rules_dir.join("good.yml"), good_yaml).unwrap();
         let fake_home = tempfile::tempdir().unwrap();
         let (rules, _metadata) = load_rules(project.path(), fake_home.path());
-        assert_eq!(rules.len(), 1, "should skip bad rule, keep good one");
-        assert_eq!(rules[0].id, "good-rule");
+        let ids: Vec<&str> = rules.iter().map(|r| r.id.as_str()).collect();
+        assert!(ids.contains(&"good-rule"), "should keep good rule");
+        assert!(!ids.contains(&"bad"), "should skip bad rule");
     }
 
     #[test]
-    fn load_rules_missing_rules_dir_returns_empty() {
+    fn load_rules_missing_rules_dir_returns_empty_project_and_user() {
         let empty = tempfile::tempdir().unwrap();
         let fake_home = tempfile::tempdir().unwrap();
         let (rules, _metadata) = load_rules(empty.path(), fake_home.path());
-        assert!(rules.is_empty());
+        let bundled_count = rules.len();
+        assert!(bundled_count > 0, "bundled rules should always load");
+        let project_dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        let (baseline, _) = load_rules(&project_dir, fake_home.path());
+        assert_eq!(rules.len(), baseline.len(), "no extra rules beyond bundled");
     }
 
     #[test]

--- a/src/judge.rs
+++ b/src/judge.rs
@@ -296,19 +296,15 @@ pub async fn judge_findings<J: JudgeLlm>(
                                     .filter(|&idx| {
                                         idx < to_judge.len()
                                             && !used[idx]
-                                            && findings[to_judge[idx]]
-                                                .rule_id
-                                                .as_deref()
+                                            && findings[to_judge[idx]].rule_id.as_deref()
                                                 == Some(&v.rule_id)
                                     })
                                     .or_else(|| {
-                                        to_judge.iter().enumerate().position(
-                                            |(pos, &i)| {
-                                                !used[pos]
-                                                    && findings[i].rule_id.as_deref()
-                                                        == Some(&v.rule_id)
-                                            },
-                                        )
+                                        to_judge.iter().enumerate().position(|(pos, &i)| {
+                                            !used[pos]
+                                                && findings[i].rule_id.as_deref()
+                                                    == Some(&v.rule_id)
+                                        })
                                     });
                                 if let Some(pos) = batch_pos {
                                     used[pos] = true;
@@ -325,8 +321,7 @@ pub async fn judge_findings<J: JudgeLlm>(
                                         .unwrap_or("");
                                     let canonical_rule_id =
                                         findings[i].rule_id.as_deref().unwrap_or("");
-                                    let key =
-                                        verdict_cache_key(canonical_rule_id, evidence);
+                                    let key = verdict_cache_key(canonical_rule_id, evidence);
                                     if let Err(e) = write_cache_entry(
                                         cache_path,
                                         &CacheEntry {

--- a/src/judge.rs
+++ b/src/judge.rs
@@ -94,6 +94,9 @@ fn extract_json_array(response: &str) -> Option<&str> {
     let trimmed = response.trim();
     let start = trimmed.find('[')?;
     let end = trimmed.rfind(']')?;
+    if start > end {
+        return None;
+    }
     Some(&trimmed[start..=end])
 }
 

--- a/src/judge.rs
+++ b/src/judge.rs
@@ -98,6 +98,36 @@ pub trait JudgeLlm: Send + Sync {
     async fn call(&self, prompt: &str) -> Option<String>;
 }
 
+const JUDGE_SYSTEM_PROMPT: &str =
+    "You are a code review judge. Respond with ONLY a JSON array, no other text.";
+
+pub struct OpenAiJudge {
+    client: std::sync::Arc<crate::llm_client::OpenAiClient>,
+    model: String,
+}
+
+impl OpenAiJudge {
+    pub fn new(client: std::sync::Arc<crate::llm_client::OpenAiClient>, model: String) -> Self {
+        Self { client, model }
+    }
+}
+
+impl JudgeLlm for OpenAiJudge {
+    async fn call(&self, prompt: &str) -> Option<String> {
+        match self
+            .client
+            .judge_completion(&self.model, prompt, JUDGE_SYSTEM_PROMPT)
+            .await
+        {
+            Ok(response) => Some(response.content),
+            Err(e) => {
+                tracing::warn!(model = %self.model, error = %e, "judge LLM call failed");
+                None
+            }
+        }
+    }
+}
+
 /// Build the LLM prompt for judging a batch of AST-detected findings.
 ///
 /// Each finding tuple is `(rule_id, title, line_start, line_end, evidence)`.

--- a/src/judge.rs
+++ b/src/judge.rs
@@ -279,19 +279,23 @@ pub async fn judge_findings<J: JudgeLlm>(
                 if let Some(json_str) = json_extracted {
                     match serde_json::from_str::<Vec<JudgeResponseItem>>(json_str) {
                         Ok(verdicts) => {
+                            let mut used = vec![false; to_judge.len()];
                             for v in &verdicts {
-                                let pos = v
+                                let batch_pos = v
                                     .index
-                                    .and_then(|idx| {
-                                        to_judge.iter().position(|&i_item| i_item == idx)
-                                    })
+                                    .filter(|&idx| idx < to_judge.len() && !used[idx])
                                     .or_else(|| {
-                                        to_judge.iter().position(|&i| {
-                                            findings[i].rule_id.as_deref() == Some(&v.rule_id)
-                                        })
+                                        to_judge.iter().enumerate().position(
+                                            |(pos, &i)| {
+                                                !used[pos]
+                                                    && findings[i].rule_id.as_deref()
+                                                        == Some(&v.rule_id)
+                                            },
+                                        )
                                     });
-                                if let Some(pos) = pos {
-                                    let i = to_judge.swap_remove(pos);
+                                if let Some(pos) = batch_pos {
+                                    used[pos] = true;
+                                    let i = to_judge[pos];
                                     let verdict = parse_verdict(&v.verdict);
                                     let confidence = v.confidence.clamp(0.0, 1.0);
                                     findings[i].judge_verdict = Some(verdict.clone());

--- a/src/judge.rs
+++ b/src/judge.rs
@@ -94,6 +94,10 @@ pub fn parse_verdict(s: &str) -> JudgeVerdict {
     }
 }
 
+pub trait JudgeLlm: Send + Sync {
+    async fn call(&self, prompt: &str) -> Option<String>;
+}
+
 /// Build the LLM prompt for judging a batch of AST-detected findings.
 ///
 /// Each finding tuple is `(rule_id, title, line_start, line_end, evidence)`.
@@ -312,6 +316,16 @@ pub fn judge_findings(
 mod tests {
     use super::*;
     use crate::finding::{FindingBuilder, Source};
+
+    struct MockJudge {
+        response: Option<String>,
+    }
+
+    impl JudgeLlm for MockJudge {
+        async fn call(&self, _prompt: &str) -> Option<String> {
+            self.response.clone()
+        }
+    }
 
     #[test]
     fn cache_key_deterministic() {

--- a/src/judge.rs
+++ b/src/judge.rs
@@ -86,6 +86,10 @@ pub struct JudgeResponseItem {
     pub reason: String,
 }
 
+fn truncate_chars(s: &str, max: usize) -> String {
+    s.chars().take(max).collect()
+}
+
 fn extract_json_array(response: &str) -> Option<&str> {
     let trimmed = response.trim();
     let start = trimmed.find('[')?;
@@ -272,7 +276,7 @@ pub async fn judge_findings<J: JudgeLlm>(
                 if json_extracted.is_none() {
                     tracing::warn!(
                         response_len = response.len(),
-                        response_prefix = &response[..response.len().min(200)],
+                        response_prefix = %truncate_chars(&response, 200),
                         "judge: no JSON array found in LLM response"
                     );
                 }
@@ -306,12 +310,15 @@ pub async fn judge_findings<J: JudgeLlm>(
                                         .first()
                                         .map(|s| s.as_str())
                                         .unwrap_or("");
-                                    let key = verdict_cache_key(&v.rule_id, evidence);
+                                    let canonical_rule_id =
+                                        findings[i].rule_id.as_deref().unwrap_or("");
+                                    let key =
+                                        verdict_cache_key(canonical_rule_id, evidence);
                                     if let Err(e) = write_cache_entry(
                                         cache_path,
                                         &CacheEntry {
                                             cache_key: key,
-                                            rule_id: v.rule_id.clone(),
+                                            rule_id: canonical_rule_id.to_string(),
                                             verdict: verdict.clone(),
                                             confidence,
                                             reason: v.reason.clone(),
@@ -336,7 +343,7 @@ pub async fn judge_findings<J: JudgeLlm>(
                         Err(e) => {
                             tracing::warn!(
                                 error = %e,
-                                json_prefix = &json_str[..json_str.len().min(200)],
+                                json_prefix = %truncate_chars(json_str, 200),
                                 "judge: failed to parse JSON response"
                             );
                         }

--- a/src/judge.rs
+++ b/src/judge.rs
@@ -287,7 +287,14 @@ pub async fn judge_findings<J: JudgeLlm>(
                             for v in &verdicts {
                                 let batch_pos = v
                                     .index
-                                    .filter(|&idx| idx < to_judge.len() && !used[idx])
+                                    .filter(|&idx| {
+                                        idx < to_judge.len()
+                                            && !used[idx]
+                                            && findings[to_judge[idx]]
+                                                .rule_id
+                                                .as_deref()
+                                                == Some(&v.rule_id)
+                                    })
                                     .or_else(|| {
                                         to_judge.iter().enumerate().position(
                                             |(pos, &i)| {

--- a/src/judge.rs
+++ b/src/judge.rs
@@ -78,10 +78,19 @@ pub fn write_cache_entry(path: &Path, entry: &CacheEntry) -> std::io::Result<()>
 
 #[derive(Debug, Deserialize)]
 pub struct JudgeResponseItem {
+    #[serde(default)]
+    pub index: Option<usize>,
     pub rule_id: String,
     pub verdict: String,
     pub confidence: f32,
     pub reason: String,
+}
+
+fn extract_json_array(response: &str) -> Option<&str> {
+    let trimmed = response.trim();
+    let start = trimmed.find('[')?;
+    let end = trimmed.rfind(']')?;
+    Some(&trimmed[start..=end])
 }
 
 /// Map wire-format verdict strings to the `JudgeVerdict` enum.
@@ -146,8 +155,9 @@ pub fn build_judge_prompt(
 
     for (i, (rule_id, title, start, end, evidence)) in findings.iter().enumerate() {
         prompt.push_str(&format!(
-            "{}. rule_id=\"{}\", title=\"{}\", lines {}-{}, evidence=\"{}\"\n",
+            "{}. [index={}] rule_id=\"{}\", title=\"{}\", lines {}-{}, evidence=\"{}\"\n",
             i + 1,
+            i,
             rule_id,
             title,
             start,
@@ -157,8 +167,8 @@ pub fn build_judge_prompt(
     }
 
     prompt.push_str(
-        "\nRespond with ONLY a JSON array. Each element: \
-         {\"rule_id\": \"...\", \"verdict\": \"tp\"|\"fp\"|\"uncertain\", \
+        "\nRespond with ONLY a JSON array. Each element must include the index field: \
+         {\"index\": N, \"rule_id\": \"...\", \"verdict\": \"tp\"|\"fp\"|\"uncertain\", \
          \"confidence\": 0.0-1.0, \"reason\": \"...\"}\n",
     );
     prompt
@@ -256,53 +266,80 @@ pub async fn judge_findings<J: JudgeLlm>(
             let prompt = build_judge_prompt(source_code, &items);
             result.calls += 1;
 
-            if let Some(response) = llm.call(&prompt).await
-                && let Ok(verdicts) = serde_json::from_str::<Vec<JudgeResponseItem>>(&response)
-            {
-                for v in &verdicts {
-                    if let Some(pos) = to_judge
-                        .iter()
-                        .position(|&i| findings[i].rule_id.as_deref() == Some(&v.rule_id))
-                    {
-                        let i = to_judge.swap_remove(pos);
-                        let verdict = parse_verdict(&v.verdict);
-                        let confidence = v.confidence.clamp(0.0, 1.0);
-                        findings[i].judge_verdict = Some(verdict.clone());
-                        findings[i].judge_confidence = Some(confidence);
+            let raw_response = llm.call(&prompt).await;
+            if let Some(response) = raw_response {
+                let json_extracted = extract_json_array(&response);
+                if json_extracted.is_none() {
+                    tracing::warn!(
+                        response_len = response.len(),
+                        response_prefix = &response[..response.len().min(200)],
+                        "judge: no JSON array found in LLM response"
+                    );
+                }
+                if let Some(json_str) = json_extracted {
+                    match serde_json::from_str::<Vec<JudgeResponseItem>>(json_str) {
+                        Ok(verdicts) => {
+                            for v in &verdicts {
+                                let pos = v
+                                    .index
+                                    .and_then(|idx| {
+                                        to_judge.iter().position(|&i_item| i_item == idx)
+                                    })
+                                    .or_else(|| {
+                                        to_judge.iter().position(|&i| {
+                                            findings[i].rule_id.as_deref() == Some(&v.rule_id)
+                                        })
+                                    });
+                                if let Some(pos) = pos {
+                                    let i = to_judge.swap_remove(pos);
+                                    let verdict = parse_verdict(&v.verdict);
+                                    let confidence = v.confidence.clamp(0.0, 1.0);
+                                    findings[i].judge_verdict = Some(verdict.clone());
+                                    findings[i].judge_confidence = Some(confidence);
 
-                        let evidence = findings[i]
-                            .evidence
-                            .first()
-                            .map(|s| s.as_str())
-                            .unwrap_or("");
-                        let key = verdict_cache_key(&v.rule_id, evidence);
-                        if let Err(e) = write_cache_entry(
-                            cache_path,
-                            &CacheEntry {
-                                cache_key: key,
-                                rule_id: v.rule_id.clone(),
-                                verdict: verdict.clone(),
-                                confidence,
-                                reason: v.reason.clone(),
-                                timestamp: Utc::now(),
-                            },
-                        ) {
-                            tracing::warn!(
-                                path = %cache_path.display(),
-                                error = %e,
-                                "failed to persist judge cache entry"
-                            );
+                                    let evidence = findings[i]
+                                        .evidence
+                                        .first()
+                                        .map(|s| s.as_str())
+                                        .unwrap_or("");
+                                    let key = verdict_cache_key(&v.rule_id, evidence);
+                                    if let Err(e) = write_cache_entry(
+                                        cache_path,
+                                        &CacheEntry {
+                                            cache_key: key,
+                                            rule_id: v.rule_id.clone(),
+                                            verdict: verdict.clone(),
+                                            confidence,
+                                            reason: v.reason.clone(),
+                                            timestamp: Utc::now(),
+                                        },
+                                    ) {
+                                        tracing::warn!(
+                                            path = %cache_path.display(),
+                                            error = %e,
+                                            "failed to persist judge cache entry"
+                                        );
+                                    }
+
+                                    match verdict {
+                                        JudgeVerdict::Approved => result.approved += 1,
+                                        JudgeVerdict::Rejected => result.rejected += 1,
+                                        _ => result.uncertain += 1,
+                                    }
+                                }
+                            }
                         }
-
-                        match verdict {
-                            JudgeVerdict::Approved => result.approved += 1,
-                            JudgeVerdict::Rejected => result.rejected += 1,
-                            _ => result.uncertain += 1,
+                        Err(e) => {
+                            tracing::warn!(
+                                error = %e,
+                                json_prefix = &json_str[..json_str.len().min(200)],
+                                "judge: failed to parse JSON response"
+                            );
                         }
                     }
                 }
-            } else if to_judge.iter().any(|&i| findings[i].judge_verdict.is_none()) {
-                tracing::warn!("judge LLM returned no usable response");
+            } else {
+                tracing::warn!("judge LLM returned no response");
             }
 
             // Any remaining unjudged findings (LLM didn't return verdict): mark uncertain

--- a/src/judge.rs
+++ b/src/judge.rs
@@ -276,7 +276,7 @@ pub async fn judge_findings<J: JudgeLlm>(
                             .map(|s| s.as_str())
                             .unwrap_or("");
                         let key = verdict_cache_key(&v.rule_id, evidence);
-                        let _ = write_cache_entry(
+                        if let Err(e) = write_cache_entry(
                             cache_path,
                             &CacheEntry {
                                 cache_key: key,
@@ -286,7 +286,13 @@ pub async fn judge_findings<J: JudgeLlm>(
                                 reason: v.reason.clone(),
                                 timestamp: Utc::now(),
                             },
-                        );
+                        ) {
+                            tracing::warn!(
+                                path = %cache_path.display(),
+                                error = %e,
+                                "failed to persist judge cache entry"
+                            );
+                        }
 
                         match verdict {
                             JudgeVerdict::Approved => result.approved += 1,

--- a/src/judge.rs
+++ b/src/judge.rs
@@ -186,14 +186,14 @@ pub struct JudgeResult {
 /// - Findings with `judge: Required` that are rejected get dropped.
 /// - Findings with `judge: Optional` that are rejected get confidence
 ///   clamped to 0.05.
-#[allow(clippy::too_many_arguments, clippy::type_complexity)]
-pub fn judge_findings(
+#[allow(clippy::too_many_arguments)]
+pub async fn judge_findings<J: JudgeLlm>(
     findings: &mut Vec<Finding>,
     source_code: &str,
     metadata: &HashMap<String, RuleMetadata>,
     cache: &HashMap<String, CacheEntry>,
     cache_path: &Path,
-    llm_call: Option<&dyn Fn(&str) -> Option<String>>,
+    llm: Option<&J>,
 ) -> JudgeResult {
     let start = std::time::Instant::now();
     let mut result = JudgeResult::default();
@@ -235,7 +235,10 @@ pub fn judge_findings(
 
     // Phase 2: Batch LLM call for uncached findings
     if !to_judge.is_empty() {
-        if let Some(llm) = llm_call {
+        if let Some(llm) = llm {
+            if to_judge.len() > 50 {
+                tracing::warn!(count = to_judge.len(), "large batch of speculative findings for judge");
+            }
             let items: Vec<_> = to_judge
                 .iter()
                 .map(|&i| {
@@ -253,7 +256,7 @@ pub fn judge_findings(
             let prompt = build_judge_prompt(source_code, &items);
             result.calls += 1;
 
-            if let Some(response) = llm(&prompt)
+            if let Some(response) = llm.call(&prompt).await
                 && let Ok(verdicts) = serde_json::from_str::<Vec<JudgeResponseItem>>(&response)
             {
                 for v in &verdicts {
@@ -292,6 +295,8 @@ pub fn judge_findings(
                         }
                     }
                 }
+            } else if to_judge.iter().any(|&i| findings[i].judge_verdict.is_none()) {
+                tracing::warn!("judge LLM returned no usable response");
             }
 
             // Any remaining unjudged findings (LLM didn't return verdict): mark uncertain
@@ -433,8 +438,8 @@ mod tests {
         assert_eq!(verdicts[1].verdict, "fp");
     }
 
-    #[test]
-    fn judge_skips_high_precision_rules() {
+    #[tokio::test]
+    async fn judge_skips_high_precision_rules() {
         let mut findings = vec![{
             let mut f = FindingBuilder::new()
                 .source(Source::Linter("ast-grep".into()))
@@ -459,14 +464,15 @@ mod tests {
             &metadata,
             &HashMap::new(),
             &cache_path,
-            None,
-        );
+            None::<&MockJudge>,
+        )
+        .await;
         assert_eq!(result.skipped, 1);
         assert_eq!(findings[0].judge_verdict, Some(JudgeVerdict::Skipped));
     }
 
-    #[test]
-    fn judge_approves_with_mock_llm() {
+    #[tokio::test]
+    async fn judge_approves_with_mock_llm() {
         let mut findings = vec![{
             let mut f = FindingBuilder::new()
                 .source(Source::Linter("ast-grep".into()))
@@ -486,10 +492,10 @@ mod tests {
         );
         let dir = tempfile::tempdir().unwrap();
         let cache_path = dir.path().join("cache.jsonl");
-        let mock_llm = |_prompt: &str| -> Option<String> {
-            Some(
+        let mock = MockJudge {
+            response: Some(
                 r#"[{"rule_id":"ast-grep:python/broad-exception-catch","verdict":"tp","confidence":0.85,"reason":"valid"}]"#.into(),
-            )
+            ),
         };
         let result = judge_findings(
             &mut findings,
@@ -497,8 +503,9 @@ mod tests {
             &metadata,
             &HashMap::new(),
             &cache_path,
-            Some(&mock_llm),
-        );
+            Some(&mock),
+        )
+        .await;
         assert_eq!(result.approved, 1);
         assert_eq!(result.calls, 1);
         assert_eq!(findings.len(), 1);
@@ -509,8 +516,8 @@ mod tests {
         assert_eq!(loaded.len(), 1);
     }
 
-    #[test]
-    fn judge_drops_required_rejected() {
+    #[tokio::test]
+    async fn judge_drops_required_rejected() {
         let mut findings = vec![{
             let mut f = FindingBuilder::new()
                 .source(Source::Linter("ast-grep".into()))
@@ -530,10 +537,10 @@ mod tests {
         );
         let dir = tempfile::tempdir().unwrap();
         let cache_path = dir.path().join("cache.jsonl");
-        let mock_llm = |_prompt: &str| -> Option<String> {
-            Some(
+        let mock = MockJudge {
+            response: Some(
                 r#"[{"rule_id":"ast-grep:python/broad-exception-catch","verdict":"fp","confidence":0.92,"reason":"intentional top-level handler"}]"#.into(),
-            )
+            ),
         };
         let result = judge_findings(
             &mut findings,
@@ -541,8 +548,9 @@ mod tests {
             &metadata,
             &HashMap::new(),
             &cache_path,
-            Some(&mock_llm),
-        );
+            Some(&mock),
+        )
+        .await;
         assert_eq!(result.rejected, 1);
         assert!(
             findings.is_empty(),
@@ -550,8 +558,8 @@ mod tests {
         );
     }
 
-    #[test]
-    fn judge_uses_cache_hit() {
+    #[tokio::test]
+    async fn judge_uses_cache_hit() {
         let mut findings = vec![{
             let mut f = FindingBuilder::new()
                 .source(Source::Linter("ast-grep".into()))
@@ -590,15 +598,16 @@ mod tests {
             &metadata,
             &cache,
             &cache_path,
-            None,
-        );
+            None::<&MockJudge>,
+        )
+        .await;
         assert_eq!(result.cache_hits, 1);
         assert_eq!(result.approved, 1);
         assert_eq!(result.calls, 0);
     }
 
-    #[test]
-    fn judge_flow_end_to_end_with_cache() {
+    #[tokio::test]
+    async fn judge_flow_end_to_end_with_cache() {
         let mut findings = vec![
             {
                 let mut f = FindingBuilder::new()
@@ -643,8 +652,8 @@ mod tests {
         let cache = HashMap::new();
 
         // Mock LLM: always approve
-        let mock_llm = |_prompt: &str| -> Option<String> {
-            Some(r#"[{"rule_id":"ast-grep:python/broad-exception-catch","verdict":"tp","confidence":0.85,"reason":"valid"}]"#.into())
+        let mock = MockJudge {
+            response: Some(r#"[{"rule_id":"ast-grep:python/broad-exception-catch","verdict":"tp","confidence":0.85,"reason":"valid"}]"#.into()),
         };
 
         let result = judge_findings(
@@ -653,8 +662,9 @@ mod tests {
             &metadata,
             &cache,
             &cache_path,
-            Some(&mock_llm),
-        );
+            Some(&mock),
+        )
+        .await;
 
         assert_eq!(result.approved, 1);
         assert_eq!(result.skipped, 1);
@@ -668,8 +678,8 @@ mod tests {
         assert_eq!(loaded_cache.len(), 1);
     }
 
-    #[test]
-    fn judge_drops_required_rejected_findings() {
+    #[tokio::test]
+    async fn judge_drops_required_rejected_findings() {
         let mut findings = vec![
             {
                 let mut f = FindingBuilder::new()
@@ -714,8 +724,8 @@ mod tests {
         let cache = HashMap::new();
 
         // Mock LLM: rejects the speculative finding
-        let mock_llm = |_prompt: &str| -> Option<String> {
-            Some(r#"[{"rule_id":"ast-grep:python/broad-exception-catch","verdict":"fp","confidence":0.92,"reason":"intentional"}]"#.into())
+        let mock = MockJudge {
+            response: Some(r#"[{"rule_id":"ast-grep:python/broad-exception-catch","verdict":"fp","confidence":0.92,"reason":"intentional"}]"#.into()),
         };
 
         let result = judge_findings(
@@ -724,8 +734,9 @@ mod tests {
             &metadata,
             &cache,
             &cache_path,
-            Some(&mock_llm),
-        );
+            Some(&mock),
+        )
+        .await;
 
         assert_eq!(result.rejected, 1);
         assert_eq!(result.skipped, 1);

--- a/src/judge.rs
+++ b/src/judge.rs
@@ -743,4 +743,145 @@ mod tests {
         assert_eq!(findings.len(), 1); // speculative finding was DROPPED
         assert_eq!(findings[0].title, "as-any-cast: as any cast"); // only the high-precision one remains
     }
+
+    #[tokio::test]
+    async fn judge_handles_llm_failure_gracefully() {
+        let judge = MockJudge { response: None };
+
+        let mut findings = vec![{
+            let mut f = FindingBuilder::new()
+                .source(Source::Linter("ast-grep".into()))
+                .rule_id("ast-grep:rust/discarded-result")
+                .evidence("let _ = foo()")
+                .build();
+            f.precision_tier = Some(PrecisionTier::Speculative);
+            f
+        }];
+        let mut metadata = HashMap::new();
+        metadata.insert(
+            "ast-grep:rust/discarded-result".into(),
+            RuleMetadata {
+                precision: PrecisionTier::Speculative,
+                judge: JudgeRequirement::Required,
+            },
+        );
+        let dir = tempfile::tempdir().unwrap();
+        let cache_path = dir.path().join("cache.jsonl");
+
+        let result = judge_findings(
+            &mut findings,
+            "fn main() { let _ = foo(); }",
+            &metadata,
+            &HashMap::new(),
+            &cache_path,
+            Some(&judge),
+        )
+        .await;
+
+        assert_eq!(result.uncertain, 1);
+        assert_eq!(result.calls, 1);
+        assert_eq!(findings[0].judge_verdict, Some(JudgeVerdict::Uncertain));
+    }
+
+    #[tokio::test]
+    async fn judge_handles_partial_llm_response() {
+        let judge = MockJudge {
+            response: Some(
+                r#"[{"rule_id":"ast-grep:python/missing-await","verdict":"tp","confidence":0.9,"reason":"ok"}]"#
+                    .into(),
+            ),
+        };
+
+        let mut findings = vec![
+            {
+                let mut f = FindingBuilder::new()
+                    .source(Source::Linter("ast-grep".into()))
+                    .rule_id("ast-grep:python/missing-await")
+                    .evidence("await missing")
+                    .build();
+                f.precision_tier = Some(PrecisionTier::Speculative);
+                f
+            },
+            {
+                let mut f = FindingBuilder::new()
+                    .source(Source::Linter("ast-grep".into()))
+                    .rule_id("ast-grep:python/logging-debug-leak")
+                    .evidence("logger.debug(secret)")
+                    .build();
+                f.precision_tier = Some(PrecisionTier::Speculative);
+                f
+            },
+        ];
+        let mut metadata = HashMap::new();
+        metadata.insert(
+            "ast-grep:python/missing-await".into(),
+            RuleMetadata {
+                precision: PrecisionTier::Speculative,
+                judge: JudgeRequirement::Required,
+            },
+        );
+        metadata.insert(
+            "ast-grep:python/logging-debug-leak".into(),
+            RuleMetadata {
+                precision: PrecisionTier::Speculative,
+                judge: JudgeRequirement::Required,
+            },
+        );
+        let dir = tempfile::tempdir().unwrap();
+        let cache_path = dir.path().join("cache.jsonl");
+
+        let result = judge_findings(
+            &mut findings,
+            "source",
+            &metadata,
+            &HashMap::new(),
+            &cache_path,
+            Some(&judge),
+        )
+        .await;
+
+        assert_eq!(result.approved, 1);
+        assert_eq!(result.uncertain, 1);
+    }
+
+    #[tokio::test]
+    async fn judge_handles_malformed_json_response() {
+        let judge = MockJudge {
+            response: Some("not valid json at all {{{".into()),
+        };
+
+        let mut findings = vec![{
+            let mut f = FindingBuilder::new()
+                .source(Source::Linter("ast-grep".into()))
+                .rule_id("ast-grep:python/missing-await")
+                .evidence("await missing")
+                .build();
+            f.precision_tier = Some(PrecisionTier::Speculative);
+            f
+        }];
+        let mut metadata = HashMap::new();
+        metadata.insert(
+            "ast-grep:python/missing-await".into(),
+            RuleMetadata {
+                precision: PrecisionTier::Speculative,
+                judge: JudgeRequirement::Required,
+            },
+        );
+        let dir = tempfile::tempdir().unwrap();
+        let cache_path = dir.path().join("cache.jsonl");
+
+        let result = judge_findings(
+            &mut findings,
+            "async def foo(): bar()",
+            &metadata,
+            &HashMap::new(),
+            &cache_path,
+            Some(&judge),
+        )
+        .await;
+
+        assert_eq!(result.uncertain, 1, "malformed JSON should degrade to Uncertain");
+        assert_eq!(result.calls, 1);
+        assert_eq!(findings[0].judge_verdict, Some(JudgeVerdict::Uncertain));
+    }
 }

--- a/src/llm_client.rs
+++ b/src/llm_client.rs
@@ -769,6 +769,12 @@ impl OpenAiClient {
         prompt: &str,
         system_prompt: &str,
     ) -> anyhow::Result<LlmResponse> {
+        if Self::needs_responses_api(model) {
+            anyhow::bail!(
+                "Judge does not support Responses-only model '{}'; use a chat-completions model",
+                model
+            );
+        }
         let safe_prompt = crate::redact::redact_secrets(prompt);
         let safe_system = crate::redact::redact_secrets(system_prompt);
         let body = serde_json::json!({
@@ -799,6 +805,15 @@ impl OpenAiClient {
 
         let json: serde_json::Value = resp.json().await?;
         let usage = parse_usage(&json);
+
+        let finish_reason = json["choices"][0]["finish_reason"]
+            .as_str()
+            .unwrap_or("unknown");
+        if finish_reason == "length" {
+            anyhow::bail!(
+                "Judge response truncated (finish_reason=length); increase max_tokens or reduce batch size"
+            );
+        }
 
         let content = json["choices"][0]["message"]["content"]
             .as_str()

--- a/src/llm_client.rs
+++ b/src/llm_client.rs
@@ -769,11 +769,13 @@ impl OpenAiClient {
         prompt: &str,
         system_prompt: &str,
     ) -> anyhow::Result<LlmResponse> {
+        let safe_prompt = crate::redact::redact_secrets(prompt);
+        let safe_system = crate::redact::redact_secrets(system_prompt);
         let body = serde_json::json!({
             "model": model,
             "messages": [
-                {"role": "system", "content": system_prompt},
-                {"role": "user", "content": prompt}
+                {"role": "system", "content": safe_system},
+                {"role": "user", "content": safe_prompt}
             ],
             "temperature": 0,
             "max_tokens": 2048

--- a/src/llm_client.rs
+++ b/src/llm_client.rs
@@ -763,6 +763,53 @@ impl OpenAiClient {
         }
     }
 
+    pub async fn judge_completion(
+        &self,
+        model: &str,
+        prompt: &str,
+        system_prompt: &str,
+    ) -> anyhow::Result<LlmResponse> {
+        let body = serde_json::json!({
+            "model": model,
+            "messages": [
+                {"role": "system", "content": system_prompt},
+                {"role": "user", "content": prompt}
+            ],
+            "temperature": 0,
+            "max_tokens": 2048
+        });
+
+        let url = format!("{}/chat/completions", self.base_url);
+        let req = self
+            .http
+            .post(&url)
+            .header("Authorization", format!("Bearer {}", self.api_key))
+            .header("Content-Type", "application/json")
+            .json(&body);
+        let resp = self.send_with_retry(req).await?;
+
+        let status = resp.status();
+        if !status.is_success() {
+            let error_text = read_capped_error_body(resp).await;
+            let truncated = sanitize_error_body(&error_text);
+            anyhow::bail!("Judge API Error ({}): {}", status.as_u16(), truncated);
+        }
+
+        let json: serde_json::Value = resp.json().await?;
+        let usage = parse_usage(&json);
+
+        let content = json["choices"][0]["message"]["content"]
+            .as_str()
+            .ok_or_else(|| {
+                anyhow::anyhow!("Unexpected judge API response: no choices[0].message.content")
+            })?;
+
+        Ok(LlmResponse {
+            content: content.to_string(),
+            usage,
+        })
+    }
+
     /// #117: send a request with retry on transient 429/5xx + bounded by
     /// `overall_retry_deadline`. Honors `Retry-After` when supplied by
     /// upstream and the wait fits the remaining budget; otherwise uses
@@ -2920,5 +2967,27 @@ mod tests {
              Current length: {} chars",
             prompt.len()
         );
+    }
+
+    #[tokio::test]
+    async fn judge_completion_returns_content() {
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/chat/completions"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "choices": [{"message": {"content": "[{\"rule_id\":\"test\",\"verdict\":\"tp\",\"confidence\":0.9,\"reason\":\"ok\"}]"}, "finish_reason": "stop"}]
+            })))
+            .mount(&server)
+            .await;
+
+        let client = build_test_client(&server.uri());
+        let resp = client
+            .judge_completion("test-model", "test prompt", "system")
+            .await
+            .unwrap();
+        assert!(resp.content.contains("\"verdict\":\"tp\""));
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1112,6 +1112,7 @@ async fn run_review(opts: cli::ReviewOpts) -> i32 {
                     .filter(|s| !s.is_empty())
             })
             .unwrap_or_else(|| "gpt-5-nano".into()),
+        judge_client: llm_client.clone(),
         ..Default::default()
     };
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1111,7 +1111,7 @@ async fn run_review(opts: cli::ReviewOpts) -> i32 {
                     .ok()
                     .filter(|s| !s.is_empty())
             })
-            .unwrap_or_else(|| "gpt-5-nano".into()),
+            .unwrap_or_else(|| "gpt-4.1-mini".into()),
         judge_client: llm_client.clone(),
         ..Default::default()
     };

--- a/src/merge.rs
+++ b/src/merge.rs
@@ -285,6 +285,50 @@ mod tests {
     }
 
     #[test]
+    fn merge_non_overlapping_linter_findings_preserved() {
+        let f1 = FindingBuilder::new()
+            .title("ignored-io-result")
+            .category("error-handling".into())
+            .lines(10, 10)
+            .source(Source::Linter("ast-grep".into()))
+            .build();
+        let f2 = FindingBuilder::new()
+            .title("ignored-io-result")
+            .category("error-handling".into())
+            .lines(100, 100)
+            .source(Source::Linter("ast-grep".into()))
+            .build();
+        let result = merge_findings(vec![vec![f1], vec![f2]], 0.8, 1);
+        assert_eq!(
+            result.len(),
+            2,
+            "non-overlapping linter findings must stay separate"
+        );
+    }
+
+    #[test]
+    fn merge_overlapping_linter_findings_collapse() {
+        let f1 = FindingBuilder::new()
+            .title("ignored-io-result")
+            .category("error-handling".into())
+            .lines(10, 20)
+            .source(Source::Linter("ast-grep".into()))
+            .build();
+        let f2 = FindingBuilder::new()
+            .title("ignored-io-result")
+            .category("error-handling".into())
+            .lines(12, 18)
+            .source(Source::Linter("ast-grep".into()))
+            .build();
+        let result = merge_findings(vec![vec![f1], vec![f2]], 0.8, 1);
+        assert_eq!(
+            result.len(),
+            1,
+            "overlapping linter findings should collapse"
+        );
+    }
+
+    #[test]
     fn merge_different_titles_not_collapsed() {
         let f1 = FindingBuilder::new()
             .title("SQL injection in query builder")

--- a/src/merge.rs
+++ b/src/merge.rs
@@ -97,7 +97,10 @@ fn similarity(a: &Finding, b: &Finding) -> f64 {
     // Exception: linter findings (ast-grep) share identical titles per rule,
     // so each match at a different location must be preserved as a separate
     // finding. Only collapse linter findings when their lines also overlap.
-    let both_linter = matches!((&a.source, &b.source), (Source::Linter(_), Source::Linter(_)));
+    let both_linter = matches!(
+        (&a.source, &b.source),
+        (Source::Linter(_), Source::Linter(_))
+    );
     if a.title == b.title && a.category == b.category {
         if both_linter {
             let overlap = line_overlap(a.line_start, a.line_end, b.line_start, b.line_end);

--- a/src/merge.rs
+++ b/src/merge.rs
@@ -93,7 +93,18 @@ fn similarity(a: &Finding, b: &Finding) -> f64 {
     // Exact title+category match collapses regardless of line overlap.
     // These are the "4x Catch-all except: pass at different lines" cases
     // that used to leak through as separate findings.
+    //
+    // Exception: linter findings (ast-grep) share identical titles per rule,
+    // so each match at a different location must be preserved as a separate
+    // finding. Only collapse linter findings when their lines also overlap.
+    let both_linter = matches!((&a.source, &b.source), (Source::Linter(_), Source::Linter(_)));
     if a.title == b.title && a.category == b.category {
+        if both_linter {
+            let overlap = line_overlap(a.line_start, a.line_end, b.line_start, b.line_end);
+            if overlap < 0.5 {
+                return 0.0;
+            }
+        }
         return 1.0;
     }
 

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -198,6 +198,10 @@ pub struct PipelineConfig {
     pub judge_enabled: bool,
     /// Model for judge calls (--judge-model / QUORUM_JUDGE_MODEL / default gpt-5-nano)
     pub judge_model: String,
+    /// Shared OpenAI client for judge LLM calls. When `Some` and
+    /// `judge_enabled` is true, an `OpenAiJudge` is constructed per file.
+    /// When `None`, judge runs in cache-only mode (existing behavior).
+    pub judge_client: Option<std::sync::Arc<crate::llm_client::OpenAiClient>>,
 }
 
 impl Default for PipelineConfig {
@@ -225,6 +229,7 @@ impl Default for PipelineConfig {
             registry_client: None,
             judge_enabled: false,
             judge_model: "gpt-5-nano".into(),
+            judge_client: None,
         }
     }
 }
@@ -733,6 +738,13 @@ pub async fn review_file(
             let cache = crate::judge::load_cache(&cache_path).unwrap_or_default();
             drop(_span);
 
+            let judge = pipeline_config.judge_client.as_ref().map(|client| {
+                crate::judge::OpenAiJudge::new(
+                    std::sync::Arc::clone(client),
+                    pipeline_config.judge_model.clone(),
+                )
+            });
+
             for source_findings in all_sources.iter_mut().skip(1) {
                 let result = crate::judge::judge_findings(
                     source_findings,
@@ -740,7 +752,7 @@ pub async fn review_file(
                     &rule_metadata,
                     &cache,
                     &cache_path,
-                    None::<&crate::judge::OpenAiJudge>, // LLM client not wired yet -- cache-only + skip for now
+                    judge.as_ref(),
                 )
                 .await;
                 judge_metrics.approved += result.approved;

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -196,7 +196,7 @@ pub struct PipelineConfig {
     pub registry_client: Option<std::sync::Arc<dyn crate::enrichment_policy::RegistryClient>>,
     /// Enable LLM micro-judge for speculative AST rules (--judge / QUORUM_JUDGE=1)
     pub judge_enabled: bool,
-    /// Model for judge calls (--judge-model / QUORUM_JUDGE_MODEL / default gpt-5-nano)
+    /// Model for judge calls (--judge-model / QUORUM_JUDGE_MODEL / default gpt-4.1-mini)
     pub judge_model: String,
     /// Shared OpenAI client for judge LLM calls. When `Some` and
     /// `judge_enabled` is true, an `OpenAiJudge` is constructed per file.
@@ -228,7 +228,7 @@ impl Default for PipelineConfig {
             mode: crate::review_mode::ReviewMode::Code,
             registry_client: None,
             judge_enabled: false,
-            judge_model: "gpt-5-nano".into(),
+            judge_model: "gpt-4.1-mini".into(),
             judge_client: None,
         }
     }

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -723,30 +723,34 @@ pub async fn review_file(
     // Only runs on ast-grep findings (index 1+), not local AST (index 0).
     let mut judge_metrics = JudgeMetrics::default();
     if pipeline_config.judge_enabled && !rule_metadata.is_empty() {
-        let _span = tracing::info_span!("phase.judge", file = %file_str).entered();
-        let home_dir = std::env::var("HOME")
-            .or_else(|_| std::env::var("USERPROFILE"))
-            .map(std::path::PathBuf::from)
-            .unwrap_or_default();
-        let cache_path = home_dir.join(".quorum").join("judge_cache.jsonl");
-        let cache = crate::judge::load_cache(&cache_path).unwrap_or_default();
+        {
+            let _span = tracing::info_span!("phase.judge", file = %file_str).entered();
+            let home_dir = std::env::var("HOME")
+                .or_else(|_| std::env::var("USERPROFILE"))
+                .map(std::path::PathBuf::from)
+                .unwrap_or_default();
+            let cache_path = home_dir.join(".quorum").join("judge_cache.jsonl");
+            let cache = crate::judge::load_cache(&cache_path).unwrap_or_default();
+            drop(_span);
 
-        for source_findings in all_sources.iter_mut().skip(1) {
-            let result = crate::judge::judge_findings(
-                source_findings,
-                source,
-                &rule_metadata,
-                &cache,
-                &cache_path,
-                None, // LLM client not wired yet -- cache-only + skip for now
-            );
-            judge_metrics.approved += result.approved;
-            judge_metrics.rejected += result.rejected;
-            judge_metrics.uncertain += result.uncertain;
-            judge_metrics.skipped += result.skipped;
-            judge_metrics.cache_hits += result.cache_hits;
-            judge_metrics.calls += result.calls;
-            judge_metrics.latency_ms += result.latency_ms;
+            for source_findings in all_sources.iter_mut().skip(1) {
+                let result = crate::judge::judge_findings(
+                    source_findings,
+                    source,
+                    &rule_metadata,
+                    &cache,
+                    &cache_path,
+                    None::<&crate::judge::OpenAiJudge>, // LLM client not wired yet -- cache-only + skip for now
+                )
+                .await;
+                judge_metrics.approved += result.approved;
+                judge_metrics.rejected += result.rejected;
+                judge_metrics.uncertain += result.uncertain;
+                judge_metrics.skipped += result.skipped;
+                judge_metrics.cache_hits += result.cache_hits;
+                judge_metrics.calls += result.calls;
+                judge_metrics.latency_ms += result.latency_ms;
+            }
         }
         tracing::info!(
             phase = "judge",


### PR DESCRIPTION
## Summary

- Wire `OpenAiClient` into the judge stage via `JudgeLlm` trait + `OpenAiJudge`, replacing the always-`Uncertain` stub
- Fix three independent pipeline bugs that prevented speculative AST findings from reaching the judge correctly:
  1. `load_rules` used `project_dir` for bundled rules — fails when `find_project_root` stops at a nested manifest. Now uses `env!(CARGO_MANIFEST_DIR)` at compile time.
  2. `merge::similarity` collapsed all linter findings with identical title+category into one. Added `both_linter` guard requiring line overlap >= 0.5.
  3. Judge response parsing: added `extract_json_array` for markdown fence stripping, index-based matching for multi-finding batches, `tracing::warn` on failures.
- Fix index mismatch bug caught by quorum self-review: batch-local indices vs original finding vector indices diverge when cache hits shift the batch. Replaced `swap_remove` with a `used`-flag array.
- Default judge model changed from `gpt-5-nano` (empty responses via LiteLLM) to `gpt-4.1-mini`
- Add eval corpus with 29 planted findings (TP+FP) across Rust, Python, TypeScript, YAML
- Add `single_quote_scalar` to jinja-loop-variable-scoping YAML rule

## Results

Judge accuracy on eval corpus with `gpt-4.1-mini`:

| Language   | Findings | Approved | Rejected | Accuracy |
|------------|----------|----------|----------|----------|
| Rust       | 9        | 5        | 4        | 100%     |
| Python     | 8        | 4        | 4        | 100%     |
| TypeScript | 8        | 4        | 4        | 100%     |
| YAML       | 4        | 2        | 2        | 100%     |
| **Total**  | **29**   | **15**   | **14**   | **100%** |

## Test plan

- [x] `cargo test --bin quorum` — 1395 tests pass
- [x] `cargo clippy` — clean
- [x] Judge produces correct verdicts on all 4 eval corpus languages
- [x] Cache hit path verified (second run uses cached verdicts)
- [x] Self-review with gpt-5.4 found and fixed index mismatch bug

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Async LLM-based judging flow with chat-completion support and bundled judge client.
  * Added curated evaluation corpora and example cases for speculative-pattern detection across Python, Rust, TypeScript, and YAML.

* **Bug Fixes**
  * Smarter merging to avoid collapsing distinct linter findings at different locations.
  * More robust judge result handling: malformed/missing outputs marked Uncertain and confidences clamped.

* **Chores**
  * Updated default judge model and refined bundled rule discovery.

* **Tests**
  * Expanded async tests and coverage for judge/client flows.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jsnyder/quorum/pull/322)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->