### PR TITLE
fix(security): harden URL credential redaction and judge prompt injection (#319, #320)

### DIFF
--- a/src/judge.rs
+++ b/src/judge.rs
@@ -160,21 +160,23 @@ pub fn build_judge_prompt(
     prompt.push_str(source_code);
     prompt.push_str("\n```\n\nFindings to judge:\n");
 
-    for (i, (rule_id, title, start, end, evidence)) in findings.iter().enumerate() {
-        prompt.push_str(&format!(
-            "{}. [index={}] rule_id=\"{}\", title=\"{}\", lines {}-{}, evidence=\"{}\"\n",
-            i + 1,
-            i,
-            rule_id,
-            title,
-            start,
-            end,
-            evidence
-        ));
-    }
+    let items: Vec<serde_json::Value> = findings
+        .iter()
+        .enumerate()
+        .map(|(i, (rule_id, title, start, end, evidence))| {
+            serde_json::json!({
+                "index": i,
+                "rule_id": rule_id,
+                "title": title,
+                "lines": format!("{}-{}", start, end),
+                "evidence": evidence,
+            })
+        })
+        .collect();
+    prompt.push_str(&serde_json::to_string_pretty(&items).unwrap_or_default());
 
     prompt.push_str(
-        "\nRespond with ONLY a JSON array. Each element must include the index field: \
+        "\n\nRespond with ONLY a JSON array. Each element must include the index field: \
          {\"index\": N, \"rule_id\": \"...\", \"verdict\": \"tp\"|\"fp\"|\"uncertain\", \
          \"confidence\": 0.0-1.0, \"reason\": \"...\"}\n",
     );
@@ -486,6 +488,73 @@ mod tests {
         assert_eq!(parse_verdict("fp"), JudgeVerdict::Rejected);
         assert_eq!(parse_verdict("uncertain"), JudgeVerdict::Uncertain);
         assert_eq!(parse_verdict("garbage"), JudgeVerdict::Uncertain);
+    }
+
+    #[test]
+    fn build_judge_prompt_escapes_special_characters() {
+        let findings = vec![(
+            "test-rule".to_string(),
+            "title with \"quotes\" and\nnewlines".to_string(),
+            1u32,
+            5u32,
+            "evidence with \\backslash and \"double quotes\"".to_string(),
+        )];
+        let prompt = build_judge_prompt("fn main() {}", &findings);
+        let json_start = prompt.find('[').expect("should contain JSON array");
+        let json_end = prompt.rfind(']').expect("should end with JSON array");
+        let json_str = &prompt[json_start..=json_end];
+        let parsed: Vec<serde_json::Value> =
+            serde_json::from_str(json_str).expect("findings must be valid JSON");
+        assert_eq!(parsed.len(), 1);
+        assert_eq!(
+            parsed[0]["title"],
+            "title with \"quotes\" and\nnewlines"
+        );
+        assert_eq!(
+            parsed[0]["evidence"],
+            "evidence with \\backslash and \"double quotes\""
+        );
+    }
+
+    #[test]
+    fn build_judge_prompt_round_trips_values() {
+        let findings = vec![
+            (
+                "rule-a".to_string(),
+                "simple title".to_string(),
+                10u32,
+                20u32,
+                "some evidence".to_string(),
+            ),
+            (
+                "rule-b".to_string(),
+                "title with {braces} and [brackets]".to_string(),
+                30u32,
+                40u32,
+                "evidence\twith\ttabs".to_string(),
+            ),
+        ];
+        let prompt = build_judge_prompt("let x = 1;", &findings);
+        let json_start = prompt.find('[').unwrap();
+        let json_end = prompt.rfind(']').unwrap();
+        let json_str = &prompt[json_start..=json_end];
+        let parsed: Vec<serde_json::Value> = serde_json::from_str(json_str).unwrap();
+        assert_eq!(parsed.len(), 2);
+        assert_eq!(parsed[0]["rule_id"], "rule-a");
+        assert_eq!(parsed[0]["index"], 0);
+        assert_eq!(parsed[1]["rule_id"], "rule-b");
+        assert_eq!(parsed[1]["index"], 1);
+        assert_eq!(parsed[1]["title"], "title with {braces} and [brackets]");
+    }
+
+    #[test]
+    fn build_judge_prompt_empty_findings_valid_json() {
+        let prompt = build_judge_prompt("fn main() {}", &[]);
+        let json_start = prompt.find('[').expect("should contain JSON array");
+        let json_end = prompt.rfind(']').expect("should end with JSON array");
+        let json_str = &prompt[json_start..=json_end];
+        let parsed: Vec<serde_json::Value> = serde_json::from_str(json_str).unwrap();
+        assert!(parsed.is_empty());
     }
 
     #[test]

--- a/src/judge.rs
+++ b/src/judge.rs
@@ -506,10 +506,7 @@ mod tests {
         let parsed: Vec<serde_json::Value> =
             serde_json::from_str(json_str).expect("findings must be valid JSON");
         assert_eq!(parsed.len(), 1);
-        assert_eq!(
-            parsed[0]["title"],
-            "title with \"quotes\" and\nnewlines"
-        );
+        assert_eq!(parsed[0]["title"], "title with \"quotes\" and\nnewlines");
         assert_eq!(
             parsed[0]["evidence"],
             "evidence with \\backslash and \"double quotes\""

--- a/src/llm_client.rs
+++ b/src/llm_client.rs
@@ -423,12 +423,10 @@ pub fn validate_base_url(base_url: &str, policy: &BaseUrlPolicy) -> anyhow::Resu
         return Ok(());
     }
 
-    let host = parsed
-        .host()
-        .ok_or_else(|| {
-            let safe = redact_userinfo_for_error(base_url);
-            anyhow::anyhow!("base_url {safe:?} has no host")
-        })?;
+    let host = parsed.host().ok_or_else(|| {
+        let safe = redact_userinfo_for_error(base_url);
+        anyhow::anyhow!("base_url {safe:?} has no host")
+    })?;
 
     // Per-branch logic: private/loopback hosts gate on `allow_private_ips`
     // and bypass the allowlist when permitted (user shouldn't have to ALSO
@@ -1808,13 +1806,25 @@ mod tests {
     fn actionable_error_helpers_redact_credentials() {
         let url = "https://admin:s3cret@proxy.example.com/v1";
         let msg = actionable_error_for_private_ip(url, "127.0.0.1");
-        assert!(!msg.contains("s3cret"), "private IP error leaks password: {msg}");
-        assert!(msg.contains("proxy.example.com"), "should preserve host: {msg}");
+        assert!(
+            !msg.contains("s3cret"),
+            "private IP error leaks password: {msg}"
+        );
+        assert!(
+            msg.contains("proxy.example.com"),
+            "should preserve host: {msg}"
+        );
 
         let policy = BaseUrlPolicy::default();
         let msg2 = actionable_error_for_unknown_host(url, "proxy.example.com", &policy);
-        assert!(!msg2.contains("s3cret"), "unknown host error leaks password: {msg2}");
-        assert!(msg2.contains("proxy.example.com"), "should preserve host: {msg2}");
+        assert!(
+            !msg2.contains("s3cret"),
+            "unknown host error leaks password: {msg2}"
+        );
+        assert!(
+            msg2.contains("proxy.example.com"),
+            "should preserve host: {msg2}"
+        );
     }
 
     #[test]
@@ -1823,22 +1833,37 @@ mod tests {
         let err = validate_base_url("http:///path", &policy)
             .unwrap_err()
             .to_string();
-        assert!(!err.contains("password"), "no-host error should not leak anything sensitive: {err}");
+        assert!(
+            !err.contains("password"),
+            "no-host error should not leak anything sensitive: {err}"
+        );
     }
 
     #[test]
     fn redact_userinfo_handles_percent_encoded_password() {
         let result = redact_userinfo_for_error("https://user:p%40ss%23word@host.com/v1");
-        assert!(!result.contains("p%40ss"), "percent-encoded password leaked: {result}");
-        assert!(result.contains("[REDACTED]@"), "should contain redaction marker: {result}");
-        assert!(result.contains("host.com"), "should preserve host: {result}");
+        assert!(
+            !result.contains("p%40ss"),
+            "percent-encoded password leaked: {result}"
+        );
+        assert!(
+            result.contains("[REDACTED]@"),
+            "should contain redaction marker: {result}"
+        );
+        assert!(
+            result.contains("host.com"),
+            "should preserve host: {result}"
+        );
     }
 
     #[test]
     fn redact_userinfo_handles_username_only() {
         let result = redact_userinfo_for_error("https://admin@host.com/v1");
         assert!(!result.contains("admin@"), "username leaked: {result}");
-        assert!(result.contains("[REDACTED]@"), "should contain redaction marker: {result}");
+        assert!(
+            result.contains("[REDACTED]@"),
+            "should contain redaction marker: {result}"
+        );
     }
 
     // --- #119: BaseUrlPolicy::from_env ---

--- a/src/llm_client.rs
+++ b/src/llm_client.rs
@@ -425,7 +425,10 @@ pub fn validate_base_url(base_url: &str, policy: &BaseUrlPolicy) -> anyhow::Resu
 
     let host = parsed
         .host()
-        .ok_or_else(|| anyhow::anyhow!("base_url {base_url:?} has no host"))?;
+        .ok_or_else(|| {
+            let safe = redact_userinfo_for_error(base_url);
+            anyhow::anyhow!("base_url {safe:?} has no host")
+        })?;
 
     // Per-branch logic: private/loopback hosts gate on `allow_private_ips`
     // and bypass the allowlist when permitted (user shouldn't have to ALSO
@@ -505,8 +508,9 @@ pub fn validate_base_url(base_url: &str, policy: &BaseUrlPolicy) -> anyhow::Resu
     //   - `unsafe_bypass` (QUORUM_UNSAFE_BASE_URL=1): handled at the top
     //     of this function; never reaches here.
     if parsed.scheme() == "http" && !host_is_private {
+        let safe = redact_userinfo_for_error(base_url);
         anyhow::bail!(
-            "base_url {base_url:?} uses plaintext http:// scheme. \
+            "base_url {safe:?} uses plaintext http:// scheme. \
              API keys and request bodies would be sent unencrypted. \
              Use https:// instead. \
              For on-prem / Ollama deployments on a trusted LAN, set:\n  \
@@ -570,8 +574,9 @@ fn ipv6_to_ipv4_mapped(ip: std::net::Ipv6Addr) -> Option<std::net::Ipv4Addr> {
 }
 
 fn actionable_error_for_private_ip(url: &str, ip_or_name: &str) -> String {
+    let safe = redact_userinfo_for_error(url);
     format!(
-        "base_url {url:?} resolves to a private/loopback/link-local address ({ip_or_name}). \
+        "base_url {safe:?} resolves to a private/loopback/link-local address ({ip_or_name}). \
          To allow this for Ollama / on-prem LLMs, set:\n  \
          export QUORUM_ALLOW_PRIVATE_BASE_URL=1"
     )
@@ -588,8 +593,9 @@ fn actionable_error_for_unknown_host(url: &str, host: &str, policy: &BaseUrlPoli
     } else {
         all.join(", ")
     };
+    let safe = redact_userinfo_for_error(url);
     format!(
-        "base_url {url:?} host {host:?} is not on the allowlist.\n\n\
+        "base_url {safe:?} host {host:?} is not on the allowlist.\n\n\
          Allowed hosts: {allowed}\n\n\
          To allow this host, set:\n  \
          export QUORUM_ALLOWED_BASE_URL_HOSTS={host}\n\
@@ -1796,6 +1802,43 @@ mod tests {
             !msg.contains("leaky-user"),
             "username must not appear in parse-error message; got: {msg}"
         );
+    }
+
+    #[test]
+    fn actionable_error_helpers_redact_credentials() {
+        let url = "https://admin:s3cret@proxy.example.com/v1";
+        let msg = actionable_error_for_private_ip(url, "127.0.0.1");
+        assert!(!msg.contains("s3cret"), "private IP error leaks password: {msg}");
+        assert!(msg.contains("proxy.example.com"), "should preserve host: {msg}");
+
+        let policy = BaseUrlPolicy::default();
+        let msg2 = actionable_error_for_unknown_host(url, "proxy.example.com", &policy);
+        assert!(!msg2.contains("s3cret"), "unknown host error leaks password: {msg2}");
+        assert!(msg2.contains("proxy.example.com"), "should preserve host: {msg2}");
+    }
+
+    #[test]
+    fn validate_base_url_no_host_does_not_leak_credentials() {
+        let policy = BaseUrlPolicy::default();
+        let err = validate_base_url("http:///path", &policy)
+            .unwrap_err()
+            .to_string();
+        assert!(!err.contains("password"), "no-host error should not leak anything sensitive: {err}");
+    }
+
+    #[test]
+    fn redact_userinfo_handles_percent_encoded_password() {
+        let result = redact_userinfo_for_error("https://user:p%40ss%23word@host.com/v1");
+        assert!(!result.contains("p%40ss"), "percent-encoded password leaked: {result}");
+        assert!(result.contains("[REDACTED]@"), "should contain redaction marker: {result}");
+        assert!(result.contains("host.com"), "should preserve host: {result}");
+    }
+
+    #[test]
+    fn redact_userinfo_handles_username_only() {
+        let result = redact_userinfo_for_error("https://admin@host.com/v1");
+        assert!(!result.contains("admin@"), "username leaked: {result}");
+        assert!(result.contains("[REDACTED]@"), "should contain redaction marker: {result}");
     }
 
     // --- #119: BaseUrlPolicy::from_env ---

--- a/src/llm_client.rs
+++ b/src/llm_client.rs
@@ -402,18 +402,19 @@ pub fn validate_base_url(base_url: &str, policy: &BaseUrlPolicy) -> anyhow::Resu
         anyhow::anyhow!("base_url {safe:?} is not a valid URL: {e}")
     })?;
 
-    if !matches!(parsed.scheme(), "http" | "https") {
-        anyhow::bail!(
-            "base_url {base_url:?} must use http or https scheme, got {:?}",
-            parsed.scheme()
-        );
-    }
-
-    // Always-on: embedded credentials. No opt-out — no legitimate use case.
+    // Always-on: embedded credentials. Checked FIRST so no subsequent error
+    // path can echo the raw URL with credentials. No opt-out.
     if !parsed.username().is_empty() || parsed.password().is_some() {
         anyhow::bail!(
             "base_url must not contain embedded credentials (user:password@host). \
              Pass the API key via QUORUM_API_KEY instead."
+        );
+    }
+
+    if !matches!(parsed.scheme(), "http" | "https") {
+        anyhow::bail!(
+            "base_url must use http or https scheme, got {:?}",
+            parsed.scheme()
         );
     }
 
@@ -1432,6 +1433,20 @@ mod tests {
         let err = validate_base_url("http://user:pass@127.0.0.1:8000/v1", &policy)
             .expect_err("must reject");
         assert!(err.to_string().contains("embedded credentials"));
+    }
+
+    #[test]
+    fn validate_base_url_scheme_error_does_not_leak_credentials() {
+        let policy = BaseUrlPolicy::default();
+        let err = validate_base_url("ftp://admin:s3cret@evil.com/v1", &policy)
+            .unwrap_err()
+            .to_string();
+        assert!(!err.contains("s3cret"), "error leaks password: {err}");
+        assert!(!err.contains("admin"), "error leaks username: {err}");
+        assert!(
+            err.contains("embedded credentials") || err.contains("evil.com"),
+            "error should mention credentials rejection or redacted host: {err}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- **#320**: Reorder `validate_base_url` to check embedded credentials before any error path that echoes the raw URL. Apply `redact_userinfo_for_error()` to all 5 remaining error paths (no-host, scheme, plaintext-http, private-IP helper, unknown-host helper).
- **#319**: Replace hand-formatted string interpolation in `build_judge_prompt` with `serde_json::to_string_pretty()` so special characters in rule IDs, titles, and evidence are properly JSON-escaped.

## Test plan

- [x] `cargo test --bin quorum` — 1420 tests pass (+8 new)
- [x] `cargo clippy` — clean
- [x] `cargo fmt` — clean
- [x] Quorum self-review — 0 in-branch findings, 2 pre-existing issues filed (#328, #329)

### New tests
- `validate_base_url_scheme_error_does_not_leak_credentials` — ftp URL with creds hits generic rejection
- `actionable_error_helpers_redact_credentials` — helper functions redact passwords, preserve hosts
- `validate_base_url_no_host_does_not_leak_credentials` — no-host path is safe
- `redact_userinfo_handles_percent_encoded_password` — percent-encoded creds redacted
- `redact_userinfo_handles_username_only` — username-only URLs redacted
- `build_judge_prompt_escapes_special_characters` — quotes/newlines produce valid JSON
- `build_judge_prompt_round_trips_values` — parsed JSON matches original input
- `build_judge_prompt_empty_findings_valid_json` — empty findings produce `[]`

### Quorum verdicts recorded
- 2 TP (filed #328, #329)
- 2 FP (already fixed in prior PRs)
- 1 partial
- 5 wontfix (known limitations, intentional design)

Closes #319, closes #320.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error reporting to prevent accidental exposure of credentials in URL validation error messages.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jsnyder/quorum/pull/330)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->