### PR TITLE
fix(calibrate): normalize file paths in trace-feedback join (#307)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2713,7 +2713,7 @@ checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quorum"
-version = "0.22.2"
+version = "0.23.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/skills/skill-review-expert/skill.md
+++ b/skills/skill-review-expert/skill.md
@@ -26,9 +26,11 @@ Review a skill file against Claude's prompting guidelines and skill authoring be
 
 ## Tooling (run first)
 
-Automated scans provide evidence for checks A1, B5, D3, and D4. Run these before the manual review:
+Automated scans provide evidence for checks A1, B5, D3, and D4. Set the target path, then run all four:
 
 ```bash
+SKILL_FILE="path/to/skill.md"
+
 # A1: Negative framing scan — each hit is a candidate for positive reframing
 grep -n "Don't\|Do not\|Do NOT\|Never\|Avoid\|don't" "$SKILL_FILE"
 
@@ -39,7 +41,7 @@ grep -n '\\\\' "$SKILL_FILE"
 grep -n -i 'see \|above\|below\|described in' "$SKILL_FILE"
 
 # D4: Terminology frequency — spot synonyms for key concepts
-grep -o -i '\bfinding\b\|issue\b\|result\b\|problem\b\|check\b' "$SKILL_FILE" | sort | uniq -c | sort -rn
+grep -o -i '\b\(finding\|issue\|result\|problem\|check\)\b' "$SKILL_FILE" | sort | uniq -c | sort -rn
 ```
 
 ## Check Categories

--- a/src/calibrate.rs
+++ b/src/calibrate.rs
@@ -7,6 +7,7 @@
 use std::collections::{HashMap, HashSet};
 
 use crate::calibrator_model::{CalibratorModel, ModelMeta, ScoreWeights};
+use crate::file_util::{normalize_file_path_deep, path_suffix_eq};
 use crate::metrics;
 use crate::threshold_config::{PathThreshold, ThresholdConfig};
 
@@ -161,6 +162,8 @@ const MIN_MINORITY_CLASS: usize = 10;
 pub struct JoinStats {
     pub exact_raw: usize,
     pub exact_normalized: usize,
+    pub path_normalized: usize,
+    pub suffix_matched: usize,
     pub fuzzy_same_file: usize,
     pub raw_title_only: usize,
     pub normalized_title_only: usize,
@@ -213,8 +216,15 @@ pub fn join_feedback_and_traces_with_options(
     let mut norm_map: HashMap<(String, String), (f64, f64)> = HashMap::new();
     let mut norm_ambiguous: HashSet<(String, String)> = HashSet::new();
 
+    // Tier 2.5: deep-normalized path (norm_title, deep_norm_path) — #307
+    let mut deep_path_map: HashMap<(String, String), (f64, f64)> = HashMap::new();
+    let mut deep_path_ambiguous: HashSet<(String, String)> = HashSet::new();
+
     // Tier 3: fuzzy same-file: file_path -> Vec<(norm_title, weights)>
     let mut file_traces: HashMap<String, Vec<(String, (f64, f64))>> = HashMap::new();
+
+    // Tier 3.5: suffix index — filename -> Vec<(deep_norm_path, norm_title, weights)> — #307
+    let mut suffix_index: HashMap<String, Vec<(String, String, (f64, f64))>> = HashMap::new();
 
     // Tier 4: normalized title-only (for traces without file_path)
     let mut norm_title_only: HashMap<String, (f64, f64)> = HashMap::new();
@@ -237,6 +247,7 @@ pub fn join_feedback_and_traces_with_options(
         let tp_w = t["tp_weight"].as_f64().unwrap_or(0.0).max(0.0);
         let fp_w = t["fp_weight"].as_f64().unwrap_or(0.0).max(0.0);
         let norm = normalize_title(&title);
+        let deep_fp = normalize_file_path_deep(&fp);
 
         if fp.is_empty() {
             // Title-only trace (legacy, no file_path)
@@ -290,12 +301,36 @@ pub fn join_feedback_and_traces_with_options(
                     }
                 }
 
+                // Tier 2.5: deep-normalized path (#307)
+                if !norm.is_empty() && !deep_fp.is_empty() {
+                    let deep_key = (norm.clone(), deep_fp.clone());
+                    match deep_path_map.entry(deep_key.clone()) {
+                        std::collections::hash_map::Entry::Occupied(_) => {
+                            deep_path_ambiguous.insert(deep_key);
+                        }
+                        std::collections::hash_map::Entry::Vacant(e) => {
+                            e.insert((tp_w, fp_w));
+                        }
+                    }
+                }
+
                 // Tier 3: file -> normalized traces for fuzzy
                 if !norm.is_empty() {
                     file_traces
                         .entry(fp)
                         .or_default()
-                        .push((norm, (tp_w, fp_w)));
+                        .push((norm.clone(), (tp_w, fp_w)));
+                }
+
+                // Tier 3.5: suffix index (#307)
+                if !norm.is_empty() && !deep_fp.is_empty() {
+                    let filename = deep_fp.rsplit('/').next().unwrap_or("").to_string();
+                    if !filename.is_empty() {
+                        suffix_index
+                            .entry(filename)
+                            .or_default()
+                            .push((deep_fp, norm, (tp_w, fp_w)));
+                    }
                 }
             }
         }
@@ -312,6 +347,9 @@ pub fn join_feedback_and_traces_with_options(
     }
     for key in &norm_ambiguous {
         norm_map.remove(key);
+    }
+    for key in &deep_path_ambiguous {
+        deep_path_map.remove(key);
     }
     for key in &raw_title_only_ambiguous {
         raw_title_only.remove(key);
@@ -344,6 +382,7 @@ pub fn join_feedback_and_traces_with_options(
         }
         let fp = f["file_path"].as_str().unwrap_or("").to_string();
         let norm = normalize_title(&title);
+        let deep_fp = normalize_file_path_deep(&fp);
 
         // Tier 1: raw exact (title, file_path)
         if let Some(weights) = raw_map.get(&(title.clone(), fp.clone()))
@@ -360,6 +399,17 @@ pub fn join_feedback_and_traces_with_options(
             && push_sample(&mut samples, weights, is_positive)
         {
             stats.exact_normalized += 1;
+            continue;
+        }
+
+        // Tier 2.5: deep-normalized path (norm_title, deep_norm_path) -- #307
+        if !disable_fuzzy
+            && !norm.is_empty()
+            && !deep_fp.is_empty()
+            && let Some(weights) = deep_path_map.get(&(norm.clone(), deep_fp.clone()))
+            && push_sample(&mut samples, weights, is_positive)
+        {
+            stats.path_normalized += 1;
             continue;
         }
 
@@ -403,6 +453,26 @@ pub fn join_feedback_and_traces_with_options(
             }
         }
 
+        // Tier 3.5: suffix match -- catches absolute vs relative paths (#307)
+        if !disable_fuzzy && !norm.is_empty() && !deep_fp.is_empty() {
+            let filename = deep_fp.rsplit('/').next().unwrap_or("");
+            if let Some(candidates) = suffix_index.get(filename) {
+                let matches: Vec<&(f64, f64)> = candidates
+                    .iter()
+                    .filter(|(cand_path, cand_norm, _)| {
+                        *cand_norm == norm && path_suffix_eq(cand_path, &deep_fp)
+                    })
+                    .map(|(_, _, w)| w)
+                    .collect();
+                if matches.len() == 1
+                    && push_sample(&mut samples, matches[0], is_positive)
+                {
+                    stats.suffix_matched += 1;
+                    continue;
+                }
+            }
+        }
+
         // Title-only fallback (raw first, then normalized -- normalized skipped when fuzzy disabled)
         if let Some(weights) = raw_title_only.get(&title)
             && push_sample(&mut samples, weights, is_positive)
@@ -429,6 +499,8 @@ pub fn join_feedback_and_traces_with_options(
     tracing::info!(
         exact_raw = stats.exact_raw,
         exact_normalized = stats.exact_normalized,
+        path_normalized = stats.path_normalized,
+        suffix_matched = stats.suffix_matched,
         fuzzy_same_file = stats.fuzzy_same_file,
         raw_title_only = stats.raw_title_only,
         normalized_title_only = stats.normalized_title_only,
@@ -812,7 +884,10 @@ pub fn rescore_samples_with_model(
     let mut raw_ambiguous: HashSet<(String, String)> = HashSet::new();
     let mut norm_map: HashMap<(String, String), TraceInfo> = HashMap::new();
     let mut norm_ambiguous: HashSet<(String, String)> = HashSet::new();
+    let mut deep_path_map: HashMap<(String, String), TraceInfo> = HashMap::new();
+    let mut deep_path_ambiguous: HashSet<(String, String)> = HashSet::new();
     let mut file_traces: HashMap<String, Vec<(String, TraceInfo)>> = HashMap::new();
+    let mut suffix_index: HashMap<String, Vec<(String, String, TraceInfo)>> = HashMap::new();
     let mut norm_title_only: HashMap<String, TraceInfo> = HashMap::new();
     let mut norm_title_only_ambiguous: HashSet<String> = HashSet::new();
     let mut raw_title_only: HashMap<String, TraceInfo> = HashMap::new();
@@ -829,6 +904,7 @@ pub fn rescore_samples_with_model(
         let tp_w = t["tp_weight"].as_f64().unwrap_or(0.0).max(0.0);
         let fp_w = t["fp_weight"].as_f64().unwrap_or(0.0).max(0.0);
         let norm = normalize_title(&title);
+        let deep_fp = normalize_file_path_deep(&fp);
         let info = TraceInfo {
             tp_weight: tp_w,
             fp_weight: fp_w,
@@ -878,6 +954,24 @@ pub fn rescore_samples_with_model(
                         e.insert(info.clone());
                     }
                 }
+                if !deep_fp.is_empty() {
+                    let deep_key = (norm.clone(), deep_fp.clone());
+                    match deep_path_map.entry(deep_key.clone()) {
+                        std::collections::hash_map::Entry::Occupied(_) => {
+                            deep_path_ambiguous.insert(deep_key);
+                        }
+                        std::collections::hash_map::Entry::Vacant(e) => {
+                            e.insert(info.clone());
+                        }
+                    }
+                    let filename = deep_fp.rsplit('/').next().unwrap_or("").to_string();
+                    if !filename.is_empty() {
+                        suffix_index
+                            .entry(filename)
+                            .or_default()
+                            .push((deep_fp, norm.clone(), info.clone()));
+                    }
+                }
                 file_traces.entry(fp).or_default().push((norm, info));
             }
         }
@@ -888,6 +982,9 @@ pub fn rescore_samples_with_model(
     }
     for key in &norm_ambiguous {
         norm_map.remove(key);
+    }
+    for key in &deep_path_ambiguous {
+        deep_path_map.remove(key);
     }
     for key in &raw_title_only_ambiguous {
         raw_title_only.remove(key);
@@ -917,12 +1014,20 @@ pub fn rescore_samples_with_model(
         }
         let fp = f["file_path"].as_str().unwrap_or("").to_string();
         let norm = normalize_title(&title);
+        let deep_fp = normalize_file_path_deep(&fp);
 
         let matched = raw_map
             .get(&(title.clone(), fp.clone()))
             .or_else(|| {
                 if !disable_fuzzy && !norm.is_empty() {
                     norm_map.get(&(norm.clone(), fp.clone()))
+                } else {
+                    None
+                }
+            })
+            .or_else(|| {
+                if !disable_fuzzy && !norm.is_empty() && !deep_fp.is_empty() {
+                    deep_path_map.get(&(norm.clone(), deep_fp.clone()))
                 } else {
                     None
                 }
@@ -950,6 +1055,24 @@ pub fn rescore_samples_with_model(
                         && (best_score - second_best) >= FUZZY_AMBIGUITY_MARGIN
                     {
                         return best_info;
+                    }
+                }
+                None
+            })
+            .or_else(|| {
+                if !disable_fuzzy && !norm.is_empty() && !deep_fp.is_empty() {
+                    let filename = deep_fp.rsplit('/').next().unwrap_or("");
+                    if let Some(candidates) = suffix_index.get(filename) {
+                        let matches: Vec<&TraceInfo> = candidates
+                            .iter()
+                            .filter(|(cand_path, cand_norm, _)| {
+                                *cand_norm == norm && path_suffix_eq(cand_path, &deep_fp)
+                            })
+                            .map(|(_, _, info)| info)
+                            .collect();
+                        if matches.len() == 1 {
+                            return Some(matches[0]);
+                        }
                     }
                 }
                 None
@@ -1464,6 +1587,90 @@ mod tests {
         assert_eq!(stats.fuzzy_same_file, 1);
     }
 
+    // --- tier 2.5: deep-normalized path (#307) ---
+
+    #[test]
+    fn deep_path_matches_dotdot_prefix() {
+        let feedback = vec![make_feedback(
+            "SQL injection risk",
+            "tp",
+            "../../../samples/rust/patterns.rs",
+        )];
+        let traces = vec![make_trace(
+            "SQL injection risk",
+            2.0,
+            0.5,
+            Some("./samples/rust/patterns.rs"),
+        )];
+        let (samples, stats) = join_feedback_and_traces(&feedback, &traces);
+        assert_eq!(samples.len(), 1, "deep path norm should match ../../../ to ./");
+        assert_eq!(stats.path_normalized, 1);
+    }
+
+    #[test]
+    fn deep_path_matches_mixed_dotdot() {
+        let feedback = vec![make_feedback(
+            "Hardcoded secret",
+            "fp",
+            "../quorum-ast-rules/rules/python/tests/bare-except.py",
+        )];
+        let traces = vec![make_trace(
+            "Hardcoded secret",
+            0.0,
+            1.0,
+            Some("../../quorum-ast-rules/rules/python/tests/bare-except.py"),
+        )];
+        let (samples, stats) = join_feedback_and_traces(&feedback, &traces);
+        assert_eq!(samples.len(), 1);
+        assert_eq!(stats.path_normalized, 1);
+    }
+
+    // --- tier 3.5: suffix matching (#307) ---
+
+    #[test]
+    fn suffix_matches_absolute_vs_relative() {
+        let feedback = vec![make_feedback(
+            "Missing error context",
+            "tp",
+            "/Users/jsnyder/Sources/github.com/jsnyder/quorum/src/main.rs",
+        )];
+        let traces = vec![make_trace(
+            "Missing error context",
+            2.0,
+            0.5,
+            Some("src/main.rs"),
+        )];
+        let (samples, stats) = join_feedback_and_traces(&feedback, &traces);
+        assert_eq!(samples.len(), 1, "suffix match should recover absolute path");
+        assert_eq!(stats.suffix_matched, 1);
+    }
+
+    #[test]
+    fn suffix_rejects_filename_only_match() {
+        let feedback = vec![make_feedback("Bug", "tp", "/some/path/main.rs")];
+        let traces = vec![make_trace("Bug", 1.0, 0.5, Some("main.rs"))];
+        let (_samples, stats) = join_feedback_and_traces(&feedback, &traces);
+        assert_eq!(stats.suffix_matched, 0, "filename-only should not suffix match");
+    }
+
+    #[test]
+    fn suffix_rejects_ambiguous_matches() {
+        let feedback = vec![make_feedback(
+            "Unused variable",
+            "tp",
+            "/Users/jsnyder/Sources/repo/src/main.rs",
+        )];
+        let traces = vec![
+            make_trace("Unused variable", 2.0, 0.0, Some("project-a/src/main.rs")),
+            make_trace("Unused variable", 0.0, 2.0, Some("project-b/src/main.rs")),
+        ];
+        let (_samples, stats) = join_feedback_and_traces(&feedback, &traces);
+        assert_eq!(
+            stats.suffix_matched, 0,
+            "ambiguous suffix matches (both share src/main.rs suffix) should be skipped"
+        );
+    }
+
     // --- tier 4: normalized title-only ---
 
     #[test]
@@ -1674,6 +1881,7 @@ mod tests {
         assert_eq!(normalize_title("a-b: rest"), "rest");
         assert_eq!(normalize_title("a: rest"), "a rest");
     }
+
 
     #[test]
     fn normalize_multiple_backticks_and_parens() {

--- a/src/calibrate.rs
+++ b/src/calibrate.rs
@@ -326,10 +326,11 @@ pub fn join_feedback_and_traces_with_options(
                 if !norm.is_empty() && !deep_fp.is_empty() {
                     let filename = deep_fp.rsplit('/').next().unwrap_or("").to_string();
                     if !filename.is_empty() {
-                        suffix_index
-                            .entry(filename)
-                            .or_default()
-                            .push((deep_fp, norm, (tp_w, fp_w)));
+                        suffix_index.entry(filename).or_default().push((
+                            deep_fp,
+                            norm,
+                            (tp_w, fp_w),
+                        ));
                     }
                 }
             }
@@ -464,9 +465,7 @@ pub fn join_feedback_and_traces_with_options(
                     })
                     .map(|(_, _, w)| w)
                     .collect();
-                if matches.len() == 1
-                    && push_sample(&mut samples, matches[0], is_positive)
-                {
+                if matches.len() == 1 && push_sample(&mut samples, matches[0], is_positive) {
                     stats.suffix_matched += 1;
                     continue;
                 }
@@ -966,10 +965,11 @@ pub fn rescore_samples_with_model(
                     }
                     let filename = deep_fp.rsplit('/').next().unwrap_or("").to_string();
                     if !filename.is_empty() {
-                        suffix_index
-                            .entry(filename)
-                            .or_default()
-                            .push((deep_fp, norm.clone(), info.clone()));
+                        suffix_index.entry(filename).or_default().push((
+                            deep_fp,
+                            norm.clone(),
+                            info.clone(),
+                        ));
                     }
                 }
                 file_traces.entry(fp).or_default().push((norm, info));
@@ -1603,7 +1603,11 @@ mod tests {
             Some("./samples/rust/patterns.rs"),
         )];
         let (samples, stats) = join_feedback_and_traces(&feedback, &traces);
-        assert_eq!(samples.len(), 1, "deep path norm should match ../../../ to ./");
+        assert_eq!(
+            samples.len(),
+            1,
+            "deep path norm should match ../../../ to ./"
+        );
         assert_eq!(stats.path_normalized, 1);
     }
 
@@ -1641,7 +1645,11 @@ mod tests {
             Some("src/main.rs"),
         )];
         let (samples, stats) = join_feedback_and_traces(&feedback, &traces);
-        assert_eq!(samples.len(), 1, "suffix match should recover absolute path");
+        assert_eq!(
+            samples.len(),
+            1,
+            "suffix match should recover absolute path"
+        );
         assert_eq!(stats.suffix_matched, 1);
     }
 
@@ -1650,7 +1658,10 @@ mod tests {
         let feedback = vec![make_feedback("Bug", "tp", "/some/path/main.rs")];
         let traces = vec![make_trace("Bug", 1.0, 0.5, Some("main.rs"))];
         let (_samples, stats) = join_feedback_and_traces(&feedback, &traces);
-        assert_eq!(stats.suffix_matched, 0, "filename-only should not suffix match");
+        assert_eq!(
+            stats.suffix_matched, 0,
+            "filename-only should not suffix match"
+        );
     }
 
     #[test]
@@ -1881,7 +1892,6 @@ mod tests {
         assert_eq!(normalize_title("a-b: rest"), "rest");
         assert_eq!(normalize_title("a: rest"), "a rest");
     }
-
 
     #[test]
     fn normalize_multiple_backticks_and_parens() {

--- a/src/embeddings.rs
+++ b/src/embeddings.rs
@@ -155,7 +155,11 @@ mod tests {
             return;
         }
         let dir = super::quorum_cache_dir();
-        assert!(dir.is_absolute(), "cache_dir must be absolute, got: {}", dir.display());
+        assert!(
+            dir.is_absolute(),
+            "cache_dir must be absolute, got: {}",
+            dir.display()
+        );
         let dir2 = super::quorum_cache_dir();
         assert_eq!(dir, dir2, "cache_dir must be deterministic across calls");
     }

--- a/src/feedback.rs
+++ b/src/feedback.rs
@@ -455,7 +455,15 @@ impl FeedbackStore {
         // chance to surface unlock failures (rare but possible on NFS).
         FileExt::lock_exclusive(&file)
             .with_context(|| format!("Failed to lock feedback file: {}", self.path.display()))?;
-        let mut buf = serde_json::to_string(entry)?;
+        // #307: normalize file_path at write time to prevent join mismatches.
+        let normalized = if entry.file_path.contains("..") || entry.file_path.starts_with('/') {
+            let mut clean = entry.clone();
+            clean.file_path = crate::file_util::normalize_file_path_deep(&entry.file_path);
+            clean
+        } else {
+            entry.clone()
+        };
+        let mut buf = serde_json::to_string(&normalized)?;
         buf.push('\n');
         let write_result = file.write_all(buf.as_bytes());
         // Always attempt unlock, even if the write failed. Ignore unlock

--- a/src/file_util.rs
+++ b/src/file_util.rs
@@ -104,7 +104,10 @@ mod tests {
 
     #[test]
     fn deep_clean_relative_unchanged() {
-        assert_eq!(normalize_file_path_deep("src/calibrate.rs"), "src/calibrate.rs");
+        assert_eq!(
+            normalize_file_path_deep("src/calibrate.rs"),
+            "src/calibrate.rs"
+        );
     }
 
     #[test]

--- a/src/file_util.rs
+++ b/src/file_util.rs
@@ -10,6 +10,37 @@ pub fn normalize_file_path(path: &str) -> &str {
     p.strip_suffix('/').unwrap_or(p)
 }
 
+/// Deep path normalization: strip `.`, `..`, root, and trailing `/` to produce
+/// a clean relative path for cross-source matching (issue #307).
+///
+/// Unlike [`normalize_file_path`] (which only handles `./` prefix), this
+/// handles `../../../x`, `/absolute/paths/x`, and mixed cases.
+pub fn normalize_file_path_deep(raw: &str) -> String {
+    raw.split('/')
+        .filter(|s| !s.is_empty() && *s != "." && *s != "..")
+        .collect::<Vec<_>>()
+        .join("/")
+}
+
+/// Check if the shorter (normalized) path is a complete suffix of the longer
+/// path at a `/` boundary. Requires at least 2 components in the shorter path
+/// to avoid false matches on filename alone.
+pub fn path_suffix_eq(a: &str, b: &str) -> bool {
+    if a == b {
+        return true;
+    }
+    if a.is_empty() || b.is_empty() {
+        return false;
+    }
+    let (shorter, longer) = if a.len() <= b.len() { (a, b) } else { (b, a) };
+    if !shorter.contains('/') {
+        return false;
+    }
+    longer.ends_with(shorter)
+        && longer.len() > shorter.len()
+        && longer.as_bytes()[longer.len() - shorter.len() - 1] == b'/'
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -37,5 +68,92 @@ mod tests {
     #[test]
     fn normalize_empty_string() {
         assert_eq!(normalize_file_path(""), "");
+    }
+
+    // --- normalize_file_path_deep tests ---
+
+    #[test]
+    fn deep_strips_dot_dot_prefix() {
+        assert_eq!(
+            normalize_file_path_deep("../../../samples/rust/patterns.rs"),
+            "samples/rust/patterns.rs"
+        );
+    }
+
+    #[test]
+    fn deep_strips_dot_prefix() {
+        assert_eq!(normalize_file_path_deep("./src/main.rs"), "src/main.rs");
+    }
+
+    #[test]
+    fn deep_strips_root() {
+        assert_eq!(
+            normalize_file_path_deep("/Users/jsnyder/Sources/repo/src/main.rs"),
+            "Users/jsnyder/Sources/repo/src/main.rs"
+        );
+    }
+
+    #[test]
+    fn deep_clean_relative_unchanged() {
+        assert_eq!(normalize_file_path_deep("src/calibrate.rs"), "src/calibrate.rs");
+    }
+
+    #[test]
+    fn deep_empty() {
+        assert_eq!(normalize_file_path_deep(""), "");
+        assert_eq!(normalize_file_path_deep(".."), "");
+        assert_eq!(normalize_file_path_deep("./"), "");
+    }
+
+    #[test]
+    fn deep_collapses_double_slashes() {
+        assert_eq!(normalize_file_path_deep("src//main.rs"), "src/main.rs");
+    }
+
+    // --- path_suffix_eq tests ---
+
+    #[test]
+    fn suffix_eq_exact_match() {
+        assert!(path_suffix_eq("src/main.rs", "src/main.rs"));
+    }
+
+    #[test]
+    fn suffix_eq_absolute_vs_relative() {
+        assert!(path_suffix_eq(
+            "Users/jsnyder/Sources/repo/src/main.rs",
+            "src/main.rs"
+        ));
+    }
+
+    #[test]
+    fn suffix_eq_symmetric() {
+        assert!(path_suffix_eq(
+            "src/main.rs",
+            "Users/jsnyder/Sources/repo/src/main.rs"
+        ));
+    }
+
+    #[test]
+    fn suffix_eq_rejects_filename_only() {
+        assert!(!path_suffix_eq("main.rs", "Users/repo/src/main.rs"));
+    }
+
+    #[test]
+    fn suffix_eq_rejects_partial_component() {
+        assert!(!path_suffix_eq("rc/main.rs", "src/main.rs"));
+    }
+
+    #[test]
+    fn suffix_eq_rejects_empty() {
+        assert!(!path_suffix_eq("", "src/main.rs"));
+        assert!(!path_suffix_eq("src/main.rs", ""));
+    }
+
+    #[test]
+    fn suffix_eq_different_repos_same_relative() {
+        assert!(!path_suffix_eq(
+            "project-a/src/main.rs",
+            "project-b/src/main.rs"
+        ));
     }
 }

--- a/src/file_util.rs
+++ b/src/file_util.rs
@@ -16,10 +16,19 @@ pub fn normalize_file_path(path: &str) -> &str {
 /// Unlike [`normalize_file_path`] (which only handles `./` prefix), this
 /// handles `../../../x`, `/absolute/paths/x`, and mixed cases.
 pub fn normalize_file_path_deep(raw: &str) -> String {
-    raw.split('/')
-        .filter(|s| !s.is_empty() && *s != "." && *s != "..")
-        .collect::<Vec<_>>()
-        .join("/")
+    let mut components: Vec<&str> = Vec::new();
+    for seg in raw.split('/') {
+        match seg {
+            "" | "." => {}
+            ".." => {
+                if !components.is_empty() {
+                    components.pop();
+                }
+            }
+            _ => components.push(seg),
+        }
+    }
+    components.join("/")
 }
 
 /// Check if the shorter (normalized) path is a complete suffix of the longer
@@ -108,6 +117,12 @@ mod tests {
     #[test]
     fn deep_collapses_double_slashes() {
         assert_eq!(normalize_file_path_deep("src//main.rs"), "src/main.rs");
+    }
+
+    #[test]
+    fn deep_resolves_interior_dotdot() {
+        assert_eq!(normalize_file_path_deep("a/../b.rs"), "b.rs");
+        assert_eq!(normalize_file_path_deep("src/sub/../../main.rs"), "main.rs");
     }
 
     // --- path_suffix_eq tests ---

--- a/src/main.rs
+++ b/src/main.rs
@@ -2375,6 +2375,8 @@ fn run_calibrate(opts: cli::CalibrateOpts) -> i32 {
     eprintln!("\nJoin strategy breakdown:");
     eprintln!("  exact (raw):        {}", join_stats.exact_raw);
     eprintln!("  exact (normalized): {}", join_stats.exact_normalized);
+    eprintln!("  path (normalized):  {}", join_stats.path_normalized);
+    eprintln!("  suffix matched:     {}", join_stats.suffix_matched);
     eprintln!("  fuzzy (same-file):  {}", join_stats.fuzzy_same_file);
     eprintln!("  title-only (raw):   {}", join_stats.raw_title_only);
     eprintln!("  title-only (norm):  {}", join_stats.normalized_title_only);

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -48,7 +48,15 @@ fn write_calibrator_traces(
             Ok(mut file) => {
                 use std::io::Write;
                 for trace in traces {
-                    match serde_json::to_string(trace) {
+                    // #307: normalize file_path at write time
+                    let mut trace = trace.clone();
+                    if let Some(ref fp) = trace.file_path {
+                        let deep = crate::file_util::normalize_file_path_deep(fp);
+                        if deep != *fp {
+                            trace.file_path = Some(deep);
+                        }
+                    }
+                    match serde_json::to_string(&trace) {
                         Ok(json) => {
                             if let Err(e) = writeln!(file, "{}", json) {
                                 tracing::warn!(


### PR DESCRIPTION
## Summary

- Add `normalize_file_path_deep()` and `path_suffix_eq()` to `file_util.rs` for robust path matching across absolute, relative, and `../`-prefixed paths
- Add two new join tiers to the calibrator trace-feedback join: **deep-normalized path** (tier 2.5) catches `../` prefix mismatches; **suffix matching** (tier 3.5) catches absolute vs relative paths
- Normalize paths at write time in `FeedbackStore::record()` and `write_calibrator_traces()` to prevent future drift
- Apply matching normalization to `rescore_samples_with_model`
- Display new tier stats in `calibrate --dry-run` output

**Before:** 1,542 joined samples (932 unmatched)
**After:** 1,558 joined samples (916 unmatched, +16 from suffix matching)

The modest improvement reflects that the dataset has evolved since #307 was filed — most cross-project feedback now has matching traces. The write-time normalization prevents future path divergence. Filed #356 for repo-aware suffix matching as a follow-up.

## Test plan

- [x] 17 new tests: `normalize_file_path_deep` (5), `path_suffix_eq` (7), join tier behavior (5)
- [x] All 1,564 unit tests pass
- [x] Clippy clean
- [x] `calibrate --dry-run` shows new tier breakdown

Closes #307

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced feedback-to-trace matching with improved path recognition strategies that handle both absolute and relative file paths.
  * Added diagnostic output showing detailed breakdown of matching strategies used during calibration.

* **Bug Fixes**
  * Improved path normalization to better resolve file path mismatches across different reference formats.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jsnyder/quorum/pull/358?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->