### PR TITLE
fix(security): tier 1 hardening — fence escape, payload limits, agent allowlist

### DIFF
--- a/src/judge.rs
+++ b/src/judge.rs
@@ -1,4 +1,5 @@
 use crate::ast_grep::RuleMetadata;
+use crate::prompt_sanitize::pick_fence_for;
 #[cfg(test)]
 use crate::finding::PrecisionTier;
 use crate::finding::{Finding, JudgeRequirement, JudgeVerdict};
@@ -156,9 +157,14 @@ pub fn build_judge_prompt(
          determine if it is a true positive (tp), false positive (fp), or \
          uncertain based on the surrounding code context.\n\n",
     );
-    prompt.push_str("Source code:\n```\n");
+    let fence = pick_fence_for(source_code);
+    prompt.push_str("Source code:\n");
+    prompt.push_str(&fence);
+    prompt.push('\n');
     prompt.push_str(source_code);
-    prompt.push_str("\n```\n\nFindings to judge:\n");
+    prompt.push('\n');
+    prompt.push_str(&fence);
+    prompt.push_str("\n\nFindings to judge:\n");
 
     let items: Vec<serde_json::Value> = findings
         .iter()
@@ -542,6 +548,27 @@ mod tests {
         assert_eq!(parsed[1]["rule_id"], "rule-b");
         assert_eq!(parsed[1]["index"], 1);
         assert_eq!(parsed[1]["title"], "title with {braces} and [brackets]");
+    }
+
+    #[test]
+    fn build_judge_prompt_uses_dynamic_fence_for_source_with_backticks() {
+        let source = "let x = \"```\"; let y = \"````\";";
+        let prompt = build_judge_prompt(source, &[]);
+        assert!(
+            !prompt.contains("Source code:\n```\n"),
+            "prompt must not use a 3-backtick fence when source contains ```; got:\n{prompt}"
+        );
+        let fence_start = prompt.find("Source code:\n").unwrap() + "Source code:\n".len();
+        let fence_end = prompt[fence_start..].find('\n').unwrap();
+        let fence = &prompt[fence_start..fence_start + fence_end];
+        assert!(
+            fence.len() >= 5,
+            "fence must be longer than the longest backtick run (4) in the source; got: {fence}"
+        );
+        assert!(
+            prompt.contains(source),
+            "source code must still appear in the prompt"
+        );
     }
 
     #[test]

--- a/src/judge.rs
+++ b/src/judge.rs
@@ -1,8 +1,8 @@
 use crate::ast_grep::RuleMetadata;
-use crate::prompt_sanitize::pick_fence_for;
 #[cfg(test)]
 use crate::finding::PrecisionTier;
 use crate::finding::{Finding, JudgeRequirement, JudgeVerdict};
+use crate::prompt_sanitize::pick_fence_for;
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};

--- a/src/mcp/handler.rs
+++ b/src/mcp/handler.rs
@@ -18,6 +18,29 @@ use crate::parser::Language;
 use crate::pipeline::{self, LlmReviewer, PipelineConfig};
 use crate::redact;
 
+const MAX_PAYLOAD_BYTES: usize = 1_048_576; // 1 MiB
+
+const ALLOWED_AGENTS: &[&str] = &[
+    "pal",
+    "third-opinion",
+    "gemini",
+    "reviewdog",
+    "claude",
+    "codex",
+    "quorum",
+];
+
+fn check_payload_size(field: &str, value: &str) -> Result<(), String> {
+    if value.len() > MAX_PAYLOAD_BYTES {
+        Err(format!(
+            "{field} exceeds maximum payload size ({} bytes > {MAX_PAYLOAD_BYTES})",
+            value.len()
+        ))
+    } else {
+        Ok(())
+    }
+}
+
 pub struct QuorumHandler {
     config: Config,
     feedback_store: FeedbackStore,
@@ -84,6 +107,7 @@ impl QuorumHandler {
     }
 
     async fn handle_review(&self, params: ReviewTool) -> Result<CallToolResult, String> {
+        check_payload_size("code", &params.code)?;
         let lang = Language::from_path(std::path::Path::new(&params.file_path))
             .ok_or_else(|| format!("Unsupported file type: {}", params.file_path))?;
 
@@ -161,6 +185,22 @@ impl QuorumHandler {
         // record_external so Provenance::External is serialized and the
         // calibrator applies the 0.7 weight. Human path is unchanged below.
         if let Some(agent) = params.from_agent {
+            let normalized = agent.trim().to_lowercase();
+            let allowed = std::env::var("QUORUM_ALLOWED_AGENTS")
+                .ok()
+                .map(|v| {
+                    v.split(',')
+                        .map(|s| s.trim().to_lowercase())
+                        .any(|a| a == normalized)
+                })
+                .unwrap_or_else(|| ALLOWED_AGENTS.iter().any(|&a| a == normalized));
+            if !allowed {
+                return Err(format!(
+                    "agent {:?} is not in the allowed agents list. \
+                     Set QUORUM_ALLOWED_AGENTS to extend the allowlist.",
+                    agent
+                ));
+            }
             if fp_kind.is_some() {
                 tracing::warn!(
                     "MCP feedback: fpKind dropped on External path \
@@ -268,6 +308,10 @@ impl QuorumHandler {
     }
 
     async fn handle_chat(&self, params: ChatTool) -> Result<CallToolResult, String> {
+        check_payload_size("question", &params.question)?;
+        if let Some(code) = &params.code {
+            check_payload_size("code", code)?;
+        }
         let reviewer = Arc::clone(
             self.llm_reviewer
                 .as_ref()
@@ -310,6 +354,8 @@ impl QuorumHandler {
     }
 
     async fn handle_debug(&self, params: DebugTool) -> Result<CallToolResult, String> {
+        check_payload_size("code", &params.code)?;
+        check_payload_size("error", &params.error)?;
         let reviewer = Arc::clone(
             self.llm_reviewer
                 .as_ref()
@@ -338,6 +384,7 @@ impl QuorumHandler {
     }
 
     async fn handle_testgen(&self, params: TestgenTool) -> Result<CallToolResult, String> {
+        check_payload_size("code", &params.code)?;
         let reviewer = Arc::clone(
             self.llm_reviewer
                 .as_ref()
@@ -1513,5 +1560,202 @@ mod tests {
             all[0].fp_kind, None,
             "fp_kind must be dropped when verdict is not fp"
         );
+    }
+
+    // --- Issue #130: MCP unbounded payload rejection ---
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn review_rejects_oversized_code_payload() {
+        let handler = handler_no_llm();
+        let big = "x".repeat(MAX_PAYLOAD_BYTES + 1);
+        let params = ReviewTool {
+            code: big,
+            file_path: "test.rs".into(),
+            focus: None,
+        };
+        let err = handler
+            .handle_review(params)
+            .await
+            .expect_err("must reject oversized payload");
+        assert!(
+            err.contains("exceeds maximum"),
+            "error must mention size limit: {err}"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn chat_rejects_oversized_code_payload() {
+        let handler = handler_with_fake_llm();
+        let big = "x".repeat(MAX_PAYLOAD_BYTES + 1);
+        let params = ChatTool {
+            question: "what?".into(),
+            code: Some(big),
+            file_path: None,
+        };
+        let err = handler
+            .handle_chat(params)
+            .await
+            .expect_err("must reject oversized payload");
+        assert!(
+            err.contains("exceeds maximum"),
+            "error must mention size limit: {err}"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn chat_rejects_oversized_question() {
+        let handler = handler_with_fake_llm();
+        let big = "x".repeat(MAX_PAYLOAD_BYTES + 1);
+        let params = ChatTool {
+            question: big,
+            code: None,
+            file_path: None,
+        };
+        let err = handler
+            .handle_chat(params)
+            .await
+            .expect_err("must reject oversized question");
+        assert!(
+            err.contains("exceeds maximum"),
+            "error must mention size limit: {err}"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn debug_rejects_oversized_code_payload() {
+        let handler = handler_with_fake_llm();
+        let big = "x".repeat(MAX_PAYLOAD_BYTES + 1);
+        let params = DebugTool {
+            error: "e".into(),
+            code: big,
+            file_path: "test.rs".into(),
+        };
+        let err = handler
+            .handle_debug(params)
+            .await
+            .expect_err("must reject oversized payload");
+        assert!(
+            err.contains("exceeds maximum"),
+            "error must mention size limit: {err}"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn testgen_rejects_oversized_code_payload() {
+        let handler = handler_with_fake_llm();
+        let big = "x".repeat(MAX_PAYLOAD_BYTES + 1);
+        let params = TestgenTool {
+            code: big,
+            file_path: "test.rs".into(),
+            framework: None,
+        };
+        let err = handler
+            .handle_testgen(params)
+            .await
+            .expect_err("must reject oversized payload");
+        assert!(
+            err.contains("exceeds maximum"),
+            "error must mention size limit: {err}"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn review_accepts_payload_at_limit() {
+        let handler = handler_no_llm();
+        let at_limit = "x".repeat(MAX_PAYLOAD_BYTES);
+        let params = ReviewTool {
+            code: at_limit,
+            file_path: "test.rs".into(),
+            focus: None,
+        };
+        let result = handler.handle_review(params).await;
+        if let Err(e) = &result {
+            assert!(
+                !e.contains("exceeds maximum"),
+                "payload at exact limit must not be rejected"
+            );
+        }
+    }
+
+    // --- Issue #128: MCP from_agent allowlist ---
+
+    #[test]
+    fn feedback_rejects_unknown_agent() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("feedback.jsonl");
+        let handler = QuorumHandler {
+            config: Config {
+                base_url: "https://example.com".into(),
+                api_key: None,
+                model: "test".into(),
+            },
+            feedback_store: FeedbackStore::new(path.clone()),
+            llm_reviewer: None,
+            parse_cache: Arc::new(ParseCache::new(10)),
+        };
+
+        let params = FeedbackTool {
+            file_path: "src/a.rs".into(),
+            finding: "SQL injection".into(),
+            verdict: crate::mcp::tools::FeedbackVerdict::Tp,
+            reason: "confirmed".into(),
+            model: None,
+            blamed_chunks: None,
+            from_agent: Some("evil-unknown-agent".into()),
+            agent_model: None,
+            confidence: Some(0.9),
+            category: None,
+            fp_kind: None,
+            in_diff: None,
+        };
+        let err = handler
+            .handle_feedback(params)
+            .expect_err("unknown agent must be rejected");
+        assert!(
+            err.contains("not in the allowed"),
+            "error must reference allowlist: {err}"
+        );
+        let store = FeedbackStore::new(path);
+        assert_eq!(
+            store.load_all().unwrap().len(),
+            0,
+            "nothing must be persisted for rejected agent"
+        );
+    }
+
+    #[test]
+    fn feedback_accepts_known_agent() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("feedback.jsonl");
+        let handler = QuorumHandler {
+            config: Config {
+                base_url: "https://example.com".into(),
+                api_key: None,
+                model: "test".into(),
+            },
+            feedback_store: FeedbackStore::new(path.clone()),
+            llm_reviewer: None,
+            parse_cache: Arc::new(ParseCache::new(10)),
+        };
+
+        let params = FeedbackTool {
+            file_path: "src/a.rs".into(),
+            finding: "SQL injection".into(),
+            verdict: crate::mcp::tools::FeedbackVerdict::Tp,
+            reason: "confirmed".into(),
+            model: None,
+            blamed_chunks: None,
+            from_agent: Some("pal".into()),
+            agent_model: None,
+            confidence: Some(0.9),
+            category: None,
+            fp_kind: None,
+            in_diff: None,
+        };
+        handler
+            .handle_feedback(params)
+            .expect("known agent must be accepted");
+        let store = FeedbackStore::new(path);
+        assert_eq!(store.load_all().unwrap().len(), 1);
     }
 }


### PR DESCRIPTION
## Summary

- **#328** — Judge prompt fence escape: `build_judge_prompt` now uses `pick_fence_for(source_code)` instead of hardcoded triple-backtick, preventing source code containing backtick runs from escaping the fence (prompt injection vector)
- **#130** — MCP unbounded payloads: All code-accepting MCP handlers (`review`, `chat`, `debug`, `testgen`) now reject payloads exceeding 1 MiB before they reach the pipeline or LLM client
- **#128** — MCP `from_agent` auth: The feedback handler validates `from_agent` against a built-in allowlist (`pal`, `third-opinion`, `gemini`, `reviewdog`, `claude`, `codex`, `quorum`). `QUORUM_ALLOWED_AGENTS` env var overrides the default list.

## Test plan

- [x] `build_judge_prompt_uses_dynamic_fence_for_source_with_backticks` — source with 4-backtick run gets a 5+ backtick fence
- [x] `review_rejects_oversized_code_payload` — 1 MiB + 1 byte rejected
- [x] `chat_rejects_oversized_code_payload` / `chat_rejects_oversized_question` — both fields checked
- [x] `debug_rejects_oversized_code_payload` / `testgen_rejects_oversized_code_payload`
- [x] `review_accepts_payload_at_limit` — exactly 1 MiB accepted
- [x] `feedback_rejects_unknown_agent` — unknown agent rejected, nothing persisted
- [x] `feedback_accepts_known_agent` — "pal" accepted, entry persisted
- [x] All 1429 existing tests pass, zero clippy warnings

Closes #328, closes #130, closes #128

🤖 Generated with [Claude Code](https://claude.com/claude-code)