### PR TITLE
feat(context): multi-source query fan-out with RRF scoring

### DIFF
--- a/src/context/bootstrap.rs
+++ b/src/context/bootstrap.rs
@@ -39,6 +39,7 @@ fn build_retrieval_embedder() -> crate::context::cli::ProdEmbedder {
 struct ValidSource {
     name: String,
     db_path: PathBuf,
+    weight: f32,
 }
 
 /// Build a production `ContextInjectionSource` from `<home>/sources.toml` and
@@ -158,6 +159,7 @@ fn collect_valid_sources_for_project(
                     Ok(_) => valid.push(ValidSource {
                         name: s.name.clone(),
                         db_path: layout.db,
+                        weight: s.weight.unwrap_or(1) as f32,
                     }),
                     Err(e) => {
                         tracing::warn!(
@@ -314,6 +316,7 @@ fn build_multi_source_retriever(
                     Ok(chunks) if !chunks.is_empty() => {
                         batches.push(SourceBatch {
                             source_name: src.name.clone(),
+                            weight: src.weight,
                             chunks,
                         });
                     }

--- a/src/context/cli.rs
+++ b/src/context/cli.rs
@@ -1317,8 +1317,11 @@ fn resolve_query_targets<D: ContextDeps>(
             .iter()
             .find(|s| s.name == name)
             .and_then(|s| s.weight)
-            .unwrap_or(1) as f32;
-        return Ok(vec![(name.to_string(), layout.db, weight)]);
+            .unwrap_or(1);
+        if weight == 0 {
+            return Err(anyhow!("source '{name}' is disabled (weight=0)"));
+        }
+        return Ok(vec![(name.to_string(), layout.db, weight as f32)]);
     }
     let max = cfg.context.multi_source.max_sources_queried as usize;
     let mut targets = Vec::new();

--- a/src/context/cli.rs
+++ b/src/context/cli.rs
@@ -71,6 +71,7 @@ impl Embedder for ProdEmbedder {
     }
 }
 use crate::context::inject::stale::{GitOps, SystemGit};
+use crate::context::retrieve::multi_source::{BoostContext, SourceBatch, merge_and_rerank};
 use crate::context::retrieve::{Filters, RetrievalQuery, Retriever};
 use crate::context::store::ChunkStore;
 
@@ -1229,51 +1230,60 @@ fn run_query<D: ContextDeps>(args: &QueryArgs, deps: &D) -> Result<CmdOutput> {
         return Err(anyhow!("query text must not be empty"));
     }
     let cfg = load_sources_or_err(deps)?;
+    let targets = resolve_query_targets(deps, &cfg, args.source.as_deref())?;
 
-    // If --source is given, verify it's registered and that its index db
-    // exists. Otherwise we query across any source that has an index db on
-    // disk (sources that were never indexed are silently skipped; warning
-    // surfaced so the user isn't confused by empty results).
-    let (source_name, db_path) = resolve_query_target(deps, &cfg, args.source.as_deref())?;
-    if !db_path.exists() {
-        return Err(anyhow!(
-            "source '{source_name}' has no index at {}; run `quorum context index --source {source_name}` first",
-            db_path.display()
-        ));
-    }
-
-    // The index schema uses the `vec0` virtual table; without the sqlite-vec
-    // auto-extension registered, opening the db succeeds but any query that
-    // touches `chunks_vec` fails with `no such module: vec0`. IndexBuilder
-    // registers the hook during `index`, but a fresh process that jumps
-    // straight to `query` has never run it.
     ensure_vec_loaded();
 
-    let conn = Connection::open_with_flags(&db_path, rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY)
-        .map_err(|e| anyhow!("open {}: {e}", db_path.display()))?;
+    let k = args.k.unwrap_or(5).max(1) as u32;
+    let per_source_k = (k * 2) as usize;
+    let mut batches: Vec<SourceBatch> = Vec::new();
 
-    let k = args.k.unwrap_or(5).max(1);
-    let filters = if args.source.is_some() {
-        Filters {
-            sources: vec![source_name.clone()],
-            kinds: Vec::new(),
-            exclude_source_paths: vec![],
+    for (name, db_path, weight) in &targets {
+        let conn =
+            Connection::open_with_flags(db_path, rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY)
+                .map_err(|e| anyhow!("open {}: {e}", db_path.display()))?;
+        let q = RetrievalQuery {
+            text: args.text.clone(),
+            identifiers: Vec::new(),
+            structural_names: Vec::new(),
+            structural_fingerprints: vec![],
+            filters: Filters {
+                sources: vec![name.clone()],
+                kinds: Vec::new(),
+                exclude_source_paths: vec![],
+            },
+            k: per_source_k,
+            min_score: 0.0,
+            reviewed_file_language: None,
+        };
+        let retriever = Retriever::new(&conn, deps.embedder(), deps.clock());
+        match retriever.query(q) {
+            Ok(chunks) if !chunks.is_empty() => {
+                batches.push(SourceBatch {
+                    source_name: name.clone(),
+                    chunks,
+                    weight: *weight,
+                });
+            }
+            Ok(_) => {}
+            Err(e) => tracing::warn!(source = %name, error = %e, "query failed; skipping"),
         }
+    }
+
+    let hits = if batches.len() == 1 && args.source.is_some() {
+        let mut chunks = batches.into_iter().next().unwrap().chunks;
+        chunks.truncate(k as usize);
+        chunks
+    } else if batches.is_empty() {
+        Vec::new()
     } else {
-        Filters::default()
+        let ctx = BoostContext {
+            current_repo_source: None,
+            dep_manifest_sources: HashSet::new(),
+            reviewed_language: None,
+        };
+        merge_and_rerank(&batches, &cfg.context.multi_source, &ctx, k)
     };
-    let q = RetrievalQuery {
-        text: args.text.clone(),
-        identifiers: Vec::new(),
-        structural_names: Vec::new(),
-        structural_fingerprints: vec![],
-        filters,
-        k,
-        min_score: 0.0,
-        reviewed_file_language: None,
-    };
-    let retriever = Retriever::new(&conn, deps.embedder(), deps.clock());
-    let hits = retriever.query(q).map_err(|e| anyhow!("query: {e}"))?;
 
     let stdout = match args.format {
         QueryFormat::Json => render_query_json(&hits, args.explain)?,
@@ -1289,29 +1299,48 @@ fn run_query<D: ContextDeps>(args: &QueryArgs, deps: &D) -> Result<CmdOutput> {
     })
 }
 
-fn resolve_query_target<D: ContextDeps>(
+fn resolve_query_targets<D: ContextDeps>(
     deps: &D,
     cfg: &SourcesConfig,
     explicit: Option<&str>,
-) -> Result<(String, PathBuf)> {
+) -> Result<Vec<(String, PathBuf, f32)>> {
     if let Some(name) = explicit {
         let _entry = find_source(cfg, name)?;
         let layout = SourceLayout::for_source(deps.home_dir(), name);
-        return Ok((name.to_string(), layout.db));
+        if !layout.db.exists() {
+            return Err(anyhow!(
+                "source '{name}' has no index; run `quorum context index --source {name}` first"
+            ));
+        }
+        let weight = cfg
+            .sources
+            .iter()
+            .find(|s| s.name == name)
+            .and_then(|s| s.weight)
+            .unwrap_or(1) as f32;
+        return Ok(vec![(name.to_string(), layout.db, weight)]);
     }
-    // No --source given: pick the first source that has an index db on disk.
-    // This is deliberately simple for MVP — the retriever already filters
-    // across sources inside a single db, but each source currently has its
-    // own db. A cross-source query surface is a later task.
+    let max = cfg.context.multi_source.max_sources_queried as usize;
+    let mut targets = Vec::new();
     for entry in &cfg.sources {
+        if targets.len() >= max {
+            break;
+        }
+        let weight = entry.weight.unwrap_or(1);
+        if weight == 0 {
+            continue;
+        }
         let layout = SourceLayout::for_source(deps.home_dir(), &entry.name);
         if layout.db.exists() {
-            return Ok((entry.name.clone(), layout.db));
+            targets.push((entry.name.clone(), layout.db, weight as f32));
         }
     }
-    Err(anyhow!(
-        "no indexed sources found; run `quorum context index --all` first"
-    ))
+    if targets.is_empty() {
+        return Err(anyhow!(
+            "no indexed sources found; run `quorum context index --all` first"
+        ));
+    }
+    Ok(targets)
 }
 
 fn render_query_table(hits: &[crate::context::retrieve::ScoredChunk], explain: bool) -> String {

--- a/src/context/retrieve/multi_source.rs
+++ b/src/context/retrieve/multi_source.rs
@@ -3,10 +3,16 @@ use std::collections::HashSet;
 use super::retriever::ScoredChunk;
 use crate::context::config::MultiSourceConfig;
 
+/// Reciprocal Rank Fusion constant. Higher values compress rank differences.
+/// k=60 is the standard value from the original RRF paper (Cormack et al. 2009).
+const RRF_K: f32 = 60.0;
+
 #[derive(Debug, Clone)]
 pub struct SourceBatch {
     pub source_name: String,
     pub chunks: Vec<ScoredChunk>,
+    /// Source weight multiplier (from sources.toml). Default 1.0.
+    pub weight: f32,
 }
 
 #[derive(Debug, Clone)]
@@ -20,11 +26,18 @@ pub struct BoostContext {
 pub(crate) struct MultiSourceCandidate {
     pub chunk: ScoredChunk,
     pub source_name: String,
-    pub normalized_score: f32,
+    pub rrf_score: f32,
     pub boosted_score: f32,
     pub is_current_repo: bool,
 }
 
+/// Merge candidates from multiple sources using Reciprocal Rank Fusion.
+///
+/// Each chunk's base score is `weight / (RRF_K + rank)` where rank is its
+/// 1-indexed position within the source batch (pre-sorted by retriever score).
+/// Multiplicative boosts (current-repo, dep-manifest, language-match) are
+/// applied on top. Diversity constraints enforce per-source caps and
+/// current-repo reserved slots.
 pub fn merge_and_rerank(
     batches: &[SourceBatch],
     config: &MultiSourceConfig,
@@ -43,8 +56,6 @@ pub fn merge_and_rerank(
             .as_ref()
             .is_some_and(|cr| cr == &batch.source_name);
 
-        // Filter NaN scores before normalization — they'd corrupt min/max
-        // and sort ordering.
         let clean_chunks: Vec<&ScoredChunk> = batch
             .chunks
             .iter()
@@ -54,15 +65,8 @@ pub fn merge_and_rerank(
             continue;
         }
 
-        let (min_score, max_score) = min_max_scores_refs(&clean_chunks);
-        let range = max_score - min_score;
-
-        for sc in &clean_chunks {
-            let normalized = if range < f32::EPSILON {
-                1.0
-            } else {
-                (sc.score - min_score) / range
-            };
+        for (rank_0, sc) in clean_chunks.iter().enumerate() {
+            let rrf_score = batch.weight / (RRF_K + (rank_0 as f32) + 1.0);
 
             let mut boost = 1.0f32;
             if is_current {
@@ -82,8 +86,8 @@ pub fn merge_and_rerank(
             candidates.push(MultiSourceCandidate {
                 chunk: (*sc).clone(),
                 source_name: batch.source_name.clone(),
-                normalized_score: normalized,
-                boosted_score: normalized * boost,
+                rrf_score,
+                boosted_score: rrf_score * boost,
                 is_current_repo: is_current,
             });
         }
@@ -97,26 +101,6 @@ pub fn merge_and_rerank(
     });
 
     apply_diversity_constraints(candidates, config, ctx, top_k as usize)
-}
-
-fn min_max_scores_refs(chunks: &[&ScoredChunk]) -> (f32, f32) {
-    let mut min = f32::INFINITY;
-    let mut max = f32::NEG_INFINITY;
-    for c in chunks {
-        if c.score < min {
-            min = c.score;
-        }
-        if c.score > max {
-            max = c.score;
-        }
-    }
-    if !min.is_finite() {
-        min = 0.0;
-    }
-    if !max.is_finite() {
-        max = 0.0;
-    }
-    (min, max)
 }
 
 fn apply_diversity_constraints(

--- a/src/context/retrieve/multi_source_tests.rs
+++ b/src/context/retrieve/multi_source_tests.rs
@@ -61,6 +61,7 @@ fn boost_ctx(current_repo: Option<&str>, dep_sources: &[&str]) -> BoostContext {
 fn single_source_passes_through() {
     let batch = SourceBatch {
         source_name: "alpha".into(),
+        weight: 1.0,
         chunks: vec![scored("a1", "alpha", 0.9), scored("a2", "alpha", 0.7)],
     };
     let config = default_config();
@@ -72,23 +73,22 @@ fn single_source_passes_through() {
 
 #[test]
 fn multi_source_interleaves_by_score() {
-    // Use 2+ chunks per source so min-max normalization differentiates them
     let b1 = SourceBatch {
         source_name: "alpha".into(),
+        weight: 1.0,
         chunks: vec![scored("a1", "alpha", 0.9), scored("a2", "alpha", 0.1)],
     };
     let b2 = SourceBatch {
         source_name: "beta".into(),
+        weight: 1.0,
         chunks: vec![scored("b1", "beta", 0.95), scored("b2", "beta", 0.1)],
     };
     let config = default_config();
     let ctx = boost_ctx(None, &[]);
     let result = merge_and_rerank(&[b1, b2], &config, &ctx, 10);
     assert_eq!(result.len(), 4);
-    // Both top chunks normalize to 1.0 (they're the max in their batch),
-    // so their boosted scores are equal (both get lang_match 1.1).
-    // With identical scores, tiebreak is by chunk id ascending: a1 < b1.
-    // The key assertion is that mixing sources works — both appear.
+    // RRF: rank-1 chunks from both sources get same score (1/61 * 1.1).
+    // Tiebreak by chunk id ascending: a1 < b1. Both sources appear.
     let sources: Vec<_> = result.iter().map(|c| c.chunk.source.as_str()).collect();
     assert!(sources.contains(&"alpha"));
     assert!(sources.contains(&"beta"));
@@ -98,16 +98,18 @@ fn multi_source_interleaves_by_score() {
 fn current_repo_boost_promotes_chunks() {
     let b1 = SourceBatch {
         source_name: "current".into(),
+        weight: 1.0,
         chunks: vec![scored("c1", "current", 0.7)],
     };
     let b2 = SourceBatch {
         source_name: "other".into(),
+        weight: 1.0,
         chunks: vec![scored("o1", "other", 0.8)],
     };
     let config = default_config();
     let ctx = boost_ctx(Some("current"), &[]);
     let result = merge_and_rerank(&[b1, b2], &config, &ctx, 10);
-    // 0.7 * 1.3 = 0.91 vs 0.8 → current should be first
+    // Both rank-1: RRF = 1/61. current gets 1.3*1.1 boost, other gets 1.1 only.
     assert_eq!(result[0].chunk.source, "current");
 }
 
@@ -115,16 +117,18 @@ fn current_repo_boost_promotes_chunks() {
 fn dep_manifest_boost_promotes_chunks() {
     let b1 = SourceBatch {
         source_name: "dep-lib".into(),
+        weight: 1.0,
         chunks: vec![scored("d1", "dep-lib", 0.7)],
     };
     let b2 = SourceBatch {
         source_name: "unrelated".into(),
+        weight: 1.0,
         chunks: vec![scored("u1", "unrelated", 0.75)],
     };
     let config = default_config();
     let ctx = boost_ctx(None, &["dep-lib"]);
     let result = merge_and_rerank(&[b1, b2], &config, &ctx, 10);
-    // 0.7 * 1.2 = 0.84 vs 0.75 → dep should be first
+    // Both rank-1: RRF = 1/61. dep-lib gets 1.2*1.1 boost, unrelated gets 1.1 only.
     assert_eq!(result[0].chunk.source, "dep-lib");
 }
 
@@ -133,21 +137,20 @@ fn boosts_compose_multiplicatively() {
     // Use multi-chunk batches so normalization spreads scores
     let b1 = SourceBatch {
         source_name: "my-dep".into(),
+        weight: 1.0,
         chunks: vec![scored("md1", "my-dep", 0.5), scored("md2", "my-dep", 0.1)],
     };
     let b2 = SourceBatch {
         source_name: "other".into(),
+        weight: 1.0,
         chunks: vec![scored("o1", "other", 0.8), scored("o2", "other", 0.1)],
     };
     let config = default_config();
     // my-dep is both current repo AND a dep AND lang match → 1.3*1.2*1.1 = 1.716
     let ctx = boost_ctx(Some("my-dep"), &["my-dep"]);
     let result = merge_and_rerank(&[b1, b2], &config, &ctx, 10);
-    // md1: normalized = (0.5-0.1)/(0.5-0.1) = 1.0, boosted = 1.0*1.716 = 1.716
-    // o1:  normalized = (0.8-0.1)/(0.8-0.1) = 1.0, boosted = 1.0*1.1 = 1.1
-    // my-dep top chunk should be first due to triple boost
+    // Both rank-1: RRF = 1/61. my-dep gets 1.716x boost, other gets 1.1x.
     assert_eq!(result[0].chunk.source, "my-dep");
-    // Verify the boost was > 1.1 (lang match only)
     assert!(result[0].score > result[1].score);
 }
 
@@ -159,6 +162,7 @@ fn per_source_cap_limits_non_current_repo() {
     }
     let batch = SourceBatch {
         source_name: "external".into(),
+        weight: 1.0,
         chunks,
     };
     let mut config = default_config();
@@ -173,6 +177,7 @@ fn current_repo_reserved_slots_guaranteed() {
     // current-repo has lower-scoring chunks, but reserved slots guarantee inclusion
     let b_current = SourceBatch {
         source_name: "current".into(),
+        weight: 1.0,
         chunks: vec![scored("c1", "current", 0.3), scored("c2", "current", 0.25)],
     };
     let mut other_chunks = Vec::new();
@@ -181,6 +186,7 @@ fn current_repo_reserved_slots_guaranteed() {
     }
     let b_other = SourceBatch {
         source_name: "other".into(),
+        weight: 1.0,
         chunks: other_chunks,
     };
     let mut config = default_config();
@@ -206,6 +212,7 @@ fn per_source_cap_does_not_apply_to_current_repo() {
     }
     let batch = SourceBatch {
         source_name: "current".into(),
+        weight: 1.0,
         chunks,
     };
     let mut config = default_config();
@@ -234,6 +241,7 @@ fn respects_top_k_limit() {
     }
     let batch = SourceBatch {
         source_name: "src".into(),
+        weight: 1.0,
         chunks,
     };
     let config = default_config();
@@ -243,22 +251,21 @@ fn respects_top_k_limit() {
 }
 
 #[test]
-fn min_max_normalization_single_chunk_source_scores_one() {
+fn rrf_single_chunk_source_uses_rank_one() {
     let batch = SourceBatch {
         source_name: "solo".into(),
+        weight: 1.0,
         chunks: vec![scored("s1", "solo", 0.5)],
     };
     let config = default_config();
     let ctx = boost_ctx(None, &[]);
     let result = merge_and_rerank(&[batch], &config, &ctx, 10);
     assert_eq!(result.len(), 1);
-    // Single-candidate source → normalized to 1.0 → lang_match boost if applicable
-    // No lang match since ctx has no current repo and "rust" matches "rust" from boost_ctx
-    // Actually boost_ctx sets reviewed_language = Some("rust") and chunk language = "rust"
-    // so lang_match = 1.1, normalized = 1.0 * 1.1 = 1.1
+    // RRF: weight=1.0 / (60 + 1) = 0.01639, lang_match boost 1.1 → ~0.01803
+    let expected = 1.0 / 61.0 * 1.1;
     assert!(
-        result[0].score > 0.9,
-        "single candidate should normalize high, got {}",
+        (result[0].score - expected).abs() < 0.001,
+        "expected ~{expected:.5}, got {}",
         result[0].score
     );
 }
@@ -267,10 +274,12 @@ fn min_max_normalization_single_chunk_source_scores_one() {
 fn output_sorted_descending_by_score() {
     let b1 = SourceBatch {
         source_name: "a".into(),
+        weight: 1.0,
         chunks: vec![scored("a1", "a", 0.3), scored("a2", "a", 0.9)],
     };
     let b2 = SourceBatch {
         source_name: "b".into(),
+        weight: 1.0,
         chunks: vec![scored("b1", "b", 0.6)],
     };
     let config = default_config();
@@ -292,10 +301,51 @@ fn candidates_preserve_source_legs() {
     chunk.source_legs = vec![RetrievalLeg::Structural];
     let batch = SourceBatch {
         source_name: "alpha".into(),
+        weight: 1.0,
         chunks: vec![chunk],
     };
     let config = default_config();
     let ctx = boost_ctx(None, &[]);
     let result = merge_and_rerank(&[batch], &config, &ctx, 10);
     assert_eq!(result[0].source_legs, vec![RetrievalLeg::Structural]);
+}
+
+#[test]
+fn higher_weight_source_ranks_above_lower_weight() {
+    let b1 = SourceBatch {
+        source_name: "heavy".into(),
+        weight: 3.0,
+        chunks: vec![scored("h1", "heavy", 0.5)],
+    };
+    let b2 = SourceBatch {
+        source_name: "light".into(),
+        weight: 1.0,
+        chunks: vec![scored("l1", "light", 0.9)],
+    };
+    let config = default_config();
+    let ctx = boost_ctx(None, &[]);
+    let result = merge_and_rerank(&[b1, b2], &config, &ctx, 10);
+    // Both rank-1: heavy gets 3/61, light gets 1/61. Heavy wins regardless of raw score.
+    assert_eq!(result[0].chunk.source, "heavy");
+    assert_eq!(result[1].chunk.source, "light");
+}
+
+#[test]
+fn rrf_rank_ordering_within_source() {
+    let batch = SourceBatch {
+        source_name: "s".into(),
+        weight: 1.0,
+        chunks: vec![
+            scored("r1", "s", 0.9),
+            scored("r2", "s", 0.8),
+            scored("r3", "s", 0.7),
+        ],
+    };
+    let config = default_config();
+    let ctx = boost_ctx(None, &[]);
+    let result = merge_and_rerank(&[batch], &config, &ctx, 10);
+    // RRF scores decrease with rank: 1/61 > 1/62 > 1/63
+    assert!(result[0].score > result[1].score);
+    assert!(result[1].score > result[2].score);
+    assert_eq!(result[0].chunk.id, "r1");
 }


### PR DESCRIPTION
## Summary

- Replace single-source `resolve_query_target` with `resolve_query_targets` that fans out `quorum context query` across all indexed sources
- Switch `merge_and_rerank` from min-max normalization to Reciprocal Rank Fusion (RRF) scoring: `score = weight / (K + rank)` where K=60
- Source weights from `sources.toml` act as RRF score multipliers; weight=0 excludes a source from fan-out
- Pass source weights through `bootstrap.rs` → `SourceBatch.weight`

Closes #370

## Test plan

- [x] 15 multi_source tests pass (including new RRF-specific tests: `higher_weight_source_ranks_above_lower_weight`, `rrf_rank_ordering_within_source`, `rrf_single_chunk_source_uses_rank_one`)
- [x] 41 query tests pass
- [x] Full suite: 1578 pass, 1 ignored
- [x] Clippy clean (`-D warnings`)
- [x] Release build succeeds

## Quorum review verdicts

| File | Finding | Verdict | Notes |
|------|---------|---------|-------|
| multi_source.rs | dedup by id only | tp | Pre-existing, filed #371 |
| multi_source.rs | trusts non-finite weights | fp (out-of-scope) | Config-validated, pre-existing |
| cli.rs | run_query complexity 12 | tp (wontfix) | Inherent orchestration complexity |
| bootstrap.rs | invalid weight values | fp (out-of-scope) | Pre-existing |
| bootstrap.rs | max_sources_queried=0 | fp (out-of-scope) | Config validation catches this |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Multi-source search results are now intelligently merged using source-weighted ranking and advanced relevance scoring.
  * Configurable source weights now influence how results are prioritized across multiple indexed sources.

* **Refactor**
  * Enhanced multi-source query processing for improved result merging and ranking across indexed sources.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jsnyder/quorum/pull/372?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->