### PR TITLE
feat: multi-source context retrieval with cross-repo scoring

### DIFF
--- a/src/context/bootstrap.rs
+++ b/src/context/bootstrap.rs
@@ -6,19 +6,14 @@
 //! `auto_inject = false`, no indexed source — so reviews degrade to the
 //! pre-context behavior instead of failing.
 //!
-//! The retriever closure opens the SQLite db read-only on every call and
-//! owns a fresh `HashEmbedder` / `SystemClock`. This keeps it `Send + Sync
-//! + 'static` without threading a shared connection through the pipeline;
-//!   review workloads query once per file so the per-call open is negligible
-//!   relative to the LLM round-trip.
-//!
-//! NOTE: the current wiring picks the first registered source that has an
-//! index on disk. Cross-source fanout (merging hits across multiple dbs) is
-//! out of scope for the initial integration — the injector already filters
-//! to that source via `RetrievalQuery.filters.sources`, so multi-source
-//! support is a closure-level change, not a pipeline change.
+//! When `context.multi_source.enabled = true` (the default), collects ALL
+//! sources with a valid index and fans out retrieval across them. Per-source
+//! results are min-max normalized and re-ranked with multiplicative boosts
+//! (current-repo, dep-manifest, language-match) before diversity constraints
+//! enforce per-source caps and current-repo reserved slots.
 
-use std::path::Path;
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use rusqlite::Connection;
@@ -31,33 +26,41 @@ use crate::context::index::builder::ensure_vec_loaded;
 use crate::context::index::traits::HashEmbedder;
 use crate::context::index::traits::SystemClock;
 use crate::context::inject::{ContextInjectionSource, ContextInjector, RetrieverFn};
+use crate::context::retrieve::multi_source::{BoostContext, SourceBatch, merge_and_rerank};
 use crate::context::retrieve::{Filters, RetrievalQuery, Retriever, ScoredChunk};
 use crate::feedback::FeedbackEntry;
 
-/// Construct the production retrieval embedder. Delegates to the shared
-/// factory in `cli::new_prod_embedder` so reviews and `quorum context
-/// query` agree on the same fastembed-with-HashEmbedder-fallback policy
-/// — using two different factories would drift the two code paths and
-/// make a first-run `context query` succeed while reviews panic.
 fn build_retrieval_embedder() -> crate::context::cli::ProdEmbedder {
     crate::context::cli::new_prod_embedder()
+}
+
+/// A validated source with its db path, ready for retrieval.
+#[derive(Debug, Clone)]
+struct ValidSource {
+    name: String,
+    db_path: PathBuf,
 }
 
 /// Build a production `ContextInjectionSource` from `<home>/sources.toml` and
 /// the associated per-source indexes.
 ///
 /// Returns `None` when:
-/// - `<home>/sources.toml` is missing or unparseable (don't fail the whole
-///   review just because the user hasn't set up context yet).
-/// - `context.auto_inject = false` in the config.
-/// - No registered source has an `index.db` on disk.
-///
-/// The returned injector is wired with a [`Calibrator`] seeded from the
-/// caller-supplied feedback entries so `ContextMisleading` verdicts raise
-/// per-chunk thresholds in real reviews.
+/// - `<home>/sources.toml` is missing or unparseable
+/// - `context.auto_inject = false` in the config
+/// - No registered source has an `index.db` on disk
 pub fn build_production_injector(
     home: &Path,
     feedback: &[FeedbackEntry],
+) -> Option<Arc<dyn ContextInjectionSource>> {
+    build_production_injector_with_project(home, feedback, None)
+}
+
+/// Like [`build_production_injector`] but accepts an optional project root
+/// for current-repo detection and dep-manifest matching.
+pub fn build_production_injector_with_project(
+    home: &Path,
+    feedback: &[FeedbackEntry],
+    project_root: Option<&Path>,
 ) -> Option<Arc<dyn ContextInjectionSource>> {
     let sources_path = home.join("sources.toml");
     if !sources_path.exists() {
@@ -78,24 +81,46 @@ pub fn build_production_injector(
         return None;
     }
 
-    // Walk registered sources and pick the first one whose `index.db` is
-    // actually openable and queryable. Existence alone isn't enough — a
-    // stale tempfile or truncated db would hand a dead connection to the
-    // retriever and fail on the first real review. Skip those and fall
-    // through so the caller degrades to pre-context behavior.
-    let picked = cfg.sources.iter().find_map(|s| {
+    let multi_enabled = cfg.context.multi_source.enabled;
+    let max_sources = cfg.context.multi_source.max_sources_queried as usize;
+
+    let valid_sources = collect_valid_sources(home, &cfg, if multi_enabled { max_sources } else { 1 });
+    if valid_sources.is_empty() {
+        tracing::info!(
+            "context bootstrap: no registered source has a usable index; run `quorum context index` to enable auto-injection"
+        );
+        return None;
+    }
+
+    let embedder = Arc::new(build_retrieval_embedder());
+    let multi_source_config = cfg.context.multi_source.clone();
+
+    let boost_ctx = build_boost_context(project_root, &cfg, &valid_sources);
+
+    let retriever: Arc<RetrieverFn> = if valid_sources.len() == 1 && !multi_enabled {
+        build_single_source_retriever(valid_sources.into_iter().next().unwrap(), embedder)
+    } else {
+        build_multi_source_retriever(valid_sources, embedder, multi_source_config, boost_ctx)
+    };
+
+    let calibrator = Calibrator::from_feedback(cfg.context.inject_min_score, feedback);
+    let injector = ContextInjector::new(&cfg, retriever).with_calibrator(Arc::new(calibrator));
+    Some(Arc::new(injector))
+}
+
+fn collect_valid_sources(home: &Path, cfg: &SourcesConfig, limit: usize) -> Vec<ValidSource> {
+    let mut valid = Vec::new();
+    for s in &cfg.sources {
+        if valid.len() >= limit {
+            break;
+        }
         let layout = SourceLayout::for_source(home, &s.name);
         if !layout.db.exists() {
-            return None;
+            continue;
         }
         ensure_vec_loaded();
         match Connection::open_with_flags(&layout.db, rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY) {
             Ok(conn) => {
-                // Probe all three tables the retriever actually uses. A db
-                // with only `chunks` would pass a naive check but fail the
-                // BM25 leg of the first query; likewise a missing
-                // `chunks_vec` would fail the vector leg. Using one
-                // compound query keeps the cost minimal.
                 let probe = conn.query_row::<u32, _, _>(
                     "SELECT (SELECT COUNT(*) FROM chunks) \
                           + (SELECT COUNT(*) FROM chunks_fts) \
@@ -104,7 +129,10 @@ pub fn build_production_injector(
                     |r| r.get(0),
                 );
                 match probe {
-                    Ok(_) => Some((s.name.clone(), layout.db)),
+                    Ok(_) => valid.push(ValidSource {
+                        name: s.name.clone(),
+                        db_path: layout.db,
+                    }),
                     Err(e) => {
                         tracing::warn!(
                             source = %s.name,
@@ -112,7 +140,6 @@ pub fn build_production_injector(
                             error = %e,
                             "context bootstrap: index.db present but unusable (missing table?); skipping"
                         );
-                        None
                     }
                 }
             }
@@ -123,63 +150,166 @@ pub fn build_production_injector(
                     error = %e,
                     "context bootstrap: index.db present but cannot be opened; skipping"
                 );
-                None
             }
         }
-    });
-    let (src_name, db_path) = match picked {
-        Some(v) => v,
-        None => {
-            tracing::info!(
-                "context bootstrap: no registered source has a usable index; run `quorum context index` to enable auto-injection"
-            );
-            return None;
-        }
+    }
+    valid
+}
+
+fn build_boost_context(
+    project_root: Option<&Path>,
+    cfg: &SourcesConfig,
+    valid_sources: &[ValidSource],
+) -> BoostContext {
+    let current_repo_source = detect_current_repo(project_root, cfg, valid_sources);
+
+    let dep_manifest_sources = match project_root {
+        Some(root) => match_dep_manifest(root, cfg),
+        None => HashSet::new(),
     };
 
-    // Own the db path directly so non-UTF-8 bytes (rare on macOS/Linux but
-    // legal on ext4/APFS) survive the hand-off into the `'static` closure
-    // without going through `to_string_lossy`.
-    let db_path_owned = db_path;
-    let src_for_filter = src_name.clone();
+    BoostContext {
+        current_repo_source,
+        dep_manifest_sources,
+        reviewed_language: None, // set per-file at query time via RetrievalQuery
+    }
+}
 
-    // Initialize fastembed once; share the `Arc` across every retriever
-    // call. Model init is expensive (~1s) and per-review cost would
-    // dominate otherwise. Mutex inside `FastEmbedEmbedder` serializes
-    // actual inference, which is fine because reviews are sequential per
-    // file anyway.
-    let embedder = std::sync::Arc::new(build_retrieval_embedder());
+fn detect_current_repo(
+    project_root: Option<&Path>,
+    cfg: &SourcesConfig,
+    valid_sources: &[ValidSource],
+) -> Option<String> {
+    let root = project_root?;
+    let canonical_root = std::fs::canonicalize(root).ok()?;
+    let valid_names: HashSet<&str> = valid_sources.iter().map(|v| v.name.as_str()).collect();
 
-    let retriever: Arc<RetrieverFn> = {
-        let embedder = std::sync::Arc::clone(&embedder);
-        Arc::new(
-            move |q: &RetrievalQuery| -> anyhow::Result<Vec<ScoredChunk>> {
-                // Every invocation is a fresh process-safe open; the vec0 hook
-                // must be registered before `Connection::open*` or the vector
-                // leg of retrieval errors with `no such module: vec0`.
+    for s in &cfg.sources {
+        if !valid_names.contains(s.name.as_str()) {
+            continue;
+        }
+        if let crate::context::config::SourceLocation::Path(ref p) = s.location {
+            let matches = std::fs::canonicalize(p).is_ok_and(|canonical_src| {
+                canonical_root.starts_with(&canonical_src)
+                    || canonical_src.starts_with(&canonical_root)
+            });
+            if matches {
+                return Some(s.name.clone());
+            }
+        }
+    }
+    None
+}
+
+fn match_dep_manifest(project_root: &Path, cfg: &SourcesConfig) -> HashSet<String> {
+    let deps = crate::dep_manifest::parse_dependencies(project_root);
+    let dep_names: HashSet<String> = deps.iter().map(|d| d.name.clone()).collect();
+    let mut matched = HashSet::new();
+    for s in &cfg.sources {
+        if dep_names.contains(&s.name) {
+            matched.insert(s.name.clone());
+            continue;
+        }
+        for alias in &s.provides {
+            if dep_names.contains(alias) {
+                matched.insert(s.name.clone());
+                break;
+            }
+        }
+    }
+    matched
+}
+
+fn build_single_source_retriever(
+    source: ValidSource,
+    embedder: Arc<crate::context::cli::ProdEmbedder>,
+) -> Arc<RetrieverFn> {
+    let src_name = source.name;
+    let db_path = source.db_path;
+    Arc::new(
+        move |q: &RetrievalQuery| -> anyhow::Result<Vec<ScoredChunk>> {
+            ensure_vec_loaded();
+            let conn = Connection::open_with_flags(
+                &db_path,
+                rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY,
+            )?;
+            let clock = SystemClock;
+            let retriever = Retriever::new(&conn, embedder.as_ref(), &clock);
+            let mut q = q.clone();
+            q.filters = Filters {
+                sources: vec![src_name.clone()],
+                kinds: q.filters.kinds,
+                exclude_source_paths: q.filters.exclude_source_paths,
+            };
+            retriever.query(q)
+        },
+    )
+}
+
+fn build_multi_source_retriever(
+    sources: Vec<ValidSource>,
+    embedder: Arc<crate::context::cli::ProdEmbedder>,
+    ms_config: crate::context::config::MultiSourceConfig,
+    boost_ctx: BoostContext,
+) -> Arc<RetrieverFn> {
+    Arc::new(
+        move |q: &RetrievalQuery| -> anyhow::Result<Vec<ScoredChunk>> {
+            let per_source_k = q.k.saturating_mul(2).max(10);
+            let mut batches = Vec::with_capacity(sources.len());
+
+            for src in &sources {
                 ensure_vec_loaded();
-                let conn = Connection::open_with_flags(
-                    &db_path_owned,
+                let conn = match Connection::open_with_flags(
+                    &src.db_path,
                     rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY,
-                )?;
+                ) {
+                    Ok(c) => c,
+                    Err(e) => {
+                        tracing::warn!(
+                            source = %src.name,
+                            error = %e,
+                            "multi-source retriever: skipping source (db open failed)"
+                        );
+                        continue;
+                    }
+                };
                 let clock = SystemClock;
                 let retriever = Retriever::new(&conn, embedder.as_ref(), &clock);
-                // Constrain to the specific source we picked so multi-source
-                // layouts don't accidentally leak hits from other indexes.
-                let mut q = q.clone();
-                q.filters = Filters {
-                    sources: vec![src_for_filter.clone()],
-                    kinds: q.filters.kinds,
-                    exclude_source_paths: q.filters.exclude_source_paths,
+                let mut local_q = q.clone();
+                local_q.k = per_source_k;
+                local_q.filters = Filters {
+                    sources: vec![src.name.clone()],
+                    kinds: q.filters.kinds.clone(),
+                    exclude_source_paths: q.filters.exclude_source_paths.clone(),
                 };
-                retriever.query(q)
-            },
-        )
-    };
+                match retriever.query(local_q) {
+                    Ok(chunks) if !chunks.is_empty() => {
+                        batches.push(SourceBatch {
+                            source_name: src.name.clone(),
+                            chunks,
+                        });
+                    }
+                    Ok(_) => {} // empty — skip
+                    Err(e) => {
+                        tracing::warn!(
+                            source = %src.name,
+                            error = %e,
+                            "multi-source retriever: query failed for source; skipping"
+                        );
+                    }
+                }
+            }
 
-    let calibrator = Calibrator::from_feedback(cfg.context.inject_min_score, feedback);
-    let injector = ContextInjector::new(&cfg, retriever).with_calibrator(Arc::new(calibrator));
-    Some(Arc::new(injector))
+            if batches.is_empty() {
+                return Ok(Vec::new());
+            }
+
+            let mut ctx = boost_ctx.clone();
+            ctx.reviewed_language = q.reviewed_file_language.clone();
+
+            Ok(merge_and_rerank(&batches, &ms_config, &ctx, q.k as u32))
+        },
+    )
 }
 
 #[cfg(test)]
@@ -258,6 +388,9 @@ path = "/tmp/demo"
             paths: vec![],
             weight: Some(10),
             ignore: vec![],
+            provides: vec![],
+            include_for: vec![],
+            exclude_for: vec![],
         };
         let clock = FixedClock::epoch();
         let extracted = extract_source(&source, &ExtractConfig::default(), &clock).unwrap();

--- a/src/context/bootstrap.rs
+++ b/src/context/bootstrap.rs
@@ -84,7 +84,16 @@ pub fn build_production_injector_with_project(
     let multi_enabled = cfg.context.multi_source.enabled;
     let max_sources = cfg.context.multi_source.max_sources_queried as usize;
 
-    let valid_sources = collect_valid_sources(home, &cfg, if multi_enabled { max_sources } else { 1 });
+    let project_name = project_root
+        .and_then(|p| p.file_name())
+        .and_then(|n| n.to_str())
+        .map(|s| s.to_string());
+    let valid_sources = collect_valid_sources_for_project(
+        home,
+        &cfg,
+        if multi_enabled { max_sources } else { 1 },
+        project_name.as_deref(),
+    );
     if valid_sources.is_empty() {
         tracing::info!(
             "context bootstrap: no registered source has a usable index; run `quorum context index` to enable auto-injection"
@@ -109,10 +118,27 @@ pub fn build_production_injector_with_project(
 }
 
 fn collect_valid_sources(home: &Path, cfg: &SourcesConfig, limit: usize) -> Vec<ValidSource> {
+    collect_valid_sources_for_project(home, cfg, limit, None)
+}
+
+fn collect_valid_sources_for_project(
+    home: &Path,
+    cfg: &SourcesConfig,
+    limit: usize,
+    project_name: Option<&str>,
+) -> Vec<ValidSource> {
     let mut valid = Vec::new();
     for s in &cfg.sources {
         if valid.len() >= limit {
             break;
+        }
+        if let Some(proj) = project_name {
+            if !s.include_for.is_empty() && !s.include_for.iter().any(|p| p == proj) {
+                continue;
+            }
+            if s.exclude_for.iter().any(|p| p == proj) {
+                continue;
+            }
         }
         let layout = SourceLayout::for_source(home, &s.name);
         if !layout.db.exists() {
@@ -189,9 +215,12 @@ fn detect_current_repo(
             continue;
         }
         if let crate::context::config::SourceLocation::Path(ref p) = s.location {
+            // Only match when the project root is inside (or equal to) the
+            // source path. The reverse direction (source inside project) would
+            // be wrong: a source at ~/code/lib is not "current repo" for a
+            // project at ~/code.
             let matches = std::fs::canonicalize(p).is_ok_and(|canonical_src| {
                 canonical_root.starts_with(&canonical_src)
-                    || canonical_src.starts_with(&canonical_root)
             });
             if matches {
                 return Some(s.name.clone());
@@ -307,7 +336,8 @@ fn build_multi_source_retriever(
             let mut ctx = boost_ctx.clone();
             ctx.reviewed_language = q.reviewed_file_language.clone();
 
-            Ok(merge_and_rerank(&batches, &ms_config, &ctx, q.k as u32))
+            let k = u32::try_from(q.k).unwrap_or(u32::MAX);
+            Ok(merge_and_rerank(&batches, &ms_config, &ctx, k))
         },
     )
 }

--- a/src/context/bootstrap.rs
+++ b/src/context/bootstrap.rs
@@ -210,24 +210,25 @@ fn detect_current_repo(
     let canonical_root = std::fs::canonicalize(root).ok()?;
     let valid_names: HashSet<&str> = valid_sources.iter().map(|v| v.name.as_str()).collect();
 
+    let mut best: Option<(usize, String)> = None;
     for s in &cfg.sources {
         if !valid_names.contains(s.name.as_str()) {
             continue;
         }
-        if let crate::context::config::SourceLocation::Path(ref p) = s.location {
-            // Only match when the project root is inside (or equal to) the
-            // source path. The reverse direction (source inside project) would
-            // be wrong: a source at ~/code/lib is not "current repo" for a
-            // project at ~/code.
-            let matches = std::fs::canonicalize(p).is_ok_and(|canonical_src| {
-                canonical_root.starts_with(&canonical_src)
-            });
-            if matches {
-                return Some(s.name.clone());
+        let crate::context::config::SourceLocation::Path(ref p) = s.location else {
+            continue;
+        };
+        let Ok(canonical_src) = std::fs::canonicalize(p) else {
+            continue;
+        };
+        if canonical_root.starts_with(&canonical_src) {
+            let depth = canonical_src.components().count();
+            if best.as_ref().is_none_or(|(d, _)| depth > *d) {
+                best = Some((depth, s.name.clone()));
             }
         }
     }
-    None
+    best.map(|(_, name)| name)
 }
 
 fn match_dep_manifest(project_root: &Path, cfg: &SourcesConfig) -> HashSet<String> {

--- a/src/context/bootstrap.rs
+++ b/src/context/bootstrap.rs
@@ -259,10 +259,8 @@ fn build_single_source_retriever(
     Arc::new(
         move |q: &RetrievalQuery| -> anyhow::Result<Vec<ScoredChunk>> {
             ensure_vec_loaded();
-            let conn = Connection::open_with_flags(
-                &db_path,
-                rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY,
-            )?;
+            let conn =
+                Connection::open_with_flags(&db_path, rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY)?;
             let clock = SystemClock;
             let retriever = Retriever::new(&conn, embedder.as_ref(), &clock);
             let mut q = q.clone();

--- a/src/context/cli.rs
+++ b/src/context/cli.rs
@@ -686,6 +686,9 @@ fn run_add<D: ContextDeps>(args: &AddArgs, deps: &D) -> Result<CmdOutput> {
         paths: Vec::new(),
         weight: args.weight,
         ignore: args.ignore.clone(),
+        provides: Vec::new(),
+        include_for: Vec::new(),
+        exclude_for: Vec::new(),
     };
 
     let sources_path = deps.home_dir().join("sources.toml");

--- a/src/context/cli_tests.rs
+++ b/src/context/cli_tests.rs
@@ -623,6 +623,9 @@ fn append_source_rejects_path_traversal_name() {
         paths: Vec::new(),
         weight: None,
         ignore: Vec::new(),
+        provides: Vec::new(),
+        include_for: Vec::new(),
+        exclude_for: Vec::new(),
     };
     let err = SourcesConfig::append_source(&path, &entry)
         .expect_err("traversal name at config layer must be rejected");

--- a/src/context/config.rs
+++ b/src/context/config.rs
@@ -610,6 +610,11 @@ fn build_context(raw: RawContext) -> Result<ContextConfig, ConfigError> {
     validate_boost("current_repo_boost", ctx.multi_source.current_repo_boost)?;
     validate_boost("dep_manifest_boost", ctx.multi_source.dep_manifest_boost)?;
     validate_boost("lang_match_boost", ctx.multi_source.lang_match_boost)?;
+    if ctx.multi_source.enabled && ctx.multi_source.max_sources_queried == 0 {
+        return Err(ConfigError::Invalid(
+            "multi_source.max_sources_queried must be greater than 0 when enabled".into(),
+        ));
+    }
 
     Ok(ctx)
 }

--- a/src/context/config.rs
+++ b/src/context/config.rs
@@ -70,6 +70,9 @@ pub struct SourceEntry {
     pub paths: Vec<PathBuf>,
     pub weight: Option<i32>,
     pub ignore: Vec<String>,
+    pub provides: Vec<String>,
+    pub include_for: Vec<String>,
+    pub exclude_for: Vec<String>,
 }
 
 #[derive(Debug, Clone)]
@@ -88,6 +91,32 @@ pub struct ContextConfig {
     pub rerank_recency_floor: f32,
     pub max_source_size_mb: u32,
     pub ignore: Vec<String>,
+    pub multi_source: MultiSourceConfig,
+}
+
+#[derive(Debug, Clone)]
+pub struct MultiSourceConfig {
+    pub enabled: bool,
+    pub max_sources_queried: u32,
+    pub per_source_cap: u32,
+    pub current_repo_reserved: u32,
+    pub current_repo_boost: f32,
+    pub dep_manifest_boost: f32,
+    pub lang_match_boost: f32,
+}
+
+impl Default for MultiSourceConfig {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            max_sources_queried: 10,
+            per_source_cap: 3,
+            current_repo_reserved: 2,
+            current_repo_boost: 1.3,
+            dep_manifest_boost: 1.2,
+            lang_match_boost: 1.1,
+        }
+    }
 }
 
 impl Default for ContextConfig {
@@ -101,6 +130,7 @@ impl Default for ContextConfig {
             rerank_recency_floor: 0.25,
             max_source_size_mb: 200,
             ignore: Vec::new(),
+            multi_source: MultiSourceConfig::default(),
         }
     }
 }
@@ -130,7 +160,6 @@ struct RawConfig {
 }
 
 #[derive(Debug, Deserialize)]
-#[serde(deny_unknown_fields)]
 struct RawSource {
     name: String,
     kind: RawKind,
@@ -146,6 +175,12 @@ struct RawSource {
     weight: Option<i32>,
     #[serde(default)]
     ignore: Vec<String>,
+    #[serde(default)]
+    provides: Vec<String>,
+    #[serde(default)]
+    include_for: Vec<String>,
+    #[serde(default)]
+    exclude_for: Vec<String>,
 }
 
 // Custom kind wrapper so we can emit a friendlier "unknown kind" message
@@ -197,6 +232,27 @@ struct RawContext {
     max_source_size_mb: Option<u32>,
     #[serde(default)]
     ignore: Vec<String>,
+    #[serde(default)]
+    multi_source: Option<RawMultiSource>,
+}
+
+#[derive(Debug, Deserialize, Default)]
+#[serde(deny_unknown_fields)]
+struct RawMultiSource {
+    #[serde(default)]
+    enabled: Option<bool>,
+    #[serde(default)]
+    max_sources_queried: Option<u32>,
+    #[serde(default)]
+    per_source_cap: Option<u32>,
+    #[serde(default)]
+    current_repo_reserved: Option<u32>,
+    #[serde(default)]
+    current_repo_boost: Option<f32>,
+    #[serde(default)]
+    dep_manifest_boost: Option<f32>,
+    #[serde(default)]
+    lang_match_boost: Option<f32>,
 }
 
 // --- Public API -------------------------------------------------------------
@@ -455,6 +511,9 @@ impl SourcesConfig {
                 paths: rs.paths.into_iter().map(PathBuf::from).collect(),
                 weight: rs.weight,
                 ignore: rs.ignore,
+                provides: rs.provides,
+                include_for: rs.include_for,
+                exclude_for: rs.exclude_for,
             });
         }
 
@@ -483,6 +542,7 @@ fn build_context(raw: RawContext) -> Result<ContextConfig, ConfigError> {
             .max_source_size_mb
             .unwrap_or(defaults.max_source_size_mb),
         ignore: raw.ignore,
+        multi_source: build_multi_source(raw.multi_source.unwrap_or_default()),
     };
 
     if !ctx.inject_min_score.is_finite() {
@@ -531,4 +591,25 @@ fn build_context(raw: RawContext) -> Result<ContextConfig, ConfigError> {
     }
 
     Ok(ctx)
+}
+
+fn build_multi_source(raw: RawMultiSource) -> MultiSourceConfig {
+    let defaults = MultiSourceConfig::default();
+    MultiSourceConfig {
+        enabled: raw.enabled.unwrap_or(defaults.enabled),
+        max_sources_queried: raw
+            .max_sources_queried
+            .unwrap_or(defaults.max_sources_queried),
+        per_source_cap: raw.per_source_cap.unwrap_or(defaults.per_source_cap),
+        current_repo_reserved: raw
+            .current_repo_reserved
+            .unwrap_or(defaults.current_repo_reserved),
+        current_repo_boost: raw
+            .current_repo_boost
+            .unwrap_or(defaults.current_repo_boost),
+        dep_manifest_boost: raw
+            .dep_manifest_boost
+            .unwrap_or(defaults.dep_manifest_boost),
+        lang_match_boost: raw.lang_match_boost.unwrap_or(defaults.lang_match_boost),
+    }
 }

--- a/src/context/config.rs
+++ b/src/context/config.rs
@@ -452,6 +452,15 @@ fn render_source_fragment(entry: &SourceEntry) -> String {
     if !entry.ignore.is_empty() {
         out.push_str(&format!("ignore = {}\n", tq_array(&entry.ignore)));
     }
+    if !entry.provides.is_empty() {
+        out.push_str(&format!("provides = {}\n", tq_array(&entry.provides)));
+    }
+    if !entry.include_for.is_empty() {
+        out.push_str(&format!("include_for = {}\n", tq_array(&entry.include_for)));
+    }
+    if !entry.exclude_for.is_empty() {
+        out.push_str(&format!("exclude_for = {}\n", tq_array(&entry.exclude_for)));
+    }
     out
 }
 
@@ -589,6 +598,18 @@ fn build_context(raw: RawContext) -> Result<ContextConfig, ConfigError> {
             "max_source_size_mb must be greater than 0".into(),
         ));
     }
+
+    fn validate_boost(name: &str, v: f32) -> Result<(), ConfigError> {
+        if !v.is_finite() || v < 0.0 {
+            return Err(ConfigError::Invalid(format!(
+                "{name} must be a finite non-negative number, got {v}"
+            )));
+        }
+        Ok(())
+    }
+    validate_boost("current_repo_boost", ctx.multi_source.current_repo_boost)?;
+    validate_boost("dep_manifest_boost", ctx.multi_source.dep_manifest_boost)?;
+    validate_boost("lang_match_boost", ctx.multi_source.lang_match_boost)?;
 
     Ok(ctx)
 }

--- a/src/context/config_tests.rs
+++ b/src/context/config_tests.rs
@@ -264,17 +264,97 @@ inject_min_socre = 0.5   # typo
 }
 
 #[test]
-fn rejects_unknown_source_field() {
+fn source_ignores_unknown_fields_for_forward_compat() {
     let toml = r#"
 [[source]]
 name = "x"
 path = "."
 kind = "rust"
-weigth = 5   # typo
+future_field = "something"
 "#;
-    let err = SourcesConfig::from_str(toml).unwrap_err();
-    let s = err.to_string().to_lowercase();
-    assert!(s.contains("unknown") || s.contains("weigth"), "got: {err}");
+    let config = SourcesConfig::from_str(toml).unwrap();
+    assert_eq!(config.sources.len(), 1);
+}
+
+#[test]
+fn parses_provides_field_on_source() {
+    let toml = r#"
+[[source]]
+name = "homeassist"
+path = "/tmp/ha"
+kind = "rust"
+provides = ["home-assistant-core", "ha-core"]
+"#;
+    let config = SourcesConfig::from_str(toml).unwrap();
+    assert_eq!(config.sources[0].provides, vec!["home-assistant-core", "ha-core"]);
+}
+
+#[test]
+fn parses_include_for_exclude_for_on_source() {
+    let toml = r#"
+[[source]]
+name = "shared-lib"
+path = "/tmp/lib"
+kind = "rust"
+include_for = ["project-a"]
+exclude_for = ["project-b", "project-c"]
+"#;
+    let config = SourcesConfig::from_str(toml).unwrap();
+    assert_eq!(config.sources[0].include_for, vec!["project-a"]);
+    assert_eq!(config.sources[0].exclude_for, vec!["project-b", "project-c"]);
+}
+
+#[test]
+fn source_fields_default_empty_when_omitted() {
+    let toml = r#"
+[[source]]
+name = "basic"
+path = "/tmp/basic"
+kind = "rust"
+"#;
+    let config = SourcesConfig::from_str(toml).unwrap();
+    assert!(config.sources[0].provides.is_empty());
+    assert!(config.sources[0].include_for.is_empty());
+    assert!(config.sources[0].exclude_for.is_empty());
+}
+
+#[test]
+fn parses_multi_source_config_sub_table() {
+    let toml = r#"
+[[source]]
+name = "x"
+path = "."
+kind = "rust"
+
+[context]
+auto_inject = true
+
+[context.multi_source]
+enabled = true
+max_sources_queried = 8
+per_source_cap = 2
+current_repo_reserved = 3
+"#;
+    let config = SourcesConfig::from_str(toml).unwrap();
+    assert!(config.context.multi_source.enabled);
+    assert_eq!(config.context.multi_source.max_sources_queried, 8);
+    assert_eq!(config.context.multi_source.per_source_cap, 2);
+    assert_eq!(config.context.multi_source.current_repo_reserved, 3);
+}
+
+#[test]
+fn multi_source_defaults_when_omitted() {
+    let toml = r#"
+[[source]]
+name = "x"
+path = "."
+kind = "rust"
+"#;
+    let config = SourcesConfig::from_str(toml).unwrap();
+    assert!(config.context.multi_source.enabled);
+    assert_eq!(config.context.multi_source.max_sources_queried, 10);
+    assert_eq!(config.context.multi_source.per_source_cap, 3);
+    assert_eq!(config.context.multi_source.current_repo_reserved, 2);
 }
 
 #[test]

--- a/src/context/config_tests.rs
+++ b/src/context/config_tests.rs
@@ -286,7 +286,10 @@ kind = "rust"
 provides = ["home-assistant-core", "ha-core"]
 "#;
     let config = SourcesConfig::from_str(toml).unwrap();
-    assert_eq!(config.sources[0].provides, vec!["home-assistant-core", "ha-core"]);
+    assert_eq!(
+        config.sources[0].provides,
+        vec!["home-assistant-core", "ha-core"]
+    );
 }
 
 #[test]
@@ -301,7 +304,10 @@ exclude_for = ["project-b", "project-c"]
 "#;
     let config = SourcesConfig::from_str(toml).unwrap();
     assert_eq!(config.sources[0].include_for, vec!["project-a"]);
-    assert_eq!(config.sources[0].exclude_for, vec!["project-b", "project-c"]);
+    assert_eq!(
+        config.sources[0].exclude_for,
+        vec!["project-b", "project-c"]
+    );
 }
 
 #[test]

--- a/src/context/extract/dispatch_tests.rs
+++ b/src/context/extract/dispatch_tests.rs
@@ -21,6 +21,9 @@ fn mk_entry(name: &str, kind: SourceKind, path: PathBuf) -> SourceEntry {
         paths: vec![],
         weight: None,
         ignore: vec![],
+        provides: vec![],
+        include_for: vec![],
+        exclude_for: vec![],
     }
 }
 
@@ -263,6 +266,9 @@ fn git_source_returns_error_for_mvp() {
         paths: vec![],
         weight: None,
         ignore: vec![],
+        provides: vec![],
+        include_for: vec![],
+        exclude_for: vec![],
     };
     let clock = FixedClock::epoch();
     let err = extract_source(&entry, &ExtractConfig::default(), &clock).unwrap_err();
@@ -357,6 +363,9 @@ fn rejects_scan_path_escaping_source_root() {
         paths: vec![PathBuf::from("../../../")],
         weight: None,
         ignore: vec![],
+        provides: vec![],
+        include_for: vec![],
+        exclude_for: vec![],
     };
     let result = extract_source(&entry, &ExtractConfig::default(), &FixedClock::epoch()).unwrap();
     assert!(result.chunks.is_empty());
@@ -372,6 +381,9 @@ fn rejects_absolute_scan_path_outside_root() {
         paths: vec![PathBuf::from("/etc")],
         weight: None,
         ignore: vec![],
+        provides: vec![],
+        include_for: vec![],
+        exclude_for: vec![],
     };
     let result = extract_source(&entry, &ExtractConfig::default(), &FixedClock::epoch()).unwrap();
     assert!(result.chunks.is_empty());

--- a/src/context/inject/injector.rs
+++ b/src/context/inject/injector.rs
@@ -398,6 +398,7 @@ impl std::fmt::Debug for ContextInjector {
 mod tests {
     use super::*;
     use crate::calibrator::Calibrator;
+    use crate::context::config::MultiSourceConfig;
     use crate::context::retrieve::ScoreBreakdown;
     use crate::context::types::{Chunk, ChunkMeta, LineRange, Provenance};
 
@@ -450,6 +451,7 @@ mod tests {
             rerank_recency_floor: 0.25,
             max_source_size_mb: 100,
             ignore: vec![],
+            multi_source: MultiSourceConfig::default(),
         }
     }
 

--- a/src/context/inject/plan_tests.rs
+++ b/src/context/inject/plan_tests.rs
@@ -1,5 +1,5 @@
 use super::plan::{TokenCounter, plan_injection};
-use crate::context::config::ContextConfig;
+use crate::context::config::{ContextConfig, MultiSourceConfig};
 use crate::context::retrieve::{ScoreBreakdown, ScoredChunk};
 use crate::context::types::{Chunk, ChunkKind, ChunkMeta, LineRange, Provenance};
 
@@ -56,6 +56,7 @@ fn config_with(budget: u32, tau: f32, max_chunks: u32) -> ContextConfig {
         rerank_recency_floor: 0.25,
         max_source_size_mb: 100,
         ignore: vec![],
+        multi_source: MultiSourceConfig::default(),
     }
 }
 

--- a/src/context/phase2_integration_tests.rs
+++ b/src/context/phase2_integration_tests.rs
@@ -20,6 +20,9 @@ fn fixture_source(name: &str) -> SourceEntry {
         paths: Vec::new(),
         weight: None,
         ignore: Vec::new(),
+        provides: Vec::new(),
+        include_for: Vec::new(),
+        exclude_for: Vec::new(),
     }
 }
 

--- a/src/context/phase3_integration_tests.rs
+++ b/src/context/phase3_integration_tests.rs
@@ -23,6 +23,9 @@ fn fixture_source(name: &str) -> SourceEntry {
         paths: Vec::new(),
         weight: None,
         ignore: Vec::new(),
+        provides: Vec::new(),
+        include_for: Vec::new(),
+        exclude_for: Vec::new(),
     }
 }
 

--- a/src/context/phase4_integration_tests.rs
+++ b/src/context/phase4_integration_tests.rs
@@ -24,6 +24,9 @@ fn fixture_source(name: &str) -> SourceEntry {
         paths: Vec::new(),
         weight: None,
         ignore: Vec::new(),
+        provides: Vec::new(),
+        include_for: Vec::new(),
+        exclude_for: Vec::new(),
     }
 }
 

--- a/src/context/phase5_integration_tests.rs
+++ b/src/context/phase5_integration_tests.rs
@@ -5,7 +5,7 @@ use std::path::PathBuf;
 use rusqlite::Connection;
 use tempfile::tempdir;
 
-use super::config::{ContextConfig, SourceEntry, SourceKind, SourceLocation};
+use super::config::{ContextConfig, MultiSourceConfig, SourceEntry, SourceKind, SourceLocation};
 use super::extract::dispatch::{ExtractConfig, extract_source};
 use super::index::builder::IndexBuilder;
 use super::index::traits::{FixedClock, HashEmbedder};
@@ -28,6 +28,9 @@ fn fixture_source(name: &str) -> SourceEntry {
         paths: Vec::new(),
         weight: None,
         ignore: Vec::new(),
+        provides: Vec::new(),
+        include_for: Vec::new(),
+        exclude_for: Vec::new(),
     }
 }
 
@@ -67,6 +70,7 @@ fn context_config_with_budget(budget: u32, tau: f32) -> ContextConfig {
         rerank_recency_floor: 0.25,
         max_source_size_mb: 100,
         ignore: Vec::new(),
+        multi_source: MultiSourceConfig::default(),
     }
 }
 

--- a/src/context/phase6_integration_tests.rs
+++ b/src/context/phase6_integration_tests.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 use rusqlite::Connection;
 use tempfile::tempdir;
 
-use super::config::{ContextConfig, SourceEntry, SourceKind, SourceLocation, SourcesConfig};
+use super::config::{ContextConfig, MultiSourceConfig, SourceEntry, SourceKind, SourceLocation, SourcesConfig};
 use super::extract::dispatch::{ExtractConfig, extract_source};
 use super::index::builder::IndexBuilder;
 use super::index::traits::{FixedClock, HashEmbedder};
@@ -24,6 +24,9 @@ fn fixture_source(name: &str) -> SourceEntry {
         paths: Vec::new(),
         weight: Some(10),
         ignore: Vec::new(),
+        provides: Vec::new(),
+        include_for: Vec::new(),
+        exclude_for: Vec::new(),
     }
 }
 
@@ -71,6 +74,7 @@ fn context_config(budget: u32) -> ContextConfig {
         rerank_recency_floor: 0.25,
         max_source_size_mb: 100,
         ignore: Vec::new(),
+        multi_source: MultiSourceConfig::default(),
     }
 }
 

--- a/src/context/phase6_integration_tests.rs
+++ b/src/context/phase6_integration_tests.rs
@@ -7,7 +7,9 @@ use std::sync::Arc;
 use rusqlite::Connection;
 use tempfile::tempdir;
 
-use super::config::{ContextConfig, MultiSourceConfig, SourceEntry, SourceKind, SourceLocation, SourcesConfig};
+use super::config::{
+    ContextConfig, MultiSourceConfig, SourceEntry, SourceKind, SourceLocation, SourcesConfig,
+};
 use super::extract::dispatch::{ExtractConfig, extract_source};
 use super::index::builder::IndexBuilder;
 use super::index::traits::{FixedClock, HashEmbedder};

--- a/src/context/retrieve/mod.rs
+++ b/src/context/retrieve/mod.rs
@@ -39,9 +39,9 @@ pub use retriever::{RetrievalQuery, Retriever, ScoredChunk};
 #[cfg(test)]
 mod bm25_tests;
 #[cfg(test)]
-mod multi_source_tests;
-#[cfg(test)]
 mod identifiers_tests;
+#[cfg(test)]
+mod multi_source_tests;
 #[cfg(test)]
 mod precedence_tests;
 #[cfg(test)]

--- a/src/context/retrieve/mod.rs
+++ b/src/context/retrieve/mod.rs
@@ -20,6 +20,7 @@ pub struct Filters {
 
 pub mod bm25;
 pub mod identifiers;
+pub mod multi_source;
 pub mod precedence;
 pub mod rerank;
 pub mod retriever;
@@ -37,6 +38,8 @@ pub use retriever::{RetrievalQuery, Retriever, ScoredChunk};
 
 #[cfg(test)]
 mod bm25_tests;
+#[cfg(test)]
+mod multi_source_tests;
 #[cfg(test)]
 mod identifiers_tests;
 #[cfg(test)]

--- a/src/context/retrieve/multi_source.rs
+++ b/src/context/retrieve/multi_source.rs
@@ -45,8 +45,11 @@ pub fn merge_and_rerank(
 
         // Filter NaN scores before normalization — they'd corrupt min/max
         // and sort ordering.
-        let clean_chunks: Vec<&ScoredChunk> =
-            batch.chunks.iter().filter(|sc| sc.score.is_finite()).collect();
+        let clean_chunks: Vec<&ScoredChunk> = batch
+            .chunks
+            .iter()
+            .filter(|sc| sc.score.is_finite())
+            .collect();
         if clean_chunks.is_empty() {
             continue;
         }

--- a/src/context/retrieve/multi_source.rs
+++ b/src/context/retrieve/multi_source.rs
@@ -19,6 +19,7 @@ pub struct BoostContext {
 #[derive(Debug, Clone)]
 pub(crate) struct MultiSourceCandidate {
     pub chunk: ScoredChunk,
+    pub source_name: String,
     pub normalized_score: f32,
     pub boosted_score: f32,
     pub is_current_repo: bool,
@@ -77,6 +78,7 @@ pub fn merge_and_rerank(
 
             candidates.push(MultiSourceCandidate {
                 chunk: (*sc).clone(),
+                source_name: batch.source_name.clone(),
                 normalized_score: normalized,
                 boosted_score: normalized * boost,
                 is_current_repo: is_current,
@@ -158,7 +160,7 @@ fn apply_diversity_constraints(
             continue;
         }
 
-        let source = &c.chunk.chunk.source;
+        let source = &c.source_name;
         let is_current = c.is_current_repo;
 
         if !is_current {

--- a/src/context/retrieve/multi_source.rs
+++ b/src/context/retrieve/multi_source.rs
@@ -42,10 +42,18 @@ pub fn merge_and_rerank(
             .as_ref()
             .is_some_and(|cr| cr == &batch.source_name);
 
-        let (min_score, max_score) = min_max_scores(&batch.chunks);
+        // Filter NaN scores before normalization — they'd corrupt min/max
+        // and sort ordering.
+        let clean_chunks: Vec<&ScoredChunk> =
+            batch.chunks.iter().filter(|sc| sc.score.is_finite()).collect();
+        if clean_chunks.is_empty() {
+            continue;
+        }
+
+        let (min_score, max_score) = min_max_scores_refs(&clean_chunks);
         let range = max_score - min_score;
 
-        for sc in &batch.chunks {
+        for sc in &clean_chunks {
             let normalized = if range < f32::EPSILON {
                 1.0
             } else {
@@ -68,7 +76,7 @@ pub fn merge_and_rerank(
             }
 
             candidates.push(MultiSourceCandidate {
-                chunk: sc.clone(),
+                chunk: (*sc).clone(),
                 normalized_score: normalized,
                 boosted_score: normalized * boost,
                 is_current_repo: is_current,
@@ -86,7 +94,7 @@ pub fn merge_and_rerank(
     apply_diversity_constraints(candidates, config, ctx, top_k as usize)
 }
 
-fn min_max_scores(chunks: &[ScoredChunk]) -> (f32, f32) {
+fn min_max_scores_refs(chunks: &[&ScoredChunk]) -> (f32, f32) {
     let mut min = f32::INFINITY;
     let mut max = f32::NEG_INFINITY;
     for c in chunks {

--- a/src/context/retrieve/multi_source.rs
+++ b/src/context/retrieve/multi_source.rs
@@ -1,0 +1,179 @@
+use std::collections::HashSet;
+
+use super::retriever::ScoredChunk;
+use crate::context::config::MultiSourceConfig;
+
+#[derive(Debug, Clone)]
+pub struct SourceBatch {
+    pub source_name: String,
+    pub chunks: Vec<ScoredChunk>,
+}
+
+#[derive(Debug, Clone)]
+pub struct BoostContext {
+    pub current_repo_source: Option<String>,
+    pub dep_manifest_sources: HashSet<String>,
+    pub reviewed_language: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct MultiSourceCandidate {
+    pub chunk: ScoredChunk,
+    pub normalized_score: f32,
+    pub boosted_score: f32,
+    pub is_current_repo: bool,
+}
+
+pub fn merge_and_rerank(
+    batches: &[SourceBatch],
+    config: &MultiSourceConfig,
+    ctx: &BoostContext,
+    top_k: u32,
+) -> Vec<ScoredChunk> {
+    if batches.is_empty() {
+        return Vec::new();
+    }
+
+    let mut candidates: Vec<MultiSourceCandidate> = Vec::new();
+
+    for batch in batches {
+        let is_current = ctx
+            .current_repo_source
+            .as_ref()
+            .is_some_and(|cr| cr == &batch.source_name);
+
+        let (min_score, max_score) = min_max_scores(&batch.chunks);
+        let range = max_score - min_score;
+
+        for sc in &batch.chunks {
+            let normalized = if range < f32::EPSILON {
+                1.0
+            } else {
+                (sc.score - min_score) / range
+            };
+
+            let mut boost = 1.0f32;
+            if is_current {
+                boost *= config.current_repo_boost;
+            }
+            if ctx.dep_manifest_sources.contains(&batch.source_name) {
+                boost *= config.dep_manifest_boost;
+            }
+            let lang_matches = matches!(
+                (&sc.chunk.metadata.language, &ctx.reviewed_language),
+                (Some(a), Some(b)) if a == b
+            );
+            if lang_matches {
+                boost *= config.lang_match_boost;
+            }
+
+            candidates.push(MultiSourceCandidate {
+                chunk: sc.clone(),
+                normalized_score: normalized,
+                boosted_score: normalized * boost,
+                is_current_repo: is_current,
+            });
+        }
+    }
+
+    candidates.sort_by(|a, b| {
+        b.boosted_score
+            .partial_cmp(&a.boosted_score)
+            .unwrap_or(std::cmp::Ordering::Equal)
+            .then_with(|| a.chunk.chunk.id.cmp(&b.chunk.chunk.id))
+    });
+
+    apply_diversity_constraints(candidates, config, ctx, top_k as usize)
+}
+
+fn min_max_scores(chunks: &[ScoredChunk]) -> (f32, f32) {
+    let mut min = f32::INFINITY;
+    let mut max = f32::NEG_INFINITY;
+    for c in chunks {
+        if c.score < min {
+            min = c.score;
+        }
+        if c.score > max {
+            max = c.score;
+        }
+    }
+    if !min.is_finite() {
+        min = 0.0;
+    }
+    if !max.is_finite() {
+        max = 0.0;
+    }
+    (min, max)
+}
+
+fn apply_diversity_constraints(
+    sorted_candidates: Vec<MultiSourceCandidate>,
+    config: &MultiSourceConfig,
+    ctx: &BoostContext,
+    top_k: usize,
+) -> Vec<ScoredChunk> {
+    let per_source_cap = config.per_source_cap as usize;
+    let reserved = config.current_repo_reserved as usize;
+
+    // First pass: fill reserved slots for current repo
+    let mut reserved_chunks: Vec<ScoredChunk> = Vec::new();
+    let mut reserved_ids: HashSet<String> = HashSet::new();
+
+    if ctx.current_repo_source.is_some() {
+        for c in &sorted_candidates {
+            if reserved_chunks.len() >= reserved {
+                break;
+            }
+            if c.is_current_repo {
+                let mut out = c.chunk.clone();
+                out.score = c.boosted_score;
+                reserved_chunks.push(out);
+                reserved_ids.insert(c.chunk.chunk.id.clone());
+            }
+        }
+    }
+
+    // Second pass: fill remaining slots from all candidates respecting per_source_cap
+    let remaining = top_k.saturating_sub(reserved_chunks.len());
+    let mut result: Vec<ScoredChunk> = Vec::new();
+    let mut source_counts: std::collections::HashMap<String, usize> =
+        std::collections::HashMap::new();
+
+    // Count reserved chunks toward current repo's non-cap count
+    // (current repo is exempt from per_source_cap)
+
+    for c in &sorted_candidates {
+        if result.len() >= remaining {
+            break;
+        }
+        if reserved_ids.contains(&c.chunk.chunk.id) {
+            continue;
+        }
+
+        let source = &c.chunk.chunk.source;
+        let is_current = c.is_current_repo;
+
+        if !is_current {
+            let count = source_counts.get(source).copied().unwrap_or(0);
+            if count >= per_source_cap {
+                continue;
+            }
+        }
+
+        *source_counts.entry(source.clone()).or_insert(0) += 1;
+        let mut out = c.chunk.clone();
+        out.score = c.boosted_score;
+        result.push(out);
+    }
+
+    // Merge reserved + remaining, re-sort by score
+    reserved_chunks.extend(result);
+    reserved_chunks.sort_by(|a, b| {
+        b.score
+            .partial_cmp(&a.score)
+            .unwrap_or(std::cmp::Ordering::Equal)
+            .then_with(|| a.chunk.id.cmp(&b.chunk.id))
+    });
+    reserved_chunks.truncate(top_k);
+    reserved_chunks
+}

--- a/src/context/retrieve/multi_source_tests.rs
+++ b/src/context/retrieve/multi_source_tests.rs
@@ -1,0 +1,291 @@
+use super::multi_source::{merge_and_rerank, BoostContext, SourceBatch};
+use super::rerank::ScoreBreakdown;
+use super::retriever::{RetrievalLeg, ScoredChunk};
+use crate::context::config::MultiSourceConfig;
+use crate::context::types::{Chunk, ChunkKind, ChunkMeta, LineRange, Provenance};
+use chrono::Utc;
+
+fn dummy_chunk(id: &str, source: &str) -> Chunk {
+    Chunk {
+        id: id.to_string(),
+        source: source.to_string(),
+        kind: ChunkKind::Symbol,
+        subtype: None,
+        qualified_name: Some(format!("{source}::{id}")),
+        signature: None,
+        content: format!("fn {id}() {{}}"),
+        metadata: ChunkMeta {
+            source_path: format!("src/{id}.rs"),
+            line_range: LineRange::new(1, 5).unwrap(),
+            commit_sha: String::new(),
+            indexed_at: Utc::now(),
+            source_version: None,
+            language: Some("rust".into()),
+            is_exported: true,
+            neighboring_symbols: vec![],
+        },
+        provenance: Provenance::new("test", 1.0, "test://").unwrap(),
+    }
+}
+
+fn scored(id: &str, source: &str, score: f32) -> ScoredChunk {
+    ScoredChunk {
+        chunk: dummy_chunk(id, source),
+        score,
+        components: ScoreBreakdown {
+            bm25_norm: score * 0.6,
+            vec_norm: score * 0.4,
+            id_boost: 0.0,
+            path_boost: 0.0,
+            recency_mul: 1.0,
+            score,
+        },
+        source_legs: vec![RetrievalLeg::Bm25, RetrievalLeg::Vector],
+    }
+}
+
+fn default_config() -> MultiSourceConfig {
+    MultiSourceConfig::default()
+}
+
+fn boost_ctx(current_repo: Option<&str>, dep_sources: &[&str]) -> BoostContext {
+    BoostContext {
+        current_repo_source: current_repo.map(|s| s.to_string()),
+        dep_manifest_sources: dep_sources.iter().map(|s| s.to_string()).collect(),
+        reviewed_language: Some("rust".to_string()),
+    }
+}
+
+#[test]
+fn single_source_passes_through() {
+    let batch = SourceBatch {
+        source_name: "alpha".into(),
+        chunks: vec![scored("a1", "alpha", 0.9), scored("a2", "alpha", 0.7)],
+    };
+    let config = default_config();
+    let ctx = boost_ctx(None, &[]);
+    let result = merge_and_rerank(&[batch], &config, &ctx, 10);
+    assert_eq!(result.len(), 2);
+    assert!(result[0].score >= result[1].score);
+}
+
+#[test]
+fn multi_source_interleaves_by_score() {
+    // Use 2+ chunks per source so min-max normalization differentiates them
+    let b1 = SourceBatch {
+        source_name: "alpha".into(),
+        chunks: vec![scored("a1", "alpha", 0.9), scored("a2", "alpha", 0.1)],
+    };
+    let b2 = SourceBatch {
+        source_name: "beta".into(),
+        chunks: vec![scored("b1", "beta", 0.95), scored("b2", "beta", 0.1)],
+    };
+    let config = default_config();
+    let ctx = boost_ctx(None, &[]);
+    let result = merge_and_rerank(&[b1, b2], &config, &ctx, 10);
+    assert_eq!(result.len(), 4);
+    // Both top chunks normalize to 1.0 (they're the max in their batch),
+    // so their boosted scores are equal (both get lang_match 1.1).
+    // With identical scores, tiebreak is by chunk id ascending: a1 < b1.
+    // The key assertion is that mixing sources works — both appear.
+    let sources: Vec<_> = result.iter().map(|c| c.chunk.source.as_str()).collect();
+    assert!(sources.contains(&"alpha"));
+    assert!(sources.contains(&"beta"));
+}
+
+#[test]
+fn current_repo_boost_promotes_chunks() {
+    let b1 = SourceBatch {
+        source_name: "current".into(),
+        chunks: vec![scored("c1", "current", 0.7)],
+    };
+    let b2 = SourceBatch {
+        source_name: "other".into(),
+        chunks: vec![scored("o1", "other", 0.8)],
+    };
+    let config = default_config();
+    let ctx = boost_ctx(Some("current"), &[]);
+    let result = merge_and_rerank(&[b1, b2], &config, &ctx, 10);
+    // 0.7 * 1.3 = 0.91 vs 0.8 → current should be first
+    assert_eq!(result[0].chunk.source, "current");
+}
+
+#[test]
+fn dep_manifest_boost_promotes_chunks() {
+    let b1 = SourceBatch {
+        source_name: "dep-lib".into(),
+        chunks: vec![scored("d1", "dep-lib", 0.7)],
+    };
+    let b2 = SourceBatch {
+        source_name: "unrelated".into(),
+        chunks: vec![scored("u1", "unrelated", 0.75)],
+    };
+    let config = default_config();
+    let ctx = boost_ctx(None, &["dep-lib"]);
+    let result = merge_and_rerank(&[b1, b2], &config, &ctx, 10);
+    // 0.7 * 1.2 = 0.84 vs 0.75 → dep should be first
+    assert_eq!(result[0].chunk.source, "dep-lib");
+}
+
+#[test]
+fn boosts_compose_multiplicatively() {
+    // Use multi-chunk batches so normalization spreads scores
+    let b1 = SourceBatch {
+        source_name: "my-dep".into(),
+        chunks: vec![
+            scored("md1", "my-dep", 0.5),
+            scored("md2", "my-dep", 0.1),
+        ],
+    };
+    let b2 = SourceBatch {
+        source_name: "other".into(),
+        chunks: vec![
+            scored("o1", "other", 0.8),
+            scored("o2", "other", 0.1),
+        ],
+    };
+    let config = default_config();
+    // my-dep is both current repo AND a dep AND lang match → 1.3*1.2*1.1 = 1.716
+    let ctx = boost_ctx(Some("my-dep"), &["my-dep"]);
+    let result = merge_and_rerank(&[b1, b2], &config, &ctx, 10);
+    // md1: normalized = (0.5-0.1)/(0.5-0.1) = 1.0, boosted = 1.0*1.716 = 1.716
+    // o1:  normalized = (0.8-0.1)/(0.8-0.1) = 1.0, boosted = 1.0*1.1 = 1.1
+    // my-dep top chunk should be first due to triple boost
+    assert_eq!(result[0].chunk.source, "my-dep");
+    // Verify the boost was > 1.1 (lang match only)
+    assert!(result[0].score > result[1].score);
+}
+
+#[test]
+fn per_source_cap_limits_non_current_repo() {
+    let mut chunks = Vec::new();
+    for i in 0..5 {
+        chunks.push(scored(&format!("e{i}"), "external", 0.9 - i as f32 * 0.01));
+    }
+    let batch = SourceBatch {
+        source_name: "external".into(),
+        chunks,
+    };
+    let mut config = default_config();
+    config.per_source_cap = 2;
+    let ctx = boost_ctx(None, &[]);
+    let result = merge_and_rerank(&[batch], &config, &ctx, 10);
+    assert_eq!(result.len(), 2);
+}
+
+#[test]
+fn current_repo_reserved_slots_guaranteed() {
+    // current-repo has lower-scoring chunks, but reserved slots guarantee inclusion
+    let b_current = SourceBatch {
+        source_name: "current".into(),
+        chunks: vec![
+            scored("c1", "current", 0.3),
+            scored("c2", "current", 0.25),
+        ],
+    };
+    let mut other_chunks = Vec::new();
+    for i in 0..6 {
+        other_chunks.push(scored(&format!("o{i}"), "other", 0.9 - i as f32 * 0.05));
+    }
+    let b_other = SourceBatch {
+        source_name: "other".into(),
+        chunks: other_chunks,
+    };
+    let mut config = default_config();
+    config.current_repo_reserved = 2;
+    config.per_source_cap = 3;
+    let ctx = boost_ctx(Some("current"), &[]);
+    let result = merge_and_rerank(&[b_current, b_other], &config, &ctx, 4);
+    let current_count = result.iter().filter(|c| c.chunk.source == "current").count();
+    assert!(current_count >= 2, "expected at least 2 current-repo chunks, got {current_count}");
+}
+
+#[test]
+fn per_source_cap_does_not_apply_to_current_repo() {
+    let mut chunks = Vec::new();
+    for i in 0..5 {
+        chunks.push(scored(&format!("c{i}"), "current", 0.9 - i as f32 * 0.01));
+    }
+    let batch = SourceBatch {
+        source_name: "current".into(),
+        chunks,
+    };
+    let mut config = default_config();
+    config.per_source_cap = 2;
+    let ctx = boost_ctx(Some("current"), &[]);
+    let result = merge_and_rerank(&[batch], &config, &ctx, 10);
+    assert!(result.len() > 2, "current repo should bypass per_source_cap");
+}
+
+#[test]
+fn empty_batches_returns_empty() {
+    let config = default_config();
+    let ctx = boost_ctx(None, &[]);
+    let result = merge_and_rerank(&[], &config, &ctx, 10);
+    assert!(result.is_empty());
+}
+
+#[test]
+fn respects_top_k_limit() {
+    let mut chunks = Vec::new();
+    for i in 0..10 {
+        chunks.push(scored(&format!("c{i}"), "src", 0.9 - i as f32 * 0.05));
+    }
+    let batch = SourceBatch {
+        source_name: "src".into(),
+        chunks,
+    };
+    let config = default_config();
+    let ctx = boost_ctx(None, &[]);
+    let result = merge_and_rerank(&[batch], &config, &ctx, 3);
+    assert_eq!(result.len(), 3);
+}
+
+#[test]
+fn min_max_normalization_single_chunk_source_scores_one() {
+    let batch = SourceBatch {
+        source_name: "solo".into(),
+        chunks: vec![scored("s1", "solo", 0.5)],
+    };
+    let config = default_config();
+    let ctx = boost_ctx(None, &[]);
+    let result = merge_and_rerank(&[batch], &config, &ctx, 10);
+    assert_eq!(result.len(), 1);
+    // Single-candidate source → normalized to 1.0 → lang_match boost if applicable
+    // No lang match since ctx has no current repo and "rust" matches "rust" from boost_ctx
+    // Actually boost_ctx sets reviewed_language = Some("rust") and chunk language = "rust"
+    // so lang_match = 1.1, normalized = 1.0 * 1.1 = 1.1
+    assert!(result[0].score > 0.9, "single candidate should normalize high, got {}", result[0].score);
+}
+
+#[test]
+fn output_sorted_descending_by_score() {
+    let b1 = SourceBatch {
+        source_name: "a".into(),
+        chunks: vec![scored("a1", "a", 0.3), scored("a2", "a", 0.9)],
+    };
+    let b2 = SourceBatch {
+        source_name: "b".into(),
+        chunks: vec![scored("b1", "b", 0.6)],
+    };
+    let config = default_config();
+    let ctx = boost_ctx(None, &[]);
+    let result = merge_and_rerank(&[b1, b2], &config, &ctx, 10);
+    for w in result.windows(2) {
+        assert!(w[0].score >= w[1].score, "not sorted: {} < {}", w[0].score, w[1].score);
+    }
+}
+
+#[test]
+fn candidates_preserve_source_legs() {
+    let mut chunk = scored("a1", "alpha", 0.9);
+    chunk.source_legs = vec![RetrievalLeg::Structural];
+    let batch = SourceBatch {
+        source_name: "alpha".into(),
+        chunks: vec![chunk],
+    };
+    let config = default_config();
+    let ctx = boost_ctx(None, &[]);
+    let result = merge_and_rerank(&[batch], &config, &ctx, 10);
+    assert_eq!(result[0].source_legs, vec![RetrievalLeg::Structural]);
+}

--- a/src/context/retrieve/multi_source_tests.rs
+++ b/src/context/retrieve/multi_source_tests.rs
@@ -1,4 +1,4 @@
-use super::multi_source::{merge_and_rerank, BoostContext, SourceBatch};
+use super::multi_source::{BoostContext, SourceBatch, merge_and_rerank};
 use super::rerank::ScoreBreakdown;
 use super::retriever::{RetrievalLeg, ScoredChunk};
 use crate::context::config::MultiSourceConfig;
@@ -132,17 +132,11 @@ fn boosts_compose_multiplicatively() {
     // Use multi-chunk batches so normalization spreads scores
     let b1 = SourceBatch {
         source_name: "my-dep".into(),
-        chunks: vec![
-            scored("md1", "my-dep", 0.5),
-            scored("md2", "my-dep", 0.1),
-        ],
+        chunks: vec![scored("md1", "my-dep", 0.5), scored("md2", "my-dep", 0.1)],
     };
     let b2 = SourceBatch {
         source_name: "other".into(),
-        chunks: vec![
-            scored("o1", "other", 0.8),
-            scored("o2", "other", 0.1),
-        ],
+        chunks: vec![scored("o1", "other", 0.8), scored("o2", "other", 0.1)],
     };
     let config = default_config();
     // my-dep is both current repo AND a dep AND lang match → 1.3*1.2*1.1 = 1.716
@@ -178,10 +172,7 @@ fn current_repo_reserved_slots_guaranteed() {
     // current-repo has lower-scoring chunks, but reserved slots guarantee inclusion
     let b_current = SourceBatch {
         source_name: "current".into(),
-        chunks: vec![
-            scored("c1", "current", 0.3),
-            scored("c2", "current", 0.25),
-        ],
+        chunks: vec![scored("c1", "current", 0.3), scored("c2", "current", 0.25)],
     };
     let mut other_chunks = Vec::new();
     for i in 0..6 {
@@ -196,8 +187,14 @@ fn current_repo_reserved_slots_guaranteed() {
     config.per_source_cap = 3;
     let ctx = boost_ctx(Some("current"), &[]);
     let result = merge_and_rerank(&[b_current, b_other], &config, &ctx, 4);
-    let current_count = result.iter().filter(|c| c.chunk.source == "current").count();
-    assert!(current_count >= 2, "expected at least 2 current-repo chunks, got {current_count}");
+    let current_count = result
+        .iter()
+        .filter(|c| c.chunk.source == "current")
+        .count();
+    assert!(
+        current_count >= 2,
+        "expected at least 2 current-repo chunks, got {current_count}"
+    );
 }
 
 #[test]
@@ -214,7 +211,10 @@ fn per_source_cap_does_not_apply_to_current_repo() {
     config.per_source_cap = 2;
     let ctx = boost_ctx(Some("current"), &[]);
     let result = merge_and_rerank(&[batch], &config, &ctx, 10);
-    assert!(result.len() > 2, "current repo should bypass per_source_cap");
+    assert!(
+        result.len() > 2,
+        "current repo should bypass per_source_cap"
+    );
 }
 
 #[test]
@@ -255,7 +255,11 @@ fn min_max_normalization_single_chunk_source_scores_one() {
     // No lang match since ctx has no current repo and "rust" matches "rust" from boost_ctx
     // Actually boost_ctx sets reviewed_language = Some("rust") and chunk language = "rust"
     // so lang_match = 1.1, normalized = 1.0 * 1.1 = 1.1
-    assert!(result[0].score > 0.9, "single candidate should normalize high, got {}", result[0].score);
+    assert!(
+        result[0].score > 0.9,
+        "single candidate should normalize high, got {}",
+        result[0].score
+    );
 }
 
 #[test]
@@ -272,7 +276,12 @@ fn output_sorted_descending_by_score() {
     let ctx = boost_ctx(None, &[]);
     let result = merge_and_rerank(&[b1, b2], &config, &ctx, 10);
     for w in result.windows(2) {
-        assert!(w[0].score >= w[1].score, "not sorted: {} < {}", w[0].score, w[1].score);
+        assert!(
+            w[0].score >= w[1].score,
+            "not sorted: {} < {}",
+            w[0].score,
+            w[1].score
+        );
     }
 }
 

--- a/src/dimensions.rs
+++ b/src/dimensions.rs
@@ -885,6 +885,12 @@ mod tests {
             nan_scores_dropped: 0,
             retrieved_by_leg: crate::review_log::LegCounts::default(),
             injected_by_leg: crate::review_log::LegCounts::default(),
+            sources_queried: 0,
+            sources_contributing: 0,
+            per_source_contributions: std::collections::BTreeMap::new(),
+            dep_boost_applied: 0,
+            current_repo_reserved_available: 0,
+            current_repo_reserved_filled: 0,
         };
         r
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -918,13 +918,12 @@ async fn run_review(opts: cli::ReviewOpts) -> i32 {
         }
     };
 
-    // Build the production context injector from `<qhome>/sources.toml`
-    // (if present and `auto_inject = true`). Returns `None` when context
-    // isn't configured, so reviews without a sources file behave exactly
-    // as before. Honors QUORUM_HOME via the same `qhome` used for
-    // feedback/telemetry/reviews — without this, hermetic runs would
-    // calibrate against one dir and source `sources.toml` from another.
-    let context_injector = context::bootstrap::build_production_injector(&qhome, &feedback_entries);
+    let injector_project_root = opts.files.first().map(|f| pipeline::find_project_root(f));
+    let context_injector = context::bootstrap::build_production_injector_with_project(
+        &qhome,
+        &feedback_entries,
+        injector_project_root.as_deref(),
+    );
     if context_injector.is_some() {
         tracing::info!(
             "context injector wired from ~/.quorum/sources.toml — auto-inject is active"

--- a/src/review_log.rs
+++ b/src/review_log.rs
@@ -159,6 +159,27 @@ pub struct ContextTelemetry {
     /// 90th percentile of retrieved rerank scores.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub rerank_score_p90: Option<f32>,
+
+    // --- Multi-source telemetry (v0.23.0+) ---
+
+    /// Number of source DBs queried in this review.
+    #[serde(default)]
+    pub sources_queried: u32,
+    /// Number of sources with at least one chunk in the final top-k.
+    #[serde(default)]
+    pub sources_contributing: u32,
+    /// Per-source chunk count in the final injected set.
+    #[serde(default, skip_serializing_if = "std::collections::BTreeMap::is_empty")]
+    pub per_source_contributions: std::collections::BTreeMap<String, u32>,
+    /// Chunks that received the dep-manifest boost.
+    #[serde(default)]
+    pub dep_boost_applied: u32,
+    /// Reserved slots available for the current repo.
+    #[serde(default)]
+    pub current_repo_reserved_available: u32,
+    /// Reserved slots actually filled by current-repo chunks.
+    #[serde(default)]
+    pub current_repo_reserved_filled: u32,
 }
 
 /// Count of chunks attributed to each retrieval leg, plus a
@@ -735,6 +756,12 @@ mod tests {
             rerank_score_p10: Some(0.55),
             rerank_score_median: Some(0.72),
             rerank_score_p90: Some(0.88),
+            sources_queried: 1,
+            sources_contributing: 1,
+            per_source_contributions: std::collections::BTreeMap::new(),
+            dep_boost_applied: 0,
+            current_repo_reserved_available: 0,
+            current_repo_reserved_filled: 0,
         }
     }
 

--- a/src/review_log.rs
+++ b/src/review_log.rs
@@ -161,7 +161,6 @@ pub struct ContextTelemetry {
     pub rerank_score_p90: Option<f32>,
 
     // --- Multi-source telemetry (v0.23.0+) ---
-
     /// Number of source DBs queried in this review.
     #[serde(default)]
     pub sources_queried: u32,


### PR DESCRIPTION
## Summary

- Replace single-source `find_map` in bootstrap.rs with multi-source fan-out that queries ALL indexed source repos
- Merge per-source results via min-max normalized scoring with multiplicative boosts (current-repo 1.3x, dep-manifest 1.2x, language-match 1.1x)
- Enforce diversity constraints: per-source cap (default 3), current-repo reserved slots (default 2)
- Detect current repo via canonicalized path matching, match dep-manifest via `parse_dependencies()` + `provides` aliases
- Add `MultiSourceConfig` sub-table in `sources.toml` (`[context.multi_source]`)
- Add `provides`, `include_for`, `exclude_for` fields on source entries for scoping and alias matching
- Add 6 multi-source telemetry fields to `ContextTelemetry` for observability
- Single-source fast path preserved when `multi_source.enabled = false`

## New modules

- `src/context/retrieve/multi_source.rs` — `merge_and_rerank()` with min-max normalization, boost composition, and two-pass diversity algorithm (13 tests)
- Config schema: `MultiSourceConfig` with validation (boost factors finite+non-negative, max_sources_queried > 0)

## Design spec

`docs/superpowers/specs/2026-05-14-multi-source-context-retrieval-design.md` (committed to main prior to implementation)

## Quorum self-review verdicts

| Finding | Verdict | Action |
|---------|---------|--------|
| `apply_diversity_constraints` caps by `chunk.source` not batch source | TP | Fixed: added `source_name` to `MultiSourceCandidate` |
| `detect_current_repo` picks first match not most specific | TP | Fixed: longest canonical path match |
| `max_sources_queried = 0` treated as none | TP | Fixed: config validation |
| Reserved items deduplicated by bare id only | Partial | ULIDs make cross-source collision near-impossible |
| Non-UTF8 project names skip filters | Partial | Edge case, graceful degradation acceptable |
| `RawSource` accepts unknown keys silently | FP | Intentional forward-compatibility |
| `append_source` read-check-write race | TP (pre-existing) | Filed #331 |
| `render_source_fragment` drops `paths` | TP (pre-existing) | Filed #332 |
| `review_log` unchecked u32 arithmetic | TP (pre-existing) | Filed #333 |

## Test plan

- [x] 25 config tests pass (6 new for multi-source schema)
- [x] 13 multi-source merge/rerank tests pass
- [x] 6 bootstrap tests pass
- [x] Full suite: 1430 tests pass, 0 failures
- [x] Zero clippy warnings
- [x] Release build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Multi-source context retrieval with intelligent merging and result ranking across multiple knowledge sources
  * Source targeting and filtering based on project context and dependency manifests

* **Refactor**
  * Overhauled context injection system to coordinate queries across multiple sources instead of a single source

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jsnyder/quorum/pull/334)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->