### PR TITLE
refactor: unify review functions, extract build_file_context (#339)

### DIFF
--- a/docs/superpowers/plans/2026-05-14-review-context-extraction.md
+++ b/docs/superpowers/plans/2026-05-14-review-context-extraction.md
@@ -1,0 +1,673 @@
+# Review Context Extraction Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Unify `review_file` and `review_file_llm_only` in `src/pipeline.rs`, extracting shared context assembly into `build_file_context()` returning an immutable `FileContext` struct.
+
+**Architecture:** Both review functions share ~60% of their logic (feedback index, Context7 enrichment, precedent lookup, prompt building, model loop, merge, grounding, diff classification, calibration). This refactor extracts that shared logic into a `build_file_context()` helper, then merges both functions into a single `review_file` that accepts `Option<AstContext>`. The result is ~250 fewer lines and a single code path for all reviews.
+
+**Tech Stack:** Rust, existing quorum crate types
+
+---
+
+### Task 1: Add AstContext and FileContext structs
+
+**Files:**
+- Modify: `src/pipeline.rs:112-205` (after existing type definitions)
+
+- [ ] **Step 1: Write failing test — AstContext constructs from parts**
+
+```rust
+#[test]
+fn ast_context_can_be_constructed() {
+    use crate::ast_grep::RuleMetadata;
+    use std::collections::HashMap;
+
+    let source = "fn main() {}";
+    let mut parser = tree_sitter::Parser::new();
+    parser.set_language(&tree_sitter_rust::LANGUAGE.into()).unwrap();
+    let tree = parser.parse(source, None).unwrap();
+    let ctx = AstContext {
+        tree: &tree,
+        language: crate::parser::Language::Rust,
+        rule_metadata: HashMap::new(),
+    };
+    assert!(ctx.rule_metadata.is_empty());
+}
+```
+
+Add this test in the `#[cfg(test)] mod tests` block of `src/pipeline.rs`.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -- ast_context_can_be_constructed`
+Expected: FAIL — `AstContext` not defined.
+
+- [ ] **Step 3: Define AstContext struct**
+
+Add after the `JudgeMetrics` struct (around line 138) in `src/pipeline.rs`:
+
+```rust
+/// Pre-parsed AST context for a file. When `Some`, enables local AST
+/// analysis, ast-grep rules, judge phase, and hydration context assembly.
+/// When `None`, the review runs LLM-only.
+pub struct AstContext<'a> {
+    pub tree: &'a tree_sitter::Tree,
+    pub language: crate::parser::Language,
+    pub rule_metadata: std::collections::HashMap<String, crate::ast_grep::RuleMetadata>,
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cargo test -- ast_context_can_be_constructed`
+Expected: PASS
+
+- [ ] **Step 5: Write failing test — FileContext constructs with defaults**
+
+```rust
+#[test]
+fn file_context_defaults_to_empty() {
+    let ctx = FileContext::default();
+    assert!(ctx.redacted_code.is_empty());
+    assert!(ctx.framework_docs.is_none());
+    assert!(ctx.feedback_precedents.is_none());
+    assert!(ctx.hydration_context.is_none());
+    assert!(ctx.context_block.is_none());
+    assert!(ctx.truncation_notice.is_none());
+}
+```
+
+- [ ] **Step 6: Run test to verify it fails**
+
+Run: `cargo test -- file_context_defaults_to_empty`
+Expected: FAIL — `FileContext` not defined.
+
+- [ ] **Step 7: Define FileContext struct**
+
+Add after `AstContext` in `src/pipeline.rs`:
+
+```rust
+/// Pre-computed, immutable context for a single file review. Built once
+/// by `build_file_context()` and consumed by `ReviewRequest` population.
+/// Does NOT contain mutable findings — those stay in the caller's scope.
+#[derive(Default)]
+pub struct FileContext {
+    pub redacted_code: String,
+    pub truncation_notice: Option<String>,
+    pub framework_docs: Option<Vec<String>>,
+    pub feedback_precedents: Option<Vec<String>>,
+    pub hydration_context: Option<crate::hydration::HydrationContext>,
+    pub context_block: Option<String>,
+    pub enrichment_metrics: crate::context_enrichment::EnrichmentMetrics,
+    pub context_telemetry: Option<crate::review_log::ContextTelemetry>,
+}
+```
+
+- [ ] **Step 8: Run test to verify it passes**
+
+Run: `cargo test -- file_context_defaults_to_empty`
+Expected: PASS
+
+- [ ] **Step 9: Run full test suite for regressions**
+
+Run: `cargo test --bin quorum`
+Expected: All pass — this is purely additive.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add src/pipeline.rs
+git commit -m "refactor: add AstContext and FileContext structs (#339)"
+```
+
+---
+
+### Task 2: Extract build_file_context()
+
+**Files:**
+- Modify: `src/pipeline.rs`
+
+This is the core extraction. `build_file_context()` pulls shared logic from both `review_file` (lines 790-1005) and `review_file_llm_only` (lines 1404-1473) into a single function.
+
+- [ ] **Step 1: Write failing test — build_file_context returns redacted code**
+
+```rust
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn build_file_context_redacts_secrets() {
+    let config = PipelineConfig::default();
+    let ctx = build_file_context(
+        std::path::Path::new("test.rs"),
+        "let api_key = \"sk-secret123\";",
+        None, // no AST
+        &config,
+    )
+    .await
+    .unwrap();
+    assert!(
+        !ctx.redacted_code.contains("sk-secret123"),
+        "FileContext must contain redacted code, got: {}",
+        ctx.redacted_code
+    );
+    assert!(
+        ctx.redacted_code.contains("REDACTED"),
+        "redacted code must replace secrets"
+    );
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -- build_file_context_redacts_secrets`
+Expected: FAIL — `build_file_context` not defined.
+
+- [ ] **Step 3: Implement build_file_context()**
+
+Create the function in `src/pipeline.rs`. This extracts the shared logic from `review_file` lines 790-1005 and `review_file_llm_only` lines 1404-1473.
+
+```rust
+/// Assemble immutable per-file context for a review. Performs secret
+/// redaction, truncation, Context7 enrichment, feedback precedent
+/// selection, hydration context assembly (if AST available), and
+/// context injection. Returns a `FileContext` that feeds directly
+/// into `ReviewRequest` population.
+pub(crate) async fn build_file_context(
+    file_path: &std::path::Path,
+    source: &str,
+    ast: Option<&AstContext<'_>>,
+    pipeline_config: &PipelineConfig,
+) -> anyhow::Result<FileContext> {
+    let mut ctx = FileContext::default();
+
+    // --- Secret redaction + truncation ---
+    // (from review_file lines 808-815)
+    let redacted = crate::redact::redact_secrets(source);
+    let max_chars = pipeline_config.max_source_chars.unwrap_or(60_000);
+    if redacted.len() > max_chars {
+        ctx.redacted_code = redacted[..max_chars].to_string();
+        ctx.truncation_notice = Some(format!(
+            "Source truncated from {} to {} characters.",
+            redacted.len(),
+            max_chars
+        ));
+    } else {
+        ctx.redacted_code = redacted;
+    }
+
+    // --- Feedback precedent selection ---
+    // (from review_file lines 951-959)
+    let file_str = file_path.to_string_lossy();
+    let lang_str = ast
+        .map(|a| a.language.as_str())
+        .unwrap_or("unknown");
+
+    if let Some(ref shared_index) = pipeline_config.shared_feedback_index {
+        let mut index = shared_index.lock().unwrap_or_else(|e| e.into_inner());
+        let precedents = query_feedback_precedents(
+            &mut index,
+            &file_str,
+            lang_str,
+            &ctx.redacted_code,
+        );
+        if !precedents.is_empty() {
+            ctx.feedback_precedents = Some(precedents);
+        }
+    }
+
+    // --- Hydration context (AST-only) ---
+    // (from review_file lines 790-861)
+    if let Some(ast_ctx) = ast {
+        {
+            let hctx = crate::hydration::build_hydration_context(
+                source,
+                ast_ctx.tree,
+                ast_ctx.language,
+            );
+            let redacted_ctx = crate::hydration::HydrationContext {
+                callee_signatures: hctx
+                    .callee_signatures
+                    .iter()
+                    .map(|s| crate::redact::redact_secrets(s))
+                    .collect(),
+                type_definitions: hctx
+                    .type_definitions
+                    .iter()
+                    .map(|s| crate::redact::redact_secrets(s))
+                    .collect(),
+                callers: hctx
+                    .callers
+                    .iter()
+                    .map(|s| crate::redact::redact_secrets(s))
+                    .collect(),
+                import_targets: hctx.import_targets.clone(),
+                qualified_names: hctx.qualified_names.clone(),
+            };
+            ctx.hydration_context = Some(redacted_ctx);
+        }
+    }
+
+    // --- Context7 enrichment ---
+    // (from review_file lines 863-949, review_file_llm_only 1404-1463)
+    if !pipeline_config.context7_disabled {
+        let import_targets = ctx
+            .hydration_context
+            .as_ref()
+            .map(|h| h.import_targets.clone())
+            .unwrap_or_default();
+
+        if let Some(ref fetcher) = pipeline_config.context7_fetcher {
+            let enrichment = crate::context_enrichment::enrich_for_review_in_project(
+                file_path,
+                &import_targets,
+                ast.map(|a| a.language),
+                fetcher.as_ref(),
+                pipeline_config.live_registry,
+                pipeline_config.framework_override.as_deref(),
+            )
+            .await;
+            ctx.framework_docs = if enrichment.docs.is_empty() {
+                None
+            } else {
+                Some(enrichment.docs)
+            };
+            ctx.enrichment_metrics = enrichment.metrics;
+        }
+    }
+
+    // --- Context injection ---
+    // (from review_file lines 961-1005, skipped in review_file_llm_only)
+    if let Some(ref injector) = pipeline_config.context_injector {
+        let injection_req = crate::context::inject::InjectionRequest {
+            file_path: file_path.to_string_lossy().to_string(),
+            code: &ctx.redacted_code,
+            import_targets: ctx
+                .hydration_context
+                .as_ref()
+                .map(|h| &h.import_targets[..])
+                .unwrap_or(&[]),
+        };
+        match injector.inject(&injection_req).await {
+            Ok(outcome) => {
+                ctx.context_block = outcome.rendered_block;
+                ctx.context_telemetry = Some(outcome.telemetry);
+            }
+            Err(e) => {
+                tracing::warn!(error = %e, "context injection failed");
+            }
+        }
+    }
+
+    Ok(ctx)
+}
+```
+
+**Important:** The exact implementation will need to match the actual parameters and methods used in the existing code. The function bodies above are templates — the implementer must read the existing `review_file` lines 790-1005 and `review_file_llm_only` lines 1404-1473 and extract the actual logic, preserving all tracing spans, error handling, and metric accumulation. The structure above shows the correct sequencing and field assignments.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cargo test -- build_file_context_redacts_secrets`
+Expected: PASS
+
+- [ ] **Step 5: Write test — build_file_context without AST skips hydration**
+
+```rust
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn build_file_context_without_ast_skips_hydration() {
+    let config = PipelineConfig::default();
+    let ctx = build_file_context(
+        std::path::Path::new("test.rs"),
+        "fn main() {}",
+        None,
+        &config,
+    )
+    .await
+    .unwrap();
+    assert!(
+        ctx.hydration_context.is_none(),
+        "no AST means no hydration context"
+    );
+}
+```
+
+- [ ] **Step 6: Run test to verify it passes**
+
+Run: `cargo test -- build_file_context_without_ast_skips_hydration`
+Expected: PASS
+
+- [ ] **Step 7: Write test — truncation notice on oversized source**
+
+```rust
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn build_file_context_truncates_large_source() {
+    let mut config = PipelineConfig::default();
+    config.max_source_chars = Some(100);
+    let big_source = "x".repeat(200);
+    let ctx = build_file_context(
+        std::path::Path::new("test.rs"),
+        &big_source,
+        None,
+        &config,
+    )
+    .await
+    .unwrap();
+    assert!(ctx.truncation_notice.is_some());
+    assert!(
+        ctx.redacted_code.len() <= 100,
+        "code must be truncated to max_source_chars"
+    );
+}
+```
+
+- [ ] **Step 8: Run test to verify it passes**
+
+Run: `cargo test -- build_file_context_truncates_large_source`
+Expected: PASS
+
+- [ ] **Step 9: Run full test suite**
+
+Run: `cargo test --bin quorum`
+Expected: All pass — `build_file_context` is additive, nothing calls it yet.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add src/pipeline.rs
+git commit -m "refactor: extract build_file_context() for shared context assembly (#339)"
+```
+
+---
+
+### Task 3: Refactor review_file to use build_file_context()
+
+**Files:**
+- Modify: `src/pipeline.rs:637-1193` (the `review_file` function)
+
+- [ ] **Step 1: Replace inline context assembly with build_file_context() call**
+
+In `review_file`, replace the context assembly blocks (roughly lines 790-1005: secret redaction, truncation, hydration context, Context7 enrichment, feedback precedents, context injection) with a single call:
+
+```rust
+// Replace ~215 lines of inline context assembly with:
+let ast_ctx = AstContext {
+    language: lang,
+    rule_metadata: rule_metadata.clone(),
+};
+let file_ctx = build_file_context(
+    file_path,
+    source,
+    Some(&ast_ctx),
+    pipeline_config,
+)
+.await?;
+```
+
+**Prompt ordering constraint:** When populating `ReviewRequest` from `FileContext`, preserve the existing field order in `build_review_prompt` — stable context (system prompt, file context, framework docs, precedents) first, variable content (focus directives, mode) last. This maximizes LLM API prefix cache hits for multi-perspective reviews. Don't reorder sections for cache optimization if it would break logical structure.
+
+Then update the `ReviewRequest` construction (around line 1008-1024) to read from `file_ctx`:
+
+```rust
+let req = crate::review::ReviewRequest {
+    file_path: file_path.to_string_lossy().to_string(),
+    language: lang.as_str().to_string(),
+    code: file_ctx.redacted_code.clone(),
+    hydration_context: file_ctx.hydration_context.clone(),
+    framework_docs: file_ctx.framework_docs.clone(),
+    feedback_precedents: file_ctx.feedback_precedents.clone(),
+    context_block: file_ctx.context_block.clone(),
+    truncation_notice: file_ctx.truncation_notice.clone(),
+    focus: pipeline_config.focus.clone(),
+    mode: pipeline_config.mode,
+};
+```
+
+And update the return value to use `file_ctx.enrichment_metrics` and `file_ctx.context_telemetry`.
+
+- [ ] **Step 2: Run full test suite to verify no regressions**
+
+Run: `cargo test --bin quorum`
+Expected: All existing tests pass. This is a behavior-preserving refactor — the same logic runs, just from a different call site.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/pipeline.rs
+git commit -m "refactor: review_file uses build_file_context() (#339)"
+```
+
+---
+
+### Task 4: Unify review_file signature to accept Option\<AstContext\>
+
+**Files:**
+- Modify: `src/pipeline.rs` (review_file signature + body)
+
+- [ ] **Step 1: Change review_file signature**
+
+Change from:
+
+```rust
+pub(crate) async fn review_file(
+    file_path: &Path,
+    source: &str,
+    lang: Language,
+    tree: &Tree,
+    reviewer: Option<&dyn LlmReviewer>,
+    pipeline_config: &PipelineConfig,
+) -> anyhow::Result<FileReviewResult>
+```
+
+To:
+
+```rust
+pub(crate) async fn review_file(
+    file_path: &Path,
+    source: &str,
+    ast: Option<AstContext<'_>>,
+    reviewer: Option<&dyn LlmReviewer>,
+    pipeline_config: &PipelineConfig,
+) -> anyhow::Result<FileReviewResult>
+```
+
+- [ ] **Step 2: Guard AST-only phases on ast.is_some()**
+
+Wrap the AST-only blocks (local AST analysis, ast-grep rules, judge phase) with:
+
+```rust
+let mut all_sources: Vec<Vec<Finding>> = Vec::new();
+
+if let Some(ref ast_ctx) = ast {
+    // Local AST complexity analysis (lines 675-694)
+    let local_findings = crate::analysis::analyze(source, ast_ctx.language);
+    all_sources.push(local_findings);
+
+    // ast-grep rules (lines 696-725)
+    let ast_grep_findings = crate::ast_grep::scan_with_rules(
+        file_path, source, &ast_ctx.rule_metadata,
+    );
+    all_sources.push(ast_grep_findings);
+
+    // Judge phase (lines 727-778)
+    if pipeline_config.judge_enabled {
+        // ... judge logic, operates on all_sources via &mut ...
+    }
+} else {
+    // LLM-only path: no local findings
+    all_sources.push(Vec::new());
+}
+```
+
+- [ ] **Step 3: Derive language string for non-AST path**
+
+For the LLM-only path, derive language from the file extension for the `ReviewRequest.language` field:
+
+```rust
+let lang_str = match &ast {
+    Some(ref ctx) => ctx.language.as_str().to_string(),
+    None => file_path
+        .extension()
+        .and_then(|e| e.to_str())
+        .unwrap_or("unknown")
+        .to_string(),
+};
+```
+
+Use `lang_str` in the `ReviewRequest` construction.
+
+- [ ] **Step 4: Update review_source to pass AstContext**
+
+In `review_source` (line 1323-1336), construct `AstContext` from the parsed tree and language:
+
+```rust
+let ast_ctx = AstContext {
+    language: lang,
+    rule_metadata: crate::ast_grep::load_rule_metadata(file_path),
+};
+review_file(
+    file_path,
+    source,
+    Some(ast_ctx),
+    reviewer,
+    pipeline_config,
+)
+.await
+```
+
+**Note:** Check how `rule_metadata` is currently loaded in `review_file` and replicate that — it may use `load_rules_from_dirs` or similar. The implementer must match the existing loading pattern.
+
+- [ ] **Step 5: Run full test suite**
+
+Run: `cargo test --bin quorum`
+Expected: All pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/pipeline.rs
+git commit -m "refactor: review_file accepts Option<AstContext> (#339)"
+```
+
+---
+
+### Task 5: Delete review_file_llm_only and update call sites
+
+**Files:**
+- Modify: `src/pipeline.rs:1362-1625` (delete `review_file_llm_only`)
+- Modify: `src/main.rs` (update call sites in `run_review`)
+
+- [ ] **Step 1: Write test — review_file with None AST matches old LLM-only behavior**
+
+```rust
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn review_file_without_ast_runs_llm_only_path() {
+    // Verify that review_file(path, source, None, ...) produces
+    // findings equivalent to the old review_file_llm_only path
+    let config = PipelineConfig::default();
+    let result = review_file(
+        std::path::Path::new("test.py"),
+        "def foo():\n    eval(input())\n",
+        None, // LLM-only
+        None, // no reviewer
+        &config,
+    )
+    .await
+    .unwrap();
+    // Without LLM, LLM-only path produces empty findings
+    // (no AST analysis, no LLM review)
+    assert!(result.findings.is_empty());
+    assert_eq!(result.judge_metrics, JudgeMetrics::default());
+}
+```
+
+- [ ] **Step 2: Run test to verify it passes**
+
+Run: `cargo test -- review_file_without_ast_runs_llm_only_path`
+Expected: PASS — unified `review_file` with `None` AST should work.
+
+- [ ] **Step 3: Update main.rs call sites**
+
+In `src/main.rs`, find the call sites where `review_file_llm_only` is called (around lines 1318-1335 for serial mode, and 1469-1479 for parallel mode). Replace:
+
+```rust
+// Old:
+if let Some(lang) = Language::from_path(file_path) {
+    pipeline::review_source(file_path, &source, lang, llm, &cfg, Some(&cache)).await
+} else {
+    pipeline::review_file_llm_only(file_path, &source, llm, &cfg).await
+}
+
+// New:
+if let Some(lang) = Language::from_path(file_path) {
+    pipeline::review_source(file_path, &source, lang, llm, &cfg, Some(&cache)).await
+} else {
+    pipeline::review_file(file_path, &source, None, llm, &cfg).await
+}
+```
+
+Apply this change to both the serial and parallel code paths.
+
+- [ ] **Step 4: Delete review_file_llm_only**
+
+Remove the entire `review_file_llm_only` function (lines 1362-1625, approximately 263 lines).
+
+Also remove any `pub(crate)` export of `review_file_llm_only` if it exists in `mod.rs` or lib exports.
+
+- [ ] **Step 5: Run full test suite**
+
+Run: `cargo test --bin quorum`
+Expected: All pass. If any tests called `review_file_llm_only` directly, update them to call `review_file` with `ast: None`.
+
+- [ ] **Step 6: Run clippy**
+
+Run: `cargo clippy`
+Expected: No warnings. Watch for unused imports that were only needed by the deleted function.
+
+- [ ] **Step 7: Run rustfmt**
+
+Run: `cargo fmt -- --check`
+Expected: No diffs.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/pipeline.rs src/main.rs
+git commit -m "refactor: delete review_file_llm_only, unify into review_file (#339)"
+```
+
+---
+
+### Task 6: Final verification and cleanup
+
+**Files:**
+- Possibly modify: `src/pipeline.rs` (dead code removal)
+
+- [ ] **Step 1: Run full test suite**
+
+Run: `cargo test --bin quorum`
+Expected: All pass.
+
+- [ ] **Step 2: Run clippy**
+
+Run: `cargo clippy`
+Expected: No warnings.
+
+- [ ] **Step 3: Run rustfmt**
+
+Run: `cargo fmt -- --check`
+Expected: No diffs.
+
+- [ ] **Step 4: Verify line count reduction**
+
+Run: `wc -l src/pipeline.rs`
+Expected: ~250 fewer lines than pre-refactor (was ~1625 lines, `review_file_llm_only` was ~263 lines, shared extraction saves additional lines from `review_file`).
+
+- [ ] **Step 5: Run release build**
+
+Run: `cargo build --release`
+Expected: Compiles without warnings.
+
+- [ ] **Step 6: Commit any cleanup**
+
+```bash
+git add -A
+git commit -m "refactor: clean up dead code from review context extraction (#339)"
+```

--- a/docs/superpowers/specs/2026-05-14-review-context-extraction-design.md
+++ b/docs/superpowers/specs/2026-05-14-review-context-extraction-design.md
@@ -1,0 +1,141 @@
+# Review Context Extraction (#339)
+
+## Problem
+
+`review_file` and `review_file_llm_only` in `src/pipeline.rs` share ~60% of their logic (feedback index setup, Context7 enrichment, precedent lookup, prompt construction, model loop, merge, grounding, diff classification) but are maintained as independent ~500-line functions. Changes to shared logic must be applied twice and diverge silently when one function is updated without the other.
+
+Issue #339 identifies a "rediscovery problem" — context is reassembled from scratch on every review run. The fix has two phases: first, make the context assembly explicit and deduplicated (this spec); second, cache it across runs (future work).
+
+## Design Review Findings
+
+Three independent reviewers (Claude oracle, GPT-5.4 via pal, and codebase exploration) converged on the same conclusion:
+
+1. **Per-model recomputation doesn't exist.** Both functions already build one prompt and loop over models. A "ReviewBundle" abstraction targeting per-model sharing would solve a non-problem.
+2. **The real waste is code duplication.** The two review functions are the maintenance hazard and the barrier to future caching.
+3. **The right seam is a context-assembly helper,** not a new struct that bundles mutable and immutable data together.
+
+## Approach
+
+### 1. Unify `review_file` and `review_file_llm_only`
+
+Merge into a single `review_file` that accepts an optional AST context:
+
+```rust
+pub async fn review_file(
+    file_path: &Path,
+    source: &str,
+    ast: Option<AstContext<'_>>,  // Tree + Language + rules, or None
+    reviewer: Option<&dyn LlmReviewer>,
+    pipeline_config: &PipelineConfig,
+    parse_cache: Option<&ParseCache>,
+) -> anyhow::Result<ReviewResult>
+```
+
+When `ast` is `None`, the function skips: local AST complexity analysis, ast-grep rule scanning, judge phase, and hydration context assembly. All shared logic (feedback index, Context7 enrichment, precedent lookup, prompt building, model loop, merge, grounding, diff classification, calibration) executes once in one code path.
+
+`AstContext` is a thin carrier struct:
+
+```rust
+pub struct AstContext<'a> {
+    pub tree: &'a Tree,
+    pub language: Language,
+    pub rule_metadata: HashMap<String, RuleMetadata>,
+}
+```
+
+### 2. Extract `build_file_context()`
+
+Extract the shared pre-prompt assembly into a helper that returns immutable, reusable context:
+
+```rust
+pub struct FileContext {
+    pub redacted_code: String,
+    pub truncation_notice: Option<String>,
+    pub framework_docs: Option<Vec<String>>,
+    pub feedback_precedents: Option<Vec<String>>,
+    pub hydration_context: Option<HydrationContext>,
+    pub context_block: Option<String>,
+    pub enrichment_metrics: EnrichmentMetrics,
+}
+
+fn build_file_context(
+    file_path: &Path,
+    source: &str,
+    ast: Option<&AstContext<'_>>,
+    pipeline_config: &PipelineConfig,
+) -> anyhow::Result<FileContext>
+```
+
+This function performs: secret redaction, truncation, Context7 enrichment, feedback precedent selection, hydration context assembly (if AST available), and context injection. It returns an immutable `FileContext` that feeds directly into `ReviewRequest` field population.
+
+The model loop stays in `review_file` — it consumes `FileContext` to build `ReviewRequest`, calls each model, and collects results.
+
+### 3. Keep mutable findings separate
+
+AST findings (`Vec<Finding>`) and judge results stay in `review_file`'s local scope, not in `FileContext`. The judge mutates findings in-place via `&mut Vec<Finding>` — bundling them into a shared immutable struct would require cloning or architectural gymnastics that aren't worth the complexity.
+
+Flow:
+
+```
+review_file(path, source, ast, reviewer, config)
+  │
+  ├─ build_file_context(path, source, ast, config)
+  │     → FileContext (immutable, reusable)
+  │
+  ├─ if ast.is_some():
+  │     ├─ run local_ast + ast_grep → Vec<Finding>
+  │     ├─ judge_findings(&mut findings, ...)
+  │     └─ push into all_sources
+  │
+  ├─ for model in models:
+  │     ├─ build ReviewRequest from &FileContext
+  │     ├─ build_review_prompt(&req)
+  │     ├─ reviewer.review(&prompt, model, sys_prompt)
+  │     └─ parse findings → all_sources
+  │
+  ├─ merge_findings(all_sources)
+  ├─ grounding pass
+  ├─ diff classification
+  └─ calibration
+```
+
+### 4. Future: perspective-based multi-run
+
+The `FileContext` seam enables a future pattern where multiple review perspectives (security focus, logic focus, performance focus) each build their own `ReviewRequest` from the same pre-computed `FileContext` with different system prompts or focus directives. This is distinct from ensemble mode (same prompt, multiple models) and more aligned with how review depth will scale.
+
+This is explicitly deferred — no code for it in this change.
+
+### 5. Future: cross-run caching
+
+`FileContext` is the natural caching unit. A future change could serialize it with a composite cache key (content hash + feedback state hash + rule version + config hash) and TTL-based staleness tracking. The extraction in this spec makes that possible without the premature `content_hash` field that the original design proposed.
+
+This is explicitly deferred — no code for it in this change.
+
+## What changes
+
+| File | Change |
+|------|--------|
+| `src/pipeline.rs` | Unify `review_file` + `review_file_llm_only` into single function; extract `build_file_context()` and `FileContext` struct |
+| `src/main.rs` | Update call sites in `run_review` to use unified signature |
+| `src/pipeline.rs` (tests) | Update/consolidate tests for the unified function |
+
+## What doesn't change
+
+- `ReviewRequest` struct (stays as-is, populated from `FileContext`)
+- LLM client interface
+- Prompt rendering (`build_review_prompt`)
+- Judge phase (still mutates findings in local scope)
+- `PipelineConfig` (still carries shared state across files)
+- External API (`review_source` public function)
+
+## Testing
+
+- Unit tests for `build_file_context`: given known inputs, returns expected `FileContext` fields (redacted code, truncation, precedents)
+- Integration test: `review_file` with `ast: None` produces same results as old `review_file_llm_only`
+- Integration test: `review_file` with `ast: Some(...)` produces same results as old `review_file`
+- Regression: all existing pipeline tests pass without behavior change
+- Property: `FileContext` fields are deterministic given same inputs (no ordering variance)
+
+## Scope guard
+
+This change is a refactor. No new features, no new user-facing behavior, no new files on disk. If the unified function grows beyond ~400 lines, extract additional helpers but don't add new abstractions. The goal is fewer lines of code, not more.

--- a/docs/superpowers/specs/2026-05-14-review-context-extraction-design.md
+++ b/docs/superpowers/specs/2026-05-14-review-context-extraction-design.md
@@ -99,7 +99,20 @@ review_file(path, source, ast, reviewer, config)
   └─ calibration
 ```
 
-### 4. Future: perspective-based multi-run
+### 4. Prompt ordering for prefix caching
+
+When building `ReviewRequest` from `FileContext`, order the prompt sections so stable content comes first:
+
+1. System prompt (identical across runs)
+2. File context block (from `FileContext` — stable for same file content)
+3. Framework docs (stable for same dependency set)
+4. Feedback precedents (stable within a session)
+5. Hydration context / AST findings (stable for same file content)
+6. Focus directives, mode-specific instructions (varies per perspective)
+
+This ordering maximizes LLM API prefix cache hits when multiple perspectives review the same file — the shared prefix is cached and only the tail (focus/mode) differs. The existing `build_review_prompt` already roughly follows this pattern; the constraint is: don't reorder sections in ways that break this property during the refactor. If natural logical structure conflicts with cache-friendly ordering, prefer structure — correctness over cache hits.
+
+### 5. Future: perspective-based multi-run
 
 The `FileContext` seam enables a future pattern where multiple review perspectives (security focus, logic focus, performance focus) each build their own `ReviewRequest` from the same pre-computed `FileContext` with different system prompts or focus directives. This is distinct from ensemble mode (same prompt, multiple models) and more aligned with how review depth will scale.
 

--- a/src/context/phase6_integration_tests.rs
+++ b/src/context/phase6_integration_tests.rs
@@ -313,7 +313,6 @@ async fn end_to_end_review_with_context_injection_logs_telemetry() {
     let ast_ctx = crate::pipeline::AstContext {
         tree: &tree,
         language: Language::Rust,
-        rule_metadata: std::collections::HashMap::new(),
     };
     let result = review_file(
         Path::new("src/auth.rs"),

--- a/src/context/phase6_integration_tests.rs
+++ b/src/context/phase6_integration_tests.rs
@@ -310,11 +310,15 @@ async fn end_to_end_review_with_context_injection_logs_telemetry() {
     let source = "fn verify_token(t: &str) -> bool { !t.is_empty() }\n\
                   pub fn check(t: &str) -> bool { verify_token(t) }\n";
     let tree = parser::parse(source, Language::Rust).unwrap();
+    let ast_ctx = crate::pipeline::AstContext {
+        tree: &tree,
+        language: Language::Rust,
+        rule_metadata: std::collections::HashMap::new(),
+    };
     let result = review_file(
         Path::new("src/auth.rs"),
         source,
-        Language::Rust,
-        &tree,
+        Some(ast_ctx),
         Some(&llm),
         &config,
     )

--- a/src/main.rs
+++ b/src/main.rs
@@ -1330,8 +1330,7 @@ async fn run_review(opts: cli::ReviewOpts) -> i32 {
                     "Note: No AST support for {}, using LLM-only review",
                     file_path.display()
                 );
-                pipeline::review_file_llm_only(file_path, &source, llm_reviewer, &pipeline_cfg)
-                    .await
+                pipeline::review_file(file_path, &source, None, llm_reviewer, &pipeline_cfg).await
             };
             match review_result {
                 Ok(mut result) => {
@@ -1476,9 +1475,10 @@ async fn run_review(opts: cli::ReviewOpts) -> i32 {
                         )
                         .await
                     } else {
-                        pipeline::review_file_llm_only(
+                        pipeline::review_file(
                             &file_path,
                             &source,
+                            None,
                             llm_reviewer,
                             &pipeline_cfg,
                         )

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -654,11 +654,15 @@ pub(crate) fn render_precedent_for_few_shot(entry: &crate::feedback::FeedbackEnt
 }
 
 /// Run the full review pipeline on a single file.
+///
+/// When `ast` is `Some`, the full pipeline runs: local AST analysis,
+/// ast-grep rules, judge phase, then LLM review with hydration and
+/// context injection. When `None` (unsupported language), AST-only
+/// phases are skipped and the LLM review proceeds without hydration.
 pub async fn review_file(
     file_path: &Path,
     source: &str,
-    lang: Language,
-    tree: &tree_sitter::Tree,
+    ast: Option<AstContext<'_>>,
     llm: Option<&dyn LlmReviewer>,
     pipeline_config: &PipelineConfig,
 ) -> anyhow::Result<FileReviewResult> {
@@ -692,62 +696,76 @@ pub async fn review_file(
 
     let mut hydration_text = String::new();
 
-    // Source 1: Local AST analysis (skipped for prose reviews)
+    // Derive language string: from AST when available, from file extension otherwise.
+    let lang_str = match &ast {
+        Some(ctx) => lang_name(ctx.language).to_string(),
+        None => lang_name_from_path(file_path),
+    };
+
+    // Source 1: Local AST analysis (skipped for prose reviews and non-AST files)
     let mut local_findings = Vec::new();
-    if !pipeline_config.mode.is_prose() {
-        let _span = tracing::info_span!("phase.local_ast", file = %file_str).entered();
-        let t0 = std::time::Instant::now();
-        local_findings.extend(analysis::analyze_complexity(
-            tree,
-            source,
-            lang,
-            pipeline_config.complexity_threshold,
-        ));
-        local_findings.extend(analysis::analyze_insecure_patterns(tree, source, lang));
-        tracing::info!(
-            phase = "local_ast",
-            duration_ms = t0.elapsed().as_millis() as u64,
-            findings = local_findings.len(),
-            "phase complete"
-        );
+    let mut rule_metadata: std::collections::HashMap<String, crate::ast_grep::RuleMetadata> =
+        std::collections::HashMap::new();
+    if let Some(ref ast_ctx) = ast {
+        if !pipeline_config.mode.is_prose() {
+            let _span = tracing::info_span!("phase.local_ast", file = %file_str).entered();
+            let t0 = std::time::Instant::now();
+            local_findings.extend(analysis::analyze_complexity(
+                ast_ctx.tree,
+                source,
+                ast_ctx.language,
+                pipeline_config.complexity_threshold,
+            ));
+            local_findings.extend(analysis::analyze_insecure_patterns(
+                ast_ctx.tree,
+                source,
+                ast_ctx.language,
+            ));
+            tracing::info!(
+                phase = "local_ast",
+                duration_ms = t0.elapsed().as_millis() as u64,
+                findings = local_findings.len(),
+                "phase complete"
+            );
+        }
     }
     all_sources.push(local_findings);
 
-    // Source 2: ast-grep library rules (skipped for prose reviews)
-    let ext = file_path.extension().and_then(|e| e.to_str()).unwrap_or("");
-    let mut rule_metadata: std::collections::HashMap<String, crate::ast_grep::RuleMetadata> =
-        std::collections::HashMap::new();
-    if !pipeline_config.mode.is_prose() && ast_grep::ext_to_language(ext).is_some() {
-        let _span = tracing::info_span!("phase.ast_grep", file = %file_str).entered();
-        let t0 = std::time::Instant::now();
-        let project_root = find_project_root(file_path);
-        let home_dir = std::env::var("HOME")
-            .or_else(|_| std::env::var("USERPROFILE"))
-            .map(std::path::PathBuf::from)
-            .unwrap_or_default();
-        let (rules, loaded_metadata) = ast_grep::load_rules(&project_root, &home_dir);
-        rule_metadata = loaded_metadata;
-        let mut ag_count = 0;
-        if !rules.is_empty() {
-            let ag_findings = ast_grep::scan_file(source, ext, &rules, &rule_metadata);
-            ag_count = ag_findings.len();
-            if !ag_findings.is_empty() {
-                all_sources.push(ag_findings);
+    // Source 2: ast-grep library rules (skipped for prose reviews and non-AST files)
+    if ast.is_some() {
+        let ext = file_path.extension().and_then(|e| e.to_str()).unwrap_or("");
+        if !pipeline_config.mode.is_prose() && ast_grep::ext_to_language(ext).is_some() {
+            let _span = tracing::info_span!("phase.ast_grep", file = %file_str).entered();
+            let t0 = std::time::Instant::now();
+            let project_root = find_project_root(file_path);
+            let home_dir = std::env::var("HOME")
+                .or_else(|_| std::env::var("USERPROFILE"))
+                .map(std::path::PathBuf::from)
+                .unwrap_or_default();
+            let (rules, loaded_metadata) = ast_grep::load_rules(&project_root, &home_dir);
+            rule_metadata = loaded_metadata;
+            let mut ag_count = 0;
+            if !rules.is_empty() {
+                let ag_findings = ast_grep::scan_file(source, ext, &rules, &rule_metadata);
+                ag_count = ag_findings.len();
+                if !ag_findings.is_empty() {
+                    all_sources.push(ag_findings);
+                }
             }
+            tracing::info!(
+                phase = "ast_grep",
+                duration_ms = t0.elapsed().as_millis() as u64,
+                rules = rules.len(),
+                findings = ag_count,
+                "phase complete"
+            );
         }
-        tracing::info!(
-            phase = "ast_grep",
-            duration_ms = t0.elapsed().as_millis() as u64,
-            rules = rules.len(),
-            findings = ag_count,
-            "phase complete"
-        );
     }
 
     // Source 2b: Judge speculative AST findings (if enabled).
     // Only runs on ast-grep findings (index 1+), not local AST (index 0).
     let mut judge_metrics = JudgeMetrics::default();
-    if pipeline_config.judge_enabled && !rule_metadata.is_empty() {
+    if ast.is_some() && pipeline_config.judge_enabled && !rule_metadata.is_empty() {
         {
             let _span = tracing::info_span!("phase.judge", file = %file_str).entered();
             let home_dir = std::env::var("HOME")
@@ -804,13 +822,8 @@ pub async fn review_file(
         } else {
             // Build shared file context: redaction, hydration, Context7,
             // feedback precedents, context injection.
-            let ast_ctx = AstContext {
-                tree,
-                language: lang,
-                rule_metadata: rule_metadata.clone(),
-            };
             let file_ctx =
-                build_file_context(file_path, source, Some(&ast_ctx), pipeline_config).await?;
+                build_file_context(file_path, source, ast.as_ref(), pipeline_config).await?;
 
             enrichment_metrics = file_ctx.enrichment_metrics;
             context_telemetry = file_ctx.context_telemetry;
@@ -823,7 +836,7 @@ pub async fn review_file(
 
             let req = ReviewRequest {
                 file_path: file_str.clone(),
-                language: lang_name(lang).to_string(),
+                language: lang_str.clone(),
                 code: file_ctx.redacted_code.clone(),
                 hydration_context: file_ctx.hydration_context.clone(),
                 framework_docs: file_ctx.framework_docs.clone(),
@@ -1022,9 +1035,6 @@ fn render_hydration_for_grounding(ctx: &crate::hydration::HydrationContext) -> S
 /// When `ast` is `Some`, hydration and context injection run against the
 /// parsed tree. When `None` (unsupported language), those phases are skipped
 /// and the import list passed to Context7 enrichment is empty.
-///
-/// This function is additive: nothing calls it yet. Tasks 3-5 will wire
-/// callers.
 pub(crate) async fn build_file_context(
     file_path: &std::path::Path,
     source: &str,
@@ -1412,7 +1422,12 @@ pub async fn review_source(
     } else {
         parser::parse(source, lang)?
     };
-    review_file(file_path, source, lang, &tree, llm, pipeline_config).await
+    let ast_ctx = AstContext {
+        tree: &tree,
+        language: lang,
+        rule_metadata: std::collections::HashMap::new(),
+    };
+    review_file(file_path, source, Some(ast_ctx), llm, pipeline_config).await
 }
 
 fn lang_name(lang: Language) -> &'static str {
@@ -2336,7 +2351,12 @@ mod tests {
             models,
             ..Default::default()
         };
-        review_file(Path::new("test.rs"), source, lang, &tree, llm, &config)
+        let ast_ctx = AstContext {
+            tree: &tree,
+            language: lang,
+            rule_metadata: std::collections::HashMap::new(),
+        };
+        review_file(Path::new("test.rs"), source, Some(ast_ctx), llm, &config)
             .await
             .unwrap()
     }
@@ -2873,11 +2893,15 @@ mod tests {
             .set_language(&tree_sitter_rust::LANGUAGE.into())
             .unwrap();
         let tree = parser.parse(source, None).unwrap();
+        let ast_ctx = AstContext {
+            tree: &tree,
+            language: Language::Rust,
+            rule_metadata: std::collections::HashMap::new(),
+        };
         let result = review_file(
             std::path::Path::new("test.rs"),
             source,
-            Language::Rust,
-            &tree,
+            Some(ast_ctx),
             Some(&EmptyReviewer),
             &cfg,
         )
@@ -3041,16 +3065,14 @@ mod tests {
             mode: crate::review_mode::ReviewMode::Plan,
             ..Default::default()
         };
-        let result = review_file(
-            Path::new("test.py"),
-            source,
-            Language::Python,
-            &tree,
-            None,
-            &config,
-        )
-        .await
-        .unwrap();
+        let ast_ctx = AstContext {
+            tree: &tree,
+            language: Language::Python,
+            rule_metadata: std::collections::HashMap::new(),
+        };
+        let result = review_file(Path::new("test.py"), source, Some(ast_ctx), None, &config)
+            .await
+            .unwrap();
 
         // No findings from LocalAst or Linter("ast-grep") should appear
         for f in &result.findings {
@@ -3076,16 +3098,14 @@ mod tests {
             mode: crate::review_mode::ReviewMode::Code,
             ..Default::default()
         };
-        let result = review_file(
-            Path::new("test.py"),
-            source,
-            Language::Python,
-            &tree,
-            None,
-            &config,
-        )
-        .await
-        .unwrap();
+        let ast_ctx = AstContext {
+            tree: &tree,
+            language: Language::Python,
+            rule_metadata: std::collections::HashMap::new(),
+        };
+        let result = review_file(Path::new("test.py"), source, Some(ast_ctx), None, &config)
+            .await
+            .unwrap();
 
         assert!(
             result

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -1222,6 +1222,273 @@ fn render_hydration_for_grounding(ctx: &crate::hydration::HydrationContext) -> S
         .join("\n")
 }
 
+/// Build shared file context (redaction, hydration, enrichment, feedback,
+/// context injection) for a single file. This is the unified extraction of
+/// the pre-prompt assembly logic previously duplicated across `review_file`
+/// and `review_file_llm_only`.
+///
+/// When `ast` is `Some`, hydration and context injection run against the
+/// parsed tree. When `None` (unsupported language), those phases are skipped
+/// and the import list passed to Context7 enrichment is empty.
+///
+/// This function is additive: nothing calls it yet. Tasks 3-5 will wire
+/// callers.
+pub(crate) async fn build_file_context(
+    file_path: &std::path::Path,
+    source: &str,
+    ast: Option<&AstContext<'_>>,
+    pipeline_config: &PipelineConfig,
+) -> anyhow::Result<FileContext> {
+    let file_str = file_path.to_string_lossy().to_string();
+
+    // ── 1. Secret redaction + truncation ────────────────────────────────
+    let redacted_code = redact::redact_secrets(source);
+    let (review_code, truncation_notice) =
+        truncate_for_review(&redacted_code, pipeline_config.max_review_lines);
+
+    // ── 2. Hydration context (only when AST is provided) ────────────────
+    let hydration_context: Option<crate::hydration::HydrationContext> = if let Some(ast_ctx) = ast {
+        if pipeline_config.mode.is_prose() {
+            Some(crate::hydration::HydrationContext::default())
+        } else {
+            let (changed_lines, path_resolved) =
+                if let Some(ref diff_ranges) = pipeline_config.diff_ranges {
+                    let repo_root = find_project_root(file_path);
+                    let resolver = ReviewPathResolver::new(&file_str, &repo_root);
+                    let lines: Vec<(u32, u32)> = diff_ranges
+                        .iter()
+                        .filter(|(path, _)| resolver.matches(path))
+                        .flat_map(|(_, ranges)| ranges.clone())
+                        .collect();
+                    (lines, resolver.resolved())
+                } else {
+                    (Vec::new(), true)
+                };
+            let hydration_ranges = if changed_lines.is_empty() {
+                if pipeline_config.diff_ranges.is_some() && !path_resolved {
+                    tracing::warn!(
+                        file = %file_str,
+                        "diff-file provided but file path could not be \
+                         resolved relative to the repository root; \
+                         falling back to full-file hydration"
+                    );
+                }
+                let total_lines = source.lines().count() as u32;
+                vec![(1, total_lines.max(1))]
+            } else {
+                changed_lines
+            };
+            let hydrate_t0 = std::time::Instant::now();
+            let ctx = {
+                let _span = tracing::info_span!("phase.hydrate", file = %file_str).entered();
+                let c =
+                    hydration::hydrate(ast_ctx.tree, source, ast_ctx.language, &hydration_ranges);
+                tracing::info!(
+                    phase = "hydrate",
+                    duration_ms = hydrate_t0.elapsed().as_millis() as u64,
+                    callees = c.callee_signatures.len(),
+                    types = c.type_definitions.len(),
+                    imports = c.import_targets.len(),
+                    "phase complete"
+                );
+                c
+            };
+
+            // Redact hydration context for parity with redacted code
+            Some(crate::hydration::HydrationContext {
+                callee_signatures: ctx
+                    .callee_signatures
+                    .iter()
+                    .map(|s| redact::redact_secrets(s))
+                    .collect(),
+                type_definitions: ctx
+                    .type_definitions
+                    .iter()
+                    .map(|s| redact::redact_secrets(s))
+                    .collect(),
+                callers: ctx.callers.clone(),
+                import_targets: ctx
+                    .import_targets
+                    .iter()
+                    .map(|s| redact::redact_secrets(s))
+                    .collect(),
+                qualified_names: ctx.qualified_names.clone(),
+            })
+        }
+    } else {
+        None
+    };
+
+    // ── 3. Context7 enrichment ──────────────────────────────────────────
+    let import_targets: &[String] = hydration_context
+        .as_ref()
+        .map(|hc| hc.import_targets.as_slice())
+        .unwrap_or(&[]);
+
+    let mut enrichment_metrics = crate::context_enrichment::EnrichmentMetrics::default();
+    let framework_docs = if let Some(reason) = context7_skip_reason(pipeline_config) {
+        tracing::debug!(reason, "Context7: enrichment skipped");
+        None
+    } else {
+        let project_root = find_project_root(file_path);
+        let mut domain = crate::domain::detect_domain(&project_root);
+        for fw in &pipeline_config.framework_overrides {
+            if !domain.frameworks.contains(fw) {
+                domain.frameworks.push(fw.clone());
+            }
+        }
+        let ctx7_t0 = std::time::Instant::now();
+        let _span = tracing::info_span!("phase.context7", file = %file_str).entered();
+        let policy = crate::enrichment_policy::EnrichmentPolicy {
+            registry: pipeline_config
+                .registry_client
+                .as_ref()
+                .map(|r| r.as_ref() as &dyn crate::enrichment_policy::RegistryClient),
+        };
+        let result = if let Some(shared) = pipeline_config.context7_fetcher.as_ref() {
+            crate::context_enrichment::enrich_for_review_in_project(
+                &project_root,
+                import_targets,
+                &domain.frameworks,
+                shared.as_ref(),
+                &policy,
+            )
+        } else {
+            let inner = crate::context_enrichment::Context7HttpFetcher::new()?;
+            let cached = crate::context_enrichment::CachedContextFetcher::new(&inner, 32);
+            crate::context_enrichment::enrich_for_review_in_project(
+                &project_root,
+                import_targets,
+                &domain.frameworks,
+                &cached,
+                &policy,
+            )
+        };
+        let docs = result.docs;
+        enrichment_metrics = result.metrics;
+        tracing::info!(
+            phase = "context7",
+            duration_ms = ctx7_t0.elapsed().as_millis() as u64,
+            frameworks = domain.frameworks.len(),
+            docs = docs.len(),
+            resolved = enrichment_metrics.context7_resolved,
+            resolve_failed = enrichment_metrics.context7_resolve_failed,
+            query_failed = enrichment_metrics.context7_query_failed,
+            skipped_popular = enrichment_metrics.context7_skipped_popular,
+            budget_reduced = enrichment_metrics.context7_budget_reduced,
+            "phase complete"
+        );
+        if !docs.is_empty() {
+            tracing::debug!(docs_injected = docs.len(), "Context7 docs injected");
+            Some(
+                docs.iter()
+                    .map(|d| {
+                        crate::context_enrichment::format_context_section(std::slice::from_ref(d))
+                    })
+                    .collect(),
+            )
+        } else if domain.frameworks.is_empty() {
+            None
+        } else {
+            anyhow::bail!(
+                "Context7: failed to fetch docs for frameworks {:?}. \
+                 This degrades review quality. Fix the Context7 connection or use --skip-context7 to proceed without framework docs.",
+                domain.frameworks
+            );
+        }
+    };
+
+    // ── 4. Feedback precedent selection ─────────────────────────────────
+    let language: String = if let Some(ast_ctx) = ast {
+        lang_name(ast_ctx.language).to_string()
+    } else {
+        lang_name_from_path(file_path)
+    };
+
+    let shared_index = pipeline_config.feedback_index.clone();
+    let mut local_index = if shared_index.is_none() {
+        if let Some(store_path) = &pipeline_config.feedback_store {
+            let store = crate::feedback::FeedbackStore::new(store_path.clone());
+            Some(if pipeline_config.fast {
+                crate::feedback_index::FeedbackIndex::build_bm25(&store)?
+            } else {
+                crate::feedback_index::FeedbackIndex::build(&store)?
+            })
+        } else {
+            None
+        }
+    } else {
+        None
+    };
+
+    let precedents = if let Some(ref shared) = shared_index {
+        let mut idx = shared.lock().unwrap();
+        query_feedback_precedents(&mut idx, &file_str, &language, &review_code)
+    } else if let Some(ref mut idx) = local_index {
+        query_feedback_precedents(idx, &file_str, &language, &review_code)
+    } else {
+        Vec::new()
+    };
+
+    // ── 5. Context injection (only when AST is provided) ────────────────
+    let mut context_block: Option<String> = None;
+    let mut context_telemetry: Option<crate::review_log::ContextTelemetry> = None;
+
+    if let Some(ast_ctx) = ast {
+        if !pipeline_config.mode.is_prose() {
+            if let Some(inj) = pipeline_config.context_injector.as_ref() {
+                let redacted_ctx = hydration_context
+                    .as_ref()
+                    .expect("hydration_context must be Some when ast is Some and not prose mode");
+                let mut identifiers: Vec<String> = redacted_ctx
+                    .callee_signatures
+                    .iter()
+                    .filter_map(|sig| extract_ident_from_signature(sig))
+                    .collect();
+                identifiers.extend(redacted_ctx.import_targets.iter().cloned());
+                identifiers.sort();
+                identifiers.dedup();
+                let text_sample: String = redacted_code.chars().take(400).collect();
+                let structural_names: Vec<String> = {
+                    let mut v: Vec<String> = redacted_ctx
+                        .qualified_names
+                        .iter()
+                        .map(|s| redact::redact_secrets(s))
+                        .collect();
+                    v.sort();
+                    v.dedup();
+                    v
+                };
+                let req = crate::context::inject::InjectionRequest {
+                    file_path: file_str.clone(),
+                    language: Some(lang_name(ast_ctx.language).to_string()),
+                    identifiers,
+                    structural_names,
+                    text: text_sample,
+                };
+                let outcome = inj.inject(&req);
+                context_telemetry = Some(outcome.telemetry);
+                context_block = outcome.rendered;
+            }
+        }
+    }
+
+    Ok(FileContext {
+        redacted_code: review_code,
+        truncation_notice,
+        framework_docs,
+        feedback_precedents: if precedents.is_empty() {
+            None
+        } else {
+            Some(precedents)
+        },
+        hydration_context,
+        context_block,
+        enrichment_metrics,
+        context_telemetry,
+    })
+}
+
 /// Best-effort extraction of an identifier from a hydrated callee signature
 /// string like `fn verify_token(s: &str) -> bool` or
 /// `def verify_token(s: str) -> bool`. Returns `None` for shapes we don't
@@ -3149,7 +3416,9 @@ mod tests {
 
         let source = "fn main() {}";
         let mut parser = tree_sitter::Parser::new();
-        parser.set_language(&tree_sitter_rust::LANGUAGE.into()).unwrap();
+        parser
+            .set_language(&tree_sitter_rust::LANGUAGE.into())
+            .unwrap();
         let tree = parser.parse(source, None).unwrap();
         let ctx = AstContext {
             tree: &tree,
@@ -3168,5 +3437,71 @@ mod tests {
         assert!(ctx.hydration_context.is_none());
         assert!(ctx.context_block.is_none());
         assert!(ctx.truncation_notice.is_none());
+    }
+
+    // -----------------------------------------------------------------
+    // build_file_context tests (#339 Task 2)
+    // -----------------------------------------------------------------
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn build_file_context_redacts_secrets() {
+        let config = PipelineConfig::default();
+        let ctx = build_file_context(
+            std::path::Path::new("test.rs"),
+            "let api_key = \"sk-secret123\";",
+            None,
+            &config,
+        )
+        .await
+        .unwrap();
+        assert!(
+            !ctx.redacted_code.contains("sk-secret123"),
+            "FileContext must contain redacted code, got: {}",
+            ctx.redacted_code
+        );
+        assert!(
+            ctx.redacted_code.contains("REDACTED"),
+            "redacted code must replace secrets"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn build_file_context_without_ast_skips_hydration() {
+        let config = PipelineConfig::default();
+        let ctx = build_file_context(
+            std::path::Path::new("test.rs"),
+            "fn main() {}",
+            None,
+            &config,
+        )
+        .await
+        .unwrap();
+        assert!(
+            ctx.hydration_context.is_none(),
+            "no AST means no hydration context"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn build_file_context_truncates_large_source() {
+        let mut config = PipelineConfig::default();
+        config.max_review_lines = 5;
+        let big_source = (0..20)
+            .map(|i| format!("let x{} = {};", i, i))
+            .collect::<Vec<_>>()
+            .join("\n");
+        let ctx = build_file_context(std::path::Path::new("test.rs"), &big_source, None, &config)
+            .await
+            .unwrap();
+        assert!(
+            ctx.truncation_notice.is_some(),
+            "should have truncation notice"
+        );
+        let lines_in_result = ctx.redacted_code.lines().count();
+        assert!(
+            lines_in_result <= 5,
+            "code must be truncated to max_review_lines, got {} lines",
+            lines_in_result
+        );
     }
 }

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -706,28 +706,28 @@ pub async fn review_file(
     let mut local_findings = Vec::new();
     let mut rule_metadata: std::collections::HashMap<String, crate::ast_grep::RuleMetadata> =
         std::collections::HashMap::new();
-    if let Some(ref ast_ctx) = ast {
-        if !pipeline_config.mode.is_prose() {
-            let _span = tracing::info_span!("phase.local_ast", file = %file_str).entered();
-            let t0 = std::time::Instant::now();
-            local_findings.extend(analysis::analyze_complexity(
-                ast_ctx.tree,
-                source,
-                ast_ctx.language,
-                pipeline_config.complexity_threshold,
-            ));
-            local_findings.extend(analysis::analyze_insecure_patterns(
-                ast_ctx.tree,
-                source,
-                ast_ctx.language,
-            ));
-            tracing::info!(
-                phase = "local_ast",
-                duration_ms = t0.elapsed().as_millis() as u64,
-                findings = local_findings.len(),
-                "phase complete"
-            );
-        }
+    if let Some(ref ast_ctx) = ast
+        && !pipeline_config.mode.is_prose()
+    {
+        let _span = tracing::info_span!("phase.local_ast", file = %file_str).entered();
+        let t0 = std::time::Instant::now();
+        local_findings.extend(analysis::analyze_complexity(
+            ast_ctx.tree,
+            source,
+            ast_ctx.language,
+            pipeline_config.complexity_threshold,
+        ));
+        local_findings.extend(analysis::analyze_insecure_patterns(
+            ast_ctx.tree,
+            source,
+            ast_ctx.language,
+        ));
+        tracing::info!(
+            phase = "local_ast",
+            duration_ms = t0.elapsed().as_millis() as u64,
+            findings = local_findings.len(),
+            "phase complete"
+        );
     }
     all_sources.push(local_findings);
 
@@ -831,7 +831,7 @@ pub async fn review_file(
             hydration_text = file_ctx
                 .hydration_context
                 .as_ref()
-                .map(|ctx| render_hydration_for_grounding(ctx))
+                .map(render_hydration_for_grounding)
                 .unwrap_or_default();
 
             let req = ReviewRequest {
@@ -1235,43 +1235,42 @@ pub(crate) async fn build_file_context(
     let mut context_block: Option<String> = None;
     let mut context_telemetry: Option<crate::review_log::ContextTelemetry> = None;
 
-    if let Some(ast_ctx) = ast {
-        if !pipeline_config.mode.is_prose() {
-            if let Some(inj) = pipeline_config.context_injector.as_ref() {
-                let redacted_ctx = hydration_context
-                    .as_ref()
-                    .expect("hydration_context must be Some when ast is Some and not prose mode");
-                let mut identifiers: Vec<String> = redacted_ctx
-                    .callee_signatures
-                    .iter()
-                    .filter_map(|sig| extract_ident_from_signature(sig))
-                    .collect();
-                identifiers.extend(redacted_ctx.import_targets.iter().cloned());
-                identifiers.sort();
-                identifiers.dedup();
-                let text_sample: String = redacted_code.chars().take(400).collect();
-                let structural_names: Vec<String> = {
-                    let mut v: Vec<String> = redacted_ctx
-                        .qualified_names
-                        .iter()
-                        .map(|s| redact::redact_secrets(s))
-                        .collect();
-                    v.sort();
-                    v.dedup();
-                    v
-                };
-                let req = crate::context::inject::InjectionRequest {
-                    file_path: file_str.clone(),
-                    language: Some(lang_name(ast_ctx.language).to_string()),
-                    identifiers,
-                    structural_names,
-                    text: text_sample,
-                };
-                let outcome = inj.inject(&req);
-                context_telemetry = Some(outcome.telemetry);
-                context_block = outcome.rendered;
-            }
-        }
+    if let Some(ast_ctx) = ast
+        && !pipeline_config.mode.is_prose()
+        && let Some(inj) = pipeline_config.context_injector.as_ref()
+    {
+        let redacted_ctx = hydration_context
+            .as_ref()
+            .expect("hydration_context must be Some when ast is Some and not prose mode");
+        let mut identifiers: Vec<String> = redacted_ctx
+            .callee_signatures
+            .iter()
+            .filter_map(|sig| extract_ident_from_signature(sig))
+            .collect();
+        identifiers.extend(redacted_ctx.import_targets.iter().cloned());
+        identifiers.sort();
+        identifiers.dedup();
+        let text_sample: String = redacted_code.chars().take(400).collect();
+        let structural_names: Vec<String> = {
+            let mut v: Vec<String> = redacted_ctx
+                .qualified_names
+                .iter()
+                .map(|s| redact::redact_secrets(s))
+                .collect();
+            v.sort();
+            v.dedup();
+            v
+        };
+        let req = crate::context::inject::InjectionRequest {
+            file_path: file_str.clone(),
+            language: Some(lang_name(ast_ctx.language).to_string()),
+            identifiers,
+            structural_names,
+            text: text_sample,
+        };
+        let outcome = inj.inject(&req);
+        context_telemetry = Some(outcome.telemetry);
+        context_block = outcome.rendered;
     }
 
     Ok(FileContext {

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -126,7 +126,7 @@ pub struct FileReviewResult {
 }
 
 /// Per-file judge result counters, propagated from pipeline to TelemetryEntry.
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq)]
 pub struct JudgeMetrics {
     pub approved: u32,
     pub rejected: u32,
@@ -1029,8 +1029,7 @@ fn render_hydration_for_grounding(ctx: &crate::hydration::HydrationContext) -> S
 
 /// Build shared file context (redaction, hydration, enrichment, feedback,
 /// context injection) for a single file. This is the unified extraction of
-/// the pre-prompt assembly logic previously duplicated across `review_file`
-/// and `review_file_llm_only`.
+/// the pre-prompt assembly logic previously duplicated in `review_file`.
 ///
 /// When `ast` is `Some`, hydration and context injection run against the
 /// parsed tree. When `None` (unsupported language), those phases are skipped
@@ -1449,273 +1448,6 @@ fn lang_name_from_path(path: &Path) -> String {
         .and_then(|e| e.to_str())
         .unwrap_or("unknown")
         .to_lowercase()
-}
-
-/// LLM-only review for files without tree-sitter support.
-/// Skips local AST analysis but still does LLM review, calibration, and auto-calibration.
-pub async fn review_file_llm_only(
-    file_path: &Path,
-    source: &str,
-    llm: Option<&dyn LlmReviewer>,
-    pipeline_config: &PipelineConfig,
-) -> anyhow::Result<FileReviewResult> {
-    let file_str = file_path.to_string_lossy().to_string();
-    let mut all_sources: Vec<Vec<Finding>> = Vec::new();
-    let mut total_usage = crate::llm_client::TokenUsage::default();
-    let mut enrichment_metrics = crate::context_enrichment::EnrichmentMetrics::default();
-
-    // Use pre-built shared index if available (parallel mode), otherwise build locally
-    let shared_index = pipeline_config.feedback_index.clone();
-    let mut local_index = if shared_index.is_none() {
-        if let Some(store_path) = &pipeline_config.feedback_store {
-            let store = crate::feedback::FeedbackStore::new(store_path.clone());
-            // Surface I/O / corrupted-store errors instead of silently
-            // proceeding without precedent injection. The embedder-unavailable
-            // path is already a soft fall-back inside FeedbackIndex::build.
-            Some(if pipeline_config.fast {
-                crate::feedback_index::FeedbackIndex::build_bm25(&store)?
-            } else {
-                crate::feedback_index::FeedbackIndex::build(&store)?
-            })
-        } else {
-            None
-        }
-    } else {
-        None
-    };
-
-    // No local AST analysis — unsupported language
-
-    // LLM review (if configured)
-    if let Some(reviewer) = llm
-        && !pipeline_config.models.is_empty()
-    {
-        let redacted_code = redact::redact_secrets(source);
-        let (review_code, truncation_notice) =
-            truncate_for_review(&redacted_code, pipeline_config.max_review_lines);
-        let language = lang_name_from_path(file_path);
-
-        // Context7 framework docs (metrics aggregate into the function-scoped var)
-        let framework_docs = if let Some(reason) = context7_skip_reason(pipeline_config) {
-            tracing::debug!(reason, "Context7: enrichment skipped");
-            None
-        } else {
-            let project_root = find_project_root(file_path);
-            let mut domain = crate::domain::detect_domain(&project_root);
-            for fw in &pipeline_config.framework_overrides {
-                if !domain.frameworks.contains(fw) {
-                    domain.frameworks.push(fw.clone());
-                }
-            }
-            let policy = crate::enrichment_policy::EnrichmentPolicy {
-                registry: pipeline_config
-                    .registry_client
-                    .as_ref()
-                    .map(|r| r.as_ref() as &dyn crate::enrichment_policy::RegistryClient),
-            };
-            let result = if let Some(shared) = pipeline_config.context7_fetcher.as_ref() {
-                crate::context_enrichment::enrich_for_review_in_project(
-                    &project_root,
-                    &[],
-                    &domain.frameworks,
-                    shared.as_ref(),
-                    &policy,
-                )
-            } else {
-                let inner = crate::context_enrichment::Context7HttpFetcher::new()?;
-                let cached = crate::context_enrichment::CachedContextFetcher::new(&inner, 32);
-                crate::context_enrichment::enrich_for_review_in_project(
-                    &project_root,
-                    &[],
-                    &domain.frameworks,
-                    &cached,
-                    &policy,
-                )
-            };
-            let docs = result.docs;
-            enrichment_metrics = result.metrics;
-            if !docs.is_empty() {
-                Some(
-                    docs.iter()
-                        .map(|d| {
-                            crate::context_enrichment::format_context_section(std::slice::from_ref(
-                                d,
-                            ))
-                        })
-                        .collect(),
-                )
-            } else if domain.frameworks.is_empty() {
-                None
-            } else {
-                // skip_context7 unreachable: outer if-let returned None already.
-                anyhow::bail!(
-                    "Context7: failed to fetch docs for frameworks {:?}. \
-                         This degrades review quality. Fix the Context7 connection or use --skip-context7 to proceed without framework docs.",
-                    domain.frameworks
-                );
-            }
-        };
-
-        // Query feedback index for few-shot precedents
-        let precedents = if let Some(ref shared) = shared_index {
-            let mut idx = shared.lock().unwrap();
-            query_feedback_precedents(&mut idx, &file_str, &language, &redacted_code)
-        } else if let Some(ref mut idx) = local_index {
-            query_feedback_precedents(idx, &file_str, &language, &redacted_code)
-        } else {
-            Vec::new()
-        };
-
-        let req = ReviewRequest {
-            file_path: file_str.clone(),
-            language,
-            code: review_code,
-            hydration_context: None,
-            framework_docs,
-            feedback_precedents: if precedents.is_empty() {
-                None
-            } else {
-                Some(precedents)
-            },
-            context_block: None,
-            truncation_notice: truncation_notice.clone(),
-            focus: pipeline_config.focus.clone(),
-            mode: pipeline_config.mode,
-        };
-
-        let prompt = review::build_review_prompt(&req);
-        let sys_prompt = system_prompt_for_mode(pipeline_config.mode);
-        for model in &pipeline_config.models {
-            let _permit = acquire_llm_permit(&pipeline_config.semaphore).await;
-            match reviewer.review(&prompt, model, sys_prompt) {
-                Ok(resp) => {
-                    if let Some(u) = &resp.usage {
-                        total_usage.prompt_tokens += u.prompt_tokens;
-                        total_usage.completion_tokens += u.completion_tokens;
-                        total_usage.cached_tokens += u.cached_tokens;
-                    }
-                    match review::parse_llm_response(&resp.content, model) {
-                        Ok(mut findings) => {
-                            if let Some(ref notice) = truncation_notice {
-                                for f in &mut findings {
-                                    if matches!(f.source, crate::finding::Source::Llm(_)) {
-                                        f.based_on_excerpt = Some(notice.clone());
-                                    }
-                                }
-                            }
-                            all_sources.push(findings);
-                        }
-                        Err(e) => {
-                            eprintln!("Warning: Failed to parse {} response: {}", model, e)
-                        }
-                    }
-                }
-                Err(e) => eprintln!("Warning: {} review failed: {}", model, e),
-            }
-        }
-    }
-
-    let merged = merge::merge_findings(
-        all_sources,
-        pipeline_config.similarity_threshold,
-        pipeline_config.models.len(),
-    );
-
-    // Grounding: verify LLM-cited symbols exist in source (skipped for prose reviews)
-    let merged = if pipeline_config.mode.is_prose() {
-        merged
-    } else {
-        let grounding_disabled = std::env::var("QUORUM_DISABLE_AST_GROUNDING")
-            .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
-            .unwrap_or(false);
-        let grounded = grounding::apply_grounding(merged, source, grounding_disabled, "");
-        let gc = grounding::count_grounding_outcomes(&grounded);
-        tracing::info!(
-            phase = "grounding",
-            verified = gc.verified,
-            verified_elsewhere = gc.verified_elsewhere,
-            symbol_not_found = gc.symbol_not_found,
-            line_out_of_range = gc.line_out_of_range,
-            not_checked = gc.not_checked,
-            "grounding pass complete"
-        );
-        grounded
-    };
-
-    let mut merged = merged;
-    if let Some(ref diff_ranges) = pipeline_config.diff_ranges {
-        let repo_root = find_project_root(file_path);
-        let resolver = ReviewPathResolver::new(&file_str, &repo_root);
-        let diff_lines: Vec<(u32, u32)> = diff_ranges
-            .iter()
-            .filter(|(path, _)| resolver.matches(path))
-            .flat_map(|(_, ranges)| ranges.clone())
-            .collect();
-        classify_in_diff(&mut merged, &diff_lines);
-    }
-
-    // Calibrate
-    let has_feedback =
-        !pipeline_config.feedback.is_empty() || pipeline_config.feedback_store.is_some();
-    let (final_findings, suppressed_count) = if pipeline_config.calibrate && has_feedback {
-        let _span = tracing::info_span!("phase.calibrate", file = %file_str).entered();
-        let cal_t0 = std::time::Instant::now();
-        let config = pipeline_config.calibrator_config.clone();
-        // Use shared FeedbackIndex (parallel mode) or local index for calibration
-        let cal_result = if let Some(ref shared) = shared_index {
-            let mut idx = shared.lock().unwrap();
-            if !idx.is_empty() {
-                calibrator::calibrate_with_index(merged, &mut idx, &config, &file_str)
-            } else {
-                calibrator::calibrate(merged, &pipeline_config.feedback, &config, &file_str)
-            }
-        } else if let Some(ref mut index) = local_index {
-            if !index.is_empty() {
-                calibrator::calibrate_with_index(merged, index, &config, &file_str)
-            } else {
-                calibrator::calibrate(merged, &pipeline_config.feedback, &config, &file_str)
-            }
-        } else {
-            calibrator::calibrate(merged, &pipeline_config.feedback, &config, &file_str)
-        };
-        if cal_result.suppressed > 0 || cal_result.boosted > 0 {
-            tracing::debug!(
-                suppressed = cal_result.suppressed,
-                boosted = cal_result.boosted,
-                feedback_entries = pipeline_config.feedback.len(),
-                "calibrator decision per-file",
-            );
-        }
-
-        write_calibrator_traces(&cal_result.traces, pipeline_config.feedback_store.as_ref());
-        tracing::info!(
-            phase = "calibrate",
-            duration_ms = cal_t0.elapsed().as_millis() as u64,
-            suppressed = cal_result.suppressed,
-            boosted = cal_result.boosted,
-            final_findings = cal_result.findings.len(),
-            "phase complete"
-        );
-
-        (cal_result.findings, cal_result.suppressed)
-    } else {
-        (merged, 0)
-    };
-
-    let mut final_findings = final_findings;
-    for f in &mut final_findings {
-        f.compute_confidence();
-    }
-
-    Ok(FileReviewResult {
-        file_path: file_str,
-        findings: final_findings,
-        usage: total_usage,
-        suppressed: suppressed_count,
-        context_telemetry: None,
-        enrichment_metrics,
-        judge_metrics: JudgeMetrics::default(),
-    })
 }
 
 /// Stamp each finding with `in_diff` based on line-range overlap with changed hunks.
@@ -3223,7 +2955,6 @@ mod tests {
 
     #[test]
     fn ast_context_can_be_constructed() {
-        use crate::ast_grep::RuleMetadata;
         use std::collections::HashMap;
 
         let source = "fn main() {}";
@@ -3315,5 +3046,22 @@ mod tests {
             "code must be truncated to max_review_lines, got {} lines",
             lines_in_result
         );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn review_file_without_ast_runs_llm_only_path() {
+        let config = PipelineConfig::default();
+        let result = review_file(
+            std::path::Path::new("test.py"),
+            "def foo():\n    eval(input())\n",
+            None, // LLM-only
+            None, // no reviewer
+            &config,
+        )
+        .await
+        .unwrap();
+        // Without LLM reviewer, LLM-only path produces empty findings
+        assert!(result.findings.is_empty());
+        assert_eq!(result.judge_metrics, JudgeMetrics::default());
     }
 }

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -137,6 +137,26 @@ pub struct JudgeMetrics {
     pub latency_ms: u64,
 }
 
+/// Borrowed AST state threaded through the review pipeline for a single file.
+pub struct AstContext<'a> {
+    pub tree: &'a tree_sitter::Tree,
+    pub language: crate::parser::Language,
+    pub rule_metadata: std::collections::HashMap<String, crate::ast_grep::RuleMetadata>,
+}
+
+/// Owned, prepared file content and enrichment data ready for LLM prompt assembly.
+#[derive(Default)]
+pub struct FileContext {
+    pub redacted_code: String,
+    pub truncation_notice: Option<String>,
+    pub framework_docs: Option<Vec<String>>,
+    pub feedback_precedents: Option<Vec<String>>,
+    pub hydration_context: Option<crate::hydration::HydrationContext>,
+    pub context_block: Option<String>,
+    pub enrichment_metrics: crate::context_enrichment::EnrichmentMetrics,
+    pub context_telemetry: Option<crate::review_log::ContextTelemetry>,
+}
+
 pub struct PipelineConfig {
     pub complexity_threshold: u32,
     pub similarity_threshold: f64,
@@ -3120,5 +3140,33 @@ mod tests {
         let changed = vec![(250, 260)];
         classify_in_diff(&mut findings, &changed);
         assert_eq!(findings[0].in_diff, Some(true));
+    }
+
+    #[test]
+    fn ast_context_can_be_constructed() {
+        use crate::ast_grep::RuleMetadata;
+        use std::collections::HashMap;
+
+        let source = "fn main() {}";
+        let mut parser = tree_sitter::Parser::new();
+        parser.set_language(&tree_sitter_rust::LANGUAGE.into()).unwrap();
+        let tree = parser.parse(source, None).unwrap();
+        let ctx = AstContext {
+            tree: &tree,
+            language: crate::parser::Language::Rust,
+            rule_metadata: HashMap::new(),
+        };
+        assert!(ctx.rule_metadata.is_empty());
+    }
+
+    #[test]
+    fn file_context_defaults_to_empty() {
+        let ctx = FileContext::default();
+        assert!(ctx.redacted_code.is_empty());
+        assert!(ctx.framework_docs.is_none());
+        assert!(ctx.feedback_precedents.is_none());
+        assert!(ctx.hydration_context.is_none());
+        assert!(ctx.context_block.is_none());
+        assert!(ctx.truncation_notice.is_none());
     }
 }

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -141,7 +141,6 @@ pub struct JudgeMetrics {
 pub struct AstContext<'a> {
     pub tree: &'a tree_sitter::Tree,
     pub language: crate::parser::Language,
-    pub rule_metadata: std::collections::HashMap<String, crate::ast_grep::RuleMetadata>,
 }
 
 /// Owned, prepared file content and enrichment data ready for LLM prompt assembly.
@@ -1423,7 +1422,6 @@ pub async fn review_source(
     let ast_ctx = AstContext {
         tree: &tree,
         language: lang,
-        rule_metadata: std::collections::HashMap::new(),
     };
     review_file(file_path, source, Some(ast_ctx), llm, pipeline_config).await
 }
@@ -2085,7 +2083,6 @@ mod tests {
         let ast_ctx = AstContext {
             tree: &tree,
             language: lang,
-            rule_metadata: std::collections::HashMap::new(),
         };
         review_file(Path::new("test.rs"), source, Some(ast_ctx), llm, &config)
             .await
@@ -2627,7 +2624,6 @@ mod tests {
         let ast_ctx = AstContext {
             tree: &tree,
             language: Language::Rust,
-            rule_metadata: std::collections::HashMap::new(),
         };
         let result = review_file(
             std::path::Path::new("test.rs"),
@@ -2799,7 +2795,6 @@ mod tests {
         let ast_ctx = AstContext {
             tree: &tree,
             language: Language::Python,
-            rule_metadata: std::collections::HashMap::new(),
         };
         let result = review_file(Path::new("test.py"), source, Some(ast_ctx), None, &config)
             .await
@@ -2832,7 +2827,6 @@ mod tests {
         let ast_ctx = AstContext {
             tree: &tree,
             language: Language::Python,
-            rule_metadata: std::collections::HashMap::new(),
         };
         let result = review_file(Path::new("test.py"), source, Some(ast_ctx), None, &config)
             .await
@@ -2954,20 +2948,16 @@ mod tests {
 
     #[test]
     fn ast_context_can_be_constructed() {
-        use std::collections::HashMap;
-
         let source = "fn main() {}";
         let mut parser = tree_sitter::Parser::new();
         parser
             .set_language(&tree_sitter_rust::LANGUAGE.into())
             .unwrap();
         let tree = parser.parse(source, None).unwrap();
-        let ctx = AstContext {
+        let _ctx = AstContext {
             tree: &tree,
             language: crate::parser::Language::Rust,
-            rule_metadata: HashMap::new(),
         };
-        assert!(ctx.rule_metadata.is_empty());
     }
 
     #[test]

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -3016,8 +3016,10 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn build_file_context_truncates_large_source() {
-        let mut config = PipelineConfig::default();
-        config.max_review_lines = 5;
+        let config = PipelineConfig {
+            max_review_lines: 5,
+            ..PipelineConfig::default()
+        };
         let big_source = (0..20)
             .map(|i| format!("let x{} = {};", i, i))
             .collect::<Vec<_>>()

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -802,242 +802,34 @@ pub async fn review_file(
         if pipeline_config.models.is_empty() {
             // No models configured — skip LLM review
         } else {
-            // Redact secrets before LLM
-            let redacted_code = redact::redact_secrets(source);
-            let (review_code, truncation_notice) =
-                truncate_for_review(&redacted_code, pipeline_config.max_review_lines);
-
-            // Hydrate context: use diff ranges if available, else full file.
-            // Prose reviews skip hydration entirely — no AST-derived context.
-            //
-            // #137: match on full repo-relative path equality (NOT ends_with),
-            // resolved through the project root so `src/foo.rs` does not
-            // cross-match `nested/src/foo.rs`.
-            let redacted_ctx = if pipeline_config.mode.is_prose() {
-                crate::hydration::HydrationContext::default()
-            } else {
-                let (changed_lines, path_resolved) =
-                    if let Some(ref diff_ranges) = pipeline_config.diff_ranges {
-                        let repo_root = find_project_root(file_path);
-                        let resolver = ReviewPathResolver::new(&file_str, &repo_root);
-                        let lines: Vec<(u32, u32)> = diff_ranges
-                            .iter()
-                            .filter(|(path, _)| resolver.matches(path))
-                            .flat_map(|(_, ranges)| ranges.clone())
-                            .collect();
-                        (lines, resolver.resolved())
-                    } else {
-                        (Vec::new(), true)
-                    };
-                let hydration_ranges = if changed_lines.is_empty() {
-                    if pipeline_config.diff_ranges.is_some() && !path_resolved {
-                        tracing::warn!(
-                            file = %file_str,
-                            "diff-file provided but file path could not be \
-                             resolved relative to the repository root; \
-                             falling back to full-file hydration"
-                        );
-                    }
-                    let total_lines = source.lines().count() as u32;
-                    vec![(1, total_lines.max(1))]
-                } else {
-                    changed_lines
-                };
-                let hydrate_t0 = std::time::Instant::now();
-                let ctx = {
-                    let _span = tracing::info_span!("phase.hydrate", file = %file_str).entered();
-                    let c = hydration::hydrate(tree, source, lang, &hydration_ranges);
-                    tracing::info!(
-                        phase = "hydrate",
-                        duration_ms = hydrate_t0.elapsed().as_millis() as u64,
-                        callees = c.callee_signatures.len(),
-                        types = c.type_definitions.len(),
-                        imports = c.import_targets.len(),
-                        "phase complete"
-                    );
-                    c
-                };
-
-                // Redact hydration context for parity with redacted code
-                crate::hydration::HydrationContext {
-                    callee_signatures: ctx
-                        .callee_signatures
-                        .iter()
-                        .map(|s| redact::redact_secrets(s))
-                        .collect(),
-                    type_definitions: ctx
-                        .type_definitions
-                        .iter()
-                        .map(|s| redact::redact_secrets(s))
-                        .collect(),
-                    callers: ctx.callers.clone(),
-                    import_targets: ctx
-                        .import_targets
-                        .iter()
-                        .map(|s| redact::redact_secrets(s))
-                        .collect(),
-                    qualified_names: ctx.qualified_names.clone(),
-                }
+            // Build shared file context: redaction, hydration, Context7,
+            // feedback precedents, context injection.
+            let ast_ctx = AstContext {
+                tree,
+                language: lang,
+                rule_metadata: rule_metadata.clone(),
             };
+            let file_ctx =
+                build_file_context(file_path, source, Some(&ast_ctx), pipeline_config).await?;
 
-            // Fetch Context7 framework docs (curated frameworks + dep-based enrichment).
-            let framework_docs = if let Some(reason) = context7_skip_reason(pipeline_config) {
-                // --skip-context7 OR upstream init failed: no Context7 client
-                // constructed, no HTTP calls. Metrics stay at defaults.
-                tracing::debug!(reason, "Context7: enrichment skipped");
-                None
-            } else {
-                let project_root = find_project_root(file_path);
-                let mut domain = crate::domain::detect_domain(&project_root);
-                for fw in &pipeline_config.framework_overrides {
-                    if !domain.frameworks.contains(fw) {
-                        domain.frameworks.push(fw.clone());
-                    }
-                }
-                // Always run enrichment: dep-based path may produce docs even when no
-                // curated framework was detected (e.g. a Rust project with tokio).
-                // Prefer a shared review-level cache from PipelineConfig so cache
-                // state (positive AND negative resolves with 24h TTL) is shared
-                // across all files in this review. Fall back to a per-file ad-hoc
-                // cache when no shared one is wired (tests, single-file CLI).
-                let ctx7_t0 = std::time::Instant::now();
-                let _span = tracing::info_span!("phase.context7", file = %file_str).entered();
-                let policy = crate::enrichment_policy::EnrichmentPolicy {
-                    registry: pipeline_config
-                        .registry_client
-                        .as_ref()
-                        .map(|r| r.as_ref() as &dyn crate::enrichment_policy::RegistryClient),
-                };
-                let result = if let Some(shared) = pipeline_config.context7_fetcher.as_ref() {
-                    crate::context_enrichment::enrich_for_review_in_project(
-                        &project_root,
-                        &redacted_ctx.import_targets,
-                        &domain.frameworks,
-                        shared.as_ref(),
-                        &policy,
-                    )
-                } else {
-                    let inner = crate::context_enrichment::Context7HttpFetcher::new()?;
-                    let cached = crate::context_enrichment::CachedContextFetcher::new(&inner, 32);
-                    crate::context_enrichment::enrich_for_review_in_project(
-                        &project_root,
-                        &redacted_ctx.import_targets,
-                        &domain.frameworks,
-                        &cached,
-                        &policy,
-                    )
-                };
-                let docs = result.docs;
-                enrichment_metrics = result.metrics;
-                tracing::info!(
-                    phase = "context7",
-                    duration_ms = ctx7_t0.elapsed().as_millis() as u64,
-                    frameworks = domain.frameworks.len(),
-                    docs = docs.len(),
-                    resolved = enrichment_metrics.context7_resolved,
-                    resolve_failed = enrichment_metrics.context7_resolve_failed,
-                    query_failed = enrichment_metrics.context7_query_failed,
-                    skipped_popular = enrichment_metrics.context7_skipped_popular,
-                    budget_reduced = enrichment_metrics.context7_budget_reduced,
-                    "phase complete"
-                );
-                if !docs.is_empty() {
-                    tracing::debug!(docs_injected = docs.len(), "Context7 docs injected");
-                    Some(
-                        docs.iter()
-                            .map(|d| {
-                                crate::context_enrichment::format_context_section(
-                                    std::slice::from_ref(d),
-                                )
-                            })
-                            .collect(),
-                    )
-                } else if domain.frameworks.is_empty() {
-                    // No curated framework was requested — silently skip if dep path
-                    // also produced nothing. Long-tail dep failures are NOT fatal.
-                    None
-                } else {
-                    // skip_context7 is impossible here: the outer if-let returned None
-                    // already if it was set. Only the explicit-framework + Context7-down
-                    // case reaches this arm.
-                    anyhow::bail!(
-                        "Context7: failed to fetch docs for frameworks {:?}. \
-                     This degrades review quality. Fix the Context7 connection or use --skip-context7 to proceed without framework docs.",
-                        domain.frameworks
-                    );
-                }
-            };
+            enrichment_metrics = file_ctx.enrichment_metrics;
+            context_telemetry = file_ctx.context_telemetry;
 
-            // Query feedback index for few-shot precedents
-            let precedents = if let Some(ref shared) = shared_index {
-                let mut idx = shared.lock().unwrap();
-                query_feedback_precedents(&mut idx, &file_str, lang_name(lang), &redacted_code)
-            } else if let Some(ref mut idx) = local_index {
-                query_feedback_precedents(idx, &file_str, lang_name(lang), &redacted_code)
-            } else {
-                Vec::new()
-            };
+            hydration_text = file_ctx
+                .hydration_context
+                .as_ref()
+                .map(|ctx| render_hydration_for_grounding(ctx))
+                .unwrap_or_default();
 
-            // Optional `quorum context` injection (retrieve → plan → render).
-            // When no injector is wired, this is a no-op and `context_block`
-            // stays `None`, preserving byte-identical prompts.
-            // Prose reviews skip context injection — no AST-derived identifiers.
-            let context_block = if pipeline_config.mode.is_prose() {
-                None
-            } else {
-                match pipeline_config.context_injector.as_ref() {
-                    Some(inj) => {
-                        let mut identifiers: Vec<String> = redacted_ctx
-                            .callee_signatures
-                            .iter()
-                            .filter_map(|sig| extract_ident_from_signature(sig))
-                            .collect();
-                        identifiers.extend(redacted_ctx.import_targets.iter().cloned());
-                        identifiers.sort();
-                        identifiers.dedup();
-                        let text_sample: String = redacted_code.chars().take(400).collect();
-                        // Structural retrieval keys: bare qualified names of
-                        // callees + imports, drawn from AST hydration. Redact for
-                        // parity with the rest of the request surface.
-                        let structural_names: Vec<String> = {
-                            let mut v: Vec<String> = redacted_ctx
-                                .qualified_names
-                                .iter()
-                                .map(|s| redact::redact_secrets(s))
-                                .collect();
-                            v.sort();
-                            v.dedup();
-                            v
-                        };
-                        let req = crate::context::inject::InjectionRequest {
-                            file_path: file_str.clone(),
-                            language: Some(lang_name(lang).to_string()),
-                            identifiers,
-                            structural_names,
-                            text: text_sample,
-                        };
-                        let outcome = inj.inject(&req);
-                        context_telemetry = Some(outcome.telemetry);
-                        outcome.rendered
-                    }
-                    None => None,
-                }
-            };
-
-            hydration_text = render_hydration_for_grounding(&redacted_ctx);
             let req = ReviewRequest {
                 file_path: file_str.clone(),
                 language: lang_name(lang).to_string(),
-                code: review_code,
-                hydration_context: Some(redacted_ctx),
-                framework_docs,
-                feedback_precedents: if precedents.is_empty() {
-                    None
-                } else {
-                    Some(precedents)
-                },
-                context_block,
-                truncation_notice: truncation_notice.clone(),
+                code: file_ctx.redacted_code.clone(),
+                hydration_context: file_ctx.hydration_context.clone(),
+                framework_docs: file_ctx.framework_docs.clone(),
+                feedback_precedents: file_ctx.feedback_precedents.clone(),
+                context_block: file_ctx.context_block.clone(),
+                truncation_notice: file_ctx.truncation_notice.clone(),
                 focus: pipeline_config.focus.clone(),
                 mode: pipeline_config.mode,
             };
@@ -1069,7 +861,7 @@ pub async fn review_file(
                         match review::parse_llm_response(&resp.content, model) {
                             Ok(mut findings) => {
                                 let n_findings = findings.len();
-                                if let Some(ref notice) = truncation_notice {
+                                if let Some(notice) = &file_ctx.truncation_notice {
                                     for f in &mut findings {
                                         if matches!(f.source, crate::finding::Source::Llm(_)) {
                                             f.based_on_excerpt = Some(notice.clone());


### PR DESCRIPTION
## Summary

- Unify `review_file` and `review_file_llm_only` into a single `review_file` accepting `Option<AstContext>` — when `None`, AST-only phases (local analysis, ast-grep, judge) are skipped
- Extract shared context assembly (secret redaction, truncation, hydration, Context7 enrichment, feedback precedents, context injection) into `build_file_context()` returning an immutable `FileContext` struct
- Delete `review_file_llm_only` (~263 lines of duplicated code)
- Remove dead `rule_metadata` field from `AstContext` (identified by code quality review)
- Fix clippy warnings (collapsible ifs, redundant closure)

## Motivation

`review_file` and `review_file_llm_only` shared ~60% of their logic but were maintained as independent ~500-line functions. Changes to shared logic had to be applied twice and could silently diverge. This refactor creates a single code path with the `FileContext` seam enabling future work:
- Ablation hooks for each context phase (per user request)
- Multi-perspective reviews sharing pre-computed context
- Cross-run caching keyed on content+config hashes

## Changes

| File | Change |
|------|--------|
| `src/pipeline.rs` | Add `AstContext`, `FileContext` structs; extract `build_file_context()`; unify `review_file` signature; delete `review_file_llm_only` |
| `src/main.rs` | Update 2 call sites from `review_file_llm_only` to `review_file(..., None, ...)` |
| `src/context/phase6_integration_tests.rs` | Update 1 call site for new `AstContext` shape |

## Test plan

- [x] 1435 unit tests pass (`cargo test --bin quorum`)
- [x] 6 new tests: struct construction, redaction, hydration skip, truncation, LLM-only path
- [x] Clippy clean (0 warnings)
- [x] rustfmt clean
- [x] Release build compiles
- [x] Quorum self-review: 4 findings triaged (3 pre-existing wontfix, 1 pre-existing TP), 0 in-branch bugs
- [x] Code quality review: clean (dead `rule_metadata` field found and removed)

Closes #339

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined the file review pipeline by consolidating redundant code paths into a unified architecture with optional Abstract Syntax Tree support, reducing code duplication while maintaining all existing functionality.
  * Reorganized context preparation logic for improved code maintainability and efficiency in the review process.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jsnyder/quorum/pull/344?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->