### PR TITLE
feat: incremental indexing + unified index command + progress output

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -68,10 +68,9 @@ pub enum ContextCommand {
     /// Example: quorum context index --source myapp
     Index(ContextIndexOpts),
 
-    /// Re-index sources that have drifted since last extract.
-    ///
-    /// Example: quorum context refresh --all
-    Refresh(ContextRefreshOpts),
+    /// Alias for `index` (deprecated).
+    #[command(hide = true)]
+    Refresh(ContextIndexOpts),
 
     /// Semantic search across indexed chunks.
     ///
@@ -189,17 +188,10 @@ pub struct ContextIndexOpts {
     /// Index every registered source.
     #[arg(long, conflicts_with = "source")]
     pub all: bool,
-}
 
-#[derive(Parser)]
-pub struct ContextRefreshOpts {
-    /// Refresh a single named source. Mutually exclusive with --all.
-    #[arg(long, conflicts_with = "all")]
-    pub source: Option<String>,
-
-    /// Refresh every registered source.
-    #[arg(long, conflicts_with = "source")]
-    pub all: bool,
+    /// Force full rebuild even if sources are unchanged.
+    #[arg(long)]
+    pub force: bool,
 }
 
 #[derive(Parser)]

--- a/src/context/cli.rs
+++ b/src/context/cli.rs
@@ -20,8 +20,10 @@ use std::path::{Path, PathBuf};
 use anyhow::{Result, anyhow};
 use rusqlite::Connection;
 
+use std::collections::HashSet;
+
 use crate::context::config::{SourceEntry, SourceKind, SourceLocation, SourcesConfig};
-use crate::context::extract::dispatch::{ExtractConfig, extract_source};
+use crate::context::extract::dispatch::{ExtractConfig, extract_source, extract_source_filtered};
 use crate::context::index::builder::{IndexBuilder, ensure_vec_loaded};
 use crate::context::index::state::IndexState;
 #[cfg(feature = "embeddings")]
@@ -1041,6 +1043,89 @@ fn index_one_source<D: ContextDeps>(
     let layout = SourceLayout::for_source(deps.home_dir(), &entry.name);
     ensure_dir(&layout.dir)?;
 
+    // Check if we can do an incremental update.
+    let prior_head = layout
+        .state
+        .exists()
+        .then(|| IndexState::load(&layout.state).ok().flatten())
+        .flatten()
+        .and_then(|s| s.head_sha);
+
+    let current_head = match source_repo_root(entry) {
+        Some(root) => deps
+            .git()
+            .head_sha(root)
+            .map_err(|e| anyhow!("git head_sha({}): {e}", root.display()))?,
+        None => None,
+    };
+
+    // Try incremental: need prior HEAD, current HEAD, git diff, and existing DB.
+    let incremental_files = if let (Some(prev), Some(_curr)) = (&prior_head, &current_head) {
+        if let Some(root) = source_repo_root(entry) {
+            deps.git()
+                .diff_files(root, prev)
+                .ok()
+                .flatten()
+                .filter(|_| layout.db.exists())
+        } else {
+            None
+        }
+    } else {
+        None
+    };
+
+    if let Some(changed_files) = incremental_files {
+        if changed_files.is_empty() {
+            // HEAD moved but no files changed (merge commit, metadata-only).
+            let state = IndexState::new(deps.embedder().model_hash())
+                .with_head_sha(current_head.clone())
+                .with_indexed_at(deps.clock().now());
+            state
+                .save(&layout.state)
+                .map_err(|e| anyhow!("save state.json: {e}"))?;
+            return Ok(IndexSuccess {
+                chunks_inserted: 0,
+                head_sha: current_head,
+                skipped: None,
+            });
+        }
+
+        let file_filter: HashSet<String> = changed_files.into_iter().collect();
+        let extracted = extract_source_filtered(
+            entry,
+            &ExtractConfig::default(),
+            deps.clock(),
+            Some(&file_filter),
+        )
+        .map_err(|e| anyhow!("extract failed for '{}': {e}", entry.name))?;
+
+        let mut builder = IndexBuilder::new(&layout.db, deps.clock(), deps.embedder())
+            .map_err(|e| anyhow!("open index db: {e}"))?;
+        let report = builder
+            .update_files(
+                &entry.name,
+                &extracted.chunks,
+                &file_filter,
+                &extracted.structural_fingerprints,
+            )
+            .map_err(|e| anyhow!("incremental update failed for '{}': {e}", entry.name))?;
+
+        let state = IndexState::new(deps.embedder().model_hash())
+            .with_head_sha(current_head.clone())
+            .with_indexed_at(deps.clock().now());
+        state
+            .save(&layout.state)
+            .map_err(|e| anyhow!("save state.json: {e}"))?;
+
+        return Ok(IndexSuccess {
+            chunks_inserted: report.chunks_inserted,
+            head_sha: current_head,
+            skipped: None,
+        });
+    }
+
+    // --- Full rebuild path (existing logic) ---
+
     // Extract chunks. This is where nonexistent Path roots error out, and
     // the error propagates up as a single-source failure (caught by
     // run_index so --all can continue).
@@ -1081,7 +1166,7 @@ fn index_one_source<D: ContextDeps>(
 
     created.push(layout.db.clone());
 
-    // Record state so refresh knows whether to re-run.
+    // Record state so staleness checks know whether to re-run.
     let head_sha = match source_repo_root(entry) {
         Some(root) => deps
             .git()

--- a/src/context/cli.rs
+++ b/src/context/cli.rs
@@ -351,7 +351,6 @@ pub enum ContextCmd {
     Add(AddArgs),
     List(ListArgs),
     Index(IndexArgs),
-    Refresh(RefreshArgs),
     Query(QueryArgs),
     Prune(PruneArgs),
     Doctor(DoctorArgs),
@@ -364,7 +363,6 @@ impl ContextCmd {
             ContextCmd::Add(_) => "add",
             ContextCmd::List(_) => "list",
             ContextCmd::Index(_) => "index",
-            ContextCmd::Refresh(_) => "refresh",
             ContextCmd::Query(_) => "query",
             ContextCmd::Prune(_) => "prune",
             ContextCmd::Doctor(_) => "doctor",
@@ -423,11 +421,7 @@ pub enum SourceSelector {
 #[derive(Debug, Clone, Default)]
 pub struct IndexArgs {
     pub selector: SourceSelector,
-}
-
-#[derive(Debug, Clone, Default)]
-pub struct RefreshArgs {
-    pub selector: SourceSelector,
+    pub force: bool,
 }
 
 /// Output format for `quorum context query`.
@@ -538,7 +532,6 @@ pub fn run_context_cmd<D: ContextDeps>(cmd: &ContextCmd, deps: &D) -> Result<Cmd
         ContextCmd::Add(args) => run_add(args, deps),
         ContextCmd::List(args) => run_list(args, deps),
         ContextCmd::Index(args) => run_index(args, deps),
-        ContextCmd::Refresh(args) => run_refresh(args, deps),
         ContextCmd::Query(args) => run_query(args, deps),
         ContextCmd::Prune(args) => run_prune(args, deps),
         ContextCmd::Doctor(args) => run_doctor(args, deps),
@@ -920,6 +913,37 @@ struct IndexOutcome {
 struct IndexSuccess {
     chunks_inserted: usize,
     head_sha: Option<String>,
+    skipped: Option<String>,
+}
+
+enum StalenessResult {
+    UpToDate(String),
+    NeedsRebuild,
+}
+
+fn check_staleness<D: ContextDeps>(entry: &SourceEntry, deps: &D) -> StalenessResult {
+    let layout = SourceLayout::for_source(deps.home_dir(), &entry.name);
+    let current_head = match source_repo_root(entry) {
+        Some(root) if root.exists() => deps.git().head_sha(root).ok().flatten(),
+        _ => None,
+    };
+    let current_model = deps.embedder().model_hash();
+    if layout.state.exists() {
+        if let Ok(Some(on_disk)) = IndexState::load(&layout.state) {
+            let model_matches = on_disk.embedder_model_hash == current_model;
+            let head_matches = match (&on_disk.head_sha, &current_head) {
+                (Some(a), Some(b)) => a == b,
+                _ => false,
+            };
+            if model_matches && head_matches {
+                return StalenessResult::UpToDate(format!(
+                    "HEAD {} unchanged",
+                    current_head.as_deref().unwrap_or("?")
+                ));
+            }
+        }
+    }
+    StalenessResult::NeedsRebuild
 }
 
 fn run_index<D: ContextDeps>(args: &IndexArgs, deps: &D) -> Result<CmdOutput> {
@@ -935,6 +959,20 @@ fn run_index<D: ContextDeps>(args: &IndexArgs, deps: &D) -> Result<CmdOutput> {
     let mut outcomes: Vec<IndexOutcome> = Vec::with_capacity(entries.len());
     let mut created: Vec<PathBuf> = Vec::new();
     for entry in &entries {
+        // When not forced, check staleness before doing work.
+        if !args.force {
+            if let StalenessResult::UpToDate(reason) = check_staleness(entry, deps) {
+                outcomes.push(IndexOutcome {
+                    name: entry.name.clone(),
+                    result: Ok(IndexSuccess {
+                        chunks_inserted: 0,
+                        head_sha: None,
+                        skipped: Some(reason),
+                    }),
+                });
+                continue;
+            }
+        }
         match index_one_source(entry, deps, &mut created) {
             Ok(success) => outcomes.push(IndexOutcome {
                 name: entry.name.clone(),
@@ -955,6 +993,13 @@ fn run_index<D: ContextDeps>(args: &IndexArgs, deps: &D) -> Result<CmdOutput> {
     let mut failures = 0usize;
     for o in &outcomes {
         match &o.result {
+            Ok(s) if s.skipped.is_some() => {
+                lines.push(format!(
+                    "skipped '{}': {}",
+                    o.name,
+                    s.skipped.as_ref().unwrap()
+                ));
+            }
             Ok(s) => lines.push(format!(
                 "indexed '{}': {} chunks",
                 o.name, s.chunks_inserted
@@ -1055,108 +1100,7 @@ fn index_one_source<D: ContextDeps>(
     Ok(IndexSuccess {
         chunks_inserted: report.chunks_inserted,
         head_sha,
-    })
-}
-
-// --- Refresh handler --------------------------------------------------------
-
-fn run_refresh<D: ContextDeps>(args: &RefreshArgs, deps: &D) -> Result<CmdOutput> {
-    let cfg = load_sources_or_err(deps)?;
-    let entries = selected_sources(&cfg, &args.selector)?;
-    if entries.is_empty() {
-        return Ok(CmdOutput {
-            stdout: "no sources to refresh".to_string(),
-            ..Default::default()
-        });
-    }
-
-    let mut created: Vec<PathBuf> = Vec::new();
-    let mut lines: Vec<String> = Vec::new();
-    let mut warnings: Vec<String> = Vec::new();
-    let mut failures = 0usize;
-    for entry in &entries {
-        match refresh_one_source(entry, deps, &mut created) {
-            Ok(RefreshOutcome::Skipped { reason }) => {
-                lines.push(format!("skipped '{}': {reason}", entry.name));
-            }
-            Ok(RefreshOutcome::Rebuilt { chunks_inserted }) => {
-                lines.push(format!(
-                    "refreshed '{}': {} chunks",
-                    entry.name, chunks_inserted
-                ));
-            }
-            Err(e) => {
-                failures += 1;
-                tracing::warn!(source = %entry.name, error = %e, "refresh failed");
-                let line = format!("failed '{}': {e}", entry.name);
-                warnings.push(line.clone());
-                lines.push(line);
-            }
-        }
-    }
-
-    if failures == entries.len() && matches!(args.selector, SourceSelector::Single(_)) {
-        return Err(anyhow!(
-            lines
-                .last()
-                .cloned()
-                .unwrap_or_else(|| "refresh failed".into())
-        ));
-    }
-
-    Ok(CmdOutput {
-        stdout: lines.join("\n"),
-        created_paths: created,
-        removed_paths: Vec::new(),
-        warnings,
-        doctor_failed: None,
-    })
-}
-
-enum RefreshOutcome {
-    Skipped { reason: String },
-    Rebuilt { chunks_inserted: usize },
-}
-
-fn refresh_one_source<D: ContextDeps>(
-    entry: &SourceEntry,
-    deps: &D,
-    created: &mut Vec<PathBuf>,
-) -> Result<RefreshOutcome> {
-    let layout = SourceLayout::for_source(deps.home_dir(), &entry.name);
-
-    // Resolve current HEAD sha for the source (None for path-only or
-    // non-git directories; always triggers re-index).
-    let current_head = match source_repo_root(entry) {
-        Some(root) if root.exists() => deps
-            .git()
-            .head_sha(root)
-            .map_err(|e| anyhow!("git head_sha({}): {e}", root.display()))?,
-        _ => None,
-    };
-    let current_model = deps.embedder().model_hash();
-
-    if layout.state.exists()
-        && let Some(on_disk) =
-            IndexState::load(&layout.state).map_err(|e| anyhow!("load state.json: {e}"))?
-    {
-        let model_matches = on_disk.embedder_model_hash == current_model;
-        let head_matches = match (&on_disk.head_sha, &current_head) {
-            (Some(a), Some(b)) => a == b,
-            // If either side is None (path source or unavailable git),
-            // we can't certify "unchanged" — fall through to re-index.
-            _ => false,
-        };
-        if model_matches && head_matches {
-            return Ok(RefreshOutcome::Skipped {
-                reason: format!("HEAD {} unchanged", current_head.as_deref().unwrap_or("?")),
-            });
-        }
-    }
-
-    let success = index_one_source(entry, deps, created)?;
-    Ok(RefreshOutcome::Rebuilt {
-        chunks_inserted: success.chunks_inserted,
+        skipped: None,
     })
 }
 

--- a/src/context/cli.rs
+++ b/src/context/cli.rs
@@ -932,19 +932,19 @@ fn check_staleness<D: ContextDeps>(entry: &SourceEntry, deps: &D) -> StalenessRe
         _ => None,
     };
     let current_model = deps.embedder().model_hash();
-    if layout.state.exists() {
-        if let Ok(Some(on_disk)) = IndexState::load(&layout.state) {
-            let model_matches = on_disk.embedder_model_hash == current_model;
-            let head_matches = match (&on_disk.head_sha, &current_head) {
-                (Some(a), Some(b)) => a == b,
-                _ => false,
-            };
-            if model_matches && head_matches {
-                return StalenessResult::UpToDate(format!(
-                    "HEAD {} unchanged",
-                    current_head.as_deref().unwrap_or("?")
-                ));
-            }
+    if layout.state.exists()
+        && let Ok(Some(on_disk)) = IndexState::load(&layout.state)
+    {
+        let model_matches = on_disk.embedder_model_hash == current_model;
+        let head_matches = match (&on_disk.head_sha, &current_head) {
+            (Some(a), Some(b)) => a == b,
+            _ => false,
+        };
+        if model_matches && head_matches {
+            return StalenessResult::UpToDate(format!(
+                "HEAD {} unchanged",
+                current_head.as_deref().unwrap_or("?")
+            ));
         }
     }
     StalenessResult::NeedsRebuild
@@ -964,20 +964,20 @@ fn run_index<D: ContextDeps>(args: &IndexArgs, deps: &D) -> Result<CmdOutput> {
     let mut created: Vec<PathBuf> = Vec::new();
     for entry in &entries {
         // When not forced, check staleness before doing work.
-        if !args.force {
-            if let StalenessResult::UpToDate(reason) = check_staleness(entry, deps) {
-                outcomes.push(IndexOutcome {
-                    name: entry.name.clone(),
-                    result: Ok(IndexSuccess {
-                        chunks_inserted: 0,
-                        head_sha: None,
-                        skipped: Some(reason),
-                        files_extracted: 0,
-                        incremental: false,
-                    }),
-                });
-                continue;
-            }
+        if !args.force
+            && let StalenessResult::UpToDate(reason) = check_staleness(entry, deps)
+        {
+            outcomes.push(IndexOutcome {
+                name: entry.name.clone(),
+                result: Ok(IndexSuccess {
+                    chunks_inserted: 0,
+                    head_sha: None,
+                    skipped: Some(reason),
+                    files_extracted: 0,
+                    incremental: false,
+                }),
+            });
+            continue;
         }
         match index_one_source(entry, deps, &mut created) {
             Ok(success) => outcomes.push(IndexOutcome {

--- a/src/context/cli.rs
+++ b/src/context/cli.rs
@@ -916,6 +916,8 @@ struct IndexSuccess {
     chunks_inserted: usize,
     head_sha: Option<String>,
     skipped: Option<String>,
+    files_extracted: usize,
+    incremental: bool,
 }
 
 enum StalenessResult {
@@ -970,6 +972,8 @@ fn run_index<D: ContextDeps>(args: &IndexArgs, deps: &D) -> Result<CmdOutput> {
                         chunks_inserted: 0,
                         head_sha: None,
                         skipped: Some(reason),
+                        files_extracted: 0,
+                        incremental: false,
                     }),
                 });
                 continue;
@@ -1002,10 +1006,18 @@ fn run_index<D: ContextDeps>(args: &IndexArgs, deps: &D) -> Result<CmdOutput> {
                     s.skipped.as_ref().unwrap()
                 ));
             }
-            Ok(s) => lines.push(format!(
-                "indexed '{}': {} chunks",
-                o.name, s.chunks_inserted
-            )),
+            Ok(s) if s.incremental => {
+                lines.push(format!(
+                    "indexed '{}': {} chunks from {} changed files",
+                    o.name, s.chunks_inserted, s.files_extracted
+                ));
+            }
+            Ok(s) => {
+                lines.push(format!(
+                    "indexed '{}': {} files, {} chunks",
+                    o.name, s.files_extracted, s.chunks_inserted
+                ));
+            }
             Err(msg) => {
                 failures += 1;
                 let line = format!("failed '{}': {msg}", o.name);
@@ -1087,6 +1099,8 @@ fn index_one_source<D: ContextDeps>(
                 chunks_inserted: 0,
                 head_sha: current_head,
                 skipped: None,
+                files_extracted: 0,
+                incremental: true,
             });
         }
 
@@ -1121,6 +1135,8 @@ fn index_one_source<D: ContextDeps>(
             chunks_inserted: report.chunks_inserted,
             head_sha: current_head,
             skipped: None,
+            files_extracted: extracted.diagnostics.extracted_files,
+            incremental: true,
         });
     }
 
@@ -1186,6 +1202,8 @@ fn index_one_source<D: ContextDeps>(
         chunks_inserted: report.chunks_inserted,
         head_sha,
         skipped: None,
+        files_extracted: extracted.diagnostics.extracted_files,
+        incremental: false,
     })
 }
 

--- a/src/context/cli.rs
+++ b/src/context/cli.rs
@@ -979,7 +979,7 @@ fn run_index<D: ContextDeps>(args: &IndexArgs, deps: &D) -> Result<CmdOutput> {
             });
             continue;
         }
-        match index_one_source(entry, deps, &mut created) {
+        match index_one_source(entry, deps, &mut created, args.force) {
             Ok(success) => outcomes.push(IndexOutcome {
                 name: entry.name.clone(),
                 result: Ok(success),
@@ -1051,17 +1051,23 @@ fn index_one_source<D: ContextDeps>(
     entry: &SourceEntry,
     deps: &D,
     created: &mut Vec<PathBuf>,
+    force: bool,
 ) -> Result<IndexSuccess> {
     let layout = SourceLayout::for_source(deps.home_dir(), &entry.name);
     ensure_dir(&layout.dir)?;
 
     // Check if we can do an incremental update.
-    let prior_head = layout
+    // Incremental requires: not forced, model hash matches, prior+current HEAD, valid diff, DB exists.
+    let prior_state = layout
         .state
         .exists()
         .then(|| IndexState::load(&layout.state).ok().flatten())
-        .flatten()
-        .and_then(|s| s.head_sha);
+        .flatten();
+    let model_matches = prior_state
+        .as_ref()
+        .map(|s| s.embedder_model_hash == deps.embedder().model_hash())
+        .unwrap_or(false);
+    let prior_head = prior_state.and_then(|s| s.head_sha);
 
     let current_head = match source_repo_root(entry) {
         Some(root) => deps
@@ -1071,8 +1077,11 @@ fn index_one_source<D: ContextDeps>(
         None => None,
     };
 
-    // Try incremental: need prior HEAD, current HEAD, git diff, and existing DB.
-    let incremental_files = if let (Some(prev), Some(_curr)) = (&prior_head, &current_head) {
+    // Try incremental: need not-forced, model match, prior HEAD, current HEAD, git diff, and existing DB.
+    let incremental_files = if !force
+        && model_matches
+        && let (Some(prev), Some(_curr)) = (&prior_head, &current_head)
+    {
         if let Some(root) = source_repo_root(entry) {
             deps.git()
                 .diff_files(root, prev)
@@ -1123,6 +1132,12 @@ fn index_one_source<D: ContextDeps>(
                 &extracted.structural_fingerprints,
             )
             .map_err(|e| anyhow!("incremental update failed for '{}': {e}", entry.name))?;
+
+        // Remove stale chunks.jsonl so repair/doctor does a full re-extract
+        // rather than rebuilding from outdated chunk data.
+        if layout.jsonl.exists() {
+            let _ = std::fs::remove_file(&layout.jsonl);
+        }
 
         let state = IndexState::new(deps.embedder().model_hash())
             .with_head_sha(current_head.clone())

--- a/src/context/cli_tests.rs
+++ b/src/context/cli_tests.rs
@@ -2,8 +2,8 @@
 
 use super::cli::{
     AddArgs, AddLocation, CheckStatus, ContextCmd, ContextDeps, DoctorArgs, DoctorFormat,
-    IndexArgs, ListArgs, ListFormat, PruneArgs, QueryArgs, QueryFormat, RefreshArgs,
-    SourceSelector, TestDeps, run_context_cmd,
+    IndexArgs, ListArgs, ListFormat, PruneArgs, QueryArgs, QueryFormat, SourceSelector, TestDeps,
+    run_context_cmd,
 };
 use super::config::{SourceLocation, SourcesConfig};
 use std::path::PathBuf;
@@ -716,6 +716,7 @@ fn index_single_source_creates_jsonl_and_db_under_home() {
 
     let args = IndexArgs {
         selector: SourceSelector::Single("mini".to_string()),
+        force: true,
     };
     let out = run_context_cmd(&ContextCmd::Index(args), &deps).expect("index");
 
@@ -777,6 +778,7 @@ fn index_all_continues_past_single_source_failure() {
 
     let args = IndexArgs {
         selector: SourceSelector::All,
+        force: true,
     };
     let out = run_context_cmd(&ContextCmd::Index(args), &deps)
         .expect("--all must not hard-error when only some sources fail");
@@ -813,6 +815,7 @@ fn index_is_idempotent() {
     seed_single_source(&deps, "mini", "mini-rust");
     let args = || IndexArgs {
         selector: SourceSelector::Single("mini".to_string()),
+        force: true,
     };
 
     run_context_cmd(&ContextCmd::Index(args()), &deps).expect("first index");
@@ -842,31 +845,33 @@ fn index_is_idempotent() {
 }
 
 #[test]
-fn refresh_skips_when_head_sha_unchanged() {
+fn index_skips_when_head_sha_unchanged_and_not_forced() {
     let deps = TestDeps::new();
     seed_single_source(&deps, "mini", "mini-rust");
 
-    // First call acts as an index (no state on disk yet), second call must
-    // short-circuit because fake git returns the same HEAD sha.
+    // First call: force index (no state on disk yet).
     run_context_cmd(
-        &ContextCmd::Refresh(RefreshArgs {
+        &ContextCmd::Index(IndexArgs {
             selector: SourceSelector::Single("mini".to_string()),
+            force: true,
         }),
         &deps,
     )
-    .expect("first refresh");
+    .expect("first index");
 
+    // Second call: non-forced; must skip because fake git returns same HEAD sha.
     let out = run_context_cmd(
-        &ContextCmd::Refresh(RefreshArgs {
+        &ContextCmd::Index(IndexArgs {
             selector: SourceSelector::Single("mini".to_string()),
+            force: false,
         }),
         &deps,
     )
-    .expect("second refresh");
+    .expect("second index");
 
     assert!(
         out.stdout.contains("skipped 'mini'"),
-        "second refresh must report a skip: {:?}",
+        "second non-forced index must report a skip: {:?}",
         out.stdout
     );
     // No fresh paths created on a skip.
@@ -878,18 +883,19 @@ fn refresh_skips_when_head_sha_unchanged() {
 }
 
 #[test]
-fn refresh_rebuilds_on_embedder_model_hash_mismatch() {
+fn index_rebuilds_on_embedder_model_hash_mismatch() {
     let deps = TestDeps::new();
     seed_single_source(&deps, "mini", "mini-rust");
 
     // First index to lay down state.json.
     run_context_cmd(
-        &ContextCmd::Refresh(RefreshArgs {
+        &ContextCmd::Index(IndexArgs {
             selector: SourceSelector::Single("mini".to_string()),
+            force: true,
         }),
         &deps,
     )
-    .expect("first refresh");
+    .expect("first index");
 
     // Corrupt state.json so the recorded model hash differs from the
     // current embedder's model hash.
@@ -903,18 +909,19 @@ fn refresh_rebuilds_on_embedder_model_hash_mismatch() {
     parsed["embedder_model_hash"] = serde_json::json!("stale-model-v0");
     std::fs::write(&state_path, serde_json::to_string_pretty(&parsed).unwrap()).unwrap();
 
-    // Refresh should now *rebuild* rather than skip, even though HEAD is
-    // unchanged.
+    // Non-forced index should now *rebuild* rather than skip because model
+    // hash doesn't match.
     let out = run_context_cmd(
-        &ContextCmd::Refresh(RefreshArgs {
+        &ContextCmd::Index(IndexArgs {
             selector: SourceSelector::Single("mini".to_string()),
+            force: false,
         }),
         &deps,
     )
-    .expect("third refresh");
+    .expect("third index");
 
     assert!(
-        out.stdout.contains("refreshed 'mini'"),
+        out.stdout.contains("indexed 'mini'"),
         "model-hash mismatch must trigger rebuild: {:?}",
         out.stdout
     );
@@ -929,12 +936,55 @@ fn refresh_rebuilds_on_embedder_model_hash_mismatch() {
 }
 
 #[test]
+fn index_skips_unchanged_source_when_not_forced() {
+    let deps = TestDeps::new();
+    seed_single_source(&deps, "mini", "mini-rust");
+    let args = IndexArgs {
+        selector: SourceSelector::Single("mini".to_string()),
+        force: true,
+    };
+    run_context_cmd(&ContextCmd::Index(args), &deps).expect("first index");
+    let args2 = IndexArgs {
+        selector: SourceSelector::Single("mini".to_string()),
+        force: false,
+    };
+    let out = run_context_cmd(&ContextCmd::Index(args2), &deps).expect("second index");
+    assert!(
+        out.stdout.contains("skipped 'mini'"),
+        "must skip unchanged: {:?}",
+        out.stdout
+    );
+}
+
+#[test]
+fn index_force_rebuilds_even_when_unchanged() {
+    let deps = TestDeps::new();
+    seed_single_source(&deps, "mini", "mini-rust");
+    let args = IndexArgs {
+        selector: SourceSelector::Single("mini".to_string()),
+        force: true,
+    };
+    run_context_cmd(&ContextCmd::Index(args), &deps).expect("first index");
+    let forced = IndexArgs {
+        selector: SourceSelector::Single("mini".to_string()),
+        force: true,
+    };
+    let out = run_context_cmd(&ContextCmd::Index(forced), &deps).expect("forced index");
+    assert!(
+        out.stdout.contains("indexed 'mini'"),
+        "forced must rebuild: {:?}",
+        out.stdout
+    );
+}
+
+#[test]
 fn query_returns_ranked_hits_for_indexed_source() {
     let deps = TestDeps::new();
     seed_single_source(&deps, "mini", "mini-rust");
     run_context_cmd(
         &ContextCmd::Index(IndexArgs {
             selector: SourceSelector::Single("mini".to_string()),
+            force: true,
         }),
         &deps,
     )
@@ -962,6 +1012,7 @@ fn query_json_output_has_stable_schema() {
     run_context_cmd(
         &ContextCmd::Index(IndexArgs {
             selector: SourceSelector::Single("mini".to_string()),
+            force: true,
         }),
         &deps,
     )
@@ -1005,6 +1056,7 @@ fn query_explain_includes_score_breakdown() {
     run_context_cmd(
         &ContextCmd::Index(IndexArgs {
             selector: SourceSelector::Single("mini".to_string()),
+            force: true,
         }),
         &deps,
     )
@@ -1215,6 +1267,7 @@ fn seed_and_index(deps: &TestDeps, name: &str, fixture: &str) {
     run_context_cmd(
         &ContextCmd::Index(IndexArgs {
             selector: SourceSelector::Single(name.to_string()),
+            force: true,
         }),
         deps,
     )
@@ -1479,6 +1532,7 @@ fn doctor_repair_is_best_effort_continues_past_one_source_failure() {
     run_context_cmd(
         &ContextCmd::Index(IndexArgs {
             selector: SourceSelector::Single("good".to_string()),
+            force: true,
         }),
         &deps,
     )

--- a/src/context/cli_tests.rs
+++ b/src/context/cli_tests.rs
@@ -1031,6 +1031,25 @@ fn index_incremental_skips_reembed_when_no_files_changed() {
 }
 
 #[test]
+fn index_output_includes_file_count() {
+    let deps = TestDeps::new();
+    seed_single_source(&deps, "mini", "mini-rust");
+    let out = run_context_cmd(
+        &ContextCmd::Index(IndexArgs {
+            selector: SourceSelector::Single("mini".to_string()),
+            force: true,
+        }),
+        &deps,
+    )
+    .expect("index");
+    assert!(
+        out.stdout.contains("files") && out.stdout.contains("chunks"),
+        "output should include files/chunks: {:?}",
+        out.stdout
+    );
+}
+
+#[test]
 fn query_returns_ranked_hits_for_indexed_source() {
     let deps = TestDeps::new();
     seed_single_source(&deps, "mini", "mini-rust");

--- a/src/context/cli_tests.rs
+++ b/src/context/cli_tests.rs
@@ -978,6 +978,59 @@ fn index_force_rebuilds_even_when_unchanged() {
 }
 
 #[test]
+fn index_incremental_skips_reembed_when_no_files_changed() {
+    let mut deps = TestDeps::new();
+    seed_single_source(&deps, "mini", "mini-rust");
+
+    // Full index first.
+    run_context_cmd(
+        &ContextCmd::Index(IndexArgs {
+            selector: SourceSelector::Single("mini".to_string()),
+            force: true,
+        }),
+        &deps,
+    )
+    .expect("first index");
+
+    let db_path = deps.home_dir().join("sources/mini/index.db");
+    let count_before: i64 = {
+        let conn = rusqlite::Connection::open(&db_path).unwrap();
+        conn.query_row("SELECT COUNT(*) FROM chunks", [], |r| r.get(0))
+            .unwrap()
+    };
+
+    // Advance HEAD but set empty diff (merge commit / metadata-only).
+    let fixture_root = fixture_path("mini-rust");
+    deps.git_mut()
+        .set_head(&fixture_root, Some("newhead123".to_string()));
+    deps.git_mut().set_diff_files(&fixture_root, vec![]);
+
+    let out = run_context_cmd(
+        &ContextCmd::Index(IndexArgs {
+            selector: SourceSelector::Single("mini".to_string()),
+            force: false,
+        }),
+        &deps,
+    )
+    .expect("incremental");
+
+    let count_after: i64 = {
+        let conn = rusqlite::Connection::open(&db_path).unwrap();
+        conn.query_row("SELECT COUNT(*) FROM chunks", [], |r| r.get(0))
+            .unwrap()
+    };
+    assert_eq!(
+        count_before, count_after,
+        "no files changed -> chunks unchanged"
+    );
+    assert!(
+        out.stdout.contains("indexed 'mini'"),
+        "should report indexed: {:?}",
+        out.stdout
+    );
+}
+
+#[test]
 fn query_returns_ranked_hits_for_indexed_source() {
     let deps = TestDeps::new();
     seed_single_source(&deps, "mini", "mini-rust");

--- a/src/context/extract/dispatch.rs
+++ b/src/context/extract/dispatch.rs
@@ -222,10 +222,10 @@ fn extract_source_inner(
             diagnostics.total_files_scanned += 1;
 
             // File filter: skip files not in the changed set.
-            if let Some(filter) = file_filter {
-                if !filter.contains(&rel) {
-                    continue;
-                }
+            if let Some(filter) = file_filter
+                && !filter.contains(&rel)
+            {
+                continue;
             }
 
             // Tier 1: per-source ignore.

--- a/src/context/extract/dispatch.rs
+++ b/src/context/extract/dispatch.rs
@@ -5,7 +5,7 @@
 //! the produced [`Chunk`]s and a [`Diagnostics`] summary. One bad file does
 //! not abort the run; extractor errors are collected per-file.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 
 use glob::Pattern;
@@ -101,6 +101,28 @@ pub fn extract_source(
     source: &SourceEntry,
     config: &ExtractConfig,
     clock: &dyn Clock,
+) -> anyhow::Result<ExtractResult> {
+    extract_source_inner(source, config, clock, None)
+}
+
+/// Like [`extract_source`], but accepts an optional file filter. When
+/// `file_filter` is `Some`, only files whose relative (forward-slash) path
+/// appears in the set are extracted; all others are skipped before any
+/// further processing. When `None`, every file is considered (full extract).
+pub fn extract_source_filtered(
+    source: &SourceEntry,
+    config: &ExtractConfig,
+    clock: &dyn Clock,
+    file_filter: Option<&HashSet<String>>,
+) -> anyhow::Result<ExtractResult> {
+    extract_source_inner(source, config, clock, file_filter)
+}
+
+fn extract_source_inner(
+    source: &SourceEntry,
+    config: &ExtractConfig,
+    clock: &dyn Clock,
+    file_filter: Option<&HashSet<String>>,
 ) -> anyhow::Result<ExtractResult> {
     let root = match &source.location {
         SourceLocation::Path(p) => p.clone(),
@@ -198,6 +220,13 @@ pub fn extract_source(
             };
 
             diagnostics.total_files_scanned += 1;
+
+            // File filter: skip files not in the changed set.
+            if let Some(filter) = file_filter {
+                if !filter.contains(&rel) {
+                    continue;
+                }
+            }
 
             // Tier 1: per-source ignore.
             if let Some(pat) = first_match(&per_source_patterns, &rel) {
@@ -533,4 +562,58 @@ fn relative_forward_slash(root: &Path, file: &Path) -> Option<String> {
         out.push_str(comp.as_os_str().to_str()?);
     }
     Some(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::context::config::{SourceEntry, SourceKind, SourceLocation};
+    use crate::context::index::traits::FixedClock;
+    use std::collections::HashSet;
+
+    fn mini_rust_source() -> SourceEntry {
+        let fixture = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("tests/fixtures/context/repos/mini-rust");
+        SourceEntry {
+            name: "test".into(),
+            kind: SourceKind::Rust,
+            location: SourceLocation::Path(fixture),
+            weight: None,
+            ignore: vec![],
+            paths: vec![],
+            provides: vec![],
+            include_for: vec![],
+            exclude_for: vec![],
+        }
+    }
+
+    #[test]
+    fn extract_with_file_filter_only_extracts_matching_files() {
+        let source = mini_rust_source();
+        let clock = FixedClock::epoch();
+        let config = ExtractConfig::default();
+        let filter: HashSet<String> = ["src/token.rs".to_string()].into_iter().collect();
+        let result = extract_source_filtered(&source, &config, &clock, Some(&filter)).unwrap();
+        for chunk in &result.chunks {
+            assert_eq!(
+                chunk.metadata.source_path, "src/token.rs",
+                "chunk from wrong file: {:?}",
+                chunk.metadata.source_path
+            );
+        }
+        assert!(
+            !result.chunks.is_empty(),
+            "filter should still extract matching file"
+        );
+    }
+
+    #[test]
+    fn extract_with_no_filter_extracts_all() {
+        let source = mini_rust_source();
+        let clock = FixedClock::epoch();
+        let config = ExtractConfig::default();
+        let unfiltered = extract_source_filtered(&source, &config, &clock, None).unwrap();
+        let all = extract_source(&source, &config, &clock).unwrap();
+        assert_eq!(unfiltered.chunks.len(), all.chunks.len());
+    }
 }

--- a/src/context/index/builder.rs
+++ b/src/context/index/builder.rs
@@ -235,9 +235,7 @@ impl<'a, C: Clock, E: Embedder> IndexBuilder<'a, C, E> {
         // insertion of unrelated chunks.
         let valid_chunks: Vec<&Chunk> = new_chunks
             .iter()
-            .filter(|c| {
-                c.source == source_name && changed_files.contains(&c.metadata.source_path)
-            })
+            .filter(|c| c.source == source_name && changed_files.contains(&c.metadata.source_path))
             .collect();
 
         // Pre-embed outside the transaction.

--- a/src/context/index/builder.rs
+++ b/src/context/index/builder.rs
@@ -206,70 +206,163 @@ impl<'a, C: Clock, E: Embedder> IndexBuilder<'a, C, E> {
         };
         report.prior_source_chunks_removed = prior_removed;
 
-        {
-            let mut ins_chunk = tx.prepare(
-                "INSERT INTO chunks (
-                    id, source, kind, subtype, qualified_name, signature, content,
-                    source_path, line_start, line_end, commit_sha, indexed_at,
-                    source_version, language, is_exported, neighboring_symbols,
-                    extractor, confidence, source_uri
-                ) VALUES (
-                    ?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12,
-                    ?13, ?14, ?15, ?16, ?17, ?18, ?19
-                )",
+        Self::insert_embedded_chunks(&tx, &embedded)?;
+
+        report.chunks_inserted = embedded.len();
+        tx.commit()?;
+        Ok(report)
+    }
+
+    /// Surgical update: delete chunks belonging to `changed_files`, then insert
+    /// `new_chunks` (which should come from re-extracting only those files).
+    /// Chunks for files NOT in `changed_files` are untouched.
+    pub fn update_files(
+        &mut self,
+        source_name: &str,
+        new_chunks: &[Chunk],
+        changed_files: &std::collections::HashSet<String>,
+        fingerprints: &std::collections::HashMap<String, [f32; FINGERPRINT_DIMS]>,
+    ) -> anyhow::Result<RebuildReport> {
+        let mut report = RebuildReport {
+            source: source_name.to_string(),
+            chunks_loaded: new_chunks.len(),
+            ..RebuildReport::default()
+        };
+
+        // Pre-embed outside the transaction.
+        let mut embedded: Vec<(Chunk, Vec<f32>)> = Vec::with_capacity(new_chunks.len());
+        for chunk in new_chunks {
+            if chunk.content.is_empty() {
+                continue;
+            }
+            let vec = self.embedder.embed(&chunk.content);
+            embedded.push((chunk.clone(), vec));
+        }
+        report.chunks_embedded = embedded.len();
+
+        let tx = self.conn.transaction()?;
+
+        // Delete rows for changed files across all 4 tables.
+        if !changed_files.is_empty() {
+            let file_vec: Vec<&str> = changed_files.iter().map(|s| s.as_str()).collect();
+            let placeholders: String = (0..file_vec.len())
+                .map(|i| format!("?{}", i + 2))
+                .collect::<Vec<_>>()
+                .join(",");
+
+            for table_sql in [
+                format!(
+                    "DELETE FROM chunks_struct_vec WHERE chunk_id IN \
+                     (SELECT id FROM chunks WHERE source = ?1 AND source_path IN ({placeholders}))"
+                ),
+                format!(
+                    "DELETE FROM chunks_vec WHERE id IN \
+                     (SELECT id FROM chunks WHERE source = ?1 AND source_path IN ({placeholders}))"
+                ),
+                format!(
+                    "DELETE FROM chunks_fts WHERE id IN \
+                     (SELECT id FROM chunks WHERE source = ?1 AND source_path IN ({placeholders}))"
+                ),
+                format!(
+                    "DELETE FROM chunks WHERE source = ?1 AND source_path IN ({placeholders})"
+                ),
+            ] {
+                let mut stmt = tx.prepare(&table_sql)?;
+                let mut all_params: Vec<&dyn rusqlite::types::ToSql> = Vec::new();
+                all_params.push(&source_name as &dyn rusqlite::types::ToSql);
+                for f in &file_vec {
+                    all_params.push(f as &dyn rusqlite::types::ToSql);
+                }
+                stmt.execute(all_params.as_slice())?;
+            }
+        }
+
+        // Insert new chunks using the shared helper.
+        Self::insert_embedded_chunks(&tx, &embedded)?;
+
+        // Insert structural fingerprints for the new chunks.
+        if !fingerprints.is_empty() {
+            let mut fp_stmt = tx.prepare(
+                "INSERT OR REPLACE INTO chunks_struct_vec(chunk_id, structural_vec)
+                 SELECT ?1, ?2
+                 WHERE EXISTS (SELECT 1 FROM chunks WHERE id = ?1)",
             )?;
-            let mut ins_fts = tx.prepare(
-                "INSERT INTO chunks_fts (id, content, qualified_name, signature)
-                 VALUES (?1, ?2, ?3, ?4)",
-            )?;
-            let mut ins_vec =
-                tx.prepare("INSERT INTO chunks_vec(id, embedding) VALUES (?1, ?2)")?;
-
-            for (chunk, vec) in &embedded {
-                let kind_str = serde_json::to_value(&chunk.kind)
-                    .ok()
-                    .and_then(|v| v.as_str().map(str::to_string))
-                    .unwrap_or_default();
-                let neighbors_json = serde_json::to_string(&chunk.metadata.neighboring_symbols)?;
-                let indexed_at = chunk.metadata.indexed_at.to_rfc3339();
-
-                ins_chunk.execute(params![
-                    chunk.id,
-                    chunk.source,
-                    kind_str,
-                    chunk.subtype,
-                    chunk.qualified_name,
-                    chunk.signature,
-                    chunk.content,
-                    chunk.metadata.source_path,
-                    chunk.metadata.line_range.start(),
-                    chunk.metadata.line_range.end(),
-                    chunk.metadata.commit_sha,
-                    indexed_at,
-                    chunk.metadata.source_version,
-                    chunk.metadata.language,
-                    i32::from(chunk.metadata.is_exported),
-                    neighbors_json,
-                    chunk.provenance.extractor(),
-                    chunk.provenance.confidence(),
-                    chunk.provenance.source_uri(),
-                ])?;
-
-                ins_fts.execute(params![
-                    chunk.id,
-                    chunk.content,
-                    chunk.qualified_name.clone().unwrap_or_default(),
-                    chunk.signature.clone().unwrap_or_default(),
-                ])?;
-
+            for (chunk_id, vec) in fingerprints {
                 let bytes = f32_vec_to_le_bytes(vec);
-                ins_vec.execute(params![chunk.id, bytes])?;
+                fp_stmt.execute(params![chunk_id, bytes])?;
             }
         }
 
         report.chunks_inserted = embedded.len();
         tx.commit()?;
         Ok(report)
+    }
+
+    /// Shared INSERT logic for `chunks`, `chunks_fts`, and `chunks_vec` tables.
+    fn insert_embedded_chunks(
+        tx: &rusqlite::Transaction,
+        embedded: &[(Chunk, Vec<f32>)],
+    ) -> anyhow::Result<()> {
+        let mut ins_chunk = tx.prepare(
+            "INSERT INTO chunks (
+                id, source, kind, subtype, qualified_name, signature, content,
+                source_path, line_start, line_end, commit_sha, indexed_at,
+                source_version, language, is_exported, neighboring_symbols,
+                extractor, confidence, source_uri
+            ) VALUES (
+                ?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12,
+                ?13, ?14, ?15, ?16, ?17, ?18, ?19
+            )",
+        )?;
+        let mut ins_fts = tx.prepare(
+            "INSERT INTO chunks_fts (id, content, qualified_name, signature)
+             VALUES (?1, ?2, ?3, ?4)",
+        )?;
+        let mut ins_vec =
+            tx.prepare("INSERT INTO chunks_vec(id, embedding) VALUES (?1, ?2)")?;
+
+        for (chunk, vec) in embedded {
+            let kind_str = serde_json::to_value(&chunk.kind)
+                .ok()
+                .and_then(|v| v.as_str().map(str::to_string))
+                .unwrap_or_default();
+            let neighbors_json = serde_json::to_string(&chunk.metadata.neighboring_symbols)?;
+            let indexed_at = chunk.metadata.indexed_at.to_rfc3339();
+
+            ins_chunk.execute(params![
+                chunk.id,
+                chunk.source,
+                kind_str,
+                chunk.subtype,
+                chunk.qualified_name,
+                chunk.signature,
+                chunk.content,
+                chunk.metadata.source_path,
+                chunk.metadata.line_range.start(),
+                chunk.metadata.line_range.end(),
+                chunk.metadata.commit_sha,
+                indexed_at,
+                chunk.metadata.source_version,
+                chunk.metadata.language,
+                i32::from(chunk.metadata.is_exported),
+                neighbors_json,
+                chunk.provenance.extractor(),
+                chunk.provenance.confidence(),
+                chunk.provenance.source_uri(),
+            ])?;
+
+            ins_fts.execute(params![
+                chunk.id,
+                chunk.content,
+                chunk.qualified_name.clone().unwrap_or_default(),
+                chunk.signature.clone().unwrap_or_default(),
+            ])?;
+
+            let bytes = f32_vec_to_le_bytes(vec);
+            ins_vec.execute(params![chunk.id, bytes])?;
+        }
+
+        Ok(())
     }
 
     fn open_with_vec(db_path: &Path) -> rusqlite::Result<Connection> {
@@ -473,4 +566,254 @@ pub fn query_structural_knn(
         results.push(row?);
     }
     Ok(results)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::context::extract::fingerprint::FINGERPRINT_DIMS;
+    use crate::context::index::traits::{FixedClock, HashEmbedder};
+    use crate::context::types::{Chunk, ChunkKind, ChunkMeta, LineRange, Provenance};
+    use std::collections::{HashMap, HashSet};
+
+    /// Build a test chunk with the given id, source, source_path, and content.
+    fn make_chunk(id: &str, source: &str, source_path: &str, content: &str) -> Chunk {
+        Chunk {
+            id: id.to_string(),
+            source: source.to_string(),
+            kind: ChunkKind::Symbol,
+            subtype: None,
+            qualified_name: Some(format!("test::{id}")),
+            signature: None,
+            content: content.to_string(),
+            metadata: ChunkMeta {
+                source_path: source_path.to_string(),
+                line_range: LineRange::new(1, 10).unwrap(),
+                commit_sha: "abc123".to_string(),
+                indexed_at: chrono::Utc::now(),
+                source_version: None,
+                language: Some("rust".to_string()),
+                is_exported: true,
+                neighboring_symbols: vec![],
+            },
+            provenance: Provenance::new("test-extractor", 0.95, "file:///test").unwrap(),
+        }
+    }
+
+    /// Helper: count chunks in the `chunks` table matching given source and source_path.
+    fn count_chunks(conn: &Connection, source: &str, source_path: &str) -> usize {
+        conn.query_row(
+            "SELECT COUNT(*) FROM chunks WHERE source = ?1 AND source_path = ?2",
+            params![source, source_path],
+            |r| r.get::<_, usize>(0),
+        )
+        .unwrap()
+    }
+
+    /// Helper: count all chunks in the `chunks` table for a given source.
+    fn count_all_chunks(conn: &Connection, source: &str) -> usize {
+        conn.query_row(
+            "SELECT COUNT(*) FROM chunks WHERE source = ?1",
+            params![source],
+            |r| r.get::<_, usize>(0),
+        )
+        .unwrap()
+    }
+
+    /// Helper: get a specific chunk's content by id.
+    fn get_chunk_content(conn: &Connection, id: &str) -> Option<String> {
+        conn.query_row(
+            "SELECT content FROM chunks WHERE id = ?1",
+            params![id],
+            |r| r.get::<_, String>(0),
+        )
+        .optional()
+        .unwrap()
+    }
+
+    /// Helper: count rows in chunks_fts for a given chunk id.
+    fn fts_exists(conn: &Connection, id: &str) -> bool {
+        conn.query_row(
+            "SELECT COUNT(*) FROM chunks_fts WHERE id = ?1",
+            params![id],
+            |r| r.get::<_, usize>(0),
+        )
+        .unwrap()
+            > 0
+    }
+
+    /// Helper: count rows in chunks_vec for a given chunk id.
+    fn vec_exists(conn: &Connection, id: &str) -> bool {
+        conn.query_row(
+            "SELECT COUNT(*) FROM chunks_vec WHERE id = ?1",
+            params![id],
+            |r| r.get::<_, usize>(0),
+        )
+        .unwrap()
+            > 0
+    }
+
+    fn setup_builder() -> IndexBuilder<'static, FixedClock, HashEmbedder> {
+        // Leak the clock and embedder so they live for 'static — acceptable in tests.
+        let clock: &'static FixedClock = Box::leak(Box::new(FixedClock::epoch()));
+        let embedder: &'static HashEmbedder = Box::leak(Box::new(HashEmbedder::new(8)));
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        let db_path = tmp.path().to_path_buf();
+        // Drop the tempfile so rusqlite can create the file fresh.
+        drop(tmp);
+        ensure_vec_loaded();
+        IndexBuilder::new(&db_path, clock, embedder).unwrap()
+    }
+
+    /// Insert chunks directly into the builder's DB for test setup.
+    fn insert_chunks_direct(
+        builder: &mut IndexBuilder<'static, FixedClock, HashEmbedder>,
+        chunks: &[Chunk],
+    ) {
+        let embedder = HashEmbedder::new(8);
+        let mut embedded: Vec<(Chunk, Vec<f32>)> = Vec::new();
+        for c in chunks {
+            let vec = embedder.embed(&c.content);
+            embedded.push((c.clone(), vec));
+        }
+        let tx = builder.conn_mut().transaction().unwrap();
+        IndexBuilder::<FixedClock, HashEmbedder>::insert_embedded_chunks(&tx, &embedded).unwrap();
+        tx.commit().unwrap();
+    }
+
+    #[test]
+    fn test_update_files_only_deletes_changed_files() {
+        let mut builder = setup_builder();
+
+        // Insert chunks for two files: src/a.rs and src/b.rs
+        let chunk_a1 = make_chunk("a1", "my-source", "src/a.rs", "fn foo() {}");
+        let chunk_a2 = make_chunk("a2", "my-source", "src/a.rs", "fn bar() {}");
+        let chunk_b1 = make_chunk("b1", "my-source", "src/b.rs", "fn baz() {}");
+
+        insert_chunks_direct(&mut builder, &[chunk_a1, chunk_a2, chunk_b1]);
+
+        // Verify initial state
+        assert_eq!(count_chunks(builder.conn(), "my-source", "src/a.rs"), 2);
+        assert_eq!(count_chunks(builder.conn(), "my-source", "src/b.rs"), 1);
+
+        // Create a new replacement chunk for src/a.rs
+        let new_a = make_chunk("a3", "my-source", "src/a.rs", "fn foo_updated() {}");
+
+        let mut changed = HashSet::new();
+        changed.insert("src/a.rs".to_string());
+
+        let fingerprints: HashMap<String, [f32; FINGERPRINT_DIMS]> = HashMap::new();
+
+        let report = builder
+            .update_files("my-source", &[new_a], &changed, &fingerprints)
+            .unwrap();
+
+        // Old a.rs chunks should be gone
+        assert!(get_chunk_content(builder.conn(), "a1").is_none());
+        assert!(get_chunk_content(builder.conn(), "a2").is_none());
+        assert!(!fts_exists(builder.conn(), "a1"));
+        assert!(!fts_exists(builder.conn(), "a2"));
+        assert!(!vec_exists(builder.conn(), "a1"));
+        assert!(!vec_exists(builder.conn(), "a2"));
+
+        // New a.rs chunk should be present
+        assert_eq!(
+            get_chunk_content(builder.conn(), "a3"),
+            Some("fn foo_updated() {}".to_string())
+        );
+        assert!(fts_exists(builder.conn(), "a3"));
+        assert!(vec_exists(builder.conn(), "a3"));
+
+        // b.rs chunk should be untouched
+        assert_eq!(
+            get_chunk_content(builder.conn(), "b1"),
+            Some("fn baz() {}".to_string())
+        );
+        assert!(fts_exists(builder.conn(), "b1"));
+        assert!(vec_exists(builder.conn(), "b1"));
+
+        // Report
+        assert_eq!(report.source, "my-source");
+        assert_eq!(report.chunks_loaded, 1);
+        assert_eq!(report.chunks_embedded, 1);
+        assert_eq!(report.chunks_inserted, 1);
+    }
+
+    #[test]
+    fn test_update_files_with_fingerprints() {
+        let mut builder = setup_builder();
+
+        let chunk_a = make_chunk("a1", "my-source", "src/a.rs", "fn foo() {}");
+        insert_chunks_direct(&mut builder, &[chunk_a]);
+
+        let new_a = make_chunk("a2", "my-source", "src/a.rs", "fn foo_v2() {}");
+        let mut changed = HashSet::new();
+        changed.insert("src/a.rs".to_string());
+
+        let mut fingerprints: HashMap<String, [f32; FINGERPRINT_DIMS]> = HashMap::new();
+        fingerprints.insert("a2".to_string(), [0.5; FINGERPRINT_DIMS]);
+
+        let _report = builder
+            .update_files("my-source", &[new_a], &changed, &fingerprints)
+            .unwrap();
+
+        // Verify structural fingerprint was inserted
+        let fp_count: usize = builder
+            .conn()
+            .query_row(
+                "SELECT COUNT(*) FROM chunks_struct_vec WHERE chunk_id = ?1",
+                params!["a2"],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(fp_count, 1);
+    }
+
+    #[test]
+    fn test_update_files_empty_changed_set_only_inserts() {
+        let mut builder = setup_builder();
+
+        let chunk_a = make_chunk("a1", "my-source", "src/a.rs", "fn foo() {}");
+        insert_chunks_direct(&mut builder, &[chunk_a]);
+
+        // Call update_files with empty changed set — should only add, not delete.
+        let new_b = make_chunk("b1", "my-source", "src/b.rs", "fn bar() {}");
+        let changed: HashSet<String> = HashSet::new();
+        let fingerprints: HashMap<String, [f32; FINGERPRINT_DIMS]> = HashMap::new();
+
+        let _report = builder
+            .update_files("my-source", &[new_b], &changed, &fingerprints)
+            .unwrap();
+
+        // Both should exist
+        assert_eq!(count_all_chunks(builder.conn(), "my-source"), 2);
+        assert!(get_chunk_content(builder.conn(), "a1").is_some());
+        assert!(get_chunk_content(builder.conn(), "b1").is_some());
+    }
+
+    #[test]
+    fn test_rebuild_from_jsonl_uses_shared_insert_logic() {
+        // This test verifies that rebuild_from_jsonl still works correctly
+        // after refactoring to use insert_embedded_chunks.
+        let mut builder = setup_builder();
+
+        // Write a JSONL file with test chunks
+        let tmp_jsonl = tempfile::NamedTempFile::new().unwrap();
+        let chunk = make_chunk("c1", "my-source", "src/c.rs", "fn test() {}");
+        let line = serde_json::to_string(&chunk).unwrap();
+        std::fs::write(tmp_jsonl.path(), format!("{line}\n")).unwrap();
+
+        let report = builder
+            .rebuild_from_jsonl("my-source", tmp_jsonl.path())
+            .unwrap();
+
+        assert_eq!(report.chunks_loaded, 1);
+        assert_eq!(report.chunks_inserted, 1);
+        assert_eq!(
+            get_chunk_content(builder.conn(), "c1"),
+            Some("fn test() {}".to_string())
+        );
+        assert!(fts_exists(builder.conn(), "c1"));
+        assert!(vec_exists(builder.conn(), "c1"));
+    }
 }

--- a/src/context/index/builder.rs
+++ b/src/context/index/builder.rs
@@ -263,9 +263,7 @@ impl<'a, C: Clock, E: Embedder> IndexBuilder<'a, C, E> {
                     "DELETE FROM chunks_fts WHERE id IN \
                      (SELECT id FROM chunks WHERE source = ?1 AND source_path IN ({placeholders}))"
                 ),
-                format!(
-                    "DELETE FROM chunks WHERE source = ?1 AND source_path IN ({placeholders})"
-                ),
+                format!("DELETE FROM chunks WHERE source = ?1 AND source_path IN ({placeholders})"),
             ] {
                 let mut stmt = tx.prepare(&table_sql)?;
                 let mut all_params: Vec<&dyn rusqlite::types::ToSql> = Vec::new();
@@ -318,8 +316,7 @@ impl<'a, C: Clock, E: Embedder> IndexBuilder<'a, C, E> {
             "INSERT INTO chunks_fts (id, content, qualified_name, signature)
              VALUES (?1, ?2, ?3, ?4)",
         )?;
-        let mut ins_vec =
-            tx.prepare("INSERT INTO chunks_vec(id, embedding) VALUES (?1, ?2)")?;
+        let mut ins_vec = tx.prepare("INSERT INTO chunks_vec(id, embedding) VALUES (?1, ?2)")?;
 
         for (chunk, vec) in embedded {
             let kind_str = serde_json::to_value(&chunk.kind)

--- a/src/context/index/builder.rs
+++ b/src/context/index/builder.rs
@@ -229,16 +229,31 @@ impl<'a, C: Clock, E: Embedder> IndexBuilder<'a, C, E> {
             ..RebuildReport::default()
         };
 
+        // Defense-in-depth: only accept chunks that belong to this source AND
+        // whose source_path is in the declared changed_files set. This mirrors
+        // the partition check in `rebuild_from_jsonl` and prevents accidental
+        // insertion of unrelated chunks.
+        let valid_chunks: Vec<&Chunk> = new_chunks
+            .iter()
+            .filter(|c| {
+                c.source == source_name && changed_files.contains(&c.metadata.source_path)
+            })
+            .collect();
+
         // Pre-embed outside the transaction.
-        let mut embedded: Vec<(Chunk, Vec<f32>)> = Vec::with_capacity(new_chunks.len());
-        for chunk in new_chunks {
+        let mut embedded: Vec<(Chunk, Vec<f32>)> = Vec::with_capacity(valid_chunks.len());
+        for chunk in &valid_chunks {
             if chunk.content.is_empty() {
                 continue;
             }
             let vec = self.embedder.embed(&chunk.content);
-            embedded.push((chunk.clone(), vec));
+            embedded.push(((*chunk).clone(), vec));
         }
         report.chunks_embedded = embedded.len();
+
+        // Collect valid chunk ids so we can filter fingerprint inserts.
+        let valid_ids: std::collections::HashSet<&str> =
+            valid_chunks.iter().map(|c| c.id.as_str()).collect();
 
         let tx = self.conn.transaction()?;
 
@@ -278,7 +293,7 @@ impl<'a, C: Clock, E: Embedder> IndexBuilder<'a, C, E> {
         // Insert new chunks using the shared helper.
         Self::insert_embedded_chunks(&tx, &embedded)?;
 
-        // Insert structural fingerprints for the new chunks.
+        // Insert structural fingerprints only for chunks we actually inserted.
         if !fingerprints.is_empty() {
             let mut fp_stmt = tx.prepare(
                 "INSERT OR REPLACE INTO chunks_struct_vec(chunk_id, structural_vec)
@@ -286,6 +301,9 @@ impl<'a, C: Clock, E: Embedder> IndexBuilder<'a, C, E> {
                  WHERE EXISTS (SELECT 1 FROM chunks WHERE id = ?1)",
             )?;
             for (chunk_id, vec) in fingerprints {
+                if !valid_ids.contains(chunk_id.as_str()) {
+                    continue;
+                }
                 let bytes = f32_vec_to_le_bytes(vec);
                 fp_stmt.execute(params![chunk_id, bytes])?;
             }
@@ -767,25 +785,28 @@ mod tests {
     }
 
     #[test]
-    fn test_update_files_empty_changed_set_only_inserts() {
+    fn test_update_files_empty_changed_set_inserts_nothing() {
         let mut builder = setup_builder();
 
         let chunk_a = make_chunk("a1", "my-source", "src/a.rs", "fn foo() {}");
         insert_chunks_direct(&mut builder, &[chunk_a]);
 
-        // Call update_files with empty changed set — should only add, not delete.
+        // Call update_files with empty changed set — chunks whose source_path
+        // is not in the changed set are filtered out (defense-in-depth).
         let new_b = make_chunk("b1", "my-source", "src/b.rs", "fn bar() {}");
         let changed: HashSet<String> = HashSet::new();
         let fingerprints: HashMap<String, [f32; FINGERPRINT_DIMS]> = HashMap::new();
 
-        let _report = builder
+        let report = builder
             .update_files("my-source", &[new_b], &changed, &fingerprints)
             .unwrap();
 
-        // Both should exist
-        assert_eq!(count_all_chunks(builder.conn(), "my-source"), 2);
+        // Only the original chunk should exist; new_b was filtered out.
+        assert_eq!(count_all_chunks(builder.conn(), "my-source"), 1);
         assert!(get_chunk_content(builder.conn(), "a1").is_some());
-        assert!(get_chunk_content(builder.conn(), "b1").is_some());
+        assert!(get_chunk_content(builder.conn(), "b1").is_none());
+        assert_eq!(report.chunks_embedded, 0);
+        assert_eq!(report.chunks_inserted, 0);
     }
 
     #[test]

--- a/src/context/inject/stale.rs
+++ b/src/context/inject/stale.rs
@@ -42,6 +42,12 @@ pub trait GitOps {
     /// when `git` itself is broken (missing binary, I/O error). Callers use
     /// this to decide whether a re-index is needed.
     fn head_sha(&self, repo_root: &Path) -> std::io::Result<Option<String>>;
+
+    /// List files changed between `from_sha` and current HEAD.
+    /// Returns `Ok(None)` when the directory is not a git repo or
+    /// `from_sha` is not a valid ancestor (e.g. after force push/rebase).
+    /// Returns `Ok(Some(vec))` with relative paths of changed files.
+    fn diff_files(&self, repo_root: &Path, from_sha: &str) -> std::io::Result<Option<Vec<String>>>;
 }
 
 /// Production GitOps implementation using `git status --porcelain`.
@@ -85,6 +91,26 @@ impl GitOps for SystemGit {
             Ok(Some(sha))
         }
     }
+
+    fn diff_files(&self, repo_root: &Path, from_sha: &str) -> std::io::Result<Option<Vec<String>>> {
+        let output = std::process::Command::new("git")
+            .arg("-C")
+            .arg(repo_root)
+            .arg("diff")
+            .arg("--name-only")
+            .arg(format!("{from_sha}..HEAD"))
+            .output()?;
+        if !output.status.success() {
+            return Ok(None);
+        }
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let files: Vec<String> = stdout
+            .lines()
+            .filter(|l| !l.is_empty())
+            .map(|l| l.replace('\\', "/"))
+            .collect();
+        Ok(Some(files))
+    }
 }
 
 /// Fake GitOps for tests — returns canned values.
@@ -96,6 +122,9 @@ pub struct FakeGit {
     /// which is the common case for tests that only care that a sha exists.
     pub head_by_path: std::collections::HashMap<std::path::PathBuf, Option<String>>,
     pub default_head: Option<String>,
+    /// Canned diff file lists keyed by repo root path. When a path isn't
+    /// present in the map, `diff_files` returns `Ok(None)`.
+    pub diff_by_path: std::collections::HashMap<std::path::PathBuf, Vec<String>>,
 }
 
 impl Default for FakeGit {
@@ -104,6 +133,7 @@ impl Default for FakeGit {
             dirty: false,
             head_by_path: std::collections::HashMap::new(),
             default_head: Some("deadbeefdeadbeefdeadbeefdeadbeefdeadbeef".to_string()),
+            diff_by_path: std::collections::HashMap::new(),
         }
     }
 }
@@ -122,6 +152,11 @@ impl FakeGit {
     pub fn set_head(&mut self, path: &Path, sha: Option<String>) {
         self.head_by_path.insert(path.to_path_buf(), sha);
     }
+
+    /// Register canned diff file list for a specific repo root path.
+    pub fn set_diff_files(&mut self, path: &Path, files: Vec<String>) {
+        self.diff_by_path.insert(path.to_path_buf(), files);
+    }
 }
 
 impl GitOps for FakeGit {
@@ -134,6 +169,10 @@ impl GitOps for FakeGit {
             return Ok(override_sha.clone());
         }
         Ok(self.default_head.clone())
+    }
+
+    fn diff_files(&self, repo_root: &Path, _from_sha: &str) -> std::io::Result<Option<Vec<String>>> {
+        Ok(self.diff_by_path.get(repo_root).cloned())
     }
 }
 
@@ -223,5 +262,31 @@ fn format_age(age: chrono::Duration) -> String {
         } else {
             format!("{mins}m")
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    #[test]
+    fn fake_git_diff_files_returns_canned_list() {
+        let mut git = FakeGit::default();
+        let root = PathBuf::from("/repo");
+        git.set_diff_files(&root, vec!["src/main.rs".into(), "src/lib.rs".into()]);
+        let files = git.diff_files(&root, "abc123").unwrap();
+        assert_eq!(
+            files,
+            Some(vec!["src/main.rs".to_string(), "src/lib.rs".to_string()])
+        );
+    }
+
+    #[test]
+    fn fake_git_diff_files_returns_none_when_not_set() {
+        let git = FakeGit::default();
+        let root = PathBuf::from("/repo");
+        let files = git.diff_files(&root, "abc123").unwrap();
+        assert_eq!(files, None);
     }
 }

--- a/src/context/inject/stale.rs
+++ b/src/context/inject/stale.rs
@@ -101,13 +101,18 @@ impl GitOps for SystemGit {
             .arg(format!("{from_sha}..HEAD"))
             .output()?;
         if !output.status.success() {
+            tracing::debug!(
+                from_sha,
+                stderr = %String::from_utf8_lossy(&output.stderr).trim(),
+                "git diff --name-only failed; falling back to full rebuild"
+            );
             return Ok(None);
         }
         let stdout = String::from_utf8_lossy(&output.stdout);
         let files: Vec<String> = stdout
             .lines()
             .filter(|l| !l.is_empty())
-            .map(|l| l.replace('\\', "/"))
+            .map(|l| l.to_string())
             .collect();
         Ok(Some(files))
     }

--- a/src/context/inject/stale.rs
+++ b/src/context/inject/stale.rs
@@ -171,7 +171,11 @@ impl GitOps for FakeGit {
         Ok(self.default_head.clone())
     }
 
-    fn diff_files(&self, repo_root: &Path, _from_sha: &str) -> std::io::Result<Option<Vec<String>>> {
+    fn diff_files(
+        &self,
+        repo_root: &Path,
+        _from_sha: &str,
+    ) -> std::io::Result<Option<Vec<String>>> {
         Ok(self.diff_by_path.get(repo_root).cloned())
     }
 }

--- a/src/context/inject/stale_tests.rs
+++ b/src/context/inject/stale_tests.rs
@@ -127,6 +127,9 @@ impl GitOps for FailingGit {
     fn head_sha(&self, _: &Path) -> std::io::Result<Option<String>> {
         Err(std::io::Error::other("fake error"))
     }
+    fn diff_files(&self, _: &Path, _: &str) -> std::io::Result<Option<Vec<String>>> {
+        Err(std::io::Error::other("fake error"))
+    }
 }
 
 #[test]
@@ -166,6 +169,9 @@ impl GitOps for CountingGit {
         Ok(self.dirty)
     }
     fn head_sha(&self, _: &Path) -> std::io::Result<Option<String>> {
+        Ok(None)
+    }
+    fn diff_files(&self, _: &Path, _: &str) -> std::io::Result<Option<Vec<String>>> {
         Ok(None)
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -547,7 +547,7 @@ fn run_join_health(quorum_home: &std::path::Path) -> i32 {
 fn run_context(opts: cli::ContextOpts) -> i32 {
     use context::cli::{
         AddArgs, AddLocation, ContextCmd, DoctorArgs, DoctorFormat, IndexArgs, ListArgs,
-        ListFormat, ProdDeps, PruneArgs, QueryArgs, QueryFormat, RefreshArgs, SourceSelector,
+        ListFormat, ProdDeps, PruneArgs, QueryArgs, QueryFormat, SourceSelector,
         run_context_cmd,
     };
 
@@ -599,10 +599,15 @@ fn run_context(opts: cli::ContextOpts) -> i32 {
         }
         cli::ContextCommand::Index(i) => ContextCmd::Index(IndexArgs {
             selector: selector(i.source, i.all),
+            force: i.force,
         }),
-        cli::ContextCommand::Refresh(r) => ContextCmd::Refresh(RefreshArgs {
-            selector: selector(r.source, r.all),
-        }),
+        cli::ContextCommand::Refresh(r) => {
+            eprintln!("warning: `refresh` is deprecated, use `index` instead");
+            ContextCmd::Index(IndexArgs {
+                selector: selector(r.source, r.all),
+                force: false,
+            })
+        }
         cli::ContextCommand::Query(q) => {
             let format = if q.json {
                 QueryFormat::Json
@@ -635,12 +640,12 @@ fn run_context(opts: cli::ContextOpts) -> i32 {
         }
     };
 
-    // `index` and `refresh` write to `chunks_vec`; if fastembed fell back to
-    // HashEmbedder we'd rebuild the vector table with hashing-noise vectors
-    // and silently degrade every subsequent retrieval. Use the strict
-    // factory so a fastembed init failure surfaces as a clear error the
-    // user can retry, rather than a corrupted index they have to discover.
-    let needs_strict_embedder = matches!(cmd, ContextCmd::Index(_) | ContextCmd::Refresh(_));
+    // `index` writes to `chunks_vec`; if fastembed fell back to HashEmbedder
+    // we'd rebuild the vector table with hashing-noise vectors and silently
+    // degrade every subsequent retrieval. Use the strict factory so a
+    // fastembed init failure surfaces as a clear error the user can retry,
+    // rather than a corrupted index they have to discover.
+    let needs_strict_embedder = matches!(cmd, ContextCmd::Index(_));
     let deps_result = if needs_strict_embedder {
         ProdDeps::from_env_strict()
     } else {

--- a/src/main.rs
+++ b/src/main.rs
@@ -547,8 +547,7 @@ fn run_join_health(quorum_home: &std::path::Path) -> i32 {
 fn run_context(opts: cli::ContextOpts) -> i32 {
     use context::cli::{
         AddArgs, AddLocation, ContextCmd, DoctorArgs, DoctorFormat, IndexArgs, ListArgs,
-        ListFormat, ProdDeps, PruneArgs, QueryArgs, QueryFormat, SourceSelector,
-        run_context_cmd,
+        ListFormat, ProdDeps, PruneArgs, QueryArgs, QueryFormat, SourceSelector, run_context_cmd,
     };
 
     // Map `--source X` / `--all` / neither into a SourceSelector. The default

--- a/src/main.rs
+++ b/src/main.rs
@@ -604,7 +604,7 @@ fn run_context(opts: cli::ContextOpts) -> i32 {
             eprintln!("warning: `refresh` is deprecated, use `index` instead");
             ContextCmd::Index(IndexArgs {
                 selector: selector(r.source, r.all),
-                force: false,
+                force: r.force,
             })
         }
         cli::ContextCommand::Query(q) => {

--- a/tests/context_cli.rs
+++ b/tests/context_cli.rs
@@ -57,7 +57,7 @@ fn context_help_lists_all_subcommands() {
         .clone();
     let stdout = String::from_utf8(out).unwrap();
     for cmd in [
-        "init", "add", "list", "index", "refresh", "query", "prune", "doctor",
+        "init", "add", "list", "index", "query", "prune", "doctor",
     ] {
         let needle = format!("  {cmd}  ");
         assert!(

--- a/tests/context_cli.rs
+++ b/tests/context_cli.rs
@@ -63,6 +63,11 @@ fn context_help_lists_all_subcommands() {
             "expected subcommand row `{needle}` in help output:\n{stdout}"
         );
     }
+    // `refresh` is a hidden deprecated alias — must NOT appear in help.
+    assert!(
+        !stdout.contains("  refresh  "),
+        "hidden alias `refresh` should not appear in help output:\n{stdout}"
+    );
 }
 
 #[test]

--- a/tests/context_cli.rs
+++ b/tests/context_cli.rs
@@ -56,9 +56,7 @@ fn context_help_lists_all_subcommands() {
         .stdout
         .clone();
     let stdout = String::from_utf8(out).unwrap();
-    for cmd in [
-        "init", "add", "list", "index", "query", "prune", "doctor",
-    ] {
+    for cmd in ["init", "add", "list", "index", "query", "prune", "doctor"] {
         let needle = format!("  {cmd}  ");
         assert!(
             stdout.contains(&needle),


### PR DESCRIPTION
## Summary

Three tightly coupled improvements to `quorum context index`, implementing #342, #360, and #361:

- **Merge index/refresh into one command (#360):** `quorum context index` now defaults to smart behavior — skips unchanged sources (same HEAD sha + same embedder model). `--force` triggers unconditional full rebuild. `refresh` remains as a hidden deprecated alias.
- **Incremental indexing (#361):** When HEAD has moved, uses `git diff --name-only` to identify changed files and only re-extracts/re-embeds those. Unchanged file chunks remain in the DB untouched. Falls back to full rebuild when: no prior state, non-git source, force push/rebase (diff fails), or DB missing.
- **Progress output (#342):** Output now includes file counts and distinguishes full rebuild vs incremental vs skipped sources. Example: `indexed 'myapp': 3 chunks from 2 changed files` vs `indexed 'myapp': 47 files, 312 chunks`.

## Architecture

```
quorum context index [--source X | --all] [--force]
                           │
                    ┌──────┴──────┐
                    │ staleness   │
                    │  check      │
                    └──────┬──────┘
              ┌────────────┼────────────┐
          up-to-date    stale+diff    stale/no-diff
              │            │               │
           skip      incremental      full rebuild
                     (diff files     (all files,
                      only, surgical   nuke+rebuild)
                      DB update)
```

### New trait method
- `GitOps::diff_files(repo_root, from_sha)` → `Option<Vec<String>>` — returns changed file paths via `git diff --name-only`

### New builder method
- `IndexBuilder::update_files(source, chunks, changed_files, fingerprints)` — deletes chunks for changed files only, inserts new ones. Shared insert logic extracted from `rebuild_from_jsonl` (DRY).

### New extraction function
- `extract_source_filtered(source, config, clock, file_filter)` — filters the walkdir scan to only process files in the filter set

## Files changed (8)

| File | Change |
|------|--------|
| `src/context/inject/stale.rs` | `GitOps::diff_files` + `SystemGit`/`FakeGit` impls |
| `src/context/extract/dispatch.rs` | `extract_source_filtered` with optional `HashSet` filter |
| `src/context/index/builder.rs` | `update_files`, extracted `insert_embedded_chunks` shared helper |
| `src/context/cli.rs` | Unified `run_index` with staleness check, incremental path, progress output; removed `run_refresh`/`RefreshArgs`/`RefreshOutcome` |
| `src/context/cli_tests.rs` | Converted refresh tests to index+force, added skip/force/incremental/progress tests |
| `src/cli/mod.rs` | Added `--force` flag, `refresh` as hidden alias |
| `src/main.rs` | Updated dispatch, deprecation warning for `refresh` |
| `src/context/inject/stale_tests.rs` | `diff_files` stubs for test implementations |

## Quorum review verdicts

| Finding | File | Verdict | Notes |
|---------|------|---------|-------|
| `update_files` doesn't validate chunks belong to source | `builder.rs` | **TP (fixed)** | Added source_name + changed_files filter |
| `update_files` trusts fingerprint keys | `builder.rs` | **TP (fixed)** | Fingerprints filtered to valid chunk_ids |
| `update_files` inserts outside changed_files | `builder.rs` | **TP (fixed)** | Chunks now filtered by changed_files set |
| `diff_files` corrupts backslash paths | `stale.rs` | **TP (fixed)** | Removed unnecessary `.replace('\\', "/")` |
| `diff_files` swallows failures silently | `stale.rs` | **TP (fixed)** | Added `tracing::debug` |
| `diff_files` misparses newline filenames | `stale.rs` | FP (trust-model) | Extreme edge case; git uses newline-delimited output |
| `run_index` complexity 13 | `cli.rs` | FP | Acceptable for orchestration function |
| `index_one_source` complexity 12 | `cli.rs` | FP | Natural branching for incremental vs full |

Pre-existing findings filed as: #365, #366, #367, #368, #369.

## Test plan

- [x] 1576 unit tests pass (0 failures)
- [x] 3 integration tests pass
- [x] clippy clean (no warnings)
- [x] cargo fmt clean
- [x] quorum review — all in-diff findings triaged and fixed
- [ ] CI passes
- [ ] Manual test: `quorum context index --source <name>` (first run = full, second run = skip, after git commit = incremental)
- [ ] Manual test: `quorum context index --force --source <name>` (always full rebuild)
- [ ] Manual test: `quorum context refresh --source <name>` (hidden alias, deprecation warning)

Closes #342, closes #360, closes #361.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Incremental indexing with staleness detection: skips unchanged sources based on git HEAD and model hash, performs targeted updates for modified files
  * Added `--force` flag to `context index` to force full rebuilds

* **Deprecations**
  * `context refresh` subcommand is now hidden; use `context index` with `--force` instead

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jsnyder/quorum/pull/364?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->