### PR TITLE
feat: inline logistic calibrator for FP suppression and TP boosting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2713,7 +2713,7 @@ checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quorum"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quorum"
-version = "0.23.0"
+version = "0.24.0"
 edition = "2024"
 # `str::floor_char_boundary` (used in src/agent.rs and src/tools.rs to
 # truncate UTF-8 safely) stabilized in Rust 1.93. Older constraints —

--- a/docs/superpowers/plans/2026-05-16-logistic-calibrator.md
+++ b/docs/superpowers/plans/2026-05-16-logistic-calibrator.md
@@ -1,0 +1,2045 @@
+# Logistic Calibrator Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the broken 4-feature grid-search weight learner with an inline L2-regularized logistic regression over ~15 expanded features, modeling P(FP) directly, with dual thresholds for suppress and boost decisions at review time.
+
+**Architecture:** New `src/logistic.rs` implements batch gradient descent with backtracking line search. `src/calibrate.rs` gains expanded feature extraction (15 features) with per-fold univariate screening. `src/calibrator_model.rs` gains a `LogisticModel` struct stored in TOML. `src/calibrator.rs` gains a logistic scoring path that replaces composite scoring when a logistic model is present.
+
+**Tech Stack:** Rust (no external deps beyond existing), inline logistic regression, z-score standardization, stepwise Average Precision metric.
+
+---
+
+## File Structure
+
+| File | Responsibility | Change Type |
+|------|---------------|-------------|
+| `src/logistic.rs` | Logistic regression: standardization, gradient descent, line search, prediction | New (~200 LOC) |
+| `src/metrics.rs` | Add `average_precision_stepwise()` and `fp_recall_at_tp_recall()` | Modify |
+| `src/calibrate.rs` | `ExpandedFeatures` struct (15 fields), fold-local extraction, univariate screening, `learn_logistic()` orchestrator | Modify |
+| `src/calibrator_model.rs` | `LogisticModel` struct + TOML ser/de | Modify |
+| `src/calibrator.rs` | Review-time logistic scoring path (dual threshold) | Modify |
+| `src/main.rs` | Wire `--feature-importance`, upgraded `--learn-weights` flow | Modify |
+| `src/cli/mod.rs` | `--feature-importance` flag definition | Modify |
+
+---
+
+### Task 1: Stepwise Average Precision Metric
+
+**Files:**
+- Modify: `src/metrics.rs`
+
+This task adds the two metrics needed for feature screening and model evaluation. The existing `pr_auc` uses trapezoidal integration which inflates at high prevalence — stepwise AP fixes this.
+
+- [ ] **Step 1: Write failing test for `average_precision_stepwise`**
+
+```rust
+#[test]
+fn average_precision_stepwise_basic() {
+    // 3 positives, 2 negatives. Scores: [0.9(+), 0.8(-), 0.7(+), 0.4(+), 0.2(-)]
+    let samples = vec![
+        (0.9, true),
+        (0.8, false),
+        (0.7, true),
+        (0.4, true),
+        (0.2, false),
+    ];
+    let ap = average_precision_stepwise(&samples);
+    // At rank 1: P=1/1, recall jumps -> contributes 1.0 * (1/3)
+    // At rank 3: P=2/3, recall jumps -> contributes (2/3) * (1/3)
+    // At rank 4: P=3/4, recall jumps -> contributes (3/4) * (1/3)
+    // AP = (1.0 + 2/3 + 3/4) / 3 = 2.4167/3 = 0.8056
+    assert!((ap - 0.8056).abs() < 0.001);
+}
+
+#[test]
+fn average_precision_stepwise_perfect() {
+    let samples = vec![(0.9, true), (0.8, true), (0.1, false)];
+    let ap = average_precision_stepwise(&samples);
+    assert!((ap - 1.0).abs() < 1e-9);
+}
+
+#[test]
+fn average_precision_stepwise_worst() {
+    // All negatives ranked first
+    let samples = vec![(0.9, false), (0.8, false), (0.1, true)];
+    let ap = average_precision_stepwise(&samples);
+    // Only recall jump at rank 3: P=1/3
+    assert!((ap - 1.0 / 3.0).abs() < 0.001);
+}
+
+#[test]
+fn average_precision_stepwise_empty() {
+    let samples: Vec<(f64, bool)> = vec![];
+    let ap = average_precision_stepwise(&samples);
+    assert_eq!(ap, 0.0);
+}
+
+#[test]
+fn average_precision_stepwise_no_positives() {
+    let samples = vec![(0.9, false), (0.5, false)];
+    let ap = average_precision_stepwise(&samples);
+    assert_eq!(ap, 0.0);
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test --bin quorum average_precision_stepwise`
+Expected: FAIL — function not found
+
+- [ ] **Step 3: Implement `average_precision_stepwise`**
+
+Add to `src/metrics.rs`:
+
+```rust
+/// Stepwise Average Precision (interpolation-free).
+/// Sums P(k) * delta_recall(k) over ranks where recall increases.
+/// Higher score = more likely positive class.
+pub fn average_precision_stepwise(samples: &[(f64, bool)]) -> f64 {
+    if samples.is_empty() {
+        return 0.0;
+    }
+    let total_pos = samples.iter().filter(|(_, p)| *p).count();
+    if total_pos == 0 {
+        return 0.0;
+    }
+
+    let mut sorted: Vec<(f64, bool)> = samples.to_vec();
+    sorted.sort_by(|a, b| b.0.partial_cmp(&a.0).unwrap_or(std::cmp::Ordering::Equal));
+
+    let mut tp = 0u64;
+    let mut ap_sum = 0.0;
+    for (rank, &(_, is_pos)) in sorted.iter().enumerate() {
+        if is_pos {
+            tp += 1;
+            let precision = tp as f64 / (rank as f64 + 1.0);
+            ap_sum += precision;
+        }
+    }
+    ap_sum / total_pos as f64
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cargo test --bin quorum average_precision_stepwise`
+Expected: PASS (all 5 tests)
+
+- [ ] **Step 5: Write failing test for `fp_recall_at_tp_recall`**
+
+```rust
+#[test]
+fn fp_recall_at_tp_recall_basic() {
+    // 10 samples: 8 TP (label=false in FP-positive), 2 FP (label=true)
+    // Model P(FP): FP items scored high, TP items scored low
+    // FP items at scores 0.9, 0.7. TP items at 0.1-0.5.
+    let predictions: Vec<(f64, bool)> = vec![
+        (0.9, true),  // FP
+        (0.7, true),  // FP
+        (0.5, false), // TP
+        (0.4, false), // TP
+        (0.3, false), // TP
+        (0.3, false), // TP
+        (0.2, false), // TP
+        (0.2, false), // TP
+        (0.1, false), // TP
+        (0.1, false), // TP
+    ];
+    // At threshold=0.6: suppress 2 items (both FP). FP recall = 2/2 = 1.0.
+    // TP recall = 8/8 = 1.0 (no TPs suppressed). Meets 99% TP recall.
+    let fp_recall = fp_recall_at_tp_recall(&predictions, 0.99);
+    assert!((fp_recall - 1.0).abs() < 1e-9);
+}
+
+#[test]
+fn fp_recall_at_tp_recall_no_separation() {
+    // All same score — can't separate
+    let predictions: Vec<(f64, bool)> = vec![
+        (0.5, true),
+        (0.5, true),
+        (0.5, false),
+        (0.5, false),
+    ];
+    let fp_recall = fp_recall_at_tp_recall(&predictions, 0.99);
+    assert_eq!(fp_recall, 0.0);
+}
+```
+
+- [ ] **Step 6: Implement `fp_recall_at_tp_recall`**
+
+```rust
+/// FP recall achievable at a given minimum TP recall constraint.
+///
+/// predictions: (P(FP), is_fp) — higher P(FP) means more likely false positive.
+/// Sweeps thresholds from high to low, counting how many FPs we catch
+/// while keeping TP false-suppression rate within (1 - min_tp_recall).
+pub fn fp_recall_at_tp_recall(predictions: &[(f64, bool)], min_tp_recall: f64) -> f64 {
+    if predictions.is_empty() {
+        return 0.0;
+    }
+    let total_fp = predictions.iter().filter(|(_, fp)| *fp).count();
+    let total_tp = predictions.iter().filter(|(_, fp)| !*fp).count();
+    if total_fp == 0 || total_tp == 0 {
+        return 0.0;
+    }
+
+    let max_tp_suppressed = ((1.0 - min_tp_recall) * total_tp as f64).floor() as usize;
+
+    let mut sorted: Vec<(f64, bool)> = predictions.to_vec();
+    sorted.sort_by(|a, b| b.0.partial_cmp(&a.0).unwrap_or(std::cmp::Ordering::Equal));
+
+    let mut fp_caught = 0usize;
+    let mut tp_suppressed = 0usize;
+
+    for &(_, is_fp) in &sorted {
+        if is_fp {
+            fp_caught += 1;
+        } else {
+            tp_suppressed += 1;
+            if tp_suppressed > max_tp_suppressed {
+                break;
+            }
+        }
+    }
+
+    fp_caught as f64 / total_fp as f64
+}
+```
+
+- [ ] **Step 7: Run tests to verify both pass**
+
+Run: `cargo test --bin quorum fp_recall_at_tp_recall`
+Expected: PASS
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/metrics.rs
+git commit -m "feat(metrics): add stepwise average precision and fp_recall_at_tp_recall"
+```
+
+---
+
+### Task 2: Logistic Regression Core (`src/logistic.rs`)
+
+**Files:**
+- Create: `src/logistic.rs`
+- Modify: `src/main.rs` (add `mod logistic;`)
+
+The logistic regression module handles standardization, gradient computation, backtracking line search, and prediction. No external deps.
+
+- [ ] **Step 1: Write failing tests**
+
+Create the test module at the bottom of the new file. Tests cover: sigmoid, standardization, gradient computation, fitting on linearly separable data, and prediction.
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sigmoid_at_zero() {
+        assert!((sigmoid(0.0) - 0.5).abs() < 1e-9);
+    }
+
+    #[test]
+    fn sigmoid_extreme_positive() {
+        assert!((sigmoid(100.0) - 1.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn sigmoid_extreme_negative() {
+        assert!(sigmoid(-100.0) < 1e-6);
+    }
+
+    #[test]
+    fn standardize_basic() {
+        let data = vec![vec![1.0, 10.0], vec![3.0, 20.0], vec![5.0, 30.0]];
+        let (normed, means, stddevs) = standardize(&data);
+        // Mean of col 0: 3.0, stddev: ~1.633
+        assert!((means[0] - 3.0).abs() < 1e-9);
+        // Normalized first element: (1.0 - 3.0) / stddev
+        assert!(normed[0][0] < 0.0);
+        // All columns have mean ~0
+        let col0_mean: f64 = normed.iter().map(|r| r[0]).sum::<f64>() / 3.0;
+        assert!(col0_mean.abs() < 1e-9);
+    }
+
+    #[test]
+    fn standardize_constant_column() {
+        let data = vec![vec![5.0, 1.0], vec![5.0, 2.0], vec![5.0, 3.0]];
+        let (normed, _, stddevs) = standardize(&data);
+        // Constant column: stddev ~ 0, but epsilon prevents div by zero
+        assert!(normed[0][0].is_finite());
+        assert!(stddevs[0] < 1e-6);
+    }
+
+    #[test]
+    fn fit_linearly_separable() {
+        // Class 1 (FP): feature > 0.5; Class 0 (TP): feature < 0.5
+        let x: Vec<Vec<f64>> = (0..100)
+            .map(|i| vec![i as f64 / 100.0])
+            .collect();
+        let y: Vec<bool> = (0..100).map(|i| i >= 50).collect();
+        let result = fit(&x, &y, 0.1, 500);
+        // Should achieve high accuracy
+        let correct = x.iter().zip(y.iter()).filter(|(xi, &yi)| {
+            let p = result.predict_one(xi);
+            (p >= 0.5) == yi
+        }).count();
+        assert!(correct >= 90);
+    }
+
+    #[test]
+    fn predict_batch() {
+        let model = LogisticFit {
+            coefficients: vec![1.0],
+            intercept: 0.0,
+            feature_means: vec![0.0],
+            feature_stddevs: vec![1.0],
+        };
+        let x = vec![vec![2.0], vec![-2.0]];
+        let preds = model.predict(&x);
+        assert!(preds[0] > 0.5);
+        assert!(preds[1] < 0.5);
+    }
+}
+```
+
+- [ ] **Step 2: Create `src/logistic.rs` with stubs and tests, add module declaration**
+
+Add `mod logistic;` to `src/main.rs` (near other mod declarations).
+
+Create `src/logistic.rs`:
+
+```rust
+const EPSILON: f64 = 1e-8;
+const ARMIJO_C: f64 = 1e-4;
+const ARMIJO_BETA: f64 = 0.5;
+
+pub fn sigmoid(z: f64) -> f64 {
+    if z >= 0.0 {
+        let e = (-z).exp();
+        1.0 / (1.0 + e)
+    } else {
+        let e = z.exp();
+        e / (1.0 + e)
+    }
+}
+
+/// Z-score normalization. Returns (normalized_data, means, stddevs).
+pub fn standardize(data: &[Vec<f64>]) -> (Vec<Vec<f64>>, Vec<f64>, Vec<f64>) {
+    let n = data.len();
+    if n == 0 {
+        return (vec![], vec![], vec![]);
+    }
+    let d = data[0].len();
+    let mut means = vec![0.0; d];
+    let mut stddevs = vec![0.0; d];
+
+    for row in data {
+        for (j, val) in row.iter().enumerate() {
+            means[j] += val;
+        }
+    }
+    for m in &mut means {
+        *m /= n as f64;
+    }
+
+    for row in data {
+        for (j, val) in row.iter().enumerate() {
+            let diff = val - means[j];
+            stddevs[j] += diff * diff;
+        }
+    }
+    for s in &mut stddevs {
+        *s = (*s / n as f64).sqrt();
+    }
+
+    let normed: Vec<Vec<f64>> = data
+        .iter()
+        .map(|row| {
+            row.iter()
+                .enumerate()
+                .map(|(j, val)| (val - means[j]) / (stddevs[j] + EPSILON))
+                .collect()
+        })
+        .collect();
+
+    (normed, means, stddevs)
+}
+
+/// Result of logistic regression fitting.
+#[derive(Debug, Clone)]
+pub struct LogisticFit {
+    pub coefficients: Vec<f64>,
+    pub intercept: f64,
+    pub feature_means: Vec<f64>,
+    pub feature_stddevs: Vec<f64>,
+}
+
+impl LogisticFit {
+    /// Predict P(positive) for a single raw (unstandardized) sample.
+    pub fn predict_one(&self, x: &[f64]) -> f64 {
+        let z: f64 = x
+            .iter()
+            .enumerate()
+            .map(|(j, val)| {
+                let normed = (val - self.feature_means[j]) / (self.feature_stddevs[j] + EPSILON);
+                self.coefficients[j] * normed
+            })
+            .sum::<f64>()
+            + self.intercept;
+        sigmoid(z)
+    }
+
+    /// Predict P(positive) for a batch of raw samples.
+    pub fn predict(&self, data: &[Vec<f64>]) -> Vec<f64> {
+        data.iter().map(|x| self.predict_one(x)).collect()
+    }
+}
+
+/// L2-regularized logistic regression via batch gradient descent with
+/// backtracking line search (Armijo condition).
+///
+/// - `x`: feature matrix (raw, will be standardized internally)
+/// - `y`: labels (true = positive class)
+/// - `lambda`: L2 regularization strength
+/// - `max_iter`: maximum gradient descent iterations
+pub fn fit(x: &[Vec<f64>], y: &[bool], lambda: f64, max_iter: usize) -> LogisticFit {
+    let (normed, means, stddevs) = standardize(x);
+    let n = normed.len();
+    let d = if n > 0 { normed[0].len() } else { 0 };
+
+    let mut w = vec![0.0; d];
+    let mut b = 0.0;
+
+    let y_f: Vec<f64> = y.iter().map(|&v| if v { 1.0 } else { 0.0 }).collect();
+
+    let mut prev_loss = f64::MAX;
+
+    for _iter in 0..max_iter {
+        let (loss, grad_w, grad_b) = compute_loss_and_grad(&normed, &y_f, &w, b, lambda);
+
+        // Convergence check: relative loss change
+        if prev_loss < f64::MAX {
+            let rel_change = (prev_loss - loss) / (prev_loss.abs() + EPSILON);
+            if rel_change < 1e-4 && rel_change >= 0.0 {
+                break;
+            }
+        }
+        prev_loss = loss;
+
+        // Backtracking line search (Armijo)
+        let mut step = 1.0;
+        let grad_norm_sq: f64 =
+            grad_w.iter().map(|g| g * g).sum::<f64>() + grad_b * grad_b;
+
+        for _ in 0..20 {
+            let new_w: Vec<f64> = w
+                .iter()
+                .zip(grad_w.iter())
+                .map(|(wi, gi)| wi - step * gi)
+                .collect();
+            let new_b = b - step * grad_b;
+            let new_loss = compute_loss(&normed, &y_f, &new_w, new_b, lambda);
+            if new_loss <= loss - ARMIJO_C * step * grad_norm_sq {
+                w = new_w;
+                b = new_b;
+                break;
+            }
+            step *= ARMIJO_BETA;
+            if step < 1e-10 {
+                // Step too small, just take the gradient step
+                w = w
+                    .iter()
+                    .zip(grad_w.iter())
+                    .map(|(wi, gi)| wi - step * gi)
+                    .collect();
+                b -= step * grad_b;
+                break;
+            }
+        }
+    }
+
+    LogisticFit {
+        coefficients: w,
+        intercept: b,
+        feature_means: means,
+        feature_stddevs: stddevs,
+    }
+}
+
+fn compute_loss_and_grad(
+    x: &[Vec<f64>],
+    y: &[f64],
+    w: &[f64],
+    b: f64,
+    lambda: f64,
+) -> (f64, Vec<f64>, f64) {
+    let n = x.len();
+    let d = w.len();
+    let mut loss = 0.0;
+    let mut grad_w = vec![0.0; d];
+    let mut grad_b = 0.0;
+
+    for (i, xi) in x.iter().enumerate() {
+        let z: f64 = xi.iter().zip(w.iter()).map(|(xj, wj)| xj * wj).sum::<f64>() + b;
+        let p = sigmoid(z);
+        let yi = y[i];
+
+        // Cross-entropy loss (numerically stable)
+        loss += -yi * z + z.max(0.0) + (1.0 + (-z.abs()).exp()).ln();
+
+        let err = p - yi;
+        for (j, xj) in xi.iter().enumerate() {
+            grad_w[j] += err * xj;
+        }
+        grad_b += err;
+    }
+
+    // Average + L2 regularization (not on intercept)
+    loss /= n as f64;
+    loss += 0.5 * lambda * w.iter().map(|wi| wi * wi).sum::<f64>();
+
+    for (j, gj) in grad_w.iter_mut().enumerate() {
+        *gj = *gj / n as f64 + lambda * w[j];
+    }
+    grad_b /= n as f64;
+
+    (loss, grad_w, grad_b)
+}
+
+fn compute_loss(x: &[Vec<f64>], y: &[f64], w: &[f64], b: f64, lambda: f64) -> f64 {
+    let n = x.len();
+    let mut loss = 0.0;
+    for (i, xi) in x.iter().enumerate() {
+        let z: f64 = xi.iter().zip(w.iter()).map(|(xj, wj)| xj * wj).sum::<f64>() + b;
+        let yi = y[i];
+        loss += -yi * z + z.max(0.0) + (1.0 + (-z.abs()).exp()).ln();
+    }
+    loss /= n as f64;
+    loss += 0.5 * lambda * w.iter().map(|wi| wi * wi).sum::<f64>();
+    loss
+}
+```
+
+- [ ] **Step 3: Run tests to verify they pass**
+
+Run: `cargo test --bin quorum logistic::tests`
+Expected: PASS (all 6 tests)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/logistic.rs src/main.rs
+git commit -m "feat: add inline L2-regularized logistic regression (src/logistic.rs)"
+```
+
+---
+
+### Task 3: Expanded Feature Extraction
+
+**Files:**
+- Modify: `src/calibrate.rs`
+
+Replace the 4-field `SampleFeatures` with 15-field `ExpandedFeatures`. Keep `SampleFeatures` intact for backward compat with existing grid search (it still runs as a comparison). Add a new `extract_expanded_features()` function.
+
+- [ ] **Step 1: Write failing test for `ExpandedFeatures` construction**
+
+```rust
+#[test]
+fn expanded_features_to_vec_correct_order() {
+    let f = ExpandedFeatures {
+        log1p_tp_weight: 1.0,
+        log1p_fp_weight: 0.5,
+        precedent_count: 3.0,
+        max_similarity: 0.9,
+        mean_similarity: 0.7,
+        has_no_precedents: 0.0,
+        log1p_soft_fp_weight: 0.3,
+        log1p_full_suppress_weight: 0.1,
+        log1p_wontfix_weight: 0.0,
+        category_fp_rate: 0.25,
+        severity_fp_rate: 0.18,
+        model_fp_rate: 0.22,
+        max_word_lor: 2.1,
+        min_word_lor: -1.5,
+        count_negative_lor_tokens: 3.0,
+    };
+    let v = f.to_vec();
+    assert_eq!(v.len(), 15);
+    assert!((v[0] - 1.0).abs() < 1e-9);
+    assert!((v[14] - 3.0).abs() < 1e-9);
+}
+
+#[test]
+fn expanded_features_names_match_vec_order() {
+    let names = ExpandedFeatures::feature_names();
+    assert_eq!(names.len(), 15);
+    assert_eq!(names[0], "log1p_tp_weight");
+    assert_eq!(names[5], "has_no_precedents");
+    assert_eq!(names[14], "count_negative_lor_tokens");
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cargo test --bin quorum expanded_features`
+Expected: FAIL — struct not found
+
+- [ ] **Step 3: Implement `ExpandedFeatures` struct**
+
+Add to `src/calibrate.rs` below the existing `SampleFeatures`:
+
+```rust
+/// Expanded feature vector for logistic calibrator (15 dimensions).
+/// Field order matches `to_vec()` and `feature_names()`.
+#[derive(Debug, Clone)]
+pub struct ExpandedFeatures {
+    // Precedent decomposition (6)
+    pub log1p_tp_weight: f64,
+    pub log1p_fp_weight: f64,
+    pub precedent_count: f64,
+    pub max_similarity: f64,
+    pub mean_similarity: f64,
+    pub has_no_precedents: f64,
+    // Weight accumulators (3)
+    pub log1p_soft_fp_weight: f64,
+    pub log1p_full_suppress_weight: f64,
+    pub log1p_wontfix_weight: f64,
+    // Smoothed priors (3)
+    pub category_fp_rate: f64,
+    pub severity_fp_rate: f64,
+    pub model_fp_rate: f64,
+    // Text statistics (3)
+    pub max_word_lor: f64,
+    pub min_word_lor: f64,
+    pub count_negative_lor_tokens: f64,
+}
+
+impl ExpandedFeatures {
+    pub fn to_vec(&self) -> Vec<f64> {
+        vec![
+            self.log1p_tp_weight,
+            self.log1p_fp_weight,
+            self.precedent_count,
+            self.max_similarity,
+            self.mean_similarity,
+            self.has_no_precedents,
+            self.log1p_soft_fp_weight,
+            self.log1p_full_suppress_weight,
+            self.log1p_wontfix_weight,
+            self.category_fp_rate,
+            self.severity_fp_rate,
+            self.model_fp_rate,
+            self.max_word_lor,
+            self.min_word_lor,
+            self.count_negative_lor_tokens,
+        ]
+    }
+
+    pub fn feature_names() -> Vec<&'static str> {
+        vec![
+            "log1p_tp_weight",
+            "log1p_fp_weight",
+            "precedent_count",
+            "max_similarity",
+            "mean_similarity",
+            "has_no_precedents",
+            "log1p_soft_fp_weight",
+            "log1p_full_suppress_weight",
+            "log1p_wontfix_weight",
+            "category_fp_rate",
+            "severity_fp_rate",
+            "model_fp_rate",
+            "max_word_lor",
+            "min_word_lor",
+            "count_negative_lor_tokens",
+        ]
+    }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cargo test --bin quorum expanded_features`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/calibrate.rs
+git commit -m "feat(calibrate): add ExpandedFeatures struct with 15 dimensions"
+```
+
+---
+
+### Task 4: Fold-Local Feature Extraction
+
+**Files:**
+- Modify: `src/calibrate.rs`
+
+Add `extract_expanded_features()` that computes all 15 features from the joined corpus. Target-encoded features (category_fp_rate, severity_fp_rate, model_fp_rate, word_lor) are computed from a provided subset (enabling fold-local computation in Task 6).
+
+- [ ] **Step 1: Write failing test for fold-local target encoding**
+
+```rust
+#[test]
+fn beta_smoothed_rate_basic() {
+    // 3 FP out of 10 total, alpha=5
+    let rate = beta_smoothed_rate(3, 10, 5.0);
+    // (3 + 5*global) / (10 + 5) where global = 0.18 (example)
+    // But we pass the global_rate in, so: (3 + 5*0.18) / (10 + 5) = 3.9/15 = 0.26
+    assert!((rate - 0.26).abs() < 0.01);
+}
+
+#[test]
+fn extract_expanded_features_produces_correct_count() {
+    // Minimal integration test with synthetic data
+    let features = extract_expanded_features_from_fold(
+        &sample_traces(),
+        &sample_feedback(),
+        &FoldLocalStats::default(),
+    );
+    assert!(!features.is_empty());
+    for (f, _label) in &features {
+        let v = f.to_vec();
+        assert_eq!(v.len(), 15);
+        assert!(v.iter().all(|x| x.is_finite()));
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test --bin quorum extract_expanded_features`
+Expected: FAIL
+
+- [ ] **Step 3: Implement `FoldLocalStats` and `extract_expanded_features_from_fold`**
+
+```rust
+/// Per-fold computed statistics for target-encoded features.
+/// Prevents leakage by computing rates only from the training partition.
+#[derive(Debug, Clone)]
+pub struct FoldLocalStats {
+    pub category_fp_rates: HashMap<String, f64>,
+    pub severity_fp_rates: HashMap<String, f64>,
+    pub model_fp_rates: HashMap<String, f64>,
+    pub word_lor: HashMap<String, f64>,
+    pub global_fp_rate: f64,
+}
+
+impl Default for FoldLocalStats {
+    fn default() -> Self {
+        Self {
+            category_fp_rates: HashMap::new(),
+            severity_fp_rates: HashMap::new(),
+            model_fp_rates: HashMap::new(),
+            word_lor: HashMap::new(),
+            global_fp_rate: 0.18,
+        }
+    }
+}
+
+const BETA_ALPHA: f64 = 5.0;
+
+pub fn beta_smoothed_rate(fp_count: usize, total: usize, global_rate: f64) -> f64 {
+    (fp_count as f64 + BETA_ALPHA * global_rate) / (total as f64 + BETA_ALPHA)
+}
+
+/// Compute FoldLocalStats from a training partition of feedback entries.
+pub fn compute_fold_local_stats(
+    feedback_partition: &[&serde_json::Value],
+    traces_partition: &[&serde_json::Value],
+) -> FoldLocalStats {
+    let mut total_fp = 0usize;
+    let mut total = 0usize;
+    let mut category_counts: HashMap<String, (usize, usize)> = HashMap::new(); // (fp, total)
+    let mut severity_counts: HashMap<String, (usize, usize)> = HashMap::new();
+    let mut model_counts: HashMap<String, (usize, usize)> = HashMap::new();
+    let mut word_tp: HashMap<String, usize> = HashMap::new();
+    let mut word_fp: HashMap<String, usize> = HashMap::new();
+
+    for entry in feedback_partition {
+        let verdict = entry["verdict"].as_str().unwrap_or("");
+        let is_fp = verdict == "fp";
+        let is_tp = verdict == "tp" || verdict == "partial";
+        if !is_fp && !is_tp {
+            continue;
+        }
+        total += 1;
+        if is_fp {
+            total_fp += 1;
+        }
+
+        let category = entry["finding_category"].as_str().unwrap_or("unknown").to_string();
+        let severity = entry["input_severity"].as_str().unwrap_or("medium").to_string();
+        let model = entry["model"].as_str().unwrap_or("unknown").to_string();
+
+        let cat_entry = category_counts.entry(category).or_insert((0, 0));
+        cat_entry.1 += 1;
+        if is_fp { cat_entry.0 += 1; }
+
+        let sev_entry = severity_counts.entry(severity).or_insert((0, 0));
+        sev_entry.1 += 1;
+        if is_fp { sev_entry.0 += 1; }
+
+        let mod_entry = model_counts.entry(model).or_insert((0, 0));
+        mod_entry.1 += 1;
+        if is_fp { mod_entry.0 += 1; }
+
+        // Word LOR from title
+        let title = entry["finding_title"].as_str().unwrap_or("");
+        for word in tokenize_title(title) {
+            if is_tp {
+                *word_tp.entry(word.clone()).or_insert(0) += 1;
+            } else {
+                *word_fp.entry(word.clone()).or_insert(0) += 1;
+            }
+        }
+    }
+
+    let global_fp_rate = if total > 0 { total_fp as f64 / total as f64 } else { 0.18 };
+
+    let category_fp_rates = category_counts
+        .iter()
+        .map(|(k, (fp, t))| (k.clone(), beta_smoothed_rate(*fp, *t, global_fp_rate)))
+        .collect();
+
+    let severity_fp_rates = severity_counts
+        .iter()
+        .map(|(k, (fp, t))| (k.clone(), beta_smoothed_rate(*fp, *t, global_fp_rate)))
+        .collect();
+
+    let model_fp_rates = model_counts
+        .iter()
+        .map(|(k, (fp, t))| (k.clone(), beta_smoothed_rate(*fp, *t, global_fp_rate)))
+        .collect();
+
+    // Word LOR: ln((fp_rate + eps) / (tp_rate + eps)), min support 5
+    let mut word_lor = HashMap::new();
+    let all_words: HashSet<&String> = word_tp.keys().chain(word_fp.keys()).collect();
+    for word in all_words {
+        let tp_c = word_tp.get(word).copied().unwrap_or(0);
+        let fp_c = word_fp.get(word).copied().unwrap_or(0);
+        if tp_c + fp_c < 5 {
+            continue;
+        }
+        let tp_rate = (tp_c as f64 + 0.5) / (total.saturating_sub(total_fp) as f64 + 1.0);
+        let fp_rate = (fp_c as f64 + 0.5) / (total_fp as f64 + 1.0);
+        word_lor.insert(word.clone(), (fp_rate / tp_rate).ln());
+    }
+
+    FoldLocalStats {
+        category_fp_rates,
+        severity_fp_rates,
+        model_fp_rates,
+        word_lor,
+        global_fp_rate,
+    }
+}
+
+fn tokenize_title(title: &str) -> Vec<String> {
+    title
+        .to_lowercase()
+        .split(|c: char| !c.is_alphanumeric() && c != '_')
+        .filter(|w| w.len() >= 2)
+        .map(|s| s.to_string())
+        .collect()
+}
+
+/// Extract expanded features for each sample using fold-local stats.
+pub fn extract_expanded_features_from_fold(
+    joined_samples: &[JoinedSample],
+    fold_stats: &FoldLocalStats,
+) -> Vec<(ExpandedFeatures, bool)> {
+    joined_samples
+        .iter()
+        .map(|s| {
+            let words = tokenize_title(&s.title);
+            let word_lors: Vec<f64> = words
+                .iter()
+                .filter_map(|w| fold_stats.word_lor.get(w).copied())
+                .collect();
+
+            let max_word_lor = word_lors.iter().copied().fold(0.0_f64, f64::max);
+            let min_word_lor = word_lors.iter().copied().fold(0.0_f64, f64::min);
+            let count_negative_lor = word_lors.iter().filter(|&&v| v < -0.5).count() as f64;
+
+            let category_fp = fold_stats
+                .category_fp_rates
+                .get(&s.category)
+                .copied()
+                .unwrap_or(fold_stats.global_fp_rate);
+            let severity_fp = fold_stats
+                .severity_fp_rates
+                .get(&s.severity)
+                .copied()
+                .unwrap_or(fold_stats.global_fp_rate);
+            let model_fp = fold_stats
+                .model_fp_rates
+                .get(&s.model)
+                .copied()
+                .unwrap_or(fold_stats.global_fp_rate);
+
+            let features = ExpandedFeatures {
+                log1p_tp_weight: s.tp_weight.ln_1p(),
+                log1p_fp_weight: s.fp_weight.ln_1p(),
+                precedent_count: (s.precedent_count as f64).min(10.0),
+                max_similarity: s.max_similarity,
+                mean_similarity: s.mean_similarity,
+                has_no_precedents: if s.precedent_count == 0 { 1.0 } else { 0.0 },
+                log1p_soft_fp_weight: s.soft_fp_weight.ln_1p(),
+                log1p_full_suppress_weight: s.full_suppress_weight.ln_1p(),
+                log1p_wontfix_weight: s.wontfix_weight.ln_1p(),
+                category_fp_rate: category_fp,
+                severity_fp_rate: severity_fp,
+                model_fp_rate: model_fp,
+                max_word_lor,
+                min_word_lor,
+                count_negative_lor_tokens: count_negative_lor,
+            };
+            (features, s.is_fp)
+        })
+        .collect()
+}
+
+/// Intermediate representation of a joined sample before feature extraction.
+#[derive(Debug, Clone)]
+pub struct JoinedSample {
+    pub title: String,
+    pub category: String,
+    pub severity: String,
+    pub model: String,
+    pub tp_weight: f64,
+    pub fp_weight: f64,
+    pub soft_fp_weight: f64,
+    pub full_suppress_weight: f64,
+    pub wontfix_weight: f64,
+    pub precedent_count: usize,
+    pub max_similarity: f64,
+    pub mean_similarity: f64,
+    pub is_fp: bool,
+    pub family: String,
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cargo test --bin quorum extract_expanded_features`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/calibrate.rs
+git commit -m "feat(calibrate): fold-local feature extraction with 15 expanded features"
+```
+
+---
+
+### Task 5: Univariate Feature Screening
+
+**Files:**
+- Modify: `src/calibrate.rs`
+
+Per-fold screening: compute stepwise AP for each feature individually, retain those with AP >= baseline + 0.02.
+
+- [ ] **Step 1: Write failing test**
+
+```rust
+#[test]
+fn univariate_screen_selects_discriminative_features() {
+    // Feature 0: perfect separation (AP=1.0)
+    // Feature 1: random (AP~=baseline)
+    // Feature 2: moderate (AP=0.5)
+    let samples: Vec<(ExpandedFeatures, bool)> = (0..100)
+        .map(|i| {
+            let is_fp = i < 20; // 20% FP
+            let mut f = ExpandedFeatures::zeros();
+            f.log1p_tp_weight = if is_fp { 0.9 } else { 0.1 }; // perfect
+            f.log1p_fp_weight = (i as f64 * 0.01) % 1.0; // random
+            f.precedent_count = if is_fp { 0.6 } else { 0.3 }; // moderate
+            (f, is_fp)
+        })
+        .collect();
+
+    let selected = univariate_screen(&samples, 0.20);
+    // baseline AP = 0.20 (prevalence). Threshold = 0.22.
+    // Feature 0 (AP=1.0): selected
+    // Feature 1 (AP~0.20): NOT selected
+    // Feature 2 (AP~0.5+): selected
+    assert!(selected.contains(&0));
+    assert!(!selected.contains(&1));
+    assert!(selected.contains(&2));
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test --bin quorum univariate_screen`
+Expected: FAIL
+
+- [ ] **Step 3: Implement `univariate_screen`**
+
+```rust
+impl ExpandedFeatures {
+    pub fn zeros() -> Self {
+        Self {
+            log1p_tp_weight: 0.0,
+            log1p_fp_weight: 0.0,
+            precedent_count: 0.0,
+            max_similarity: 0.0,
+            mean_similarity: 0.0,
+            has_no_precedents: 0.0,
+            log1p_soft_fp_weight: 0.0,
+            log1p_full_suppress_weight: 0.0,
+            log1p_wontfix_weight: 0.0,
+            category_fp_rate: 0.0,
+            severity_fp_rate: 0.0,
+            model_fp_rate: 0.0,
+            max_word_lor: 0.0,
+            min_word_lor: 0.0,
+            count_negative_lor_tokens: 0.0,
+        }
+    }
+}
+
+/// Univariate feature screening: returns indices of features with
+/// stepwise AP >= baseline_ap + 0.02.
+pub fn univariate_screen(
+    samples: &[(ExpandedFeatures, bool)],
+    baseline_ap: f64,
+) -> Vec<usize> {
+    let threshold = baseline_ap + 0.02;
+    let n_features = 15;
+    let mut selected = Vec::new();
+
+    for feat_idx in 0..n_features {
+        let univariate: Vec<(f64, bool)> = samples
+            .iter()
+            .map(|(f, label)| (f.to_vec()[feat_idx], *label))
+            .collect();
+        let ap = crate::metrics::average_precision_stepwise(&univariate);
+        if ap >= threshold {
+            selected.push(feat_idx);
+        }
+    }
+
+    selected
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cargo test --bin quorum univariate_screen`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/calibrate.rs
+git commit -m "feat(calibrate): univariate feature screening by stepwise AP"
+```
+
+---
+
+### Task 6: Cross-Validated Logistic Training Orchestrator
+
+**Files:**
+- Modify: `src/calibrate.rs`
+
+Implements the full `learn_logistic()` pipeline: GroupKFold splitting, per-fold feature extraction + screening, logistic fitting with lambda grid, OOF prediction collection, consensus feature selection, and production model training.
+
+- [ ] **Step 1: Write failing test for `learn_logistic`**
+
+```rust
+#[test]
+fn learn_logistic_returns_none_below_min_samples() {
+    let samples: Vec<(JoinedSample, &str)> = vec![]; // empty
+    let result = learn_logistic(&[], 5);
+    assert!(result.is_none());
+}
+
+#[test]
+fn learn_logistic_on_synthetic_separable_data() {
+    // Generate 200 samples with known separation
+    let mut samples = Vec::new();
+    for i in 0..200 {
+        let is_fp = i < 40; // 20% FP
+        let s = JoinedSample {
+            title: if is_fp { "bad pattern".to_string() } else { "good code".to_string() },
+            category: "correctness".to_string(),
+            severity: "medium".to_string(),
+            model: "gpt-5.4".to_string(),
+            tp_weight: if is_fp { 0.1 } else { 2.0 },
+            fp_weight: if is_fp { 2.0 } else { 0.1 },
+            soft_fp_weight: if is_fp { 1.5 } else { 0.0 },
+            full_suppress_weight: if is_fp { 2.0 } else { 0.0 },
+            wontfix_weight: 0.0,
+            precedent_count: if is_fp { 0 } else { 3 },
+            max_similarity: if is_fp { 0.3 } else { 0.8 },
+            mean_similarity: if is_fp { 0.2 } else { 0.7 },
+            is_fp,
+            family: format!("family_{}", i % 20),
+        };
+        samples.push(s);
+    }
+
+    let result = learn_logistic(&samples, 5);
+    assert!(result.is_some());
+    let model = result.unwrap();
+    assert!(model.ap_score > 0.30); // should beat baseline 0.20
+    assert!(!model.selected_features.is_empty());
+    assert!(model.selected_features.len() >= 2);
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cargo test --bin quorum learn_logistic`
+Expected: FAIL
+
+- [ ] **Step 3: Implement `LogisticResult` and `learn_logistic`**
+
+```rust
+const MIN_SAMPLES_FOR_LOGISTIC: usize = 200;
+const MIN_CLASS_COUNT: usize = 30;
+const LAMBDA_GRID: &[f64] = &[0.01, 0.1, 1.0, 10.0];
+const MAX_LOGISTIC_ITER: usize = 500;
+
+#[derive(Debug, Clone)]
+pub struct LogisticResult {
+    pub selected_features: Vec<usize>,
+    pub selected_feature_names: Vec<String>,
+    pub coefficients: Vec<f64>,
+    pub intercept: f64,
+    pub feature_means: Vec<f64>,
+    pub feature_stddevs: Vec<f64>,
+    pub suppress_threshold: f64,
+    pub boost_threshold: f64,
+    pub ap_score: f64,
+    pub fp_recall_at_99_tp_recall: f64,
+    pub baseline_ap: f64,
+    pub n_samples: usize,
+    pub n_fp: usize,
+}
+
+pub fn learn_logistic(samples: &[JoinedSample], k_folds: usize) -> Option<LogisticResult> {
+    let n = samples.len();
+    let n_fp = samples.iter().filter(|s| s.is_fp).count();
+    let n_tp = n - n_fp;
+
+    if n < MIN_SAMPLES_FOR_LOGISTIC {
+        return None;
+    }
+    if n_fp.min(n_tp) < MIN_CLASS_COUNT {
+        return None;
+    }
+
+    let baseline_ap = n_fp as f64 / n as f64;
+
+    // GroupKFold by family
+    let families: Vec<&str> = samples.iter().map(|s| s.family.as_str()).collect();
+    let folds = group_k_fold(&families, k_folds);
+
+    // Collect OOF predictions and per-fold feature selections
+    let mut oof_predictions: Vec<(f64, bool)> = vec![(0.0, false); n];
+    let mut fold_selected_features: Vec<Vec<usize>> = Vec::new();
+
+    for fold_idx in 0..k_folds {
+        let train_indices: Vec<usize> = (0..n).filter(|i| folds[*i] != fold_idx).collect();
+        let val_indices: Vec<usize> = (0..n).filter(|i| folds[*i] == fold_idx).collect();
+
+        // Compute fold-local stats from training partition feedback
+        let train_feedback: Vec<&serde_json::Value> = Vec::new(); // placeholder — see step 4
+        let fold_stats = compute_fold_local_stats_from_samples(
+            &train_indices.iter().map(|&i| &samples[i]).collect::<Vec<_>>(),
+        );
+
+        // Extract features for train and val
+        let train_features: Vec<(ExpandedFeatures, bool)> = train_indices
+            .iter()
+            .map(|&i| extract_single_expanded(&samples[i], &fold_stats))
+            .collect();
+        let val_features: Vec<(ExpandedFeatures, bool)> = val_indices
+            .iter()
+            .map(|&i| extract_single_expanded(&samples[i], &fold_stats))
+            .collect();
+
+        // Univariate screening on train
+        let selected = univariate_screen(&train_features, baseline_ap);
+        if selected.len() < 2 {
+            return None;
+        }
+        fold_selected_features.push(selected.clone());
+
+        // Build feature matrices (selected features only)
+        let train_x: Vec<Vec<f64>> = train_features
+            .iter()
+            .map(|(f, _)| {
+                let v = f.to_vec();
+                selected.iter().map(|&idx| v[idx]).collect()
+            })
+            .collect();
+        let train_y: Vec<bool> = train_features.iter().map(|(_, l)| *l).collect();
+        let val_x: Vec<Vec<f64>> = val_features
+            .iter()
+            .map(|(f, _)| {
+                let v = f.to_vec();
+                selected.iter().map(|&idx| v[idx]).collect()
+            })
+            .collect();
+
+        // Lambda selection via validation AP
+        let mut best_lambda = 1.0;
+        let mut best_val_ap = 0.0;
+        for &lambda in LAMBDA_GRID {
+            let fit = crate::logistic::fit(&train_x, &train_y, lambda, MAX_LOGISTIC_ITER);
+            let val_preds = fit.predict(&val_x);
+            let val_scored: Vec<(f64, bool)> = val_preds
+                .into_iter()
+                .zip(val_features.iter().map(|(_, l)| *l))
+                .collect();
+            let ap = crate::metrics::average_precision_stepwise(&val_scored);
+            if ap > best_val_ap {
+                best_val_ap = ap;
+                best_lambda = lambda;
+            }
+        }
+
+        // Refit with best lambda and produce OOF predictions
+        let fit = crate::logistic::fit(&train_x, &train_y, best_lambda, MAX_LOGISTIC_ITER);
+        let val_preds = fit.predict(&val_x);
+        for (i, &val_idx) in val_indices.iter().enumerate() {
+            oof_predictions[val_idx] = (val_preds[i], samples[val_idx].is_fp);
+        }
+    }
+
+    // Consensus feature selection: features selected in >= 3/5 folds
+    let consensus_threshold = (k_folds + 1) / 2 + 1; // 3 for 5-fold
+    let mut feature_votes = vec![0usize; 15];
+    for selected in &fold_selected_features {
+        for &idx in selected {
+            feature_votes[idx] += 1;
+        }
+    }
+    let consensus_features: Vec<usize> = (0..15)
+        .filter(|&i| feature_votes[i] >= consensus_threshold)
+        .collect();
+    if consensus_features.len() < 2 {
+        return None;
+    }
+
+    // Aggregated OOF metrics
+    let ap_score = crate::metrics::average_precision_stepwise(&oof_predictions);
+    let fp_recall = crate::metrics::fp_recall_at_tp_recall(&oof_predictions, 0.99);
+
+    if ap_score <= baseline_ap + 0.02 {
+        return None;
+    }
+
+    // Production model: retrain on 100% with consensus features
+    let full_stats = compute_fold_local_stats_from_samples(
+        &samples.iter().collect::<Vec<_>>(),
+    );
+    let all_features: Vec<(ExpandedFeatures, bool)> = samples
+        .iter()
+        .map(|s| extract_single_expanded(s, &full_stats))
+        .collect();
+    let full_x: Vec<Vec<f64>> = all_features
+        .iter()
+        .map(|(f, _)| {
+            let v = f.to_vec();
+            consensus_features.iter().map(|&idx| v[idx]).collect()
+        })
+        .collect();
+    let full_y: Vec<bool> = all_features.iter().map(|(_, l)| *l).collect();
+
+    // Use best lambda from last fold (or median — simple approach: 1.0)
+    let production_fit = crate::logistic::fit(&full_x, &full_y, 1.0, MAX_LOGISTIC_ITER);
+
+    // Threshold selection
+    let full_preds = production_fit.predict(&full_x);
+    let tp_preds: Vec<f64> = full_preds
+        .iter()
+        .zip(full_y.iter())
+        .filter(|(_, &is_fp)| !is_fp)
+        .map(|(&p, _)| p)
+        .collect();
+    let fp_preds: Vec<f64> = full_preds
+        .iter()
+        .zip(full_y.iter())
+        .filter(|(_, &is_fp)| *is_fp)
+        .map(|(&p, _)| p)
+        .collect();
+
+    // Suppress: 1st percentile of TP predictions (99% TP safety)
+    let mut tp_sorted = tp_preds.clone();
+    tp_sorted.sort_by(|a, b| b.partial_cmp(a).unwrap_or(std::cmp::Ordering::Equal));
+    let suppress_idx = (tp_sorted.len() as f64 * 0.01).ceil() as usize;
+    let suppress_threshold = tp_sorted.get(suppress_idx).copied().unwrap_or(0.5);
+
+    // Boost: 5th percentile of FP predictions (95% FP safety)
+    let mut fp_sorted = fp_preds.clone();
+    fp_sorted.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+    let boost_idx = (fp_sorted.len() as f64 * 0.05).ceil() as usize;
+    let boost_threshold = fp_sorted.get(boost_idx).copied().unwrap_or(0.1);
+
+    let feature_names = ExpandedFeatures::feature_names();
+    let selected_names: Vec<String> = consensus_features
+        .iter()
+        .map(|&i| feature_names[i].to_string())
+        .collect();
+
+    Some(LogisticResult {
+        selected_features: consensus_features,
+        selected_feature_names: selected_names,
+        coefficients: production_fit.coefficients,
+        intercept: production_fit.intercept,
+        feature_means: production_fit.feature_means,
+        feature_stddevs: production_fit.feature_stddevs,
+        suppress_threshold,
+        boost_threshold,
+        ap_score,
+        fp_recall_at_99_tp_recall: fp_recall,
+        baseline_ap,
+        n_samples: n,
+        n_fp,
+    })
+}
+
+/// GroupKFold assignment: samples with the same family go in the same fold.
+fn group_k_fold(families: &[&str], k: usize) -> Vec<usize> {
+    let mut family_to_fold: HashMap<&str, usize> = HashMap::new();
+    let mut next_fold = 0usize;
+    families
+        .iter()
+        .map(|f| {
+            *family_to_fold.entry(f).or_insert_with(|| {
+                let fold = next_fold % k;
+                next_fold += 1;
+                fold
+            })
+        })
+        .collect()
+}
+
+fn compute_fold_local_stats_from_samples(samples: &[&JoinedSample]) -> FoldLocalStats {
+    let total = samples.len();
+    let total_fp = samples.iter().filter(|s| s.is_fp).count();
+    let global_fp_rate = if total > 0 { total_fp as f64 / total as f64 } else { 0.18 };
+
+    let mut category_counts: HashMap<String, (usize, usize)> = HashMap::new();
+    let mut severity_counts: HashMap<String, (usize, usize)> = HashMap::new();
+    let mut model_counts: HashMap<String, (usize, usize)> = HashMap::new();
+    let mut word_tp: HashMap<String, usize> = HashMap::new();
+    let mut word_fp: HashMap<String, usize> = HashMap::new();
+
+    for s in samples {
+        let cat = category_counts.entry(s.category.clone()).or_insert((0, 0));
+        cat.1 += 1;
+        if s.is_fp { cat.0 += 1; }
+
+        let sev = severity_counts.entry(s.severity.clone()).or_insert((0, 0));
+        sev.1 += 1;
+        if s.is_fp { sev.0 += 1; }
+
+        let m = model_counts.entry(s.model.clone()).or_insert((0, 0));
+        m.1 += 1;
+        if s.is_fp { m.0 += 1; }
+
+        for word in tokenize_title(&s.title) {
+            if s.is_fp {
+                *word_fp.entry(word).or_insert(0) += 1;
+            } else {
+                *word_tp.entry(word).or_insert(0) += 1;
+            }
+        }
+    }
+
+    let category_fp_rates = category_counts
+        .iter()
+        .map(|(k, (fp, t))| (k.clone(), beta_smoothed_rate(*fp, *t, global_fp_rate)))
+        .collect();
+    let severity_fp_rates = severity_counts
+        .iter()
+        .map(|(k, (fp, t))| (k.clone(), beta_smoothed_rate(*fp, *t, global_fp_rate)))
+        .collect();
+    let model_fp_rates = model_counts
+        .iter()
+        .map(|(k, (fp, t))| (k.clone(), beta_smoothed_rate(*fp, *t, global_fp_rate)))
+        .collect();
+
+    let all_words: HashSet<String> = word_tp.keys().chain(word_fp.keys()).cloned().collect();
+    let tp_total = total - total_fp;
+    let word_lor: HashMap<String, f64> = all_words
+        .into_iter()
+        .filter_map(|word| {
+            let tp_c = word_tp.get(&word).copied().unwrap_or(0);
+            let fp_c = word_fp.get(&word).copied().unwrap_or(0);
+            if tp_c + fp_c < 5 { return None; }
+            let tp_rate = (tp_c as f64 + 0.5) / (tp_total as f64 + 1.0);
+            let fp_rate = (fp_c as f64 + 0.5) / (total_fp as f64 + 1.0);
+            Some((word, (fp_rate / tp_rate).ln()))
+        })
+        .collect();
+
+    FoldLocalStats { category_fp_rates, severity_fp_rates, model_fp_rates, word_lor, global_fp_rate }
+}
+
+fn extract_single_expanded(s: &JoinedSample, stats: &FoldLocalStats) -> (ExpandedFeatures, bool) {
+    let words = tokenize_title(&s.title);
+    let word_lors: Vec<f64> = words
+        .iter()
+        .filter_map(|w| stats.word_lor.get(w).copied())
+        .collect();
+
+    let features = ExpandedFeatures {
+        log1p_tp_weight: s.tp_weight.ln_1p(),
+        log1p_fp_weight: s.fp_weight.ln_1p(),
+        precedent_count: (s.precedent_count as f64).min(10.0),
+        max_similarity: s.max_similarity,
+        mean_similarity: s.mean_similarity,
+        has_no_precedents: if s.precedent_count == 0 { 1.0 } else { 0.0 },
+        log1p_soft_fp_weight: s.soft_fp_weight.ln_1p(),
+        log1p_full_suppress_weight: s.full_suppress_weight.ln_1p(),
+        log1p_wontfix_weight: s.wontfix_weight.ln_1p(),
+        category_fp_rate: stats.category_fp_rates.get(&s.category).copied().unwrap_or(stats.global_fp_rate),
+        severity_fp_rate: stats.severity_fp_rates.get(&s.severity).copied().unwrap_or(stats.global_fp_rate),
+        model_fp_rate: stats.model_fp_rates.get(&s.model).copied().unwrap_or(stats.global_fp_rate),
+        max_word_lor: word_lors.iter().copied().fold(0.0_f64, f64::max),
+        min_word_lor: word_lors.iter().copied().fold(0.0_f64, f64::min),
+        count_negative_lor_tokens: word_lors.iter().filter(|&&v| v < -0.5).count() as f64,
+    };
+    (features, s.is_fp)
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cargo test --bin quorum learn_logistic`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/calibrate.rs
+git commit -m "feat(calibrate): cross-validated logistic training with GroupKFold and lambda grid"
+```
+
+---
+
+### Task 7: `LogisticModel` Storage
+
+**Files:**
+- Modify: `src/calibrator_model.rs`
+
+Add `LogisticModel` struct with TOML serialization, stored as `[logistic_model]` section.
+
+- [ ] **Step 1: Write failing test for TOML roundtrip**
+
+```rust
+#[test]
+fn logistic_model_toml_roundtrip() {
+    let lm = LogisticModel {
+        computed_at: "2026-05-16T12:00:00Z".to_string(),
+        n_samples: 1567,
+        n_fp: 279,
+        selected_features: vec!["log1p_fp_weight".to_string(), "category_fp_rate".to_string()],
+        coefficients: vec![0.42, -1.3],
+        intercept: -1.2,
+        feature_means: vec![0.5, 0.27],
+        feature_stddevs: vec![0.3, 0.15],
+        suppress_threshold: 0.45,
+        boost_threshold: 0.08,
+        ap_score: 0.67,
+        fp_recall_at_99_tp_recall: 0.35,
+        baseline_ap: 0.18,
+    };
+    let model = CalibratorModel {
+        meta: ModelMeta::default(),
+        weights: ScoreWeights::default(),
+        word_lor: HashMap::new(),
+        family_fp_rate: HashMap::new(),
+        language_fp_rate: HashMap::new(),
+        logistic_model: Some(lm.clone()),
+    };
+    let toml_str = model.to_toml();
+    let parsed = CalibratorModel::from_toml(&toml_str).unwrap();
+    let parsed_lm = parsed.logistic_model.unwrap();
+    assert_eq!(parsed_lm.n_samples, 1567);
+    assert_eq!(parsed_lm.selected_features.len(), 2);
+    assert!((parsed_lm.suppress_threshold - 0.45).abs() < 1e-9);
+    assert!((parsed_lm.boost_threshold - 0.08).abs() < 1e-9);
+    assert!((parsed_lm.coefficients[0] - 0.42).abs() < 1e-9);
+}
+
+#[test]
+fn logistic_model_absent_is_none() {
+    let model = CalibratorModel {
+        meta: ModelMeta::default(),
+        weights: ScoreWeights::default(),
+        word_lor: HashMap::new(),
+        family_fp_rate: HashMap::new(),
+        language_fp_rate: HashMap::new(),
+        logistic_model: None,
+    };
+    let toml_str = model.to_toml();
+    let parsed = CalibratorModel::from_toml(&toml_str).unwrap();
+    assert!(parsed.logistic_model.is_none());
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test --bin quorum logistic_model_toml`
+Expected: FAIL
+
+- [ ] **Step 3: Implement `LogisticModel` struct**
+
+Add to `src/calibrator_model.rs`:
+
+```rust
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LogisticModel {
+    pub computed_at: String,
+    pub n_samples: usize,
+    pub n_fp: usize,
+    pub selected_features: Vec<String>,
+    pub coefficients: Vec<f64>,
+    pub intercept: f64,
+    pub feature_means: Vec<f64>,
+    pub feature_stddevs: Vec<f64>,
+    pub suppress_threshold: f64,
+    pub boost_threshold: f64,
+    pub ap_score: f64,
+    pub fp_recall_at_99_tp_recall: f64,
+    pub baseline_ap: f64,
+}
+```
+
+Add `logistic_model: Option<LogisticModel>` field to `CalibratorModel` struct. Use `#[serde(skip_serializing_if = "Option::is_none")]` to omit when absent.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cargo test --bin quorum logistic_model_toml`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/calibrator_model.rs
+git commit -m "feat(model): add LogisticModel struct with TOML persistence"
+```
+
+---
+
+### Task 8: Review-Time Logistic Scoring
+
+**Files:**
+- Modify: `src/calibrator.rs`
+
+When `CalibratorConfig` has a logistic model loaded, use it for suppress/boost decisions instead of the composite score path.
+
+- [ ] **Step 1: Write failing test**
+
+```rust
+#[test]
+fn logistic_scoring_suppresses_high_pfp() {
+    let lm = LogisticModel {
+        computed_at: "2026-05-16T12:00:00Z".to_string(),
+        n_samples: 1567,
+        n_fp: 279,
+        selected_features: vec!["log1p_fp_weight".to_string()],
+        coefficients: vec![2.0],
+        intercept: 0.0,
+        feature_means: vec![0.5],
+        feature_stddevs: vec![0.3],
+        suppress_threshold: 0.6,
+        boost_threshold: 0.1,
+        ap_score: 0.67,
+        fp_recall_at_99_tp_recall: 0.35,
+        baseline_ap: 0.18,
+    };
+    // A finding with high fp_weight should get P(FP) > suppress_threshold
+    let features = ReviewFeatures {
+        log1p_fp_weight: 2.0, // well above mean
+        ..ReviewFeatures::zeros()
+    };
+    let p_fp = logistic_score(&lm, &features);
+    assert!(p_fp > 0.6);
+}
+
+#[test]
+fn logistic_scoring_boosts_low_pfp() {
+    let lm = LogisticModel {
+        computed_at: "2026-05-16T12:00:00Z".to_string(),
+        n_samples: 1567,
+        n_fp: 279,
+        selected_features: vec!["log1p_tp_weight".to_string()],
+        coefficients: vec![-2.0], // negative = more TP weight → lower P(FP)
+        intercept: 0.0,
+        feature_means: vec![0.5],
+        feature_stddevs: vec![0.3],
+        suppress_threshold: 0.6,
+        boost_threshold: 0.1,
+        ap_score: 0.67,
+        fp_recall_at_99_tp_recall: 0.35,
+        baseline_ap: 0.18,
+    };
+    let features = ReviewFeatures {
+        log1p_tp_weight: 2.0,
+        ..ReviewFeatures::zeros()
+    };
+    let p_fp = logistic_score(&lm, &features);
+    assert!(p_fp < 0.1);
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cargo test --bin quorum logistic_scoring`
+Expected: FAIL
+
+- [ ] **Step 3: Implement `logistic_score` and integrate into `calibrate_core_decision`**
+
+```rust
+/// Feature vector computed at review time for logistic model scoring.
+/// Same 15 fields as ExpandedFeatures but computed from runtime data.
+pub struct ReviewFeatures {
+    pub log1p_tp_weight: f64,
+    pub log1p_fp_weight: f64,
+    pub precedent_count: f64,
+    pub max_similarity: f64,
+    pub mean_similarity: f64,
+    pub has_no_precedents: f64,
+    pub log1p_soft_fp_weight: f64,
+    pub log1p_full_suppress_weight: f64,
+    pub log1p_wontfix_weight: f64,
+    pub category_fp_rate: f64,
+    pub severity_fp_rate: f64,
+    pub model_fp_rate: f64,
+    pub max_word_lor: f64,
+    pub min_word_lor: f64,
+    pub count_negative_lor_tokens: f64,
+}
+
+impl ReviewFeatures {
+    pub fn zeros() -> Self {
+        Self {
+            log1p_tp_weight: 0.0, log1p_fp_weight: 0.0, precedent_count: 0.0,
+            max_similarity: 0.0, mean_similarity: 0.0, has_no_precedents: 1.0,
+            log1p_soft_fp_weight: 0.0, log1p_full_suppress_weight: 0.0,
+            log1p_wontfix_weight: 0.0, category_fp_rate: 0.0, severity_fp_rate: 0.0,
+            model_fp_rate: 0.0, max_word_lor: 0.0, min_word_lor: 0.0,
+            count_negative_lor_tokens: 0.0,
+        }
+    }
+
+    fn get_by_name(&self, name: &str) -> f64 {
+        match name {
+            "log1p_tp_weight" => self.log1p_tp_weight,
+            "log1p_fp_weight" => self.log1p_fp_weight,
+            "precedent_count" => self.precedent_count,
+            "max_similarity" => self.max_similarity,
+            "mean_similarity" => self.mean_similarity,
+            "has_no_precedents" => self.has_no_precedents,
+            "log1p_soft_fp_weight" => self.log1p_soft_fp_weight,
+            "log1p_full_suppress_weight" => self.log1p_full_suppress_weight,
+            "log1p_wontfix_weight" => self.log1p_wontfix_weight,
+            "category_fp_rate" => self.category_fp_rate,
+            "severity_fp_rate" => self.severity_fp_rate,
+            "model_fp_rate" => self.model_fp_rate,
+            "max_word_lor" => self.max_word_lor,
+            "min_word_lor" => self.min_word_lor,
+            "count_negative_lor_tokens" => self.count_negative_lor_tokens,
+            _ => 0.0,
+        }
+    }
+}
+
+/// Compute P(FP) using the stored logistic model.
+pub fn logistic_score(model: &LogisticModel, features: &ReviewFeatures) -> f64 {
+    let mut logit = model.intercept;
+    for (i, feat_name) in model.selected_features.iter().enumerate() {
+        let raw = features.get_by_name(feat_name);
+        let normed = (raw - model.feature_means[i]) / (model.feature_stddevs[i] + 1e-8);
+        logit += model.coefficients[i] * normed;
+    }
+    crate::logistic::sigmoid(logit)
+}
+```
+
+Then modify `calibrate_core_decision` to check for logistic model before the existing composite path:
+
+```rust
+// Logistic model path: when loaded, use P(FP) for suppress/boost decisions.
+if let Some(ref logistic) = config.logistic_model {
+    let review_features = compute_review_features(/* ... */);
+    let p_fp = logistic_score(logistic, &review_features);
+    
+    // Record both scores in trace for A/B comparison
+    trace.logistic_p_fp = Some(p_fp);
+    trace.composite_score = composite;
+    
+    if p_fp > logistic.suppress_threshold && fp_weight > 0.0 {
+        // Suppress
+        finding.calibrator_action = Some(CalibratorAction::Disputed);
+        suppressed = true;
+        return CoreDecision { suppressed, boosted, trace };
+    }
+    if p_fp < logistic.boost_threshold && tp_weight > 0.0 && config.boost_tp {
+        // Boost
+        let proposed = boost_severity(&finding.severity);
+        // ... rubric gate same as existing ...
+    }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cargo test --bin quorum logistic_scoring`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/calibrator.rs
+git commit -m "feat(calibrator): review-time logistic scoring with dual thresholds"
+```
+
+---
+
+### Task 9: CLI Integration (`--feature-importance` and Upgraded `--learn-weights`)
+
+**Files:**
+- Modify: `src/cli/mod.rs`
+- Modify: `src/main.rs`
+
+- [ ] **Step 1: Add `--feature-importance` flag to CLI**
+
+In `src/cli/mod.rs`, add to the calibrate subcommand:
+
+```rust
+#[arg(long, help = "Show per-feature importance diagnostics (univariate AP)")]
+pub feature_importance: bool,
+```
+
+- [ ] **Step 2: Wire up `--feature-importance` in `src/main.rs`**
+
+After `extract_join_features`, add:
+
+```rust
+if args.feature_importance {
+    let joined = extract_joined_samples(&feedback, &traces, &model, &filter, disable_fuzzy);
+    let stats = compute_fold_local_stats_from_samples(&joined.iter().collect::<Vec<_>>());
+    let expanded = joined.iter().map(|s| extract_single_expanded(s, &stats)).collect::<Vec<_>>();
+    let n_fp = expanded.iter().filter(|(_, l)| *l).count();
+    let n_tp = expanded.len() - n_fp;
+    let baseline = n_fp as f64 / expanded.len() as f64;
+    
+    eprintln!("Feature importance ({} FP, {} non-FP):", n_fp, n_tp);
+    let names = ExpandedFeatures::feature_names();
+    let mut importances: Vec<(usize, f64)> = (0..15)
+        .map(|i| {
+            let univariate: Vec<(f64, bool)> = expanded.iter().map(|(f, l)| (f.to_vec()[i], *l)).collect();
+            (i, crate::metrics::average_precision_stepwise(&univariate))
+        })
+        .collect();
+    importances.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
+    
+    for (idx, ap) in &importances {
+        let lift = ap - baseline;
+        let marker = if lift < 0.02 { "  [below threshold]" } else { "" };
+        eprintln!("  {:30} AP={:.4}  (lift {:+.4}){}", names[*idx], ap, lift, marker);
+    }
+    return Ok(());
+}
+```
+
+- [ ] **Step 3: Upgrade `--learn-weights` to use logistic pipeline**
+
+Replace the grid search flow in `src/main.rs` with:
+
+```rust
+if args.learn_weights {
+    let joined = extract_joined_samples(&feedback, &traces, &model, &filter, disable_fuzzy);
+    
+    // Attempt logistic model first
+    match learn_logistic(&joined, 5) {
+        Some(result) => {
+            eprintln!("Logistic model ({} FP, {} non-FP, 5-fold GroupKFold):", result.n_fp, result.n_samples - result.n_fp);
+            eprintln!("  Selected features ({}/15): {:?}", result.selected_feature_names.len(), result.selected_feature_names);
+            eprintln!("  AP (OOF):    {:.4}", result.ap_score);
+            eprintln!("  AP (baseline): {:.4}", result.baseline_ap);
+            eprintln!("  FP recall @ 99% TP recall: {:.4}", result.fp_recall_at_99_tp_recall);
+            eprintln!("  Suppress threshold: {:.4}", result.suppress_threshold);
+            eprintln!("  Boost threshold: {:.4}", result.boost_threshold);
+            
+            // Store logistic model
+            let lm = LogisticModel {
+                computed_at: chrono::Utc::now().to_rfc3339(),
+                n_samples: result.n_samples,
+                n_fp: result.n_fp,
+                selected_features: result.selected_feature_names,
+                coefficients: result.coefficients,
+                intercept: result.intercept,
+                feature_means: result.feature_means,
+                feature_stddevs: result.feature_stddevs,
+                suppress_threshold: result.suppress_threshold,
+                boost_threshold: result.boost_threshold,
+                ap_score: result.ap_score,
+                fp_recall_at_99_tp_recall: result.fp_recall_at_99_tp_recall,
+                baseline_ap: result.baseline_ap,
+            };
+            model.logistic_model = Some(lm);
+            eprintln!("  -> Logistic model written to calibrator_model.toml");
+        }
+        None => {
+            eprintln!("  Logistic model: insufficient data or no improvement over baseline.");
+            eprintln!("  Falling back to grid search...");
+            // existing grid search logic as fallback
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Test the CLI integration**
+
+Run: `cargo build --bin quorum && target/debug/quorum calibrate --feature-importance 2>&1 | head -20`
+Expected: Feature importance table with 15 rows
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/cli/mod.rs src/main.rs
+git commit -m "feat(cli): --feature-importance diagnostics and logistic --learn-weights upgrade"
+```
+
+---
+
+### Task 10: Joined Sample Extraction (`extract_joined_samples`)
+
+**Files:**
+- Modify: `src/calibrate.rs`
+
+Bridge function that walks the same multi-tier join as `extract_join_features` but produces `JoinedSample` structs with the full metadata needed for expanded feature computation (category, severity, model, soft_fp_weight, precedent_count, etc.).
+
+- [ ] **Step 1: Write failing test**
+
+```rust
+#[test]
+fn extract_joined_samples_captures_metadata() {
+    let traces = make_test_traces_with_metadata();
+    let feedback = make_test_feedback_with_categories();
+    let model = CalibratorModel::default();
+    let filter = JoinFilter::default();
+    
+    let samples = extract_joined_samples(&feedback, &traces, &model, &filter, false);
+    assert!(!samples.is_empty());
+    for s in &samples {
+        assert!(!s.title.is_empty());
+        assert!(!s.category.is_empty());
+        assert!(!s.severity.is_empty());
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test --bin quorum extract_joined_samples_captures`
+Expected: FAIL
+
+- [ ] **Step 3: Implement `extract_joined_samples`**
+
+This function walks the same multi-tier index logic as existing `extract_join_features` but extracts all metadata fields. The trace entries contain `finding_category`, `input_severity`, `model` (from review telemetry). For missing metadata, use sensible defaults:
+
+```rust
+pub fn extract_joined_samples(
+    feedback: &[serde_json::Value],
+    traces: &[serde_json::Value],
+    model: &CalibratorModel,
+    filter: &JoinFilter,
+    disable_fuzzy: bool,
+) -> Vec<JoinedSample> {
+    // ... same index-building and matching logic as extract_join_features ...
+    // But for each match, produce a JoinedSample with:
+    //   title, category (from trace or "unknown"), severity (from trace or "medium"),
+    //   model (from trace or "unknown"), tp_weight, fp_weight,
+    //   soft_fp_weight (from trace["soft_fp_weight"]),
+    //   full_suppress_weight (= fp_weight, matching calibrator logic),
+    //   wontfix_weight (from trace["wontfix_weight"]),
+    //   precedent_count (from trace["precedent_count"] or inferred from weight magnitude),
+    //   max_similarity (from trace["max_similarity"] or 0.0),
+    //   mean_similarity (from trace["mean_similarity"] or 0.0),
+    //   is_fp (verdict == "fp"),
+    //   family (CalibratorModel::title_family(&title))
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cargo test --bin quorum extract_joined_samples`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/calibrate.rs
+git commit -m "feat(calibrate): extract_joined_samples with full metadata for expanded features"
+```
+
+---
+
+### Task 11: Backfill Validation
+
+**Files:**
+- Modify: `src/main.rs` (or add as integration test)
+
+Validate that the existing ~1567-sample feedback corpus can successfully produce expanded features and train a logistic model. This exercises the full pipeline end-to-end against real data.
+
+- [ ] **Step 1: Add integration test that loads real corpus**
+
+```rust
+#[test]
+#[ignore] // requires real feedback file at ~/.quorum/feedback.jsonl
+fn backfill_real_corpus_produces_logistic_model() {
+    let feedback_path = dirs::home_dir().unwrap().join(".quorum/feedback.jsonl");
+    if !feedback_path.exists() {
+        return; // skip in CI
+    }
+    let feedback = load_feedback_jsonl(&feedback_path);
+    let traces_path = dirs::home_dir().unwrap().join(".quorum/traces.jsonl");
+    let traces = load_traces_jsonl(&traces_path);
+    let model = compute_calibrator_model(&feedback).unwrap();
+    let filter = JoinFilter::default();
+    
+    let joined = extract_joined_samples(&feedback, &traces, &model, &filter, false);
+    eprintln!("Joined samples: {} ({} FP)", joined.len(), joined.iter().filter(|s| s.is_fp).count());
+    assert!(joined.len() >= 200);
+    
+    let result = learn_logistic(&joined, 5);
+    assert!(result.is_some(), "Logistic model should succeed on real corpus");
+    let r = result.unwrap();
+    eprintln!("AP: {:.4} (baseline {:.4}, lift {:.4})", r.ap_score, r.baseline_ap, r.ap_score - r.baseline_ap);
+    eprintln!("FP recall @ 99% TP recall: {:.4}", r.fp_recall_at_99_tp_recall);
+    eprintln!("Selected: {:?}", r.selected_feature_names);
+    eprintln!("Suppress threshold: {:.4}", r.suppress_threshold);
+    eprintln!("Boost threshold: {:.4}", r.boost_threshold);
+    
+    assert!(r.ap_score > r.baseline_ap + 0.02);
+    assert!(r.selected_feature_names.len() >= 2);
+}
+```
+
+- [ ] **Step 2: Run the backfill validation**
+
+Run: `cargo test --bin quorum backfill_real_corpus -- --ignored --nocapture`
+Expected: PASS, prints metrics showing lift over baseline
+
+- [ ] **Step 3: Run the CLI end-to-end**
+
+Run: `cargo run -- calibrate --feature-importance`
+Run: `cargo run -- calibrate --learn-weights`
+Expected: Both produce output, learn-weights writes model to `~/.quorum/calibrator_model.toml`
+
+- [ ] **Step 4: Verify model file was written correctly**
+
+Run: `grep -A5 '\[logistic_model\]' ~/.quorum/calibrator_model.toml`
+Expected: Shows selected_features, coefficients, thresholds
+
+- [ ] **Step 5: Commit integration test**
+
+```bash
+git add tests/
+git commit -m "test: add backfill validation for logistic calibrator on real corpus"
+```
+
+---
+
+### Task 12: Trace Enrichment for A/B Comparison
+
+**Files:**
+- Modify: `src/calibrator_trace.rs`
+
+Add `logistic_p_fp: Option<f64>` to `CalibratorTraceEntry` so both old composite and new logistic scores are visible in trace output for validation.
+
+- [ ] **Step 1: Add field to trace struct**
+
+```rust
+pub logistic_p_fp: Option<f64>,
+```
+
+With `#[serde(skip_serializing_if = "Option::is_none")]`.
+
+- [ ] **Step 2: Populate in `calibrate_core_decision`**
+
+When logistic model is present, set `trace.logistic_p_fp = Some(p_fp)` before returning.
+
+- [ ] **Step 3: Run full test suite**
+
+Run: `cargo test --bin quorum`
+Expected: All tests pass
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/calibrator_trace.rs src/calibrator.rs
+git commit -m "feat(trace): emit logistic_p_fp alongside composite_score for A/B comparison"
+```
+
+---
+
+### Task 13: Final Verification
+
+- [ ] **Step 1: Run full test suite**
+
+Run: `cargo test --bin quorum`
+Expected: All tests pass (existing + new)
+
+- [ ] **Step 2: Run clippy**
+
+Run: `cargo clippy --bin quorum -- -D warnings`
+Expected: No warnings
+
+- [ ] **Step 3: Run release build**
+
+Run: `cargo build --release`
+Expected: Compiles successfully
+
+- [ ] **Step 4: Run backfill on real data**
+
+Run: `cargo run --release -- calibrate --learn-weights`
+Expected: Prints logistic model metrics, writes to calibrator_model.toml
+
+- [ ] **Step 5: Run a review with the new model**
+
+Run: `cargo run --release -- review src/calibrate.rs --trace`
+Then check trace: `tail -1 ~/.quorum/trace.jsonl | jq '.logistic_p_fp'`
+Expected: Trace entries contain `logistic_p_fp` field
+
+- [ ] **Step 6: Final commit (if any fixups needed)**
+
+```bash
+git add -u
+git commit -m "fix: address clippy/test issues from final verification"
+```
+
+---
+
+## Task Dependency Graph
+
+```
+Task 1 (metrics) ──┐
+                    ├─→ Task 5 (screening) ──→ Task 6 (orchestrator) ──→ Task 9 (CLI)
+Task 2 (logistic) ─┘                                                         │
+                                                                              ▼
+Task 3 (struct) ──→ Task 4 (extraction) ──→ Task 10 (join bridge) ──→ Task 11 (backfill)
+                                                                              │
+Task 7 (model storage) ──→ Task 8 (review-time scoring) ──→ Task 12 (trace) ──→ Task 13 (verify)
+```
+
+Tasks 1, 2, 3, 7 can be done in parallel. Tasks 4 and 5 depend on 3 and 1 respectively. Task 6 depends on 1, 2, 4, 5. Tasks 8-13 are sequential.

--- a/docs/superpowers/specs/2026-05-16-logistic-calibrator-design.md
+++ b/docs/superpowers/specs/2026-05-16-logistic-calibrator-design.md
@@ -1,0 +1,178 @@
+# Logistic Calibrator Scoring — Design Spec
+
+**Date:** 2026-05-16
+**Status:** Approved
+**Issue:** Continuation of #312 (learned weights)
+
+## Problem
+
+The grid-search weight learner (`quorum calibrate --learn-weights`) cannot beat the trivial baseline on the current feedback corpus (1567 samples, 82% TP). Root causes:
+
+1. **Metric artifact**: Trapezoidal PR-AUC inflates the trivial classifier to 0.911 at 82% prevalence.
+2. **Feature poverty**: 4 features (precedent ratio, avg word_lor, family FP inv, language FP inv) lack discriminative power. The ratio compresses evidence strength.
+3. **Model poverty**: Coarse grid search over 4 weights is too blunt.
+
+## Solution
+
+Replace the grid-search approach with an inline L2-regularized logistic regression over ~15 expanded features, modeling P(FP|features) (label flip). Per-fold univariate screening selects the features that carry signal.
+
+## Design
+
+### 1. Label Flip
+
+The model predicts P(FP). Positive class = FP (18% prevalence after flip). This gives massive headroom over baseline AP (~0.18 vs prior 0.91).
+
+### 2. Expanded Feature Set (15 candidates)
+
+All computed during `extract_join_features`. Per-fold univariate screening (AP ≥ baseline + 0.02) typically retains 8-12.
+
+**Precedent decomposition (6):**
+- `log1p_tp_weight`: log1p of accumulated TP precedent weight
+- `log1p_fp_weight`: log1p of accumulated FP precedent weight
+- `precedent_count`: number of matched precedents (capped at 10)
+- `max_similarity`: highest similarity score among matched precedents
+- `mean_similarity`: mean similarity across matched precedents (0.0 if none)
+- `has_no_precedents`: 1.0 if no precedents matched, 0.0 otherwise
+
+**Weight accumulators (3):**
+- `log1p_soft_fp_weight`: log1p of soft FP weight from trace
+- `log1p_full_suppress_weight`: log1p of full suppress weight
+- `log1p_wontfix_weight`: log1p of wontfix weight
+
+**Smoothed priors (3):**
+- `category_fp_rate`: Beta-smoothed FP rate for finding_category (α=5)
+- `severity_fp_rate`: Beta-smoothed FP rate for input_severity
+- `model_fp_rate`: Beta-smoothed FP rate for generating model
+
+**Text statistics (3):**
+- `max_word_lor`: maximum word log-odds ratio in title
+- `min_word_lor`: minimum word log-odds ratio in title
+- `count_negative_lor_tokens`: count of tokens with LOR < -0.5
+
+### 3. Logistic Regression (~150 LOC, src/logistic.rs)
+
+Inline implementation, no external dependencies.
+
+- **Standardization**: z-score normalization (mean/stddev per feature, computed from training fold)
+- **Training**: Batch gradient descent with L2 regularization
+- **Lambda selection**: Small grid {0.01, 0.1, 1.0, 10.0}, best by validation AP
+- **Convergence**: max 1000 iterations, early stop when gradient norm < 1e-6
+- **Output**: coefficient vector, intercept, feature means/stddevs, selected feature indices
+
+### 4. Per-Fold Feature Selection
+
+Inside each CV fold's training partition:
+1. Compute univariate AP (FP-positive) for each of the 15 features
+2. Retain features where AP ≥ baseline_ap + 0.02 (baseline = class prevalence in fold)
+3. Train logistic regression on retained features only
+4. Report selected features and their univariate APs
+
+### 5. Fold-Local Feature Computation
+
+All target-encoded features recomputed per training fold to prevent leakage:
+- `category_fp_rate`: computed from train fold's feedback only
+- `severity_fp_rate`: computed from train fold's feedback only
+- `model_fp_rate`: computed from train fold's feedback only
+- `word_lor` vocabulary: computed from train fold's feedback only
+- `family_fp_rate` / `language_fp_rate`: computed from train fold's traces only
+
+### 6. Cross-Validation
+
+- 5-fold GroupKFold by title family (avoids near-duplicate leakage)
+- Each fold: univariate screen → fit logistic → evaluate on held-out fold
+- Stability check: feature selection agreement across folds (≥3/5 folds must select a feature for it to be in the final model)
+
+### 7. Metrics
+
+- **Primary (operational):** FP recall at TP recall ≥ 99% ("how many FPs can we suppress while losing ≤1% of real issues?")
+- **Secondary:** Average Precision (stepwise, FP-positive)
+- **Safety:** TP false-suppression rate
+- **Baseline comparison:** all metrics vs trivial classifier (predict all negative in FP-positive framing)
+
+### 8. Model Storage (calibrator_model.toml)
+
+New section `[logistic_model]`:
+
+```toml
+[logistic_model]
+computed_at = "2026-05-16T..."
+n_samples = 1567
+n_fp = 279
+selected_features = ["log1p_fp_weight", "category_fp_rate", "max_similarity", ...]
+coefficients = [0.42, -1.3, 0.88, ...]
+intercept = -1.2
+feature_means = [0.5, 0.27, 0.6, ...]
+feature_stddevs = [0.3, 0.15, 0.25, ...]
+threshold = 0.45
+ap_score = 0.67
+fp_recall_at_99_tp_recall = 0.35
+baseline_ap = 0.18
+```
+
+### 9. Review-Time Scoring (src/calibrator.rs)
+
+When `CalibratorModel` has a `logistic_model` section:
+1. Compute the selected features for the finding (same extraction logic)
+2. Standardize using stored means/stddevs
+3. Compute logit = dot(coefficients, features) + intercept
+4. P(FP) = sigmoid(logit)
+5. If P(FP) > threshold → suppress (severity → Info, action → Suppressed)
+6. Also emit the old composite score in the trace for A/B comparison
+
+When no logistic model exists → fall back to existing composite scoring (unchanged behavior).
+
+### 10. CLI Surface
+
+```
+quorum calibrate --learn-weights      # existing flag, upgraded behavior
+quorum calibrate --feature-importance  # new: univariate diagnostics only
+```
+
+`--feature-importance` output:
+```
+Feature importance (279 FP, 1288 non-FP):
+  log1p_fp_weight:       AP=0.42  (lift +0.24)
+  category_fp_rate:      AP=0.38  (lift +0.20)
+  max_similarity:        AP=0.31  (lift +0.13)
+  ...
+  language_fp_inv:       AP=0.19  (lift +0.01)  [below threshold]
+```
+
+`--learn-weights` output:
+```
+Logistic model (279 FP, 1288 non-FP, 5-fold GroupKFold):
+  Selected features (9/15): [...]
+  Lambda: 1.0
+  AP (full):     0.67
+  AP (baseline): 0.18
+  AP (5-fold):   0.61
+  FP recall @ 99% TP recall: 0.35
+  -> Model written to ~/.quorum/calibrator_model.toml
+```
+
+### 11. Fallback & Safety
+
+- If fewer than 50 joined samples: skip learning (existing gate)
+- If best AP ≤ baseline + 0.02: refuse to write model, print diagnostic
+- If feature selection retains < 2 features: refuse to write model
+- Missing model file at review time: silent fallback to composite scoring
+- Malformed model file: warn + fallback
+
+### 12. Files Changed
+
+| File | Change |
+|------|--------|
+| `src/logistic.rs` | New: logistic regression implementation |
+| `src/calibrate.rs` | Expanded `SampleFeatures`, fold-local computation, feature screening, `--feature-importance` |
+| `src/calibrator_model.rs` | `LogisticModel` struct, serialization |
+| `src/calibrator.rs` | Review-time logistic scoring path |
+| `src/cli/mod.rs` | `--feature-importance` flag |
+| `src/main.rs` | Wire up feature importance + upgraded learn-weights |
+| `src/metrics.rs` | `average_precision()` (stepwise), `fp_recall_at_tp_recall()` |
+
+### 13. Not In Scope
+
+- Online learning / incremental updates (future)
+- Non-linear models (decision trees, etc.)
+- Feature interactions as explicit terms (L2 logistic handles some implicitly)
+- Automated lambda tuning beyond the 4-point grid

--- a/docs/superpowers/specs/2026-05-16-logistic-calibrator-design.md
+++ b/docs/superpowers/specs/2026-05-16-logistic-calibrator-design.md
@@ -49,14 +49,14 @@ All computed during `extract_join_features`. Per-fold univariate screening (AP �
 - `min_word_lor`: minimum word log-odds ratio in title
 - `count_negative_lor_tokens`: count of tokens with LOR < -0.5
 
-### 3. Logistic Regression (~150 LOC, src/logistic.rs)
+### 3. Logistic Regression (~200 LOC, src/logistic.rs)
 
 Inline implementation, no external dependencies.
 
-- **Standardization**: z-score normalization (mean/stddev per feature, computed from training fold)
-- **Training**: Batch gradient descent with L2 regularization
-- **Lambda selection**: Small grid {0.01, 0.1, 1.0, 10.0}, best by validation AP
-- **Convergence**: max 1000 iterations, early stop when gradient norm < 1e-6
+- **Standardization**: z-score normalization (mean/stddev per feature, computed from training fold). Division-safe: use `stddev + 1e-8` to handle constant features.
+- **Training**: Batch gradient descent with L2 regularization and backtracking line search (Armijo condition) for step size selection.
+- **Lambda selection**: Small grid {0.01, 0.1, 1.0, 10.0}, best by validation AP (Average Precision, not operational metric — see §7).
+- **Convergence**: max 500 iterations, early stop when relative loss change < 1e-4 (`(prev_loss - loss) / prev_loss`).
 - **Output**: coefficient vector, intercept, feature means/stddevs, selected feature indices
 
 ### 4. Per-Fold Feature Selection
@@ -81,10 +81,12 @@ All target-encoded features recomputed per training fold to prevent leakage:
 - 5-fold GroupKFold by title family (avoids near-duplicate leakage)
 - Each fold: univariate screen → fit logistic → evaluate on held-out fold
 - Stability check: feature selection agreement across folds (≥3/5 folds must select a feature for it to be in the final model)
+- **Separation of concerns**: CV phase produces out-of-fold predictions for evaluation only. Production model is retrained on 100% of data with the consensus feature set.
 
 ### 7. Metrics
 
-- **Primary (operational):** FP recall at TP recall ≥ 99% ("how many FPs can we suppress while losing ≤1% of real issues?")
+- **Fold-level evaluation (for lambda selection):** Average Precision (stepwise, FP-positive). NOT the operational metric — per-fold TP counts (~257) have only ~2 TPs of margin at 99% recall, making fold-level operational metrics too volatile.
+- **Aggregated OOF metric (reported):** FP recall at TP recall ≥ 99%, computed on concatenated out-of-fold predictions across all 5 folds.
 - **Secondary:** Average Precision (stepwise, FP-positive)
 - **Safety:** TP false-suppression rate
 - **Baseline comparison:** all metrics vs trivial classifier (predict all negative in FP-positive framing)
@@ -109,11 +111,19 @@ fp_recall_at_99_tp_recall = 0.35
 baseline_ap = 0.18
 ```
 
-### 9. Review-Time Scoring (src/calibrator.rs)
+### 9. Threshold Selection
+
+During the production training phase (on 100% of data):
+1. Compute P(FP) for all training samples
+2. Sort TP samples by their P(FP) descending
+3. Pick threshold at the 1st percentile of TP predictions (ensures 99% TP recall)
+4. Store this threshold in the model file
+
+### 10. Review-Time Scoring (src/calibrator.rs)
 
 When `CalibratorModel` has a `logistic_model` section:
 1. Compute the selected features for the finding (same extraction logic)
-2. Standardize using stored means/stddevs
+2. Standardize using stored means/stddevs (+ 1e-8 for division safety)
 3. Compute logit = dot(coefficients, features) + intercept
 4. P(FP) = sigmoid(logit)
 5. If P(FP) > threshold → suppress (severity → Info, action → Suppressed)
@@ -152,7 +162,8 @@ Logistic model (279 FP, 1288 non-FP, 5-fold GroupKFold):
 
 ### 11. Fallback & Safety
 
-- If fewer than 50 joined samples: skip learning (existing gate)
+- If fewer than 200 joined samples: skip learning, print "insufficient data" diagnostic
+- If min(FP count, TP count) < 30: skip learning (need both classes represented)
 - If best AP ≤ baseline + 0.02: refuse to write model, print diagnostic
 - If feature selection retains < 2 features: refuse to write model
 - Missing model file at review time: silent fallback to composite scoring
@@ -174,5 +185,5 @@ Logistic model (279 FP, 1288 non-FP, 5-fold GroupKFold):
 
 - Online learning / incremental updates (future)
 - Non-linear models (decision trees, etc.)
-- Feature interactions as explicit terms (L2 logistic handles some implicitly)
+- Feature interactions as explicit terms
 - Automated lambda tuning beyond the 4-point grid

--- a/docs/superpowers/specs/2026-05-16-logistic-calibrator-design.md
+++ b/docs/superpowers/specs/2026-05-16-logistic-calibrator-design.md
@@ -105,7 +105,8 @@ coefficients = [0.42, -1.3, 0.88, ...]
 intercept = -1.2
 feature_means = [0.5, 0.27, 0.6, ...]
 feature_stddevs = [0.3, 0.15, 0.25, ...]
-threshold = 0.45
+suppress_threshold = 0.45
+boost_threshold = 0.08
 ap_score = 0.67
 fp_recall_at_99_tp_recall = 0.35
 baseline_ap = 0.18
@@ -115,9 +116,9 @@ baseline_ap = 0.18
 
 During the production training phase (on 100% of data):
 1. Compute P(FP) for all training samples
-2. Sort TP samples by their P(FP) descending
-3. Pick threshold at the 1st percentile of TP predictions (ensures 99% TP recall)
-4. Store this threshold in the model file
+2. **Suppress threshold**: Sort TP samples by their P(FP) descending. Pick threshold at the 1st percentile of TP predictions (ensures 99% TP recall — at most 1% of TPs will be falsely suppressed).
+3. **Boost threshold**: Sort FP samples by their P(FP) ascending. Pick threshold at the 5th percentile of FP predictions (ensures 95% of FPs will not be falsely boosted).
+4. Store both thresholds in the model file
 
 ### 10. Review-Time Scoring (src/calibrator.rs)
 
@@ -126,8 +127,9 @@ When `CalibratorModel` has a `logistic_model` section:
 2. Standardize using stored means/stddevs (+ 1e-8 for division safety)
 3. Compute logit = dot(coefficients, features) + intercept
 4. P(FP) = sigmoid(logit)
-5. If P(FP) > threshold → suppress (severity → Info, action → Suppressed)
-6. Also emit the old composite score in the trace for A/B comparison
+5. If P(FP) > suppress_threshold → suppress (severity → Info, action → Suppressed)
+6. If P(FP) < boost_threshold → boost (severity upgraded one level, e.g. medium → high)
+7. Also emit the old composite score in the trace for A/B comparison
 
 When no logistic model exists → fall back to existing composite scoring (unchanged behavior).
 

--- a/src/calibrate.rs
+++ b/src/calibrate.rs
@@ -1434,7 +1434,219 @@ fn tokenize_title(title: &str) -> Vec<String> {
     crate::calibrator_model::WORD_RE
         .find_iter(&lower)
         .map(|m| m.as_str().to_string())
+        .filter(|w| w.len() >= 2)
         .collect()
+}
+
+// ---------------------------------------------------------------------------
+// Fold-local feature extraction (logistic calibrator infrastructure)
+// ---------------------------------------------------------------------------
+
+/// Intermediate representation of a joined sample before feature extraction.
+/// Contains all metadata needed to compute expanded features.
+#[derive(Debug, Clone)]
+pub struct JoinedSample {
+    pub title: String,
+    pub category: String,
+    pub severity: String,
+    pub model: String,
+    pub tp_weight: f64,
+    pub fp_weight: f64,
+    pub soft_fp_weight: f64,
+    pub full_suppress_weight: f64,
+    pub wontfix_weight: f64,
+    pub precedent_count: usize,
+    pub max_similarity: f64,
+    pub mean_similarity: f64,
+    pub is_fp: bool,
+    pub family: String,
+}
+
+/// Per-fold computed statistics for target-encoded features.
+/// Prevents leakage by computing rates only from the training partition.
+#[derive(Debug, Clone)]
+pub struct FoldLocalStats {
+    pub category_fp_rates: HashMap<String, f64>,
+    pub severity_fp_rates: HashMap<String, f64>,
+    pub model_fp_rates: HashMap<String, f64>,
+    pub word_lor: HashMap<String, f64>,
+    pub global_fp_rate: f64,
+}
+
+/// Smoothing parameter for beta-smoothed empirical rates.
+const BETA_ALPHA: f64 = 5.0;
+
+/// Beta-smoothed empirical rate: (count + alpha * prior) / (total + alpha)
+pub fn beta_smoothed_rate(fp_count: usize, total: usize, global_rate: f64) -> f64 {
+    (fp_count as f64 + BETA_ALPHA * global_rate) / (total as f64 + BETA_ALPHA)
+}
+
+/// Compute `FoldLocalStats` from a slice of `JoinedSample` references (training partition).
+///
+/// Builds per-category, per-severity, and per-model FP rates using beta smoothing,
+/// plus word log-odds ratios with Laplace smoothing and minimum support filtering.
+pub fn compute_fold_local_stats(samples: &[&JoinedSample]) -> FoldLocalStats {
+    let total = samples.len();
+    let fp_total = samples.iter().filter(|s| s.is_fp).count();
+    let tp_total = total.saturating_sub(fp_total);
+    let global_fp_rate = if total > 0 {
+        fp_total as f64 / total as f64
+    } else {
+        0.0
+    };
+
+    // Per-category FP rates
+    let mut cat_fp: HashMap<String, usize> = HashMap::new();
+    let mut cat_total: HashMap<String, usize> = HashMap::new();
+    // Per-severity FP rates
+    let mut sev_fp: HashMap<String, usize> = HashMap::new();
+    let mut sev_total: HashMap<String, usize> = HashMap::new();
+    // Per-model FP rates
+    let mut model_fp: HashMap<String, usize> = HashMap::new();
+    let mut model_total: HashMap<String, usize> = HashMap::new();
+    // Word counts for LOR
+    let mut word_fp_count: HashMap<String, usize> = HashMap::new();
+    let mut word_tp_count: HashMap<String, usize> = HashMap::new();
+
+    for s in samples {
+        // Category
+        *cat_total.entry(s.category.clone()).or_default() += 1;
+        if s.is_fp {
+            *cat_fp.entry(s.category.clone()).or_default() += 1;
+        }
+        // Severity
+        *sev_total.entry(s.severity.clone()).or_default() += 1;
+        if s.is_fp {
+            *sev_fp.entry(s.severity.clone()).or_default() += 1;
+        }
+        // Model
+        *model_total.entry(s.model.clone()).or_default() += 1;
+        if s.is_fp {
+            *model_fp.entry(s.model.clone()).or_default() += 1;
+        }
+        // Words
+        let words = tokenize_title(&s.title);
+        for w in &words {
+            if s.is_fp {
+                *word_fp_count.entry(w.clone()).or_default() += 1;
+            } else {
+                *word_tp_count.entry(w.clone()).or_default() += 1;
+            }
+        }
+    }
+
+    // Beta-smoothed category FP rates
+    let category_fp_rates: HashMap<String, f64> = cat_total
+        .iter()
+        .map(|(cat, &tot)| {
+            let fp_c = cat_fp.get(cat).copied().unwrap_or(0);
+            (cat.clone(), beta_smoothed_rate(fp_c, tot, global_fp_rate))
+        })
+        .collect();
+
+    // Beta-smoothed severity FP rates
+    let severity_fp_rates: HashMap<String, f64> = sev_total
+        .iter()
+        .map(|(sev, &tot)| {
+            let fp_c = sev_fp.get(sev).copied().unwrap_or(0);
+            (sev.clone(), beta_smoothed_rate(fp_c, tot, global_fp_rate))
+        })
+        .collect();
+
+    // Beta-smoothed model FP rates
+    let model_fp_rates: HashMap<String, f64> = model_total
+        .iter()
+        .map(|(m, &tot)| {
+            let fp_c = model_fp.get(m).copied().unwrap_or(0);
+            (m.clone(), beta_smoothed_rate(fp_c, tot, global_fp_rate))
+        })
+        .collect();
+
+    // Word log-odds ratios with Laplace smoothing
+    let mut word_lor_map: HashMap<String, f64> = HashMap::new();
+    if tp_total > 0 && fp_total > 0 {
+        let all_words: HashSet<&String> = word_fp_count.keys().chain(word_tp_count.keys()).collect();
+        let eps = 0.5_f64; // Laplace smoothing
+        for w in all_words {
+            let fp_c = word_fp_count.get(w).copied().unwrap_or(0);
+            let tp_c = word_tp_count.get(w).copied().unwrap_or(0);
+            let support = fp_c + tp_c;
+            if support < WORD_MIN_SUPPORT {
+                continue;
+            }
+            let fp_rate = (fp_c as f64 + eps) / (fp_total as f64 + eps);
+            let tp_rate = (tp_c as f64 + eps) / (tp_total as f64 + eps);
+            let lor = (fp_rate / tp_rate).ln();
+            if lor.is_finite() {
+                word_lor_map.insert(w.clone(), lor);
+            }
+        }
+    }
+
+    FoldLocalStats {
+        category_fp_rates,
+        severity_fp_rates,
+        model_fp_rates,
+        word_lor: word_lor_map,
+        global_fp_rate,
+    }
+}
+
+/// Extract expanded features for a single sample using fold-local stats.
+///
+/// Returns the feature vector and the label (`true` = FP for logistic regression).
+pub fn extract_single_expanded(s: &JoinedSample, stats: &FoldLocalStats) -> (ExpandedFeatures, bool) {
+    let words = tokenize_title(&s.title);
+
+    let max_word_lor = words
+        .iter()
+        .filter_map(|w| stats.word_lor.get(w))
+        .copied()
+        .fold(0.0_f64, f64::max);
+
+    let min_word_lor = words
+        .iter()
+        .filter_map(|w| stats.word_lor.get(w))
+        .copied()
+        .fold(0.0_f64, f64::min);
+
+    let count_negative_lor_tokens = words
+        .iter()
+        .filter_map(|w| stats.word_lor.get(w))
+        .filter(|&&lor| lor < -0.5)
+        .count() as f64;
+
+    let features = ExpandedFeatures {
+        log1p_tp_weight: s.tp_weight.ln_1p(),
+        log1p_fp_weight: s.fp_weight.ln_1p(),
+        precedent_count: (s.precedent_count as f64).min(10.0),
+        max_similarity: s.max_similarity,
+        mean_similarity: s.mean_similarity,
+        has_no_precedents: if s.precedent_count == 0 { 1.0 } else { 0.0 },
+        log1p_soft_fp_weight: s.soft_fp_weight.ln_1p(),
+        log1p_full_suppress_weight: s.full_suppress_weight.ln_1p(),
+        log1p_wontfix_weight: s.wontfix_weight.ln_1p(),
+        category_fp_rate: stats
+            .category_fp_rates
+            .get(&s.category)
+            .copied()
+            .unwrap_or(stats.global_fp_rate),
+        severity_fp_rate: stats
+            .severity_fp_rates
+            .get(&s.severity)
+            .copied()
+            .unwrap_or(stats.global_fp_rate),
+        model_fp_rate: stats
+            .model_fp_rates
+            .get(&s.model)
+            .copied()
+            .unwrap_or(stats.global_fp_rate),
+        max_word_lor,
+        min_word_lor,
+        count_negative_lor_tokens,
+    };
+
+    (features, s.is_fp)
 }
 
 #[cfg(test)]
@@ -3161,5 +3373,104 @@ mod tests {
         let f = ExpandedFeatures::zeros();
         let v = f.to_vec();
         assert!(v.iter().all(|&x| x == 0.0));
+    }
+
+    // --- fold-local feature extraction ---
+
+    #[test]
+    fn beta_smoothed_rate_basic() {
+        // 3 FP out of 10 total, global_rate=0.18, alpha=5
+        let rate = beta_smoothed_rate(3, 10, 0.18);
+        // (3 + 5*0.18) / (10 + 5) = 3.9/15 = 0.26
+        assert!((rate - 0.26).abs() < 0.01);
+    }
+
+    #[test]
+    fn beta_smoothed_rate_zero_observations() {
+        // No observations -> converges to global rate
+        let rate = beta_smoothed_rate(0, 0, 0.18);
+        // (0 + 5*0.18) / (0 + 5) = 0.9/5 = 0.18
+        assert!((rate - 0.18).abs() < 0.01);
+    }
+
+    #[test]
+    fn compute_fold_local_stats_basic() {
+        let samples: Vec<JoinedSample> = (0..100)
+            .map(|i| JoinedSample {
+                title: if i < 20 {
+                    "bad unwrap pattern".to_string()
+                } else {
+                    "good error handling".to_string()
+                },
+                category: "correctness".to_string(),
+                severity: "medium".to_string(),
+                model: "gpt-5.4".to_string(),
+                tp_weight: if i < 20 { 0.1 } else { 2.0 },
+                fp_weight: if i < 20 { 2.0 } else { 0.1 },
+                soft_fp_weight: 0.0,
+                full_suppress_weight: 0.0,
+                wontfix_weight: 0.0,
+                precedent_count: 1,
+                max_similarity: 0.5,
+                mean_similarity: 0.5,
+                is_fp: i < 20,
+                family: format!("family_{}", i % 10),
+            })
+            .collect();
+        let refs: Vec<&JoinedSample> = samples.iter().collect();
+        let stats = compute_fold_local_stats(&refs);
+        assert!(
+            (stats.global_fp_rate - 0.20).abs() < 0.01,
+            "global FP rate should be 0.20, got {}",
+            stats.global_fp_rate
+        );
+        // "correctness" has 20/100 FP -> beta_smoothed(20, 100, 0.20) = (20+1)/(100+5) approx 0.20
+        assert!(stats.category_fp_rates.contains_key("correctness"));
+        let cat_rate = stats.category_fp_rates["correctness"];
+        assert!(
+            (cat_rate - 0.20).abs() < 0.02,
+            "category FP rate should be close to 0.20, got {cat_rate}"
+        );
+    }
+
+    #[test]
+    fn extract_single_expanded_all_finite() {
+        let s = JoinedSample {
+            title: "potential SQL injection".to_string(),
+            category: "security".to_string(),
+            severity: "high".to_string(),
+            model: "gpt-5.4".to_string(),
+            tp_weight: 1.5,
+            fp_weight: 0.5,
+            soft_fp_weight: 0.3,
+            full_suppress_weight: 0.5,
+            wontfix_weight: 0.0,
+            precedent_count: 3,
+            max_similarity: 0.85,
+            mean_similarity: 0.72,
+            is_fp: false,
+            family: "sql_injection".to_string(),
+        };
+        let stats = FoldLocalStats {
+            category_fp_rates: HashMap::from([("security".to_string(), 0.15)]),
+            severity_fp_rates: HashMap::from([("high".to_string(), 0.12)]),
+            model_fp_rates: HashMap::from([("gpt-5.4".to_string(), 0.20)]),
+            word_lor: HashMap::from([
+                ("sql".to_string(), -0.8),
+                ("injection".to_string(), -1.2),
+            ]),
+            global_fp_rate: 0.18,
+        };
+        let (features, is_fp) = extract_single_expanded(&s, &stats);
+        assert!(!is_fp);
+        let v = features.to_vec();
+        assert_eq!(v.len(), 15);
+        assert!(v.iter().all(|x| x.is_finite()));
+        // Check specific values
+        assert!((features.log1p_tp_weight - 1.5_f64.ln_1p()).abs() < 1e-9);
+        assert!((features.precedent_count - 3.0).abs() < 1e-9);
+        assert!((features.category_fp_rate - 0.15).abs() < 1e-9);
+        assert!((features.min_word_lor - (-1.2)).abs() < 1e-9);
+        assert!((features.count_negative_lor_tokens - 2.0).abs() < 1e-9);
     }
 }

--- a/src/calibrate.rs
+++ b/src/calibrate.rs
@@ -1659,13 +1659,15 @@ pub fn extract_single_expanded(s: &JoinedSample, stats: &FoldLocalStats) -> (Exp
         .iter()
         .filter_map(|w| stats.word_lor.get(w))
         .copied()
-        .fold(0.0_f64, f64::max);
+        .reduce(f64::max)
+        .unwrap_or(0.0);
 
     let min_word_lor = words
         .iter()
         .filter_map(|w| stats.word_lor.get(w))
         .copied()
-        .fold(0.0_f64, f64::min);
+        .reduce(f64::min)
+        .unwrap_or(0.0);
 
     let count_negative_lor_tokens = words
         .iter()
@@ -2236,18 +2238,24 @@ pub fn learn_logistic(samples: &[JoinedSample], k_folds: usize) -> Option<Logist
         .map(|(pred, _)| *pred)
         .collect();
 
+    if oof_tp_predictions.is_empty() || oof_fp_predictions.is_empty() {
+        return None;
+    }
+
     // Suppress threshold: sort TP OOF predictions descending, pick at ceil(n_tp * 0.01)
     // This ensures 99% of TPs have OOF prediction below the threshold (safe from suppression)
     oof_tp_predictions.sort_by(|a, b| b.partial_cmp(a).unwrap_or(std::cmp::Ordering::Equal));
-    let suppress_idx =
-        ((oof_tp_predictions.len() as f64 * 0.01).ceil() as usize).min(oof_tp_predictions.len() - 1);
+    let suppress_idx = ((oof_tp_predictions.len() as f64 * 0.01).ceil() as usize)
+        .saturating_sub(1)
+        .min(oof_tp_predictions.len() - 1);
     let suppress_threshold = oof_tp_predictions[suppress_idx];
 
     // Boost threshold: sort FP OOF predictions ascending, pick at ceil(n_fp * 0.05)
     // This ensures 95% of FPs have OOF prediction above the threshold
     oof_fp_predictions.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
-    let boost_idx =
-        ((oof_fp_predictions.len() as f64 * 0.05).ceil() as usize).min(oof_fp_predictions.len() - 1);
+    let boost_idx = ((oof_fp_predictions.len() as f64 * 0.05).ceil() as usize)
+        .saturating_sub(1)
+        .min(oof_fp_predictions.len() - 1);
     let boost_threshold = oof_fp_predictions[boost_idx];
 
     let feature_names = ExpandedFeatures::feature_names();

--- a/src/calibrate.rs
+++ b/src/calibrate.rs
@@ -1989,6 +1989,280 @@ pub fn extract_joined_samples(
     samples
 }
 
+// ---------------------------------------------------------------------------
+// Logistic calibrator: cross-validated training pipeline
+// ---------------------------------------------------------------------------
+
+/// Minimum total samples required for logistic model training.
+const MIN_SAMPLES_FOR_LOGISTIC: usize = 200;
+
+/// Minimum count of each class (FP and TP) required.
+const MIN_CLASS_COUNT: usize = 30;
+
+/// L2 regularization strengths to search over.
+const LAMBDA_GRID: &[f64] = &[0.01, 0.1, 1.0, 10.0];
+
+/// Maximum iterations for logistic regression fitting.
+const MAX_LOGISTIC_ITER: usize = 500;
+
+/// Result of logistic calibrator training.
+#[derive(Debug, Clone)]
+pub struct LogisticResult {
+    pub selected_features: Vec<usize>,
+    pub selected_feature_names: Vec<String>,
+    pub coefficients: Vec<f64>,
+    pub intercept: f64,
+    pub feature_means: Vec<f64>,
+    pub feature_stddevs: Vec<f64>,
+    pub suppress_threshold: f64,
+    pub boost_threshold: f64,
+    pub ap_score: f64,
+    pub fp_recall_at_99_tp_recall: f64,
+    pub baseline_ap: f64,
+    pub n_samples: usize,
+    pub n_fp: usize,
+}
+
+/// Assigns each sample to a fold based on its family (group).
+/// Families are assigned to folds round-robin in order of first appearance.
+fn group_k_fold(families: &[&str], k: usize) -> Vec<usize> {
+    let mut family_to_fold: HashMap<&str, usize> = HashMap::new();
+    let mut next_fold = 0usize;
+    families
+        .iter()
+        .map(|f| {
+            *family_to_fold.entry(f).or_insert_with(|| {
+                let fold = next_fold % k;
+                next_fold += 1;
+                fold
+            })
+        })
+        .collect()
+}
+
+/// Train a logistic model via cross-validation with per-fold feature screening.
+///
+/// Returns `None` when:
+/// - Insufficient samples (< 200)
+/// - Class imbalance (min class < 30)
+/// - Fewer than 2 features pass consensus selection
+/// - Model fails to beat baseline AP by >= 0.02
+pub fn learn_logistic(samples: &[JoinedSample], k_folds: usize) -> Option<LogisticResult> {
+    let n = samples.len();
+
+    // Safety gate: minimum sample count
+    if n < MIN_SAMPLES_FOR_LOGISTIC {
+        return None;
+    }
+
+    let n_fp = samples.iter().filter(|s| s.is_fp).count();
+    let n_tp = n - n_fp;
+
+    // Safety gate: minimum class count
+    if n_fp < MIN_CLASS_COUNT || n_tp < MIN_CLASS_COUNT {
+        return None;
+    }
+
+    // Baseline AP: FP prevalence (trivial classifier)
+    let baseline_ap = n_fp as f64 / n as f64;
+
+    // GroupKFold assignment by family
+    let families: Vec<&str> = samples.iter().map(|s| s.family.as_str()).collect();
+    let fold_assignments = group_k_fold(&families, k_folds);
+
+    // Per-fold tracking
+    let mut all_oof_predictions: Vec<(f64, bool)> = vec![(0.0, false); n];
+    let mut oof_filled = vec![false; n];
+    let mut fold_selected_features: Vec<Vec<usize>> = Vec::with_capacity(k_folds);
+
+    for fold_idx in 0..k_folds {
+        // Split into train/val by fold assignment
+        let train_indices: Vec<usize> = (0..n)
+            .filter(|&i| fold_assignments[i] != fold_idx)
+            .collect();
+        let val_indices: Vec<usize> = (0..n)
+            .filter(|&i| fold_assignments[i] == fold_idx)
+            .collect();
+
+        if val_indices.is_empty() || train_indices.is_empty() {
+            continue;
+        }
+
+        // Compute FoldLocalStats from training samples
+        let train_refs: Vec<&JoinedSample> = train_indices.iter().map(|&i| &samples[i]).collect();
+        let stats = compute_fold_local_stats(&train_refs);
+
+        // Extract expanded features for train and val
+        let train_expanded: Vec<(ExpandedFeatures, bool)> = train_indices
+            .iter()
+            .map(|&i| extract_single_expanded(&samples[i], &stats))
+            .collect();
+        let val_expanded: Vec<(ExpandedFeatures, bool)> = val_indices
+            .iter()
+            .map(|&i| extract_single_expanded(&samples[i], &stats))
+            .collect();
+
+        // Univariate screen on train features
+        let selected = univariate_screen(&train_expanded, baseline_ap);
+
+        // If < 2 features selected, this fold cannot proceed
+        if selected.len() < 2 {
+            return None;
+        }
+
+        fold_selected_features.push(selected.clone());
+
+        // Build feature matrices (only selected columns)
+        let train_x: Vec<Vec<f64>> = train_expanded
+            .iter()
+            .map(|(f, _)| {
+                let full = f.to_vec();
+                selected.iter().map(|&idx| full[idx]).collect()
+            })
+            .collect();
+        let train_y: Vec<bool> = train_expanded.iter().map(|(_, label)| *label).collect();
+
+        let val_x: Vec<Vec<f64>> = val_expanded
+            .iter()
+            .map(|(f, _)| {
+                let full = f.to_vec();
+                selected.iter().map(|&idx| full[idx]).collect()
+            })
+            .collect();
+
+        // Lambda grid search
+        let mut best_lambda = LAMBDA_GRID[0];
+        let mut best_ap = f64::NEG_INFINITY;
+
+        for &lambda in LAMBDA_GRID {
+            let model = crate::logistic::fit(&train_x, &train_y, lambda, MAX_LOGISTIC_ITER);
+            let val_preds = model.predict(&val_x);
+            let val_scored: Vec<(f64, bool)> = val_preds
+                .into_iter()
+                .zip(val_expanded.iter().map(|(_, label)| *label))
+                .collect();
+            let ap = crate::metrics::average_precision_stepwise(&val_scored);
+            if ap > best_ap {
+                best_ap = ap;
+                best_lambda = lambda;
+            }
+        }
+
+        // Refit with best lambda, produce OOF predictions for val indices
+        let best_model =
+            crate::logistic::fit(&train_x, &train_y, best_lambda, MAX_LOGISTIC_ITER);
+        let oof_preds = best_model.predict(&val_x);
+
+        for (local_idx, &global_idx) in val_indices.iter().enumerate() {
+            all_oof_predictions[global_idx] = (oof_preds[local_idx], val_expanded[local_idx].1);
+            oof_filled[global_idx] = true;
+        }
+    }
+
+    // Consensus feature selection: feature must be selected in >= ceil(k_folds/2 + 1) folds
+    let consensus_threshold = k_folds / 2 + 1;
+    let n_features = ExpandedFeatures::feature_names().len();
+    let mut feature_vote_count = vec![0usize; n_features];
+    for fold_features in &fold_selected_features {
+        for &feat_idx in fold_features {
+            feature_vote_count[feat_idx] += 1;
+        }
+    }
+    let consensus_features: Vec<usize> = (0..n_features)
+        .filter(|&i| feature_vote_count[i] >= consensus_threshold)
+        .collect();
+
+    if consensus_features.len() < 2 {
+        return None;
+    }
+
+    // Aggregated OOF metrics (only use filled slots)
+    let filled_predictions: Vec<(f64, bool)> = all_oof_predictions
+        .iter()
+        .zip(oof_filled.iter())
+        .filter(|(_, filled)| **filled)
+        .map(|(pred, _)| *pred)
+        .collect();
+
+    let ap_score = crate::metrics::average_precision_stepwise(&filled_predictions);
+    let fp_recall = crate::metrics::fp_recall_at_tp_recall(&filled_predictions, 0.99);
+
+    // If AP does not beat baseline by at least 0.02, return None
+    if ap_score <= baseline_ap + 0.02 {
+        return None;
+    }
+
+    // Production model: retrain on 100% of data with consensus features
+    let all_refs: Vec<&JoinedSample> = samples.iter().collect();
+    let all_stats = compute_fold_local_stats(&all_refs);
+    let all_expanded: Vec<(ExpandedFeatures, bool)> = samples
+        .iter()
+        .map(|s| extract_single_expanded(s, &all_stats))
+        .collect();
+
+    let prod_x: Vec<Vec<f64>> = all_expanded
+        .iter()
+        .map(|(f, _)| {
+            let full = f.to_vec();
+            consensus_features.iter().map(|&idx| full[idx]).collect()
+        })
+        .collect();
+    let prod_y: Vec<bool> = all_expanded.iter().map(|(_, label)| *label).collect();
+
+    let prod_model = crate::logistic::fit(&prod_x, &prod_y, 1.0, MAX_LOGISTIC_ITER);
+
+    // Threshold selection from production model predictions
+    let prod_predictions = prod_model.predict(&prod_x);
+
+    // Separate predictions by class
+    let mut tp_predictions: Vec<f64> = prod_predictions
+        .iter()
+        .zip(prod_y.iter())
+        .filter(|(_, is_fp)| !**is_fp)
+        .map(|(pred, _)| *pred)
+        .collect();
+    let mut fp_predictions: Vec<f64> = prod_predictions
+        .iter()
+        .zip(prod_y.iter())
+        .filter(|(_, is_fp)| **is_fp)
+        .map(|(pred, _)| *pred)
+        .collect();
+
+    // Suppress threshold: sort TP predictions descending, pick at ceil(n_tp * 0.01)
+    // This ensures 99% of TPs have prediction below the threshold (safe from suppression)
+    tp_predictions.sort_by(|a, b| b.partial_cmp(a).unwrap_or(std::cmp::Ordering::Equal));
+    let suppress_idx = ((n_tp as f64 * 0.01).ceil() as usize).min(tp_predictions.len() - 1);
+    let suppress_threshold = tp_predictions[suppress_idx];
+
+    // Boost threshold: sort FP predictions ascending, pick at ceil(n_fp * 0.05)
+    // This ensures 95% of FPs have prediction above the threshold
+    fp_predictions.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+    let boost_idx = ((n_fp as f64 * 0.05).ceil() as usize).min(fp_predictions.len() - 1);
+    let boost_threshold = fp_predictions[boost_idx];
+
+    let feature_names = ExpandedFeatures::feature_names();
+    let selected_feature_names: Vec<String> = consensus_features
+        .iter()
+        .map(|&i| feature_names[i].to_string())
+        .collect();
+
+    Some(LogisticResult {
+        selected_features: consensus_features,
+        selected_feature_names,
+        coefficients: prod_model.coefficients,
+        intercept: prod_model.intercept,
+        feature_means: prod_model.feature_means,
+        feature_stddevs: prod_model.feature_stddevs,
+        suppress_threshold,
+        boost_threshold,
+        ap_score,
+        fp_recall_at_99_tp_recall: fp_recall,
+        baseline_ap,
+        n_samples: n,
+        n_fp,
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -4084,5 +4358,134 @@ mod tests {
         let samples = extract_joined_samples(&feedback, &traces, &model, &filter, false);
         assert_eq!(samples.len(), 1);
         assert_eq!(samples[0].family, "dangerous pattern");
+    }
+
+    // --- learn_logistic tests ---
+
+    #[test]
+    fn learn_logistic_returns_none_below_min_samples() {
+        let samples: Vec<JoinedSample> = (0..50)
+            .map(|i| JoinedSample {
+                title: format!("finding {}", i),
+                category: "correctness".to_string(),
+                severity: "medium".to_string(),
+                model: "gpt-5.4".to_string(),
+                tp_weight: 1.0,
+                fp_weight: 0.5,
+                soft_fp_weight: 0.0,
+                full_suppress_weight: 0.5,
+                wontfix_weight: 0.0,
+                precedent_count: 1,
+                max_similarity: 0.5,
+                mean_similarity: 0.5,
+                is_fp: i < 10,
+                family: format!("family_{}", i % 5),
+            })
+            .collect();
+        assert!(learn_logistic(&samples, 5).is_none());
+    }
+
+    #[test]
+    fn learn_logistic_returns_none_class_imbalance() {
+        // 200 samples but only 5 FP (below MIN_CLASS_COUNT=30)
+        let samples: Vec<JoinedSample> = (0..200)
+            .map(|i| JoinedSample {
+                title: format!("finding {}", i),
+                category: "correctness".to_string(),
+                severity: "medium".to_string(),
+                model: "gpt-5.4".to_string(),
+                tp_weight: 1.0,
+                fp_weight: 0.5,
+                soft_fp_weight: 0.0,
+                full_suppress_weight: 0.5,
+                wontfix_weight: 0.0,
+                precedent_count: 1,
+                max_similarity: 0.5,
+                mean_similarity: 0.5,
+                is_fp: i < 5, // only 5 FP
+                family: format!("family_{}", i % 20),
+            })
+            .collect();
+        assert!(learn_logistic(&samples, 5).is_none());
+    }
+
+    #[test]
+    fn learn_logistic_on_separable_synthetic_data() {
+        // 300 samples with clear signal in tp_weight/fp_weight
+        let samples: Vec<JoinedSample> = (0..300)
+            .map(|i| {
+                let is_fp = i < 60; // 20% FP
+                JoinedSample {
+                    title: if is_fp {
+                        "bad pattern unwrap".to_string()
+                    } else {
+                        "good error handling code".to_string()
+                    },
+                    category: if is_fp {
+                        "style".to_string()
+                    } else {
+                        "correctness".to_string()
+                    },
+                    severity: "medium".to_string(),
+                    model: "gpt-5.4".to_string(),
+                    tp_weight: if is_fp { 0.1 } else { 2.5 },
+                    fp_weight: if is_fp { 2.5 } else { 0.1 },
+                    soft_fp_weight: if is_fp { 1.5 } else { 0.0 },
+                    full_suppress_weight: if is_fp { 2.5 } else { 0.1 },
+                    wontfix_weight: 0.0,
+                    precedent_count: if is_fp { 0 } else { 4 },
+                    max_similarity: if is_fp { 0.3 } else { 0.85 },
+                    mean_similarity: if is_fp { 0.2 } else { 0.75 },
+                    is_fp,
+                    family: format!("family_{}", i % 30),
+                }
+            })
+            .collect();
+
+        let result = learn_logistic(&samples, 5);
+        assert!(result.is_some(), "Should succeed on well-separated data");
+        let r = result.unwrap();
+        assert!(
+            r.ap_score > r.baseline_ap + 0.02,
+            "AP {} should beat baseline {} + 0.02",
+            r.ap_score,
+            r.baseline_ap
+        );
+        assert!(
+            r.selected_feature_names.len() >= 2,
+            "Should select at least 2 features"
+        );
+        assert_eq!(r.n_samples, 300);
+        assert_eq!(r.n_fp, 60);
+        assert!(
+            r.suppress_threshold < r.boost_threshold,
+            "suppress {} should be < boost {} for well-separated data (suppress = 99th pctl TP P(FP), boost = 5th pctl FP P(FP))",
+            r.suppress_threshold,
+            r.boost_threshold
+        );
+        assert!(r.coefficients.len() == r.selected_features.len());
+        assert!(r.feature_means.len() == r.selected_features.len());
+    }
+
+    #[test]
+    fn group_k_fold_same_family_same_fold() {
+        let families = vec!["a", "a", "b", "b", "c", "c", "a", "b"];
+        let folds = group_k_fold(&families, 3);
+        // All "a" should be in the same fold
+        let a_folds: Vec<usize> = families
+            .iter()
+            .zip(folds.iter())
+            .filter(|(f, _)| **f == "a")
+            .map(|(_, fold)| *fold)
+            .collect();
+        assert!(a_folds.iter().all(|f| *f == a_folds[0]));
+        // All "b" should be in the same fold
+        let b_folds: Vec<usize> = families
+            .iter()
+            .zip(folds.iter())
+            .filter(|(f, _)| **f == "b")
+            .map(|(_, fold)| *fold)
+            .collect();
+        assert!(b_folds.iter().all(|f| *f == b_folds[0]));
     }
 }

--- a/src/calibrate.rs
+++ b/src/calibrate.rs
@@ -130,12 +130,17 @@ pub fn univariate_screen(
 ) -> Vec<usize> {
     let threshold = baseline_ap + 0.02;
     let n_features = ExpandedFeatures::feature_names().len(); // 15
+
+    // Pre-compute feature matrix to avoid repeated to_vec() allocations (N*15 -> N).
+    let matrix: Vec<Vec<f64>> = samples.iter().map(|(f, _)| f.to_vec()).collect();
+    let labels: Vec<bool> = samples.iter().map(|(_, l)| *l).collect();
     let mut selected = Vec::new();
 
     for feat_idx in 0..n_features {
-        let univariate: Vec<(f64, bool)> = samples
+        let univariate: Vec<(f64, bool)> = matrix
             .iter()
-            .map(|(f, label)| (f.to_vec()[feat_idx], *label))
+            .zip(labels.iter())
+            .map(|(row, &label)| (row[feat_idx], label))
             .collect();
         let ap = crate::metrics::average_precision_stepwise(&univariate);
         if ap >= threshold {
@@ -152,11 +157,17 @@ pub fn feature_importance_scores(
     samples: &[(ExpandedFeatures, bool)],
 ) -> Vec<(usize, f64)> {
     let n_features = ExpandedFeatures::feature_names().len();
+
+    // Pre-compute feature matrix to avoid repeated to_vec() allocations.
+    let matrix: Vec<Vec<f64>> = samples.iter().map(|(f, _)| f.to_vec()).collect();
+    let labels: Vec<bool> = samples.iter().map(|(_, l)| *l).collect();
+
     let mut scores: Vec<(usize, f64)> = (0..n_features)
         .map(|feat_idx| {
-            let univariate: Vec<(f64, bool)> = samples
+            let univariate: Vec<(f64, bool)> = matrix
                 .iter()
-                .map(|(f, label)| (f.to_vec()[feat_idx], *label))
+                .zip(labels.iter())
+                .map(|(row, &label)| (row[feat_idx], label))
                 .collect();
             (feat_idx, crate::metrics::average_precision_stepwise(&univariate))
         })

--- a/src/calibrate.rs
+++ b/src/calibrate.rs
@@ -963,6 +963,7 @@ pub fn compute_calibrator_model(feedback: &[serde_json::Value]) -> Option<Calibr
             family_fp_inv: 1.0,
             language_fp_inv: 0.5,
         },
+        logistic_model: None,
         word_lor: word_lor_map,
         family_fp_rate: family_fp_rate_map,
         language_fp_rate: lang_fp_rate_map,

--- a/src/calibrate.rs
+++ b/src/calibrate.rs
@@ -29,6 +29,96 @@ impl SampleFeatures {
     }
 }
 
+/// Expanded feature vector for logistic calibrator (15 dimensions).
+/// Field order matches `to_vec()` and `feature_names()`.
+#[derive(Debug, Clone)]
+pub struct ExpandedFeatures {
+    // Precedent decomposition (6)
+    pub log1p_tp_weight: f64,
+    pub log1p_fp_weight: f64,
+    pub precedent_count: f64,
+    pub max_similarity: f64,
+    pub mean_similarity: f64,
+    pub has_no_precedents: f64,
+    // Weight accumulators (3)
+    pub log1p_soft_fp_weight: f64,
+    pub log1p_full_suppress_weight: f64,
+    pub log1p_wontfix_weight: f64,
+    // Smoothed priors (3)
+    pub category_fp_rate: f64,
+    pub severity_fp_rate: f64,
+    pub model_fp_rate: f64,
+    // Text statistics (3)
+    pub max_word_lor: f64,
+    pub min_word_lor: f64,
+    pub count_negative_lor_tokens: f64,
+}
+
+impl ExpandedFeatures {
+    /// Convert to ordered `Vec<f64>` matching `feature_names()` order.
+    pub fn to_vec(&self) -> Vec<f64> {
+        vec![
+            self.log1p_tp_weight,
+            self.log1p_fp_weight,
+            self.precedent_count,
+            self.max_similarity,
+            self.mean_similarity,
+            self.has_no_precedents,
+            self.log1p_soft_fp_weight,
+            self.log1p_full_suppress_weight,
+            self.log1p_wontfix_weight,
+            self.category_fp_rate,
+            self.severity_fp_rate,
+            self.model_fp_rate,
+            self.max_word_lor,
+            self.min_word_lor,
+            self.count_negative_lor_tokens,
+        ]
+    }
+
+    /// Feature names matching `to_vec()` order.
+    pub fn feature_names() -> Vec<&'static str> {
+        vec![
+            "log1p_tp_weight",
+            "log1p_fp_weight",
+            "precedent_count",
+            "max_similarity",
+            "mean_similarity",
+            "has_no_precedents",
+            "log1p_soft_fp_weight",
+            "log1p_full_suppress_weight",
+            "log1p_wontfix_weight",
+            "category_fp_rate",
+            "severity_fp_rate",
+            "model_fp_rate",
+            "max_word_lor",
+            "min_word_lor",
+            "count_negative_lor_tokens",
+        ]
+    }
+
+    /// All zeros (useful for tests).
+    pub fn zeros() -> Self {
+        Self {
+            log1p_tp_weight: 0.0,
+            log1p_fp_weight: 0.0,
+            precedent_count: 0.0,
+            max_similarity: 0.0,
+            mean_similarity: 0.0,
+            has_no_precedents: 0.0,
+            log1p_soft_fp_weight: 0.0,
+            log1p_full_suppress_weight: 0.0,
+            log1p_wontfix_weight: 0.0,
+            category_fp_rate: 0.0,
+            severity_fp_rate: 0.0,
+            model_fp_rate: 0.0,
+            max_word_lor: 0.0,
+            min_word_lor: 0.0,
+            count_negative_lor_tokens: 0.0,
+        }
+    }
+}
+
 /// Filters applied to traces before joining with feedback.
 ///
 /// Default filter retains all traces (including legacy ones without provenance).
@@ -3026,5 +3116,49 @@ mod tests {
             language_fp_inv: 1.5,
         };
         assert!(!super::weights_stable(&[w1, w2], 0.20));
+    }
+
+    #[test]
+    fn expanded_features_to_vec_correct_order() {
+        let f = ExpandedFeatures {
+            log1p_tp_weight: 1.0,
+            log1p_fp_weight: 0.5,
+            precedent_count: 3.0,
+            max_similarity: 0.9,
+            mean_similarity: 0.7,
+            has_no_precedents: 0.0,
+            log1p_soft_fp_weight: 0.3,
+            log1p_full_suppress_weight: 0.1,
+            log1p_wontfix_weight: 0.0,
+            category_fp_rate: 0.25,
+            severity_fp_rate: 0.18,
+            model_fp_rate: 0.22,
+            max_word_lor: 2.1,
+            min_word_lor: -1.5,
+            count_negative_lor_tokens: 3.0,
+        };
+        let v = f.to_vec();
+        assert_eq!(v.len(), 15);
+        assert!((v[0] - 1.0).abs() < 1e-9); // log1p_tp_weight
+        assert!((v[1] - 0.5).abs() < 1e-9); // log1p_fp_weight
+        assert!((v[5] - 0.0).abs() < 1e-9); // has_no_precedents
+        assert!((v[14] - 3.0).abs() < 1e-9); // count_negative_lor_tokens
+    }
+
+    #[test]
+    fn expanded_features_names_match_vec_order() {
+        let names = ExpandedFeatures::feature_names();
+        assert_eq!(names.len(), 15);
+        assert_eq!(names[0], "log1p_tp_weight");
+        assert_eq!(names[5], "has_no_precedents");
+        assert_eq!(names[9], "category_fp_rate");
+        assert_eq!(names[14], "count_negative_lor_tokens");
+    }
+
+    #[test]
+    fn expanded_features_zeros() {
+        let f = ExpandedFeatures::zeros();
+        let v = f.to_vec();
+        assert!(v.iter().all(|&x| x == 0.0));
     }
 }

--- a/src/calibrate.rs
+++ b/src/calibrate.rs
@@ -119,6 +119,52 @@ impl ExpandedFeatures {
     }
 }
 
+/// Univariate feature screening: returns indices of features with
+/// stepwise AP >= baseline_ap + 0.02 (the minimum lift threshold).
+///
+/// Each feature is evaluated independently as a predictor of the positive class.
+/// `baseline_ap` is typically the class prevalence (proportion of positives).
+pub fn univariate_screen(
+    samples: &[(ExpandedFeatures, bool)],
+    baseline_ap: f64,
+) -> Vec<usize> {
+    let threshold = baseline_ap + 0.02;
+    let n_features = ExpandedFeatures::feature_names().len(); // 15
+    let mut selected = Vec::new();
+
+    for feat_idx in 0..n_features {
+        let univariate: Vec<(f64, bool)> = samples
+            .iter()
+            .map(|(f, label)| (f.to_vec()[feat_idx], *label))
+            .collect();
+        let ap = crate::metrics::average_precision_stepwise(&univariate);
+        if ap >= threshold {
+            selected.push(feat_idx);
+        }
+    }
+
+    selected
+}
+
+/// Compute per-feature univariate AP scores for diagnostics.
+/// Returns (feature_index, ap_score) pairs sorted by AP descending.
+pub fn feature_importance_scores(
+    samples: &[(ExpandedFeatures, bool)],
+) -> Vec<(usize, f64)> {
+    let n_features = ExpandedFeatures::feature_names().len();
+    let mut scores: Vec<(usize, f64)> = (0..n_features)
+        .map(|feat_idx| {
+            let univariate: Vec<(f64, bool)> = samples
+                .iter()
+                .map(|(f, label)| (f.to_vec()[feat_idx], *label))
+                .collect();
+            (feat_idx, crate::metrics::average_precision_stepwise(&univariate))
+        })
+        .collect();
+    scores.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
+    scores
+}
+
 /// Filters applied to traces before joining with feedback.
 ///
 /// Default filter retains all traces (including legacy ones without provenance).
@@ -3472,5 +3518,61 @@ mod tests {
         assert!((features.category_fp_rate - 0.15).abs() < 1e-9);
         assert!((features.min_word_lor - (-1.2)).abs() < 1e-9);
         assert!((features.count_negative_lor_tokens - 2.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn univariate_screen_selects_discriminative_features() {
+        // 100 samples, 20% FP (baseline AP = 0.20)
+        let samples: Vec<(ExpandedFeatures, bool)> = (0..100)
+            .map(|i| {
+                let is_fp = i < 20;
+                let mut f = ExpandedFeatures::zeros();
+                // Feature 0 (log1p_tp_weight): perfect separation
+                f.log1p_tp_weight = if is_fp { 0.9 } else { 0.1 };
+                // Feature 1 (log1p_fp_weight): anti-correlated with label order
+                // Assign linearly increasing scores so positives (first 20) get LOW
+                // scores and negatives (last 80) get HIGH scores. This means ranking
+                // by descending score puts negatives first -> AP should be near baseline.
+                f.log1p_fp_weight = i as f64 / 100.0;
+                // Feature 2 (precedent_count): moderate separation
+                f.precedent_count = if is_fp { 0.7 } else { 0.3 };
+                (f, is_fp)
+            })
+            .collect();
+
+        let selected = univariate_screen(&samples, 0.20);
+        // Feature 0 should be selected (perfect -> AP=1.0, lift=0.80)
+        assert!(selected.contains(&0), "Perfect feature should be selected");
+        // Feature 1 should NOT be selected (random -> AP~0.20, lift~0)
+        assert!(!selected.contains(&1), "Random feature should not be selected");
+        // Feature 2 should be selected (moderate separation)
+        assert!(selected.contains(&2), "Moderate feature should be selected");
+    }
+
+    #[test]
+    fn univariate_screen_empty_returns_empty() {
+        let samples: Vec<(ExpandedFeatures, bool)> = vec![];
+        let selected = univariate_screen(&samples, 0.20);
+        assert!(selected.is_empty());
+    }
+
+    #[test]
+    fn feature_importance_scores_sorted_descending() {
+        let samples: Vec<(ExpandedFeatures, bool)> = (0..50)
+            .map(|i| {
+                let is_fp = i < 10;
+                let mut f = ExpandedFeatures::zeros();
+                f.log1p_tp_weight = if is_fp { 1.0 } else { 0.0 };
+                (f, is_fp)
+            })
+            .collect();
+        let scores = feature_importance_scores(&samples);
+        assert_eq!(scores.len(), 15);
+        // Should be sorted descending by AP
+        for w in scores.windows(2) {
+            assert!(w[0].1 >= w[1].1);
+        }
+        // Feature 0 should be first (highest AP)
+        assert_eq!(scores[0].0, 0);
     }
 }

--- a/src/calibrate.rs
+++ b/src/calibrate.rs
@@ -2089,6 +2089,7 @@ pub fn learn_logistic(samples: &[JoinedSample], k_folds: usize) -> Option<Logist
     let mut all_oof_predictions: Vec<(f64, bool)> = vec![(0.0, false); n];
     let mut oof_filled = vec![false; n];
     let mut fold_selected_features: Vec<Vec<usize>> = Vec::with_capacity(k_folds);
+    let mut fold_best_lambdas: Vec<f64> = Vec::with_capacity(k_folds);
 
     for fold_idx in 0..k_folds {
         // Split into train/val by fold assignment
@@ -2163,6 +2164,8 @@ pub fn learn_logistic(samples: &[JoinedSample], k_folds: usize) -> Option<Logist
             }
         }
 
+        fold_best_lambdas.push(best_lambda);
+
         // Refit with best lambda, produce OOF predictions for val indices
         let best_model = crate::logistic::fit(&train_x, &train_y, best_lambda, MAX_LOGISTIC_ITER);
         let oof_preds = best_model.predict(&val_x);
@@ -2223,7 +2226,13 @@ pub fn learn_logistic(samples: &[JoinedSample], k_folds: usize) -> Option<Logist
         .collect();
     let prod_y: Vec<bool> = all_expanded.iter().map(|(_, label)| *label).collect();
 
-    let prod_model = crate::logistic::fit(&prod_x, &prod_y, 1.0, MAX_LOGISTIC_ITER);
+    // Use median of per-fold CV-selected lambdas for production refit
+    let prod_lambda = {
+        let mut sorted_lambdas = fold_best_lambdas.clone();
+        sorted_lambdas.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+        sorted_lambdas[sorted_lambdas.len() / 2]
+    };
+    let prod_model = crate::logistic::fit(&prod_x, &prod_y, prod_lambda, MAX_LOGISTIC_ITER);
 
     // Threshold selection from OOF predictions (not in-sample) to avoid
     // optimistic safety estimates. The production model provides deployed

--- a/src/calibrate.rs
+++ b/src/calibrate.rs
@@ -1164,6 +1164,7 @@ const WEIGHT_STABILITY_TOLERANCE: f64 = 0.20;
 pub struct LearnedWeights {
     pub weights: ScoreWeights,
     pub pr_auc: f64,
+    pub baseline_auc: f64,
     pub stable: bool,
     pub fold_aucs: Vec<f64>,
 }
@@ -1181,6 +1182,10 @@ pub fn learn_weights(
         return None;
     }
 
+    // Baseline: PR-AUC of trivial classifier (constant score, all samples tied)
+    let baseline_scored: Vec<(f64, bool)> = features.iter().map(|(_, l)| (0.0, *l)).collect();
+    let baseline_auc = metrics::pr_auc(&baseline_scored);
+
     let score_grid: &[f64] = &[0.0, 0.25, 0.5, 1.0, 1.5, 2.0];
     let word_lor_grid: &[f64] = &[0.0, 0.5, 1.0, 1.5, 2.0, 3.0];
     let family_grid: &[f64] = &[0.0, 0.25, 0.5, 1.0, 1.5, 2.0];
@@ -1193,6 +1198,7 @@ pub fn learn_weights(
         return Some(LearnedWeights {
             weights: full_best.0,
             pr_auc: full_best.1,
+            baseline_auc,
             stable: true,
             fold_aucs: vec![full_best.1],
         });
@@ -1236,6 +1242,7 @@ pub fn learn_weights(
     Some(LearnedWeights {
         weights: full_best.0,
         pr_auc: full_best.1,
+        baseline_auc,
         stable,
         fold_aucs,
     })
@@ -1260,6 +1267,9 @@ fn grid_search_best(
         for &w in word_lor_grid {
             for &f in family_grid {
                 for &l in lang_grid {
+                    if s == 0.0 && w == 0.0 && f == 0.0 && l == 0.0 {
+                        continue;
+                    }
                     let weights = ScoreWeights {
                         score: s,
                         word_lor: w,

--- a/src/calibrate.rs
+++ b/src/calibrate.rs
@@ -1695,6 +1695,300 @@ pub fn extract_single_expanded(s: &JoinedSample, stats: &FoldLocalStats) -> (Exp
     (features, s.is_fp)
 }
 
+// ---------------------------------------------------------------------------
+// Expanded trace info for extract_joined_samples
+// ---------------------------------------------------------------------------
+
+/// Richer variant of `TraceInfo` carrying all metadata fields needed to
+/// populate a `JoinedSample`.
+#[derive(Clone)]
+struct TraceInfoExpanded {
+    tp_weight: f64,
+    fp_weight: f64,
+    soft_fp_weight: f64,
+    full_suppress_weight: f64,
+    wontfix_weight: f64,
+    precedent_count: usize,
+    max_similarity: f64,
+    mean_similarity: f64,
+    category: String,
+    severity: String,
+    model: String,
+}
+
+/// Extract `JoinedSample` records by walking the same multi-tier join as
+/// `extract_join_features`, but returning richer metadata instead of composite
+/// features. Used by the logistic calibrator's cross-validation pipeline.
+pub fn extract_joined_samples(
+    feedback: &[serde_json::Value],
+    traces: &[serde_json::Value],
+    _model: &CalibratorModel,
+    filter: &JoinFilter,
+    disable_fuzzy: bool,
+) -> Vec<JoinedSample> {
+    let filtered_traces: Vec<&serde_json::Value> =
+        traces.iter().filter(|t| filter.accepts(t)).collect();
+
+    // Build the same index structures as extract_join_features, using TraceInfoExpanded.
+    let mut raw_map: HashMap<(String, String), TraceInfoExpanded> = HashMap::new();
+    let mut raw_ambiguous: HashSet<(String, String)> = HashSet::new();
+    let mut norm_map: HashMap<(String, String), TraceInfoExpanded> = HashMap::new();
+    let mut norm_ambiguous: HashSet<(String, String)> = HashSet::new();
+    let mut deep_path_map: HashMap<(String, String), TraceInfoExpanded> = HashMap::new();
+    let mut deep_path_ambiguous: HashSet<(String, String)> = HashSet::new();
+    let mut file_traces: HashMap<String, Vec<(String, TraceInfoExpanded)>> = HashMap::new();
+    let mut suffix_index: HashMap<String, Vec<(String, String, TraceInfoExpanded)>> = HashMap::new();
+    let mut norm_title_only: HashMap<String, TraceInfoExpanded> = HashMap::new();
+    let mut norm_title_only_ambiguous: HashSet<String> = HashSet::new();
+    let mut raw_title_only: HashMap<String, TraceInfoExpanded> = HashMap::new();
+    let mut raw_title_only_ambiguous: HashSet<String> = HashSet::new();
+    let mut norm_titles_with_file_scoped: HashSet<String> = HashSet::new();
+    let mut raw_titles_with_file_scoped: HashSet<String> = HashSet::new();
+
+    for t in &filtered_traces {
+        let title = t["finding_title"].as_str().unwrap_or("").to_string();
+        if title.is_empty() {
+            continue;
+        }
+        let fp = t["file_path"].as_str().unwrap_or("").to_string();
+        let tp_w = t["tp_weight"].as_f64().unwrap_or(0.0).max(0.0);
+        let fp_w = t["fp_weight"].as_f64().unwrap_or(0.0).max(0.0);
+        let soft_fp_w = t["soft_fp_weight"].as_f64().unwrap_or(0.0).max(0.0);
+        let full_suppress_w = t["full_suppress_weight"].as_f64().unwrap_or(fp_w).max(0.0);
+        let wontfix_w = t["wontfix_weight"].as_f64().unwrap_or(0.0).max(0.0);
+        let precedent_count = t["precedent_count"]
+            .as_u64()
+            .map(|v| v as usize)
+            .unwrap_or_else(|| if tp_w > 0.0 || fp_w > 0.0 { 1 } else { 0 });
+        let max_sim = t["max_similarity"].as_f64().unwrap_or(0.0);
+        let mean_sim = t["mean_similarity"].as_f64().unwrap_or(0.0);
+        let category = t["finding_category"]
+            .as_str()
+            .unwrap_or("unknown")
+            .to_string();
+        let severity = t["input_severity"]
+            .as_str()
+            .unwrap_or("medium")
+            .to_string();
+        let model_name = t["model"].as_str().unwrap_or("unknown").to_string();
+
+        let norm = normalize_title(&title);
+        let deep_fp = normalize_file_path_deep(&fp);
+        let info = TraceInfoExpanded {
+            tp_weight: tp_w,
+            fp_weight: fp_w,
+            soft_fp_weight: soft_fp_w,
+            full_suppress_weight: full_suppress_w,
+            wontfix_weight: wontfix_w,
+            precedent_count,
+            max_similarity: max_sim,
+            mean_similarity: mean_sim,
+            category,
+            severity,
+            model: model_name,
+        };
+
+        if fp.is_empty() {
+            match raw_title_only.entry(title.clone()) {
+                std::collections::hash_map::Entry::Occupied(_) => {
+                    raw_title_only_ambiguous.insert(title.clone());
+                }
+                std::collections::hash_map::Entry::Vacant(e) => {
+                    e.insert(info.clone());
+                }
+            }
+            if !disable_fuzzy && !norm.is_empty() {
+                let norm_for_ambiguous = norm.clone();
+                match norm_title_only.entry(norm) {
+                    std::collections::hash_map::Entry::Occupied(_) => {
+                        norm_title_only_ambiguous.insert(norm_for_ambiguous);
+                    }
+                    std::collections::hash_map::Entry::Vacant(e) => {
+                        e.insert(info);
+                    }
+                }
+            }
+        } else {
+            raw_titles_with_file_scoped.insert(title.clone());
+            if !norm.is_empty() {
+                norm_titles_with_file_scoped.insert(norm.clone());
+            }
+            let raw_key = (title, fp.clone());
+            match raw_map.entry(raw_key.clone()) {
+                std::collections::hash_map::Entry::Occupied(_) => {
+                    raw_ambiguous.insert(raw_key);
+                }
+                std::collections::hash_map::Entry::Vacant(e) => {
+                    e.insert(info.clone());
+                }
+            }
+            if !disable_fuzzy && !norm.is_empty() {
+                let norm_key = (norm.clone(), fp.clone());
+                match norm_map.entry(norm_key.clone()) {
+                    std::collections::hash_map::Entry::Occupied(_) => {
+                        norm_ambiguous.insert(norm_key);
+                    }
+                    std::collections::hash_map::Entry::Vacant(e) => {
+                        e.insert(info.clone());
+                    }
+                }
+                if !deep_fp.is_empty() {
+                    let deep_key = (norm.clone(), deep_fp.clone());
+                    match deep_path_map.entry(deep_key.clone()) {
+                        std::collections::hash_map::Entry::Occupied(_) => {
+                            deep_path_ambiguous.insert(deep_key);
+                        }
+                        std::collections::hash_map::Entry::Vacant(e) => {
+                            e.insert(info.clone());
+                        }
+                    }
+                    let filename = deep_fp.rsplit('/').next().unwrap_or("").to_string();
+                    if !filename.is_empty() {
+                        suffix_index.entry(filename).or_default().push((
+                            deep_fp,
+                            norm.clone(),
+                            info.clone(),
+                        ));
+                    }
+                }
+                file_traces.entry(fp).or_default().push((norm, info));
+            }
+        }
+    }
+
+    for key in &raw_ambiguous {
+        raw_map.remove(key);
+    }
+    for key in &norm_ambiguous {
+        norm_map.remove(key);
+    }
+    for key in &deep_path_ambiguous {
+        deep_path_map.remove(key);
+    }
+    for key in &raw_title_only_ambiguous {
+        raw_title_only.remove(key);
+    }
+    for key in &norm_title_only_ambiguous {
+        norm_title_only.remove(key);
+    }
+    for title in &raw_titles_with_file_scoped {
+        raw_title_only.remove(title);
+    }
+    for norm in &norm_titles_with_file_scoped {
+        norm_title_only.remove(norm);
+    }
+
+    let mut samples = Vec::new();
+
+    for f in feedback {
+        let verdict = f["verdict"].as_str().unwrap_or("");
+        let is_fp = match verdict {
+            "tp" | "partial" => false,
+            "fp" => true,
+            _ => continue,
+        };
+        let title = f["finding_title"].as_str().unwrap_or("").to_string();
+        if title.is_empty() {
+            continue;
+        }
+        let fp = f["file_path"].as_str().unwrap_or("").to_string();
+        let norm = normalize_title(&title);
+        let deep_fp = normalize_file_path_deep(&fp);
+
+        let matched = raw_map
+            .get(&(title.clone(), fp.clone()))
+            .or_else(|| {
+                if !disable_fuzzy && !norm.is_empty() {
+                    norm_map.get(&(norm.clone(), fp.clone()))
+                } else {
+                    None
+                }
+            })
+            .or_else(|| {
+                if !disable_fuzzy && !norm.is_empty() && !deep_fp.is_empty() {
+                    deep_path_map.get(&(norm.clone(), deep_fp.clone()))
+                } else {
+                    None
+                }
+            })
+            .or_else(|| {
+                if !disable_fuzzy
+                    && !norm.is_empty()
+                    && !fp.is_empty()
+                    && let Some(candidates) = file_traces.get(&fp)
+                {
+                    let mut best_score = 0.0_f64;
+                    let mut second_best = 0.0_f64;
+                    let mut best_info: Option<&TraceInfoExpanded> = None;
+                    for (cand_norm, info) in candidates {
+                        let j = token_jaccard(&norm, cand_norm);
+                        if j > best_score {
+                            second_best = best_score;
+                            best_score = j;
+                            best_info = Some(info);
+                        } else if j > second_best {
+                            second_best = j;
+                        }
+                    }
+                    if best_score >= FUZZY_THRESHOLD
+                        && (best_score - second_best) >= FUZZY_AMBIGUITY_MARGIN
+                    {
+                        return best_info;
+                    }
+                }
+                None
+            })
+            .or_else(|| {
+                if !disable_fuzzy && !norm.is_empty() && !deep_fp.is_empty() {
+                    let filename = deep_fp.rsplit('/').next().unwrap_or("");
+                    if let Some(candidates) = suffix_index.get(filename) {
+                        let matches: Vec<&TraceInfoExpanded> = candidates
+                            .iter()
+                            .filter(|(cand_path, cand_norm, _)| {
+                                *cand_norm == norm && path_suffix_eq(cand_path, &deep_fp)
+                            })
+                            .map(|(_, _, info)| info)
+                            .collect();
+                        if matches.len() == 1 {
+                            return Some(matches[0]);
+                        }
+                    }
+                }
+                None
+            })
+            .or_else(|| raw_title_only.get(&title))
+            .or_else(|| {
+                if !disable_fuzzy && !norm.is_empty() {
+                    norm_title_only.get(&norm)
+                } else {
+                    None
+                }
+            });
+
+        if let Some(info) = matched {
+            let family = CalibratorModel::title_family(&title);
+            samples.push(JoinedSample {
+                title,
+                category: info.category.clone(),
+                severity: info.severity.clone(),
+                model: info.model.clone(),
+                tp_weight: info.tp_weight,
+                fp_weight: info.fp_weight,
+                soft_fp_weight: info.soft_fp_weight,
+                full_suppress_weight: info.full_suppress_weight,
+                wontfix_weight: info.wontfix_weight,
+                precedent_count: info.precedent_count,
+                max_similarity: info.max_similarity,
+                mean_similarity: info.mean_similarity,
+                is_fp,
+                family,
+            });
+        }
+    }
+
+    samples
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -3574,5 +3868,221 @@ mod tests {
         }
         // Feature 0 should be first (highest AP)
         assert_eq!(scores[0].0, 0);
+    }
+
+    // -----------------------------------------------------------------------
+    // extract_joined_samples tests
+    // -----------------------------------------------------------------------
+
+    fn make_test_model() -> CalibratorModel {
+        CalibratorModel {
+            meta: ModelMeta {
+                computed_at: "2026-05-16T00:00:00Z".to_string(),
+                feedback_count: 10,
+                global_fp_rate: 0.3,
+                learned_weights: None,
+            },
+            weights: ScoreWeights {
+                score: 0.5,
+                word_lor: 1.5,
+                family_fp_inv: 1.0,
+                language_fp_inv: 0.5,
+            },
+            logistic_model: None,
+            word_lor: HashMap::new(),
+            family_fp_rate: HashMap::new(),
+            language_fp_rate: HashMap::new(),
+        }
+    }
+
+    #[test]
+    fn extract_joined_samples_basic() {
+        let trace = serde_json::json!({
+            "finding_title": "SQL injection risk",
+            "file_path": "src/db.rs",
+            "tp_weight": 1.5,
+            "fp_weight": 0.5,
+            "soft_fp_weight": 0.3,
+            "wontfix_weight": 0.0,
+            "finding_category": "security",
+            "input_severity": "high",
+            "model": "gpt-5.4",
+            "precedent_count": 2,
+            "max_similarity": 0.85,
+            "mean_similarity": 0.72,
+        });
+        let feedback_entry = serde_json::json!({
+            "finding_title": "SQL injection risk",
+            "file_path": "src/db.rs",
+            "verdict": "tp",
+        });
+        let traces = vec![trace];
+        let feedback = vec![feedback_entry];
+        let model = make_test_model();
+        let filter = JoinFilter::default();
+
+        let samples = extract_joined_samples(&feedback, &traces, &model, &filter, false);
+        assert_eq!(samples.len(), 1);
+        let s = &samples[0];
+        assert_eq!(s.title, "SQL injection risk");
+        assert_eq!(s.category, "security");
+        assert_eq!(s.severity, "high");
+        assert_eq!(s.model, "gpt-5.4");
+        assert!(!s.is_fp);
+        assert!((s.tp_weight - 1.5).abs() < 1e-9);
+        assert!((s.fp_weight - 0.5).abs() < 1e-9);
+        assert!((s.soft_fp_weight - 0.3).abs() < 1e-9);
+        assert_eq!(s.precedent_count, 2);
+        assert!((s.max_similarity - 0.85).abs() < 1e-9);
+        assert!((s.mean_similarity - 0.72).abs() < 1e-9);
+    }
+
+    #[test]
+    fn extract_joined_samples_fp_label() {
+        let trace = serde_json::json!({
+            "finding_title": "Unused import",
+            "file_path": "src/lib.rs",
+            "tp_weight": 0.1,
+            "fp_weight": 2.0,
+        });
+        let feedback_entry = serde_json::json!({
+            "finding_title": "Unused import",
+            "file_path": "src/lib.rs",
+            "verdict": "fp",
+        });
+        let traces = vec![trace];
+        let feedback = vec![feedback_entry];
+        let model = make_test_model();
+        let filter = JoinFilter::default();
+
+        let samples = extract_joined_samples(&feedback, &traces, &model, &filter, false);
+        assert_eq!(samples.len(), 1);
+        assert!(samples[0].is_fp);
+        // Verify defaults for missing fields
+        assert_eq!(samples[0].category, "unknown");
+        assert_eq!(samples[0].severity, "medium");
+        assert_eq!(samples[0].model, "unknown");
+    }
+
+    #[test]
+    fn extract_joined_samples_skips_wontfix() {
+        let trace = serde_json::json!({
+            "finding_title": "Style issue",
+            "file_path": "src/main.rs",
+            "tp_weight": 0.5,
+            "fp_weight": 0.5,
+        });
+        let feedback_entry = serde_json::json!({
+            "finding_title": "Style issue",
+            "file_path": "src/main.rs",
+            "verdict": "wontfix",
+        });
+        let traces = vec![trace];
+        let feedback = vec![feedback_entry];
+        let model = make_test_model();
+        let filter = JoinFilter::default();
+
+        let samples = extract_joined_samples(&feedback, &traces, &model, &filter, false);
+        assert!(samples.is_empty());
+    }
+
+    #[test]
+    fn extract_joined_samples_partial_counts_as_tp() {
+        let trace = serde_json::json!({
+            "finding_title": "Buffer overflow",
+            "file_path": "src/buf.rs",
+            "tp_weight": 1.0,
+            "fp_weight": 0.2,
+            "finding_category": "memory-safety",
+            "input_severity": "critical",
+            "model": "gemini-2.5-pro",
+            "precedent_count": 5,
+            "max_similarity": 0.95,
+            "mean_similarity": 0.80,
+        });
+        let feedback_entry = serde_json::json!({
+            "finding_title": "Buffer overflow",
+            "file_path": "src/buf.rs",
+            "verdict": "partial",
+        });
+        let traces = vec![trace];
+        let feedback = vec![feedback_entry];
+        let model = make_test_model();
+        let filter = JoinFilter::default();
+
+        let samples = extract_joined_samples(&feedback, &traces, &model, &filter, false);
+        assert_eq!(samples.len(), 1);
+        assert!(!samples[0].is_fp); // partial = not FP
+        assert_eq!(samples[0].category, "memory-safety");
+        assert_eq!(samples[0].severity, "critical");
+    }
+
+    #[test]
+    fn extract_joined_samples_precedent_count_inferred() {
+        // When precedent_count is absent but weights > 0, infer 1
+        let trace = serde_json::json!({
+            "finding_title": "Inferred precedent",
+            "file_path": "src/a.rs",
+            "tp_weight": 1.0,
+            "fp_weight": 0.0,
+        });
+        let feedback_entry = serde_json::json!({
+            "finding_title": "Inferred precedent",
+            "file_path": "src/a.rs",
+            "verdict": "tp",
+        });
+        let traces = vec![trace];
+        let feedback = vec![feedback_entry];
+        let model = make_test_model();
+        let filter = JoinFilter::default();
+
+        let samples = extract_joined_samples(&feedback, &traces, &model, &filter, false);
+        assert_eq!(samples.len(), 1);
+        assert_eq!(samples[0].precedent_count, 1);
+    }
+
+    #[test]
+    fn extract_joined_samples_unmatched_feedback_skipped() {
+        let trace = serde_json::json!({
+            "finding_title": "SQL injection",
+            "file_path": "src/db.rs",
+            "tp_weight": 1.0,
+            "fp_weight": 0.5,
+        });
+        let feedback_entry = serde_json::json!({
+            "finding_title": "Completely different finding",
+            "file_path": "src/other.rs",
+            "verdict": "tp",
+        });
+        let traces = vec![trace];
+        let feedback = vec![feedback_entry];
+        let model = make_test_model();
+        let filter = JoinFilter::default();
+
+        let samples = extract_joined_samples(&feedback, &traces, &model, &filter, false);
+        assert!(samples.is_empty());
+    }
+
+    #[test]
+    fn extract_joined_samples_family_populated() {
+        let trace = serde_json::json!({
+            "finding_title": "bare-except-pass: dangerous pattern",
+            "file_path": "src/main.py",
+            "tp_weight": 1.0,
+            "fp_weight": 0.0,
+        });
+        let feedback_entry = serde_json::json!({
+            "finding_title": "bare-except-pass: dangerous pattern",
+            "file_path": "src/main.py",
+            "verdict": "tp",
+        });
+        let traces = vec![trace];
+        let feedback = vec![feedback_entry];
+        let model = make_test_model();
+        let filter = JoinFilter::default();
+
+        let samples = extract_joined_samples(&feedback, &traces, &model, &filter, false);
+        assert_eq!(samples.len(), 1);
+        assert_eq!(samples[0].family, "dangerous pattern");
     }
 }

--- a/src/calibrate.rs
+++ b/src/calibrate.rs
@@ -124,10 +124,7 @@ impl ExpandedFeatures {
 ///
 /// Each feature is evaluated independently as a predictor of the positive class.
 /// `baseline_ap` is typically the class prevalence (proportion of positives).
-pub fn univariate_screen(
-    samples: &[(ExpandedFeatures, bool)],
-    baseline_ap: f64,
-) -> Vec<usize> {
+pub fn univariate_screen(samples: &[(ExpandedFeatures, bool)], baseline_ap: f64) -> Vec<usize> {
     let threshold = baseline_ap + 0.02;
     let n_features = ExpandedFeatures::feature_names().len(); // 15
 
@@ -153,9 +150,7 @@ pub fn univariate_screen(
 
 /// Compute per-feature univariate AP scores for diagnostics.
 /// Returns (feature_index, ap_score) pairs sorted by AP descending.
-pub fn feature_importance_scores(
-    samples: &[(ExpandedFeatures, bool)],
-) -> Vec<(usize, f64)> {
+pub fn feature_importance_scores(samples: &[(ExpandedFeatures, bool)]) -> Vec<(usize, f64)> {
     let n_features = ExpandedFeatures::feature_names().len();
 
     // Pre-compute feature matrix to avoid repeated to_vec() allocations.
@@ -169,7 +164,10 @@ pub fn feature_importance_scores(
                 .zip(labels.iter())
                 .map(|(row, &label)| (row[feat_idx], label))
                 .collect();
-            (feat_idx, crate::metrics::average_precision_stepwise(&univariate))
+            (
+                feat_idx,
+                crate::metrics::average_precision_stepwise(&univariate),
+            )
         })
         .collect();
     scores.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
@@ -1359,7 +1357,11 @@ pub fn learn_weights(
 
     for i in 0..k {
         let start = i * fold_size;
-        let end = if i == k - 1 { features.len() } else { start + fold_size };
+        let end = if i == k - 1 {
+            features.len()
+        } else {
+            start + fold_size
+        };
 
         let train: Vec<(SampleFeatures, bool)> = indices
             .iter()
@@ -1375,10 +1377,8 @@ pub fn learn_weights(
         let (best_w, _) =
             grid_search_best(&train, score_grid, word_lor_grid, family_grid, lang_grid);
 
-        let val_scored: Vec<(f64, bool)> = val
-            .iter()
-            .map(|(f, l)| (f.score(&best_w), *l))
-            .collect();
+        let val_scored: Vec<(f64, bool)> =
+            val.iter().map(|(f, l)| (f.score(&best_w), *l)).collect();
         let val_auc = metrics::pr_auc(&val_scored);
 
         fold_weights.push(best_w);
@@ -1622,7 +1622,8 @@ pub fn compute_fold_local_stats(samples: &[&JoinedSample]) -> FoldLocalStats {
     // Word log-odds ratios with Laplace smoothing
     let mut word_lor_map: HashMap<String, f64> = HashMap::new();
     if tp_total > 0 && fp_total > 0 {
-        let all_words: HashSet<&String> = word_fp_count.keys().chain(word_tp_count.keys()).collect();
+        let all_words: HashSet<&String> =
+            word_fp_count.keys().chain(word_tp_count.keys()).collect();
         let eps = 0.5_f64; // Laplace smoothing
         for w in all_words {
             let fp_c = word_fp_count.get(w).copied().unwrap_or(0);
@@ -1652,7 +1653,10 @@ pub fn compute_fold_local_stats(samples: &[&JoinedSample]) -> FoldLocalStats {
 /// Extract expanded features for a single sample using fold-local stats.
 ///
 /// Returns the feature vector and the label (`true` = FP for logistic regression).
-pub fn extract_single_expanded(s: &JoinedSample, stats: &FoldLocalStats) -> (ExpandedFeatures, bool) {
+pub fn extract_single_expanded(
+    s: &JoinedSample,
+    stats: &FoldLocalStats,
+) -> (ExpandedFeatures, bool) {
     let words = tokenize_title(&s.title);
 
     let max_word_lor = words
@@ -1750,7 +1754,8 @@ pub fn extract_joined_samples(
     let mut deep_path_map: HashMap<(String, String), TraceInfoExpanded> = HashMap::new();
     let mut deep_path_ambiguous: HashSet<(String, String)> = HashSet::new();
     let mut file_traces: HashMap<String, Vec<(String, TraceInfoExpanded)>> = HashMap::new();
-    let mut suffix_index: HashMap<String, Vec<(String, String, TraceInfoExpanded)>> = HashMap::new();
+    let mut suffix_index: HashMap<String, Vec<(String, String, TraceInfoExpanded)>> =
+        HashMap::new();
     let mut norm_title_only: HashMap<String, TraceInfoExpanded> = HashMap::new();
     let mut norm_title_only_ambiguous: HashSet<String> = HashSet::new();
     let mut raw_title_only: HashMap<String, TraceInfoExpanded> = HashMap::new();
@@ -1779,10 +1784,7 @@ pub fn extract_joined_samples(
             .as_str()
             .unwrap_or("unknown")
             .to_string();
-        let severity = t["input_severity"]
-            .as_str()
-            .unwrap_or("medium")
-            .to_string();
+        let severity = t["input_severity"].as_str().unwrap_or("medium").to_string();
         let model_name = t["model"].as_str().unwrap_or("unknown").to_string();
 
         let norm = normalize_title(&title);
@@ -2162,8 +2164,7 @@ pub fn learn_logistic(samples: &[JoinedSample], k_folds: usize) -> Option<Logist
         }
 
         // Refit with best lambda, produce OOF predictions for val indices
-        let best_model =
-            crate::logistic::fit(&train_x, &train_y, best_lambda, MAX_LOGISTIC_ITER);
+        let best_model = crate::logistic::fit(&train_x, &train_y, best_lambda, MAX_LOGISTIC_ITER);
         let oof_preds = best_model.predict(&val_x);
 
         for (local_idx, &global_idx) in val_indices.iter().enumerate() {
@@ -3902,7 +3903,10 @@ mod tests {
             result.weights.score > 0.0,
             "score weight should be positive for separable data"
         );
-        assert!(result.pr_auc > 0.8, "PR-AUC should be high for separable data");
+        assert!(
+            result.pr_auc > 0.8,
+            "PR-AUC should be high for separable data"
+        );
     }
 
     #[test]
@@ -4087,10 +4091,7 @@ mod tests {
             category_fp_rates: HashMap::from([("security".to_string(), 0.15)]),
             severity_fp_rates: HashMap::from([("high".to_string(), 0.12)]),
             model_fp_rates: HashMap::from([("gpt-5.4".to_string(), 0.20)]),
-            word_lor: HashMap::from([
-                ("sql".to_string(), -0.8),
-                ("injection".to_string(), -1.2),
-            ]),
+            word_lor: HashMap::from([("sql".to_string(), -0.8), ("injection".to_string(), -1.2)]),
             global_fp_rate: 0.18,
         };
         let (features, is_fp) = extract_single_expanded(&s, &stats);
@@ -4130,7 +4131,10 @@ mod tests {
         // Feature 0 should be selected (perfect -> AP=1.0, lift=0.80)
         assert!(selected.contains(&0), "Perfect feature should be selected");
         // Feature 1 should NOT be selected (random -> AP~0.20, lift~0)
-        assert!(!selected.contains(&1), "Random feature should not be selected");
+        assert!(
+            !selected.contains(&1),
+            "Random feature should not be selected"
+        );
         // Feature 2 should be selected (moderate separation)
         assert!(selected.contains(&2), "Moderate feature should be selected");
     }

--- a/src/calibrate.rs
+++ b/src/calibrate.rs
@@ -2222,34 +2222,33 @@ pub fn learn_logistic(samples: &[JoinedSample], k_folds: usize) -> Option<Logist
 
     let prod_model = crate::logistic::fit(&prod_x, &prod_y, 1.0, MAX_LOGISTIC_ITER);
 
-    // Threshold selection from production model predictions
-    let prod_predictions = prod_model.predict(&prod_x);
-
-    // Separate predictions by class
-    let mut tp_predictions: Vec<f64> = prod_predictions
+    // Threshold selection from OOF predictions (not in-sample) to avoid
+    // optimistic safety estimates. The production model provides deployed
+    // coefficients; thresholds come from held-out data.
+    let mut oof_tp_predictions: Vec<f64> = filled_predictions
         .iter()
-        .zip(prod_y.iter())
-        .filter(|(_, is_fp)| !**is_fp)
+        .filter(|(_, is_fp)| !*is_fp)
         .map(|(pred, _)| *pred)
         .collect();
-    let mut fp_predictions: Vec<f64> = prod_predictions
+    let mut oof_fp_predictions: Vec<f64> = filled_predictions
         .iter()
-        .zip(prod_y.iter())
-        .filter(|(_, is_fp)| **is_fp)
+        .filter(|(_, is_fp)| *is_fp)
         .map(|(pred, _)| *pred)
         .collect();
 
-    // Suppress threshold: sort TP predictions descending, pick at ceil(n_tp * 0.01)
-    // This ensures 99% of TPs have prediction below the threshold (safe from suppression)
-    tp_predictions.sort_by(|a, b| b.partial_cmp(a).unwrap_or(std::cmp::Ordering::Equal));
-    let suppress_idx = ((n_tp as f64 * 0.01).ceil() as usize).min(tp_predictions.len() - 1);
-    let suppress_threshold = tp_predictions[suppress_idx];
+    // Suppress threshold: sort TP OOF predictions descending, pick at ceil(n_tp * 0.01)
+    // This ensures 99% of TPs have OOF prediction below the threshold (safe from suppression)
+    oof_tp_predictions.sort_by(|a, b| b.partial_cmp(a).unwrap_or(std::cmp::Ordering::Equal));
+    let suppress_idx =
+        ((oof_tp_predictions.len() as f64 * 0.01).ceil() as usize).min(oof_tp_predictions.len() - 1);
+    let suppress_threshold = oof_tp_predictions[suppress_idx];
 
-    // Boost threshold: sort FP predictions ascending, pick at ceil(n_fp * 0.05)
-    // This ensures 95% of FPs have prediction above the threshold
-    fp_predictions.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
-    let boost_idx = ((n_fp as f64 * 0.05).ceil() as usize).min(fp_predictions.len() - 1);
-    let boost_threshold = fp_predictions[boost_idx];
+    // Boost threshold: sort FP OOF predictions ascending, pick at ceil(n_fp * 0.05)
+    // This ensures 95% of FPs have OOF prediction above the threshold
+    oof_fp_predictions.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+    let boost_idx =
+        ((oof_fp_predictions.len() as f64 * 0.05).ceil() as usize).min(oof_fp_predictions.len() - 1);
+    let boost_threshold = oof_fp_predictions[boost_idx];
 
     let feature_names = ExpandedFeatures::feature_names();
     let selected_feature_names: Vec<String> = consensus_features

--- a/src/calibrator.rs
+++ b/src/calibrator.rs
@@ -126,6 +126,7 @@ fn make_no_match_trace(
         same_file_precedent_count: None,
         in_diff: finding.in_diff,
         composite_score: None,
+        logistic_p_fp: None,
     }
 }
 
@@ -168,7 +169,93 @@ fn make_trace_entry(
         same_file_precedent_count: None,
         in_diff: finding.in_diff,
         composite_score: None,
+        logistic_p_fp: None,
     }
+}
+
+// ---------------------------------------------------------------------------
+// Logistic model review-time scoring
+// ---------------------------------------------------------------------------
+
+/// Feature vector computed at review time for logistic model scoring.
+#[derive(Debug, Clone)]
+pub struct ReviewFeatures {
+    pub log1p_tp_weight: f64,
+    pub log1p_fp_weight: f64,
+    pub precedent_count: f64,
+    pub max_similarity: f64,
+    pub mean_similarity: f64,
+    pub has_no_precedents: f64,
+    pub log1p_soft_fp_weight: f64,
+    pub log1p_full_suppress_weight: f64,
+    pub log1p_wontfix_weight: f64,
+    pub category_fp_rate: f64,
+    pub severity_fp_rate: f64,
+    pub model_fp_rate: f64,
+    pub max_word_lor: f64,
+    pub min_word_lor: f64,
+    pub count_negative_lor_tokens: f64,
+}
+
+impl ReviewFeatures {
+    /// Create a feature vector with all fields set to zero.
+    pub fn zeros() -> Self {
+        Self {
+            log1p_tp_weight: 0.0,
+            log1p_fp_weight: 0.0,
+            precedent_count: 0.0,
+            max_similarity: 0.0,
+            mean_similarity: 0.0,
+            has_no_precedents: 0.0,
+            log1p_soft_fp_weight: 0.0,
+            log1p_full_suppress_weight: 0.0,
+            log1p_wontfix_weight: 0.0,
+            category_fp_rate: 0.0,
+            severity_fp_rate: 0.0,
+            model_fp_rate: 0.0,
+            max_word_lor: 0.0,
+            min_word_lor: 0.0,
+            count_negative_lor_tokens: 0.0,
+        }
+    }
+
+    /// Get feature value by name (matches `LogisticModel.selected_features` entries).
+    pub fn get_by_name(&self, name: &str) -> f64 {
+        match name {
+            "log1p_tp_weight" => self.log1p_tp_weight,
+            "log1p_fp_weight" => self.log1p_fp_weight,
+            "precedent_count" => self.precedent_count,
+            "max_similarity" => self.max_similarity,
+            "mean_similarity" => self.mean_similarity,
+            "has_no_precedents" => self.has_no_precedents,
+            "log1p_soft_fp_weight" => self.log1p_soft_fp_weight,
+            "log1p_full_suppress_weight" => self.log1p_full_suppress_weight,
+            "log1p_wontfix_weight" => self.log1p_wontfix_weight,
+            "category_fp_rate" => self.category_fp_rate,
+            "severity_fp_rate" => self.severity_fp_rate,
+            "model_fp_rate" => self.model_fp_rate,
+            "max_word_lor" => self.max_word_lor,
+            "min_word_lor" => self.min_word_lor,
+            "count_negative_lor_tokens" => self.count_negative_lor_tokens,
+            _ => 0.0,
+        }
+    }
+}
+
+/// Compute P(FP) using the stored logistic model.
+///
+/// Standardizes features using stored means/stddevs, computes logit, applies sigmoid.
+pub fn logistic_score(
+    model: &crate::calibrator_model::LogisticModel,
+    features: &ReviewFeatures,
+) -> f64 {
+    let mut logit = model.intercept;
+    for (i, feat_name) in model.selected_features.iter().enumerate() {
+        let raw = features.get_by_name(feat_name);
+        let normed = (raw - model.feature_means[i]) / (model.feature_stddevs[i] + 1e-8);
+        logit += model.coefficients[i] * normed;
+    }
+    crate::logistic::sigmoid(logit)
 }
 
 /// Outcome of [`calibrate_core_decision`]: whether the finding was fully
@@ -224,6 +311,148 @@ fn calibrate_core_decision(
     let mut reason: Option<crate::calibrator_trace::SeverityChangeReason> = None;
     let mut suppressed = false;
     let mut boosted = false;
+
+    // Logistic model path: when present, P(FP) directly drives suppress/boost decisions.
+    if let Some(logistic) = config.model.as_ref().and_then(|m| m.logistic_model.as_ref()) {
+        let review_features = ReviewFeatures {
+            log1p_tp_weight: tp_weight.ln_1p(),
+            log1p_fp_weight: fp_weight.ln_1p(),
+            precedent_count: (matched_precedents.len() as f64).min(10.0),
+            max_similarity: matched_precedents
+                .iter()
+                .map(|p| p.similarity)
+                .fold(0.0_f64, f64::max),
+            mean_similarity: if matched_precedents.is_empty() {
+                0.0
+            } else {
+                matched_precedents.iter().map(|p| p.similarity).sum::<f64>()
+                    / matched_precedents.len() as f64
+            },
+            has_no_precedents: if matched_precedents.is_empty() {
+                1.0
+            } else {
+                0.0
+            },
+            log1p_soft_fp_weight: soft_fp_weight.ln_1p(),
+            log1p_full_suppress_weight: fp_weight.ln_1p(),
+            log1p_wontfix_weight: wontfix_weight.ln_1p(),
+            // Features that require fold-local stats not available at review time
+            // default to 0.0. The logistic model's standardization handles this
+            // (0.0 -> below-mean -> shifts logit accordingly).
+            category_fp_rate: 0.0,
+            severity_fp_rate: 0.0,
+            model_fp_rate: 0.0,
+            max_word_lor: 0.0,
+            min_word_lor: 0.0,
+            count_negative_lor_tokens: 0.0,
+        };
+
+        let p_fp = logistic_score(logistic, &review_features);
+
+        // Suppress: P(FP) > suppress_threshold AND some FP evidence exists
+        if p_fp > logistic.suppress_threshold && fp_weight > 0.0 {
+            finding.calibrator_action = Some(CalibratorAction::Disputed);
+            suppressed = true;
+            let mut trace = make_trace_entry(
+                finding,
+                tp_weight,
+                fp_weight,
+                wontfix_weight,
+                fp_weight, // full_suppress_weight = fp_weight
+                soft_fp_weight,
+                matched_precedents,
+                finding.calibrator_action.clone(),
+                input_severity,
+                Some(crate::calibrator_trace::SeverityChangeReason::Disputed),
+                file_path,
+            );
+            trace.logistic_p_fp = Some(p_fp);
+            return CoreDecision {
+                suppressed,
+                boosted,
+                trace,
+            };
+        }
+
+        // Boost: P(FP) < boost_threshold AND some TP evidence exists
+        if p_fp < logistic.boost_threshold && tp_weight > 0.0 && config.boost_tp {
+            let proposed = boost_severity(&finding.severity);
+            let gate_on = std::env::var("QUORUM_RUBRIC_GATE")
+                .map(|v| v != "off" && v != "0")
+                .unwrap_or(true);
+            if !gate_on || rubric_supports_severity_bump(&proposed, finding) {
+                finding.severity = proposed;
+                boosted = true;
+                reason = Some(crate::calibrator_trace::SeverityChangeReason::Boosted);
+            } else {
+                reason = Some(crate::calibrator_trace::SeverityChangeReason::BoostBlockedByGate);
+            }
+            finding.calibrator_action = Some(CalibratorAction::Confirmed);
+            let mut trace = make_trace_entry(
+                finding,
+                tp_weight,
+                fp_weight,
+                wontfix_weight,
+                fp_weight,
+                soft_fp_weight,
+                matched_precedents,
+                finding.calibrator_action.clone(),
+                input_severity,
+                reason,
+                file_path,
+            );
+            trace.logistic_p_fp = Some(p_fp);
+            return CoreDecision {
+                suppressed,
+                boosted,
+                trace,
+            };
+        }
+
+        // Neither threshold triggered: pass through (no data-driven action).
+        // Fall through to legacy soft-suppress path only.
+        // Record logistic_p_fp on trace but don't use composite/data-driven thresholds.
+        let full_suppress_weight = fp_weight;
+
+        // Legacy soft suppress still applies even with logistic model present.
+        let soft_suppressed = (soft_fp_weight >= 1.0 && soft_fp_weight > tp_weight * 2.0)
+            || (soft_fp_weight >= 0.5 && tp_weight < 0.1);
+        if soft_suppressed {
+            finding.severity = Severity::Info;
+            finding.calibrator_action = Some(CalibratorAction::Disputed);
+            reason = Some(crate::calibrator_trace::SeverityChangeReason::Disputed);
+        }
+
+        if reason.is_none() {
+            // TP confirms without boost when logistic didn't trigger boost.
+            if tp_weight > fp_weight * 1.5 {
+                finding.calibrator_action = Some(CalibratorAction::Confirmed);
+                reason = Some(crate::calibrator_trace::SeverityChangeReason::BoostWeightTooLow);
+            } else {
+                reason = Some(crate::calibrator_trace::SeverityChangeReason::BoostWeightTooLow);
+            }
+        }
+
+        let mut trace = make_trace_entry(
+            finding,
+            tp_weight,
+            fp_weight,
+            wontfix_weight,
+            full_suppress_weight,
+            soft_fp_weight,
+            matched_precedents,
+            finding.calibrator_action.clone(),
+            input_severity,
+            reason,
+            file_path,
+        );
+        trace.logistic_p_fp = Some(p_fp);
+        return CoreDecision {
+            suppressed,
+            boosted,
+            trace,
+        };
+    }
 
     let has_composite = config.model.is_some();
     let force_threshold = sanitize_threshold(config.force_threshold, has_composite);
@@ -5207,6 +5436,305 @@ mod tests {
         assert!(
             decision.trace.composite_score.unwrap() > 2.0,
             "SQL injection should have high composite score"
+        );
+    }
+
+    // --- Logistic scoring tests ---
+
+    #[test]
+    fn logistic_score_high_fp_weight() {
+        use crate::calibrator_model::LogisticModel;
+        let lm = LogisticModel {
+            computed_at: "2026-05-16T12:00:00Z".to_string(),
+            n_samples: 1567,
+            n_fp: 279,
+            selected_features: vec!["log1p_fp_weight".to_string()],
+            coefficients: vec![2.0],
+            intercept: 0.0,
+            feature_means: vec![0.5],
+            feature_stddevs: vec![0.3],
+            suppress_threshold: 0.6,
+            boost_threshold: 0.1,
+            ap_score: 0.67,
+            fp_recall_at_99_tp_recall: 0.35,
+            baseline_ap: 0.18,
+        };
+        let features = ReviewFeatures {
+            log1p_fp_weight: 2.0, // well above mean 0.5
+            ..ReviewFeatures::zeros()
+        };
+        let p_fp = logistic_score(&lm, &features);
+        // (2.0 - 0.5) / 0.3 = 5.0, logit = 2.0 * 5.0 = 10.0, sigmoid(10) ~ 1.0
+        assert!(
+            p_fp > 0.9,
+            "High FP weight should give high P(FP), got {}",
+            p_fp
+        );
+    }
+
+    #[test]
+    fn logistic_score_low_fp_weight() {
+        use crate::calibrator_model::LogisticModel;
+        let lm = LogisticModel {
+            computed_at: "2026-05-16T12:00:00Z".to_string(),
+            n_samples: 1567,
+            n_fp: 279,
+            selected_features: vec!["log1p_fp_weight".to_string()],
+            coefficients: vec![2.0],
+            intercept: 0.0,
+            feature_means: vec![0.5],
+            feature_stddevs: vec![0.3],
+            suppress_threshold: 0.6,
+            boost_threshold: 0.1,
+            ap_score: 0.67,
+            fp_recall_at_99_tp_recall: 0.35,
+            baseline_ap: 0.18,
+        };
+        let features = ReviewFeatures {
+            log1p_fp_weight: 0.0, // below mean
+            ..ReviewFeatures::zeros()
+        };
+        let p_fp = logistic_score(&lm, &features);
+        // (0.0 - 0.5) / 0.3 ~ -1.67, logit = 2.0 * -1.67 = -3.33, sigmoid(-3.33) ~ 0.034
+        assert!(
+            p_fp < 0.1,
+            "Low FP weight should give low P(FP), got {}",
+            p_fp
+        );
+    }
+
+    #[test]
+    fn review_features_get_by_name() {
+        let mut f = ReviewFeatures::zeros();
+        f.log1p_tp_weight = 1.5;
+        f.category_fp_rate = 0.25;
+        assert!((f.get_by_name("log1p_tp_weight") - 1.5).abs() < 1e-9);
+        assert!((f.get_by_name("category_fp_rate") - 0.25).abs() < 1e-9);
+        assert!((f.get_by_name("nonexistent") - 0.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn logistic_model_suppresses_finding() {
+        use crate::calibrator_model::{
+            CalibratorModel, LogisticModel, ModelMeta, ScoreWeights,
+        };
+        use std::collections::HashMap;
+        // Model with logistic: high P(FP) for findings with fp_weight
+        let lm = LogisticModel {
+            computed_at: "2026-05-16T12:00:00Z".to_string(),
+            n_samples: 1000,
+            n_fp: 200,
+            selected_features: vec!["log1p_fp_weight".to_string()],
+            coefficients: vec![3.0],
+            intercept: 0.0,
+            feature_means: vec![0.3],
+            feature_stddevs: vec![0.2],
+            suppress_threshold: 0.7,
+            boost_threshold: 0.1,
+            ap_score: 0.6,
+            fp_recall_at_99_tp_recall: 0.3,
+            baseline_ap: 0.15,
+        };
+        let model = CalibratorModel {
+            meta: ModelMeta {
+                computed_at: "2026-05-16".into(),
+                feedback_count: 100,
+                global_fp_rate: 0.2,
+                learned_weights: None,
+            },
+            weights: ScoreWeights {
+                score: 0.5,
+                word_lor: 1.0,
+                family_fp_inv: 1.0,
+                language_fp_inv: 0.5,
+            },
+            logistic_model: Some(lm),
+            word_lor: HashMap::new(),
+            family_fp_rate: HashMap::new(),
+            language_fp_rate: HashMap::new(),
+        };
+        let mut finding = finding_at(
+            "hardcoded secret in API_KEY",
+            "security",
+            Severity::High,
+            "hardcoded secret",
+        );
+        let config = CalibratorConfig {
+            model: Some(model),
+            ..Default::default()
+        };
+        let decision = calibrate_core_decision(
+            &mut finding,
+            &config,
+            0.1,  // tp_weight (low)
+            2.0,  // fp_weight (high -> ln_1p(2.0) ~ 1.099, well above mean 0.3)
+            0.0,
+            2.0,
+            vec![],
+            Severity::High,
+            "test.rs",
+        );
+        assert!(
+            decision.suppressed,
+            "logistic model should suppress finding with high FP weight"
+        );
+        assert!(
+            decision.trace.logistic_p_fp.is_some(),
+            "logistic_p_fp should be set on trace"
+        );
+        assert!(
+            decision.trace.logistic_p_fp.unwrap() > 0.7,
+            "P(FP) should be above suppress threshold"
+        );
+    }
+
+    #[test]
+    fn logistic_model_boosts_finding() {
+        use crate::calibrator_model::{
+            CalibratorModel, LogisticModel, ModelMeta, ScoreWeights,
+        };
+        use std::collections::HashMap;
+        // Model where low fp_weight -> low P(FP) -> boost
+        let lm = LogisticModel {
+            computed_at: "2026-05-16T12:00:00Z".to_string(),
+            n_samples: 1000,
+            n_fp: 200,
+            selected_features: vec!["log1p_fp_weight".to_string()],
+            coefficients: vec![3.0],
+            intercept: 0.0,
+            feature_means: vec![0.5],
+            feature_stddevs: vec![0.3],
+            suppress_threshold: 0.7,
+            boost_threshold: 0.2,
+            ap_score: 0.6,
+            fp_recall_at_99_tp_recall: 0.3,
+            baseline_ap: 0.15,
+        };
+        let model = CalibratorModel {
+            meta: ModelMeta {
+                computed_at: "2026-05-16".into(),
+                feedback_count: 100,
+                global_fp_rate: 0.2,
+                learned_weights: None,
+            },
+            weights: ScoreWeights {
+                score: 0.5,
+                word_lor: 1.0,
+                family_fp_inv: 1.0,
+                language_fp_inv: 0.5,
+            },
+            logistic_model: Some(lm),
+            word_lor: HashMap::new(),
+            family_fp_rate: HashMap::new(),
+            language_fp_rate: HashMap::new(),
+        };
+        let mut finding = finding_at(
+            "SQL injection via user input",
+            "security",
+            Severity::Medium,
+            "SQL injection risk via unsanitized user input in query",
+        );
+        let config = CalibratorConfig {
+            model: Some(model),
+            ..Default::default()
+        };
+        let decision = calibrate_core_decision(
+            &mut finding,
+            &config,
+            2.0,  // tp_weight (high TP evidence)
+            0.0,  // fp_weight (zero -> ln_1p(0) = 0.0, below mean 0.5)
+            0.0,
+            0.0,
+            vec![],
+            Severity::Medium,
+            "app.py",
+        );
+        // P(FP) = sigmoid(3.0 * (0.0 - 0.5) / 0.3) = sigmoid(-5.0) ~ 0.0067
+        // 0.0067 < 0.2 boost threshold -> boost triggered
+        assert!(
+            decision.boosted,
+            "logistic model should boost finding with low P(FP) and high TP weight"
+        );
+        assert!(
+            decision.trace.logistic_p_fp.unwrap() < 0.2,
+            "P(FP) should be below boost threshold"
+        );
+    }
+
+    #[test]
+    fn logistic_model_passthrough_no_action() {
+        use crate::calibrator_model::{
+            CalibratorModel, LogisticModel, ModelMeta, ScoreWeights,
+        };
+        use std::collections::HashMap;
+        // Model where P(FP) is between thresholds -> no suppress or boost
+        let lm = LogisticModel {
+            computed_at: "2026-05-16T12:00:00Z".to_string(),
+            n_samples: 1000,
+            n_fp: 200,
+            selected_features: vec!["log1p_fp_weight".to_string()],
+            coefficients: vec![1.0],
+            intercept: 0.0,
+            feature_means: vec![0.5],
+            feature_stddevs: vec![0.5],
+            suppress_threshold: 0.8,
+            boost_threshold: 0.1,
+            ap_score: 0.6,
+            fp_recall_at_99_tp_recall: 0.3,
+            baseline_ap: 0.15,
+        };
+        let model = CalibratorModel {
+            meta: ModelMeta {
+                computed_at: "2026-05-16".into(),
+                feedback_count: 100,
+                global_fp_rate: 0.2,
+                learned_weights: None,
+            },
+            weights: ScoreWeights {
+                score: 0.5,
+                word_lor: 1.0,
+                family_fp_inv: 1.0,
+                language_fp_inv: 0.5,
+            },
+            logistic_model: Some(lm),
+            word_lor: HashMap::new(),
+            family_fp_rate: HashMap::new(),
+            language_fp_rate: HashMap::new(),
+        };
+        let mut finding = finding_at(
+            "unused variable x",
+            "quality",
+            Severity::Low,
+            "variable x is declared but not used",
+        );
+        let config = CalibratorConfig {
+            model: Some(model),
+            ..Default::default()
+        };
+        let decision = calibrate_core_decision(
+            &mut finding,
+            &config,
+            0.5,  // tp_weight (some TP)
+            0.3,  // fp_weight (some FP, ln_1p(0.3) ~ 0.26, near mean 0.5)
+            0.0,
+            0.3,
+            vec![],
+            Severity::Low,
+            "test.rs",
+        );
+        // P(FP) = sigmoid(1.0 * (0.26 - 0.5) / 0.5) = sigmoid(-0.48) ~ 0.38
+        // 0.38 < 0.8 (not suppress) and 0.38 > 0.1 (not boost) -> passthrough
+        assert!(
+            !decision.suppressed,
+            "should not suppress when P(FP) is between thresholds"
+        );
+        assert!(
+            !decision.boosted,
+            "should not boost when P(FP) is between thresholds"
+        );
+        assert!(
+            decision.trace.logistic_p_fp.is_some(),
+            "logistic_p_fp should still be recorded on trace"
         );
     }
 }

--- a/src/calibrator.rs
+++ b/src/calibrator.rs
@@ -338,11 +338,15 @@ fn calibrate_core_decision(
                     .filter(|w| w.len() >= 2)
                     .filter_map(|w| model.word_lor.get(w).copied())
                     .collect();
-                (
-                    word_lors.iter().copied().fold(0.0_f64, f64::max),
-                    word_lors.iter().copied().fold(0.0_f64, f64::min),
-                    word_lors.iter().filter(|&&v| v < -0.5).count() as f64,
-                )
+                if word_lors.is_empty() {
+                    (0.0, 0.0, 0.0)
+                } else {
+                    (
+                        word_lors.iter().copied().fold(f64::NEG_INFINITY, f64::max),
+                        word_lors.iter().copied().fold(f64::INFINITY, f64::min),
+                        word_lors.iter().filter(|&&v| v < -0.5).count() as f64,
+                    )
+                }
             } else {
                 (0.0, 0.0, 0.0)
             };
@@ -392,14 +396,14 @@ fn calibrate_core_decision(
 
         let p_fp = logistic_score(logistic, &review_features);
 
-        // force_threshold overrides the logistic model's thresholds (same
-        // semantics as the composite path: single value replaces both).
-        let has_composite = config.model.is_some();
+        // force_threshold overrides the logistic model's thresholds.
+        // Logistic thresholds are probabilities [0,1] — use non-composite
+        // semantics (false) so force_threshold is validated to [0,1].
         let effective_suppress =
-            sanitize_threshold(config.force_threshold, has_composite)
+            sanitize_threshold(config.force_threshold, false)
                 .unwrap_or(logistic.suppress_threshold);
         let effective_boost =
-            sanitize_threshold(config.force_threshold, has_composite)
+            sanitize_threshold(config.force_threshold, false)
                 .unwrap_or(logistic.boost_threshold);
 
         // Suppress: P(FP) > suppress_threshold AND some FP evidence exists

--- a/src/calibrator.rs
+++ b/src/calibrator.rs
@@ -328,7 +328,11 @@ fn calibrate_core_decision(
     let mut boosted = false;
 
     // Logistic model path: when present, P(FP) directly drives suppress/boost decisions.
-    if let Some(logistic) = config.model.as_ref().and_then(|m| m.logistic_model.as_ref()) {
+    if let Some(logistic) = config
+        .model
+        .as_ref()
+        .and_then(|m| m.logistic_model.as_ref())
+    {
         // Compute word LOR features from the model's vocabulary
         let (max_word_lor, min_word_lor, count_negative_lor_tokens) =
             if let Some(model) = config.model.as_ref() {
@@ -399,12 +403,10 @@ fn calibrate_core_decision(
         // force_threshold overrides the logistic model's thresholds.
         // Logistic thresholds are probabilities [0,1] — use non-composite
         // semantics (false) so force_threshold is validated to [0,1].
-        let effective_suppress =
-            sanitize_threshold(config.force_threshold, false)
-                .unwrap_or(logistic.suppress_threshold);
+        let effective_suppress = sanitize_threshold(config.force_threshold, false)
+            .unwrap_or(logistic.suppress_threshold);
         let effective_boost =
-            sanitize_threshold(config.force_threshold, false)
-                .unwrap_or(logistic.boost_threshold);
+            sanitize_threshold(config.force_threshold, false).unwrap_or(logistic.boost_threshold);
 
         // Suppress: P(FP) > suppress_threshold AND some FP evidence exists
         if p_fp > effective_suppress && fp_weight > 0.0 {
@@ -2979,8 +2981,15 @@ mod tests {
             "",
         );
         assert!(!decision.suppressed, "should not be fully suppressed");
-        assert!(!decision.boosted, "soft-suppressed finding must not be boosted");
-        assert_eq!(finding.severity, Severity::Info, "soft-suppress should downgrade to Info");
+        assert!(
+            !decision.boosted,
+            "soft-suppressed finding must not be boosted"
+        );
+        assert_eq!(
+            finding.severity,
+            Severity::Info,
+            "soft-suppress should downgrade to Info"
+        );
         assert_eq!(
             finding.calibrator_action,
             Some(CalibratorAction::Disputed),
@@ -5572,9 +5581,7 @@ mod tests {
 
     #[test]
     fn logistic_model_suppresses_finding() {
-        use crate::calibrator_model::{
-            CalibratorModel, LogisticModel, ModelMeta, ScoreWeights,
-        };
+        use crate::calibrator_model::{CalibratorModel, LogisticModel, ModelMeta, ScoreWeights};
         use std::collections::HashMap;
         // Model with logistic: high P(FP) for findings with fp_weight
         let lm = LogisticModel {
@@ -5623,8 +5630,8 @@ mod tests {
         let decision = calibrate_core_decision(
             &mut finding,
             &config,
-            0.1,  // tp_weight (low)
-            2.0,  // fp_weight (high -> ln_1p(2.0) ~ 1.099, well above mean 0.3)
+            0.1, // tp_weight (low)
+            2.0, // fp_weight (high -> ln_1p(2.0) ~ 1.099, well above mean 0.3)
             0.0,
             2.0,
             vec![],
@@ -5647,9 +5654,7 @@ mod tests {
 
     #[test]
     fn logistic_model_boosts_finding() {
-        use crate::calibrator_model::{
-            CalibratorModel, LogisticModel, ModelMeta, ScoreWeights,
-        };
+        use crate::calibrator_model::{CalibratorModel, LogisticModel, ModelMeta, ScoreWeights};
         use std::collections::HashMap;
         // Model where low fp_weight -> low P(FP) -> boost
         let lm = LogisticModel {
@@ -5698,8 +5703,8 @@ mod tests {
         let decision = calibrate_core_decision(
             &mut finding,
             &config,
-            2.0,  // tp_weight (high TP evidence)
-            0.0,  // fp_weight (zero -> ln_1p(0) = 0.0, below mean 0.5)
+            2.0, // tp_weight (high TP evidence)
+            0.0, // fp_weight (zero -> ln_1p(0) = 0.0, below mean 0.5)
             0.0,
             0.0,
             vec![],
@@ -5720,9 +5725,7 @@ mod tests {
 
     #[test]
     fn logistic_model_passthrough_no_action() {
-        use crate::calibrator_model::{
-            CalibratorModel, LogisticModel, ModelMeta, ScoreWeights,
-        };
+        use crate::calibrator_model::{CalibratorModel, LogisticModel, ModelMeta, ScoreWeights};
         use std::collections::HashMap;
         // Model where P(FP) is between thresholds -> no suppress or boost
         let lm = LogisticModel {
@@ -5771,8 +5774,8 @@ mod tests {
         let decision = calibrate_core_decision(
             &mut finding,
             &config,
-            0.5,  // tp_weight (some TP)
-            0.3,  // fp_weight (some FP, ln_1p(0.3) ~ 0.26, near mean 0.5)
+            0.5, // tp_weight (some TP)
+            0.3, // fp_weight (some FP, ln_1p(0.3) ~ 0.26, near mean 0.5)
             0.0,
             0.3,
             vec![],

--- a/src/calibrator.rs
+++ b/src/calibrator.rs
@@ -5082,6 +5082,7 @@ mod tests {
                 family_fp_inv: 1.0,
                 language_fp_inv: 0.5,
             },
+            logistic_model: None,
             word_lor: HashMap::from([
                 ("unwrap".into(), -1.0),
                 ("panic".into(), -0.8),

--- a/src/calibrator.rs
+++ b/src/calibrator.rs
@@ -329,6 +329,37 @@ fn calibrate_core_decision(
 
     // Logistic model path: when present, P(FP) directly drives suppress/boost decisions.
     if let Some(logistic) = config.model.as_ref().and_then(|m| m.logistic_model.as_ref()) {
+        // Compute word LOR features from the model's vocabulary
+        let (max_word_lor, min_word_lor, count_negative_lor_tokens) =
+            if let Some(model) = config.model.as_ref() {
+                let lower = finding.title.to_lowercase();
+                let word_lors: Vec<f64> = lower
+                    .split(|c: char| !c.is_alphanumeric() && c != '_')
+                    .filter(|w| w.len() >= 2)
+                    .filter_map(|w| model.word_lor.get(w).copied())
+                    .collect();
+                (
+                    word_lors.iter().copied().fold(0.0_f64, f64::max),
+                    word_lors.iter().copied().fold(0.0_f64, f64::min),
+                    word_lors.iter().filter(|&&v| v < -0.5).count() as f64,
+                )
+            } else {
+                (0.0, 0.0, 0.0)
+            };
+
+        // Compute category FP rate from family_fp_rate (closest available proxy)
+        let category_fp_rate = config
+            .model
+            .as_ref()
+            .map(|m| {
+                let family = CalibratorModel::title_family(&finding.title);
+                m.family_fp_rate
+                    .get(&family)
+                    .copied()
+                    .unwrap_or(m.meta.global_fp_rate)
+            })
+            .unwrap_or(0.0);
+
         let review_features = ReviewFeatures {
             log1p_tp_weight: tp_weight.ln_1p(),
             log1p_fp_weight: fp_weight.ln_1p(),
@@ -351,15 +382,12 @@ fn calibrate_core_decision(
             log1p_soft_fp_weight: soft_fp_weight.ln_1p(),
             log1p_full_suppress_weight: fp_weight.ln_1p(),
             log1p_wontfix_weight: wontfix_weight.ln_1p(),
-            // Features that require fold-local stats not available at review time
-            // default to 0.0. The logistic model's standardization handles this
-            // (0.0 -> below-mean -> shifts logit accordingly).
-            category_fp_rate: 0.0,
+            category_fp_rate,
             severity_fp_rate: 0.0,
             model_fp_rate: 0.0,
-            max_word_lor: 0.0,
-            min_word_lor: 0.0,
-            count_negative_lor_tokens: 0.0,
+            max_word_lor,
+            min_word_lor,
+            count_negative_lor_tokens,
         };
 
         let p_fp = logistic_score(logistic, &review_features);

--- a/src/calibrator.rs
+++ b/src/calibrator.rs
@@ -245,10 +245,25 @@ impl ReviewFeatures {
 /// Compute P(FP) using the stored logistic model.
 ///
 /// Standardizes features using stored means/stddevs, computes logit, applies sigmoid.
+/// Returns 0.5 (neutral) if the model has inconsistent vector lengths.
 pub fn logistic_score(
     model: &crate::calibrator_model::LogisticModel,
     features: &ReviewFeatures,
 ) -> f64 {
+    let n = model.selected_features.len();
+    if n != model.coefficients.len()
+        || n != model.feature_means.len()
+        || n != model.feature_stddevs.len()
+    {
+        tracing::warn!(
+            selected_features = n,
+            coefficients = model.coefficients.len(),
+            feature_means = model.feature_means.len(),
+            feature_stddevs = model.feature_stddevs.len(),
+            "logistic model has inconsistent vector lengths, falling back to 0.5"
+        );
+        return 0.5;
+    }
     let mut logit = model.intercept;
     for (i, feat_name) in model.selected_features.iter().enumerate() {
         let raw = features.get_by_name(feat_name);
@@ -349,8 +364,18 @@ fn calibrate_core_decision(
 
         let p_fp = logistic_score(logistic, &review_features);
 
+        // force_threshold overrides the logistic model's thresholds (same
+        // semantics as the composite path: single value replaces both).
+        let has_composite = config.model.is_some();
+        let effective_suppress =
+            sanitize_threshold(config.force_threshold, has_composite)
+                .unwrap_or(logistic.suppress_threshold);
+        let effective_boost =
+            sanitize_threshold(config.force_threshold, has_composite)
+                .unwrap_or(logistic.boost_threshold);
+
         // Suppress: P(FP) > suppress_threshold AND some FP evidence exists
-        if p_fp > logistic.suppress_threshold && fp_weight > 0.0 {
+        if p_fp > effective_suppress && fp_weight > 0.0 {
             finding.calibrator_action = Some(CalibratorAction::Disputed);
             suppressed = true;
             let mut trace = make_trace_entry(
@@ -375,7 +400,7 @@ fn calibrate_core_decision(
         }
 
         // Boost: P(FP) < boost_threshold AND some TP evidence exists
-        if p_fp < logistic.boost_threshold && tp_weight > 0.0 && config.boost_tp {
+        if p_fp < effective_boost && tp_weight > 0.0 && config.boost_tp {
             let proposed = boost_severity(&finding.severity);
             let gate_on = std::env::var("QUORUM_RUBRIC_GATE")
                 .map(|v| v != "off" && v != "0")

--- a/src/calibrator_fingerprint.rs
+++ b/src/calibrator_fingerprint.rs
@@ -182,6 +182,7 @@ mod tests {
             same_file_precedent_count: None,
             in_diff: None,
             composite_score: None,
+            logistic_p_fp: None,
         }
     }
 

--- a/src/calibrator_model.rs
+++ b/src/calibrator_model.rs
@@ -37,9 +37,29 @@ pub struct ScoreWeights {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LogisticModel {
+    pub computed_at: String,
+    pub n_samples: usize,
+    pub n_fp: usize,
+    pub selected_features: Vec<String>,
+    pub coefficients: Vec<f64>,
+    pub intercept: f64,
+    pub feature_means: Vec<f64>,
+    pub feature_stddevs: Vec<f64>,
+    pub suppress_threshold: f64,
+    pub boost_threshold: f64,
+    pub ap_score: f64,
+    pub fp_recall_at_99_tp_recall: f64,
+    pub baseline_ap: f64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CalibratorModel {
     pub meta: ModelMeta,
     pub weights: ScoreWeights,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default)]
+    pub logistic_model: Option<LogisticModel>,
     pub word_lor: HashMap<String, f64>,
     pub family_fp_rate: HashMap<String, f64>,
     pub language_fp_rate: HashMap<String, f64>,
@@ -154,6 +174,7 @@ mod tests {
                 family_fp_inv: 1.0,
                 language_fp_inv: 0.5,
             },
+            logistic_model: None,
             word_lor: HashMap::from([
                 ("hardcoded".into(), -1.88),
                 ("secret".into(), -1.50),
@@ -296,5 +317,50 @@ mod tests {
     #[test]
     fn load_from_missing_returns_none() {
         assert!(CalibratorModel::load_from("/nonexistent/path").is_none());
+    }
+
+    #[test]
+    fn logistic_model_toml_roundtrip() {
+        let lm = LogisticModel {
+            computed_at: "2026-05-16T12:00:00Z".to_string(),
+            n_samples: 1567,
+            n_fp: 279,
+            selected_features: vec![
+                "log1p_fp_weight".to_string(),
+                "category_fp_rate".to_string(),
+            ],
+            coefficients: vec![0.42, -1.3],
+            intercept: -1.2,
+            feature_means: vec![0.5, 0.27],
+            feature_stddevs: vec![0.3, 0.15],
+            suppress_threshold: 0.45,
+            boost_threshold: 0.08,
+            ap_score: 0.67,
+            fp_recall_at_99_tp_recall: 0.35,
+            baseline_ap: 0.18,
+        };
+        let mut model = make_model();
+        model.logistic_model = Some(lm);
+        let toml_str = model.to_toml();
+        assert!(toml_str.contains("[logistic_model]"));
+        let parsed = CalibratorModel::from_toml(&toml_str).unwrap();
+        let parsed_lm = parsed.logistic_model.unwrap();
+        assert_eq!(parsed_lm.n_samples, 1567);
+        assert_eq!(parsed_lm.n_fp, 279);
+        assert_eq!(parsed_lm.selected_features.len(), 2);
+        assert!((parsed_lm.suppress_threshold - 0.45).abs() < 1e-9);
+        assert!((parsed_lm.boost_threshold - 0.08).abs() < 1e-9);
+        assert!((parsed_lm.coefficients[0] - 0.42).abs() < 1e-9);
+        assert!((parsed_lm.intercept - (-1.2)).abs() < 1e-9);
+    }
+
+    #[test]
+    fn logistic_model_absent_parses_as_none() {
+        let mut model = make_model();
+        model.logistic_model = None;
+        let toml_str = model.to_toml();
+        assert!(!toml_str.contains("[logistic_model]"));
+        let parsed = CalibratorModel::from_toml(&toml_str).unwrap();
+        assert!(parsed.logistic_model.is_none());
     }
 }

--- a/src/calibrator_trace.rs
+++ b/src/calibrator_trace.rs
@@ -91,6 +91,9 @@ pub struct CalibratorTraceEntry {
     pub in_diff: Option<bool>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub composite_score: Option<f64>,
+    /// Logistic model P(FP) probability when a logistic model was used for the decision.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub logistic_p_fp: Option<f64>,
 }
 
 #[cfg(test)]
@@ -126,6 +129,7 @@ mod tests {
             same_file_precedent_count: None,
             in_diff: None,
             composite_score: None,
+            logistic_p_fp: None,
         };
         let json = serde_json::to_string(&trace).unwrap();
         assert!(json.contains("\"tp_weight\":2.5"));
@@ -152,6 +156,7 @@ mod tests {
             same_file_precedent_count: None,
             in_diff: None,
             composite_score: None,
+            logistic_p_fp: None,
         };
         let json = serde_json::to_string(&trace).unwrap();
         assert!(json.contains("\"matched_precedents\":[]"));
@@ -197,6 +202,7 @@ mod tests {
             same_file_precedent_count: None,
             in_diff: None,
             composite_score: None,
+            logistic_p_fp: None,
         };
         let json = serde_json::to_string(&trace).unwrap();
         assert!(
@@ -240,6 +246,7 @@ mod tests {
             same_file_precedent_count: None,
             in_diff: None,
             composite_score: None,
+            logistic_p_fp: None,
         };
         let json = serde_json::to_string(&trace).unwrap();
         assert!(json.contains("\"file_path\":\"src/main.rs\""));
@@ -317,6 +324,7 @@ mod tests {
             same_file_precedent_count: Some(2),
             in_diff: None,
             composite_score: None,
+            logistic_p_fp: None,
         };
         let json = serde_json::to_string(&trace).unwrap();
         assert!(json.contains("\"same_file_precedent_count\":2"));
@@ -379,6 +387,7 @@ mod tests {
             same_file_precedent_count: None,
             in_diff: None,
             composite_score: None,
+            logistic_p_fp: None,
         };
         let json = serde_json::to_string(&trace).unwrap();
         assert!(
@@ -421,6 +430,7 @@ mod tests {
             same_file_precedent_count: None,
             in_diff: None,
             composite_score: None,
+            logistic_p_fp: None,
         };
         let json = serde_json::to_string(&trace).unwrap();
         assert!(
@@ -449,6 +459,7 @@ mod tests {
             same_file_precedent_count: None,
             in_diff: Some(false),
             composite_score: None,
+            logistic_p_fp: None,
         };
         let json = serde_json::to_string(&trace).unwrap();
         assert!(

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -616,6 +616,13 @@ pub struct FeedbackOpts {
     /// unknown (omitted). Flows through both Human and External paths.
     #[arg(long)]
     pub in_diff: Option<bool>,
+
+    /// Provenance tier: post_fix (1.5x weight, strongest signal) or human
+    /// (1.0x, default). Use post_fix when recording a verdict AFTER fixing
+    /// the bug in the same branch. Ignored when --from-agent is set (External
+    /// path always uses its own provenance).
+    #[arg(long, value_parser = parse_provenance)]
+    pub provenance: Option<crate::feedback::Provenance>,
 }
 
 impl FeedbackOpts {
@@ -673,6 +680,16 @@ impl FeedbackOpts {
 /// Validate `--confidence` at the CLI boundary. Accepts finite values in
 /// [0,1] only. NaN/Inf and out-of-range values are rejected with a clear
 /// error rather than silently clamped.
+pub fn parse_provenance(s: &str) -> Result<crate::feedback::Provenance, String> {
+    match s.trim().to_lowercase().as_str() {
+        "post_fix" | "postfix" | "post-fix" => Ok(crate::feedback::Provenance::PostFix),
+        "human" => Ok(crate::feedback::Provenance::Human),
+        other => Err(format!(
+            "unknown provenance '{other}': expected post_fix or human"
+        )),
+    }
+}
+
 pub fn parse_confidence(s: &str) -> Result<f32, String> {
     let v: f32 = s
         .parse()
@@ -1687,5 +1704,31 @@ mod tests {
         use clap::Parser;
         let res = Args::try_parse_from(["quorum", "stats", "--by-file", "--top", "0"]);
         assert!(res.is_err(), "--top 0 should be rejected");
+    }
+
+    #[test]
+    fn parse_provenance_accepts_variants() {
+        assert!(matches!(
+            parse_provenance("post_fix").unwrap(),
+            crate::feedback::Provenance::PostFix
+        ));
+        assert!(matches!(
+            parse_provenance("postfix").unwrap(),
+            crate::feedback::Provenance::PostFix
+        ));
+        assert!(matches!(
+            parse_provenance("post-fix").unwrap(),
+            crate::feedback::Provenance::PostFix
+        ));
+        assert!(matches!(
+            parse_provenance("human").unwrap(),
+            crate::feedback::Provenance::Human
+        ));
+    }
+
+    #[test]
+    fn parse_provenance_rejects_unknown() {
+        assert!(parse_provenance("external").is_err());
+        assert!(parse_provenance("auto_calibrate").is_err());
     }
 }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -287,6 +287,10 @@ pub struct CalibrateOpts {
     /// Learn composite scoring weights from feedback corpus via grid search
     #[arg(long)]
     pub learn_weights: bool,
+
+    /// Show per-feature univariate AP diagnostics
+    #[arg(long)]
+    pub feature_importance: bool,
 }
 
 #[derive(Parser)]

--- a/src/context/cli.rs
+++ b/src/context/cli.rs
@@ -1239,9 +1239,8 @@ fn run_query<D: ContextDeps>(args: &QueryArgs, deps: &D) -> Result<CmdOutput> {
     let mut batches: Vec<SourceBatch> = Vec::new();
 
     for (name, db_path, weight) in &targets {
-        let conn =
-            Connection::open_with_flags(db_path, rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY)
-                .map_err(|e| anyhow!("open {}: {e}", db_path.display()))?;
+        let conn = Connection::open_with_flags(db_path, rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY)
+            .map_err(|e| anyhow!("open {}: {e}", db_path.display()))?;
         let q = RetrievalQuery {
             text: args.text.clone(),
             identifiers: Vec::new(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -94,6 +94,9 @@ pub mod threshold_config;
 // Learned model for composite calibrator scoring.
 pub mod calibrator_model;
 
+// L2-regularized logistic regression (pure Rust, no external deps).
+pub mod logistic;
+
 // Calibrate: corpus join + threshold computation from feedback + traces.
 pub mod calibrate;
 

--- a/src/logistic.rs
+++ b/src/logistic.rs
@@ -199,12 +199,10 @@ pub fn fit(x: &[Vec<f64>], y: &[bool], lambda: f64, max_iter: usize) -> Logistic
             if new_loss <= prev_loss - ARMIJO_C * step * grad_norm_sq {
                 weights = new_weights;
                 intercept = new_intercept;
-                prev_loss = new_loss;
                 break;
             }
             step *= ARMIJO_BETA;
 
-            // If we exhaust line search iterations, take the last step
             if step < 1e-15 {
                 weights = weights
                     .iter()
@@ -212,12 +210,11 @@ pub fn fit(x: &[Vec<f64>], y: &[bool], lambda: f64, max_iter: usize) -> Logistic
                     .map(|(w, g)| w - step * g)
                     .collect();
                 intercept -= step * grad_b;
-                prev_loss = loss(&x_norm, &y_f, &weights, intercept, lambda);
                 break;
             }
         }
 
-        // Check convergence: relative loss change
+        // Check convergence: relative loss change between iterations
         let curr_loss = loss(&x_norm, &y_f, &weights, intercept, lambda);
         let rel_change = (prev_loss - curr_loss).abs() / (prev_loss.abs() + EPSILON);
         prev_loss = curr_loss;

--- a/src/logistic.rs
+++ b/src/logistic.rs
@@ -2,7 +2,6 @@
 ///
 /// No external dependencies — pure Rust implementation using batch gradient
 /// descent with backtracking line search (Armijo condition).
-
 const EPSILON: f64 = 1e-8;
 const ARMIJO_C: f64 = 1e-4;
 const ARMIJO_BETA: f64 = 0.5;

--- a/src/logistic.rs
+++ b/src/logistic.rs
@@ -1,0 +1,322 @@
+/// Inline L2-regularized logistic regression.
+///
+/// No external dependencies — pure Rust implementation using batch gradient
+/// descent with backtracking line search (Armijo condition).
+
+const EPSILON: f64 = 1e-8;
+const ARMIJO_C: f64 = 1e-4;
+const ARMIJO_BETA: f64 = 0.5;
+
+/// Numerically stable sigmoid function.
+///
+/// Branches on the sign of `z` to avoid overflow in `exp()`.
+pub fn sigmoid(z: f64) -> f64 {
+    if z >= 0.0 {
+        let e = (-z).exp();
+        1.0 / (1.0 + e)
+    } else {
+        let e = z.exp();
+        e / (1.0 + e)
+    }
+}
+
+/// Z-score normalization of feature matrix.
+///
+/// Returns `(normalized_data, means, stddevs)`. Uses population stddev
+/// (divide by N) with an epsilon of 1e-8 to prevent division by zero on
+/// constant columns.
+pub fn standardize(data: &[Vec<f64>]) -> (Vec<Vec<f64>>, Vec<f64>, Vec<f64>) {
+    let n = data.len();
+    assert!(n > 0, "standardize requires at least one sample");
+    let p = data[0].len();
+
+    let mut means = vec![0.0; p];
+    for row in data {
+        for (j, val) in row.iter().enumerate() {
+            means[j] += val;
+        }
+    }
+    for m in &mut means {
+        *m /= n as f64;
+    }
+
+    let mut stddevs = vec![0.0; p];
+    for row in data {
+        for (j, val) in row.iter().enumerate() {
+            let diff = val - means[j];
+            stddevs[j] += diff * diff;
+        }
+    }
+    for s in &mut stddevs {
+        *s = (*s / n as f64).sqrt();
+    }
+
+    let normed: Vec<Vec<f64>> = data
+        .iter()
+        .map(|row| {
+            row.iter()
+                .enumerate()
+                .map(|(j, val)| (val - means[j]) / (stddevs[j] + EPSILON))
+                .collect()
+        })
+        .collect();
+
+    (normed, means, stddevs)
+}
+
+/// Result of logistic regression fitting.
+pub struct LogisticFit {
+    pub coefficients: Vec<f64>,
+    pub intercept: f64,
+    pub feature_means: Vec<f64>,
+    pub feature_stddevs: Vec<f64>,
+}
+
+impl LogisticFit {
+    /// Predict P(positive) for a single raw (unstandardized) sample.
+    pub fn predict_one(&self, x: &[f64]) -> f64 {
+        let z: f64 = x
+            .iter()
+            .enumerate()
+            .map(|(j, val)| {
+                let normed = (val - self.feature_means[j])
+                    / (self.feature_stddevs[j] + EPSILON);
+                normed * self.coefficients[j]
+            })
+            .sum::<f64>()
+            + self.intercept;
+        sigmoid(z)
+    }
+
+    /// Batch prediction on raw (unstandardized) data.
+    pub fn predict(&self, data: &[Vec<f64>]) -> Vec<f64> {
+        data.iter().map(|row| self.predict_one(row)).collect()
+    }
+}
+
+/// Numerically stable cross-entropy loss for a single sample.
+///
+/// Formula: `-y*z + max(z, 0) + ln(1 + exp(-|z|))`
+fn cross_entropy_single(z: f64, y: f64) -> f64 {
+    -y * z + z.max(0.0) + (1.0 + (-z.abs()).exp()).ln()
+}
+
+/// Compute total loss (cross-entropy + L2 penalty on weights).
+fn loss(
+    x_norm: &[Vec<f64>],
+    y: &[f64],
+    weights: &[f64],
+    intercept: f64,
+    lambda: f64,
+) -> f64 {
+    let n = x_norm.len() as f64;
+    let ce: f64 = x_norm
+        .iter()
+        .zip(y.iter())
+        .map(|(xi, &yi)| {
+            let z: f64 =
+                xi.iter().zip(weights.iter()).map(|(a, b)| a * b).sum::<f64>()
+                    + intercept;
+            cross_entropy_single(z, yi)
+        })
+        .sum();
+    let l2: f64 = weights.iter().map(|w| w * w).sum::<f64>();
+    ce / n + 0.5 * lambda * l2
+}
+
+/// Fit L2-regularized logistic regression via batch gradient descent with
+/// backtracking line search (Armijo condition).
+///
+/// `x` is the raw feature matrix, `y` is the binary label vector, `lambda`
+/// is the L2 regularization strength, and `max_iter` is the iteration cap.
+pub fn fit(x: &[Vec<f64>], y: &[bool], lambda: f64, max_iter: usize) -> LogisticFit {
+    assert!(!x.is_empty(), "fit requires at least one sample");
+    let p = x[0].len();
+    let n = x.len();
+
+    // Standardize features
+    let (x_norm, means, stddevs) = standardize(x);
+
+    // Convert labels to f64
+    let y_f: Vec<f64> = y.iter().map(|&b| if b { 1.0 } else { 0.0 }).collect();
+
+    // Initialize weights and intercept to zero
+    let mut weights = vec![0.0; p];
+    let mut intercept = 0.0;
+
+    let mut prev_loss = loss(&x_norm, &y_f, &weights, intercept, lambda);
+
+    for _ in 0..max_iter {
+        // Compute gradient
+        let mut grad_w = vec![0.0; p];
+        let mut grad_b = 0.0;
+
+        for (xi, &yi) in x_norm.iter().zip(y_f.iter()) {
+            let z: f64 =
+                xi.iter().zip(weights.iter()).map(|(a, b)| a * b).sum::<f64>()
+                    + intercept;
+            let residual = sigmoid(z) - yi;
+            for (j, xij) in xi.iter().enumerate() {
+                grad_w[j] += residual * xij;
+            }
+            grad_b += residual;
+        }
+
+        let n_f = n as f64;
+        for (j, gw) in grad_w.iter_mut().enumerate() {
+            *gw = *gw / n_f + lambda * weights[j];
+        }
+        grad_b /= n_f;
+
+        // Compute squared gradient norm for Armijo condition
+        let grad_norm_sq: f64 = grad_w.iter().map(|g| g * g).sum::<f64>()
+            + grad_b * grad_b;
+
+        // Backtracking line search
+        let mut step = 1.0;
+        let mut new_weights: Vec<f64>;
+        let mut new_intercept: f64;
+        let mut new_loss: f64;
+
+        for _ in 0..20 {
+            new_weights = weights
+                .iter()
+                .zip(grad_w.iter())
+                .map(|(w, g)| w - step * g)
+                .collect();
+            new_intercept = intercept - step * grad_b;
+            new_loss = loss(&x_norm, &y_f, &new_weights, new_intercept, lambda);
+
+            if new_loss <= prev_loss - ARMIJO_C * step * grad_norm_sq {
+                weights = new_weights;
+                intercept = new_intercept;
+                prev_loss = new_loss;
+                break;
+            }
+            step *= ARMIJO_BETA;
+
+            // If we exhaust line search iterations, take the last step
+            if step < 1e-15 {
+                weights = weights
+                    .iter()
+                    .zip(grad_w.iter())
+                    .map(|(w, g)| w - step * g)
+                    .collect();
+                intercept -= step * grad_b;
+                prev_loss = loss(&x_norm, &y_f, &weights, intercept, lambda);
+                break;
+            }
+        }
+
+        // Check convergence: relative loss change
+        let curr_loss = loss(&x_norm, &y_f, &weights, intercept, lambda);
+        let rel_change = (prev_loss - curr_loss).abs() / (prev_loss.abs() + EPSILON);
+        prev_loss = curr_loss;
+
+        if rel_change < 1e-4 {
+            break;
+        }
+    }
+
+    LogisticFit {
+        coefficients: weights,
+        intercept,
+        feature_means: means,
+        feature_stddevs: stddevs,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sigmoid_at_zero() {
+        assert!((sigmoid(0.0) - 0.5).abs() < 1e-9);
+    }
+
+    #[test]
+    fn sigmoid_extreme_positive() {
+        assert!((sigmoid(100.0) - 1.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn sigmoid_extreme_negative() {
+        assert!(sigmoid(-100.0) < 1e-6);
+    }
+
+    #[test]
+    fn standardize_basic() {
+        let data = vec![vec![1.0, 10.0], vec![3.0, 20.0], vec![5.0, 30.0]];
+        let (normed, means, stddevs) = standardize(&data);
+        assert!((means[0] - 3.0).abs() < 1e-9);
+        assert!((means[1] - 20.0).abs() < 1e-9);
+        // Normalized col 0 should have mean ~0
+        let col0_mean: f64 = normed.iter().map(|r| r[0]).sum::<f64>() / 3.0;
+        assert!(col0_mean.abs() < 1e-9);
+        // Verify stddev is population stddev
+        // stddev of [1,3,5] = sqrt(((1-3)^2 + (3-3)^2 + (5-3)^2)/3) = sqrt(8/3)
+        let expected_std = (8.0_f64 / 3.0).sqrt();
+        assert!(
+            (stddevs[0] - expected_std).abs() < 1e-9,
+            "Expected stddev {expected_std}, got {}",
+            stddevs[0]
+        );
+    }
+
+    #[test]
+    fn standardize_constant_column() {
+        let data = vec![vec![5.0, 1.0], vec![5.0, 2.0], vec![5.0, 3.0]];
+        let (normed, _, stddevs) = standardize(&data);
+        assert!(normed[0][0].is_finite()); // epsilon prevents NaN
+        assert!(stddevs[0] < 1e-6); // constant -> near-zero stddev
+    }
+
+    #[test]
+    fn fit_linearly_separable() {
+        // 100 samples: feature goes 0.0..1.0, label flips at 0.5
+        let x: Vec<Vec<f64>> = (0..100).map(|i| vec![i as f64 / 100.0]).collect();
+        let y: Vec<bool> = (0..100).map(|i| i >= 50).collect();
+        let result = fit(&x, &y, 0.1, 500);
+        let correct = x
+            .iter()
+            .zip(y.iter())
+            .filter(|(xi, yi)| (result.predict_one(xi) >= 0.5) == **yi)
+            .count();
+        assert!(correct >= 90, "Expected >=90% accuracy, got {correct}/100");
+    }
+
+    #[test]
+    fn fit_two_features() {
+        // Linearly separable: label = (a + b > 0.7)
+        let x: Vec<Vec<f64>> = (0..200)
+            .map(|i| {
+                let a = (i % 10) as f64 / 10.0;
+                let b = (i / 10) as f64 / 20.0;
+                vec![a, b]
+            })
+            .collect();
+        let y: Vec<bool> = x.iter().map(|row| row[0] + row[1] > 0.7).collect();
+        let result = fit(&x, &y, 0.1, 500);
+        let correct = x
+            .iter()
+            .zip(y.iter())
+            .filter(|(xi, yi)| (result.predict_one(xi) >= 0.5) == **yi)
+            .count();
+        assert!(
+            correct >= 170,
+            "Expected >=85% accuracy on 2-feature, got {correct}/200"
+        );
+    }
+
+    #[test]
+    fn predict_batch_matches_individual() {
+        let x: Vec<Vec<f64>> = (0..50).map(|i| vec![i as f64 / 50.0]).collect();
+        let y: Vec<bool> = (0..50).map(|i| i >= 25).collect();
+        let model = fit(&x, &y, 0.1, 500);
+        let batch = model.predict(&x);
+        for (i, xi) in x.iter().enumerate() {
+            assert!((batch[i] - model.predict_one(xi)).abs() < 1e-12);
+        }
+    }
+}

--- a/src/logistic.rs
+++ b/src/logistic.rs
@@ -83,8 +83,7 @@ impl LogisticFit {
             .iter()
             .enumerate()
             .map(|(j, val)| {
-                let normed = (val - self.feature_means[j])
-                    / (self.feature_stddevs[j] + EPSILON);
+                let normed = (val - self.feature_means[j]) / (self.feature_stddevs[j] + EPSILON);
                 normed * self.coefficients[j]
             })
             .sum::<f64>()
@@ -106,21 +105,18 @@ fn cross_entropy_single(z: f64, y: f64) -> f64 {
 }
 
 /// Compute total loss (cross-entropy + L2 penalty on weights).
-fn loss(
-    x_norm: &[Vec<f64>],
-    y: &[f64],
-    weights: &[f64],
-    intercept: f64,
-    lambda: f64,
-) -> f64 {
+fn loss(x_norm: &[Vec<f64>], y: &[f64], weights: &[f64], intercept: f64, lambda: f64) -> f64 {
     let n = x_norm.len() as f64;
     let ce: f64 = x_norm
         .iter()
         .zip(y.iter())
         .map(|(xi, &yi)| {
-            let z: f64 =
-                xi.iter().zip(weights.iter()).map(|(a, b)| a * b).sum::<f64>()
-                    + intercept;
+            let z: f64 = xi
+                .iter()
+                .zip(weights.iter())
+                .map(|(a, b)| a * b)
+                .sum::<f64>()
+                + intercept;
             cross_entropy_single(z, yi)
         })
         .sum();
@@ -135,7 +131,11 @@ fn loss(
 /// is the L2 regularization strength, and `max_iter` is the iteration cap.
 pub fn fit(x: &[Vec<f64>], y: &[bool], lambda: f64, max_iter: usize) -> LogisticFit {
     assert!(!x.is_empty(), "fit requires at least one sample");
-    assert_eq!(x.len(), y.len(), "feature matrix rows must match label count");
+    assert_eq!(
+        x.len(),
+        y.len(),
+        "feature matrix rows must match label count"
+    );
     let p = x[0].len();
     debug_assert!(
         x.iter().all(|row| row.len() == p),
@@ -161,9 +161,12 @@ pub fn fit(x: &[Vec<f64>], y: &[bool], lambda: f64, max_iter: usize) -> Logistic
         let mut grad_b = 0.0;
 
         for (xi, &yi) in x_norm.iter().zip(y_f.iter()) {
-            let z: f64 =
-                xi.iter().zip(weights.iter()).map(|(a, b)| a * b).sum::<f64>()
-                    + intercept;
+            let z: f64 = xi
+                .iter()
+                .zip(weights.iter())
+                .map(|(a, b)| a * b)
+                .sum::<f64>()
+                + intercept;
             let residual = sigmoid(z) - yi;
             for (j, xij) in xi.iter().enumerate() {
                 grad_w[j] += residual * xij;
@@ -178,8 +181,7 @@ pub fn fit(x: &[Vec<f64>], y: &[bool], lambda: f64, max_iter: usize) -> Logistic
         grad_b /= n_f;
 
         // Compute squared gradient norm for Armijo condition
-        let grad_norm_sq: f64 = grad_w.iter().map(|g| g * g).sum::<f64>()
-            + grad_b * grad_b;
+        let grad_norm_sq: f64 = grad_w.iter().map(|g| g * g).sum::<f64>() + grad_b * grad_b;
 
         // Backtracking line search
         let mut step = 1.0;

--- a/src/logistic.rs
+++ b/src/logistic.rs
@@ -74,6 +74,11 @@ pub struct LogisticFit {
 impl LogisticFit {
     /// Predict P(positive) for a single raw (unstandardized) sample.
     pub fn predict_one(&self, x: &[f64]) -> f64 {
+        debug_assert_eq!(
+            x.len(),
+            self.coefficients.len(),
+            "input dimension must match model"
+        );
         let z: f64 = x
             .iter()
             .enumerate()
@@ -130,7 +135,12 @@ fn loss(
 /// is the L2 regularization strength, and `max_iter` is the iteration cap.
 pub fn fit(x: &[Vec<f64>], y: &[bool], lambda: f64, max_iter: usize) -> LogisticFit {
     assert!(!x.is_empty(), "fit requires at least one sample");
+    assert_eq!(x.len(), y.len(), "feature matrix rows must match label count");
     let p = x[0].len();
+    debug_assert!(
+        x.iter().all(|row| row.len() == p),
+        "feature matrix must be rectangular"
+    );
     let n = x.len();
 
     // Standardize features

--- a/src/main.rs
+++ b/src/main.rs
@@ -2604,7 +2604,7 @@ fn run_calibrate(opts: cli::CalibrateOpts) -> i32 {
 
     let has_logistic = composite_model
         .as_ref()
-        .map_or(false, |m| m.logistic_model.is_some());
+        .is_some_and(|m| m.logistic_model.is_some());
 
     if opts.dry_run {
         eprintln!("\n(dry run -- no file written)");

--- a/src/main.rs
+++ b/src/main.rs
@@ -2602,9 +2602,13 @@ fn run_calibrate(opts: cli::CalibrateOpts) -> i32 {
         println!("Boost:    not computed (insufficient data or precision target unachievable)");
     }
 
+    let has_logistic = composite_model
+        .as_ref()
+        .map_or(false, |m| m.logistic_model.is_some());
+
     if opts.dry_run {
         eprintln!("\n(dry run -- no file written)");
-    } else if config.suppress.is_none() && config.boost.is_none() {
+    } else if config.suppress.is_none() && config.boost.is_none() && !has_logistic {
         eprintln!("\nNo thresholds computed (insufficient data). Existing config preserved.");
     } else {
         if let Err(e) = std::fs::create_dir_all(&qhome) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -2409,6 +2409,7 @@ fn run_calibrate(opts: cli::CalibrateOpts) -> i32 {
                 } else {
                     result.fold_aucs.iter().sum::<f64>() / result.fold_aucs.len() as f64
                 };
+                let lift = result.pr_auc - result.baseline_auc;
                 eprintln!("\nWeight learning ({} samples):", features.len());
                 eprintln!(
                     "  score={:.2}  word_lor={:.2}  family_fp_inv={:.2}  language_fp_inv={:.2}",
@@ -2418,7 +2419,9 @@ fn run_calibrate(opts: cli::CalibrateOpts) -> i32 {
                     result.weights.language_fp_inv,
                 );
                 eprintln!("  PR-AUC (full):     {:.4}", result.pr_auc);
+                eprintln!("  PR-AUC (baseline): {:.4}", result.baseline_auc);
                 eprintln!("  PR-AUC (5-fold):   {:.4}", mean_cv_auc);
+                eprintln!("  Lift over baseline: {:.4}", lift);
                 eprintln!(
                     "  Fold stability:    {}",
                     if result.stable {
@@ -2427,9 +2430,13 @@ fn run_calibrate(opts: cli::CalibrateOpts) -> i32 {
                         "UNSTABLE (fold weights diverge >20%)"
                     }
                 );
-                if result.stable {
+                let min_lift = 0.005;
+                if lift < min_lift {
+                    eprintln!("  -> No improvement over baseline (lift < {min_lift})");
+                } else if result.stable {
                     model.weights = result.weights;
                     model.meta.learned_weights = Some(true);
+                    eprintln!("  -> Weights applied to model");
                 } else {
                     eprintln!("  -> Using hardcoded weights (unstable folds)");
                 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,6 +18,7 @@ pub use quorum::file_util;
 pub use quorum::finding;
 pub use quorum::grounding;
 pub use quorum::hydration;
+pub use quorum::logistic;
 pub use quorum::merge;
 pub use quorum::parser;
 pub use quorum::patterns;
@@ -25,7 +26,6 @@ pub use quorum::prompt_sanitize;
 pub use quorum::prose_prompts;
 pub use quorum::redact;
 pub use quorum::review_mode;
-pub use quorum::logistic;
 pub use quorum::storage;
 
 mod agent;
@@ -2399,7 +2399,11 @@ fn run_calibrate(opts: cli::CalibrateOpts) -> i32 {
     if opts.feature_importance {
         if let Some(ref model) = composite_model {
             let joined = quorum::calibrate::extract_joined_samples(
-                &feedback, &traces, model, &filter, disable_fuzzy,
+                &feedback,
+                &traces,
+                model,
+                &filter,
+                disable_fuzzy,
             );
             if joined.is_empty() {
                 eprintln!("No joined samples available for feature importance.");
@@ -2431,7 +2435,9 @@ fn run_calibrate(opts: cli::CalibrateOpts) -> i32 {
                 );
             }
         } else {
-            eprintln!("No composite model available (insufficient feedback for feature importance).");
+            eprintln!(
+                "No composite model available (insufficient feedback for feature importance)."
+            );
         }
         return 0;
     }
@@ -2442,7 +2448,11 @@ fn run_calibrate(opts: cli::CalibrateOpts) -> i32 {
     {
         // Try logistic calibrator first
         let joined = quorum::calibrate::extract_joined_samples(
-            &feedback, &traces, model, &filter, disable_fuzzy,
+            &feedback,
+            &traces,
+            model,
+            &filter,
+            disable_fuzzy,
         );
 
         match quorum::calibrate::learn_logistic(&joined, 5) {
@@ -2494,15 +2504,18 @@ fn run_calibrate(opts: cli::CalibrateOpts) -> i32 {
 
                 // Fallback: existing grid search
                 let features = quorum::calibrate::extract_join_features(
-                    &feedback, &traces, model, &filter, disable_fuzzy,
+                    &feedback,
+                    &traces,
+                    model,
+                    &filter,
+                    disable_fuzzy,
                 );
                 match quorum::calibrate::learn_weights(&features, 5) {
                     Some(result) => {
                         let mean_cv_auc = if result.fold_aucs.is_empty() {
                             0.0
                         } else {
-                            result.fold_aucs.iter().sum::<f64>()
-                                / result.fold_aucs.len() as f64
+                            result.fold_aucs.iter().sum::<f64>() / result.fold_aucs.len() as f64
                         };
                         let lift = result.pr_auc - result.baseline_auc;
                         eprintln!("\nWeight learning ({} samples):", features.len());
@@ -2527,9 +2540,7 @@ fn run_calibrate(opts: cli::CalibrateOpts) -> i32 {
                         );
                         let min_lift = 0.005;
                         if lift < min_lift {
-                            eprintln!(
-                                "  -> No improvement over baseline (lift < {min_lift})"
-                            );
+                            eprintln!("  -> No improvement over baseline (lift < {min_lift})");
                         } else if result.stable {
                             model.weights = result.weights;
                             model.meta.learned_weights = Some(true);

--- a/src/main.rs
+++ b/src/main.rs
@@ -2012,6 +2012,7 @@ fn run_feedback_inner(
     category: Option<&str>,
     fp_kind: Option<feedback::FpKind>,
     in_diff: Option<bool>,
+    provenance: Option<feedback::Provenance>,
     json: bool,
     feedback_path: &std::path::Path,
 ) -> (i32, String) {
@@ -2049,7 +2050,7 @@ fn run_feedback_inner(
         reason: reason.to_string(),
         model: model.map(|s| s.to_string()),
         timestamp: chrono::Utc::now(),
-        provenance: feedback::Provenance::Human,
+        provenance: provenance.unwrap_or(feedback::Provenance::Human),
         fp_kind,
         finding_id: None,
         rule_id: None,
@@ -2211,6 +2212,7 @@ fn run_feedback(opts: cli::FeedbackOpts) -> i32 {
             opts.category.as_deref(),
             fp_kind,
             opts.in_diff,
+            opts.provenance,
             opts.json,
             &feedback_path,
         );
@@ -2751,6 +2753,7 @@ mod feedback_tests {
             None,
             None,
             None,
+            None,
             false,
             &path,
         );
@@ -2770,6 +2773,7 @@ mod feedback_tests {
             "SQL injection",
             "maybe",
             "Not sure",
+            None,
             None,
             None,
             None,
@@ -2796,12 +2800,36 @@ mod feedback_tests {
             None,
             None,
             None,
+            None,
             false,
             &path,
         );
         assert_eq!(exit_code, 0);
         let contents = std::fs::read_to_string(&path).unwrap();
         assert!(contents.contains("\"provenance\":\"human\""));
+    }
+
+    #[test]
+    fn feedback_provenance_post_fix() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("feedback.jsonl");
+        let (exit_code, _) = run_feedback_inner(
+            "src/auth.rs",
+            "SQL injection",
+            "tp",
+            "Fixed in this branch",
+            None,
+            None,
+            None,
+            None,
+            None,
+            Some(feedback::Provenance::PostFix),
+            false,
+            &path,
+        );
+        assert_eq!(exit_code, 0);
+        let contents = std::fs::read_to_string(&path).unwrap();
+        assert!(contents.contains("\"provenance\":\"post_fix\""));
     }
 
     #[test]
@@ -2813,6 +2841,7 @@ mod feedback_tests {
             "Test finding",
             "fp",
             "Not real",
+            None,
             None,
             None,
             None,
@@ -2840,6 +2869,7 @@ mod feedback_tests {
             None,
             None,
             None,
+            None,
             false,
             &path,
         );
@@ -2857,6 +2887,7 @@ mod feedback_tests {
             "SQL injection",
             "fp",
             "Not a real issue",
+            None,
             None,
             None,
             None,
@@ -2890,6 +2921,7 @@ mod feedback_tests {
             None,
             None,
             None,
+            None,
             false,
             &path,
         );
@@ -2912,6 +2944,7 @@ mod feedback_tests {
             None,
             None, // fp_kind
             None, // in_diff
+            None, // provenance
             false,
             &path,
         );
@@ -2963,6 +2996,7 @@ mod feedback_tests {
             None,
             None, // fp_kind
             None, // in_diff
+            None, // provenance
             false,
             &path,
         );
@@ -2990,6 +3024,7 @@ mod feedback_tests {
             None,
             None, // fp_kind
             None, // in_diff
+            None, // provenance
             false,
             &path,
         );

--- a/src/main.rs
+++ b/src/main.rs
@@ -1089,6 +1089,7 @@ async fn run_review(opts: cli::ReviewOpts) -> i32 {
             word_lor_entries = model.word_lor.len(),
             family_rates = model.family_fp_rate.len(),
             language_rates = model.language_fp_rate.len(),
+            has_logistic = model.logistic_model.is_some(),
             "loaded composite calibrator model"
         );
         calibrator_config.model = Some(model);

--- a/src/main.rs
+++ b/src/main.rs
@@ -45,6 +45,7 @@ mod http_server;
 mod judge;
 mod linter;
 mod llm_client;
+mod logistic;
 mod mcp;
 mod output;
 mod pipeline;

--- a/src/main.rs
+++ b/src/main.rs
@@ -2392,61 +2392,156 @@ fn run_calibrate(opts: cli::CalibrateOpts) -> i32 {
     // Compute composite model from feedback
     let mut composite_model = quorum::calibrate::compute_calibrator_model(&feedback);
 
+    // Feature importance diagnostics (early exit when --feature-importance)
+    if opts.feature_importance {
+        if let Some(ref model) = composite_model {
+            let joined = quorum::calibrate::extract_joined_samples(
+                &feedback, &traces, model, &filter, disable_fuzzy,
+            );
+            if joined.is_empty() {
+                eprintln!("No joined samples available for feature importance.");
+                return 0;
+            }
+            let refs: Vec<&quorum::calibrate::JoinedSample> = joined.iter().collect();
+            let stats = quorum::calibrate::compute_fold_local_stats(&refs);
+            let expanded: Vec<(quorum::calibrate::ExpandedFeatures, bool)> = joined
+                .iter()
+                .map(|s| quorum::calibrate::extract_single_expanded(s, &stats))
+                .collect();
+            let n_fp = expanded.iter().filter(|(_, l)| *l).count();
+            let n_tp = expanded.len() - n_fp;
+            let baseline = n_fp as f64 / expanded.len() as f64;
+
+            eprintln!("Feature importance ({} FP, {} non-FP):", n_fp, n_tp);
+            let scores = quorum::calibrate::feature_importance_scores(&expanded);
+            let names = quorum::calibrate::ExpandedFeatures::feature_names();
+            for (idx, ap) in &scores {
+                let lift = ap - baseline;
+                let marker = if lift < 0.02 {
+                    "  [below threshold]"
+                } else {
+                    ""
+                };
+                eprintln!(
+                    "  {:35} AP={:.4}  (lift {:+.4}){}",
+                    names[*idx], ap, lift, marker
+                );
+            }
+        } else {
+            eprintln!("No composite model available (insufficient feedback for feature importance).");
+        }
+        return 0;
+    }
+
     // Learn weights from data when requested
     if opts.learn_weights
         && let Some(ref mut model) = composite_model
     {
-        let features = quorum::calibrate::extract_join_features(
-            &feedback,
-            &traces,
-            model,
-            &filter,
-            disable_fuzzy,
+        // Try logistic calibrator first
+        let joined = quorum::calibrate::extract_joined_samples(
+            &feedback, &traces, model, &filter, disable_fuzzy,
         );
-        match quorum::calibrate::learn_weights(&features, 5) {
+
+        match quorum::calibrate::learn_logistic(&joined, 5) {
             Some(result) => {
-                let mean_cv_auc = if result.fold_aucs.is_empty() {
-                    0.0
-                } else {
-                    result.fold_aucs.iter().sum::<f64>() / result.fold_aucs.len() as f64
+                eprintln!(
+                    "\nLogistic model ({} FP, {} non-FP, 5-fold GroupKFold):",
+                    result.n_fp,
+                    result.n_samples - result.n_fp
+                );
+                eprintln!(
+                    "  Selected features ({}/15): {:?}",
+                    result.selected_feature_names.len(),
+                    result.selected_feature_names
+                );
+                eprintln!("  AP (OOF):      {:.4}", result.ap_score);
+                eprintln!("  AP (baseline): {:.4}", result.baseline_ap);
+                eprintln!(
+                    "  Lift:          {:+.4}",
+                    result.ap_score - result.baseline_ap
+                );
+                eprintln!(
+                    "  FP recall @ 99% TP recall: {:.4}",
+                    result.fp_recall_at_99_tp_recall
+                );
+                eprintln!("  Suppress threshold: {:.4}", result.suppress_threshold);
+                eprintln!("  Boost threshold:    {:.4}", result.boost_threshold);
+
+                let lm = quorum::calibrator_model::LogisticModel {
+                    computed_at: chrono::Utc::now().to_rfc3339(),
+                    n_samples: result.n_samples,
+                    n_fp: result.n_fp,
+                    selected_features: result.selected_feature_names,
+                    coefficients: result.coefficients,
+                    intercept: result.intercept,
+                    feature_means: result.feature_means,
+                    feature_stddevs: result.feature_stddevs,
+                    suppress_threshold: result.suppress_threshold,
+                    boost_threshold: result.boost_threshold,
+                    ap_score: result.ap_score,
+                    fp_recall_at_99_tp_recall: result.fp_recall_at_99_tp_recall,
+                    baseline_ap: result.baseline_ap,
                 };
-                let lift = result.pr_auc - result.baseline_auc;
-                eprintln!("\nWeight learning ({} samples):", features.len());
-                eprintln!(
-                    "  score={:.2}  word_lor={:.2}  family_fp_inv={:.2}  language_fp_inv={:.2}",
-                    result.weights.score,
-                    result.weights.word_lor,
-                    result.weights.family_fp_inv,
-                    result.weights.language_fp_inv,
-                );
-                eprintln!("  PR-AUC (full):     {:.4}", result.pr_auc);
-                eprintln!("  PR-AUC (baseline): {:.4}", result.baseline_auc);
-                eprintln!("  PR-AUC (5-fold):   {:.4}", mean_cv_auc);
-                eprintln!("  Lift over baseline: {:.4}", lift);
-                eprintln!(
-                    "  Fold stability:    {}",
-                    if result.stable {
-                        "stable (all folds within 20%)"
-                    } else {
-                        "UNSTABLE (fold weights diverge >20%)"
-                    }
-                );
-                let min_lift = 0.005;
-                if lift < min_lift {
-                    eprintln!("  -> No improvement over baseline (lift < {min_lift})");
-                } else if result.stable {
-                    model.weights = result.weights;
-                    model.meta.learned_weights = Some(true);
-                    eprintln!("  -> Weights applied to model");
-                } else {
-                    eprintln!("  -> Using hardcoded weights (unstable folds)");
-                }
+                model.logistic_model = Some(lm);
+                eprintln!("  -> Logistic model applied");
             }
             None => {
-                eprintln!(
-                    "\nWeight learning: skipped (need >=50 samples, have {})",
-                    features.len()
+                eprintln!("\n  Logistic model: insufficient data or no improvement over baseline.");
+                eprintln!("  Falling back to grid search...");
+
+                // Fallback: existing grid search
+                let features = quorum::calibrate::extract_join_features(
+                    &feedback, &traces, model, &filter, disable_fuzzy,
                 );
+                match quorum::calibrate::learn_weights(&features, 5) {
+                    Some(result) => {
+                        let mean_cv_auc = if result.fold_aucs.is_empty() {
+                            0.0
+                        } else {
+                            result.fold_aucs.iter().sum::<f64>()
+                                / result.fold_aucs.len() as f64
+                        };
+                        let lift = result.pr_auc - result.baseline_auc;
+                        eprintln!("\nWeight learning ({} samples):", features.len());
+                        eprintln!(
+                            "  score={:.2}  word_lor={:.2}  family_fp_inv={:.2}  language_fp_inv={:.2}",
+                            result.weights.score,
+                            result.weights.word_lor,
+                            result.weights.family_fp_inv,
+                            result.weights.language_fp_inv,
+                        );
+                        eprintln!("  PR-AUC (full):     {:.4}", result.pr_auc);
+                        eprintln!("  PR-AUC (baseline): {:.4}", result.baseline_auc);
+                        eprintln!("  PR-AUC (5-fold):   {:.4}", mean_cv_auc);
+                        eprintln!("  Lift over baseline: {:.4}", lift);
+                        eprintln!(
+                            "  Fold stability:    {}",
+                            if result.stable {
+                                "stable (all folds within 20%)"
+                            } else {
+                                "UNSTABLE (fold weights diverge >20%)"
+                            }
+                        );
+                        let min_lift = 0.005;
+                        if lift < min_lift {
+                            eprintln!(
+                                "  -> No improvement over baseline (lift < {min_lift})"
+                            );
+                        } else if result.stable {
+                            model.weights = result.weights;
+                            model.meta.learned_weights = Some(true);
+                            eprintln!("  -> Weights applied to model");
+                        } else {
+                            eprintln!("  -> Using hardcoded weights (unstable folds)");
+                        }
+                    }
+                    None => {
+                        eprintln!(
+                            "\nWeight learning: skipped (need >=50 samples, have {})",
+                            features.len()
+                        );
+                    }
+                }
             }
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,6 +25,7 @@ pub use quorum::prompt_sanitize;
 pub use quorum::prose_prompts;
 pub use quorum::redact;
 pub use quorum::review_mode;
+pub use quorum::logistic;
 pub use quorum::storage;
 
 mod agent;
@@ -45,7 +46,6 @@ mod http_server;
 mod judge;
 mod linter;
 mod llm_client;
-mod logistic;
 mod mcp;
 mod output;
 mod pipeline;

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -134,19 +134,19 @@ pub fn fp_recall_at_tp_recall(predictions: &[(f64, bool)], min_tp_recall: f64) -
         return 0.0;
     }
 
-    let total_fp = predictions.iter().filter(|(_, is_fp)| *is_fp).count();
-    let total_non_fp = predictions.iter().filter(|(_, is_fp)| !*is_fp).count();
-
-    if total_fp == 0 || total_non_fp == 0 {
-        return 0.0;
-    }
-
     let mut sorted: Vec<(f64, bool)> = predictions
         .iter()
         .filter(|(s, _)| s.is_finite())
         .copied()
         .collect();
     sorted.sort_by(|a, b| b.0.partial_cmp(&a.0).unwrap_or(std::cmp::Ordering::Equal));
+
+    let total_fp = sorted.iter().filter(|(_, is_fp)| *is_fp).count();
+    let total_non_fp = sorted.iter().filter(|(_, is_fp)| !*is_fp).count();
+
+    if total_fp == 0 || total_non_fp == 0 {
+        return 0.0;
+    }
 
     // If all scores are tied, we can't make any distinction
     if sorted.first().map(|f| f.0) == sorted.last().map(|l| l.0) {

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -287,14 +287,20 @@ mod tests {
     fn pr_auc_basic() {
         let samples = vec![(0.9, true), (0.7, false), (0.5, true), (0.3, false)];
         let auc = pr_auc(&samples);
-        assert!(auc > 0.0 && auc <= 1.0, "PR-AUC should be in (0,1], got {auc}");
+        assert!(
+            auc > 0.0 && auc <= 1.0,
+            "PR-AUC should be in (0,1], got {auc}"
+        );
     }
 
     #[test]
     fn pr_auc_perfect_separation() {
         let samples = vec![(0.9, true), (0.8, true), (0.2, false), (0.1, false)];
         let auc = pr_auc(&samples);
-        assert!(auc > 0.9, "perfect separation should yield high PR-AUC, got {auc}");
+        assert!(
+            auc > 0.9,
+            "perfect separation should yield high PR-AUC, got {auc}"
+        );
     }
 
     #[test]
@@ -406,12 +412,7 @@ mod tests {
     #[test]
     fn fp_recall_no_separation() {
         // All items have the same score -> can't distinguish, return 0.0
-        let predictions = vec![
-            (0.5, true),
-            (0.5, false),
-            (0.5, true),
-            (0.5, false),
-        ];
+        let predictions = vec![(0.5, true), (0.5, false), (0.5, true), (0.5, false)];
         let recall = fp_recall_at_tp_recall(&predictions, 0.95);
         assert!(
             (recall - 0.0).abs() < 1e-9,

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -80,6 +80,103 @@ pub fn pr_auc(samples: &[(f64, bool)]) -> f64 {
     auc
 }
 
+/// Stepwise Average Precision (no interpolation).
+///
+/// Sorts by score descending, sums P(k) at each rank where recall increases,
+/// divides by total positives. Higher score = more likely positive.
+///
+/// Returns 0.0 for empty input or when there are no positives.
+pub fn average_precision_stepwise(samples: &[(f64, bool)]) -> f64 {
+    if samples.is_empty() {
+        return 0.0;
+    }
+
+    let mut sorted: Vec<(f64, bool)> = samples
+        .iter()
+        .filter(|(s, _)| s.is_finite())
+        .copied()
+        .collect();
+    sorted.sort_by(|a, b| b.0.partial_cmp(&a.0).unwrap_or(std::cmp::Ordering::Equal));
+
+    let total_positives = sorted.iter().filter(|(_, p)| *p).count();
+    if total_positives == 0 {
+        return 0.0;
+    }
+
+    let mut tp: f64 = 0.0;
+    let mut fp: f64 = 0.0;
+    let mut sum_precision = 0.0;
+
+    for &(_, is_positive) in &sorted {
+        if is_positive {
+            tp += 1.0;
+            let precision = tp / (tp + fp);
+            sum_precision += precision;
+        } else {
+            fp += 1.0;
+        }
+    }
+
+    sum_precision / total_positives as f64
+}
+
+/// Compute FP recall at a given TP recall constraint.
+///
+/// Input: `(score, is_fp)` pairs where higher score = more likely false positive.
+/// Sweeps threshold from high to low: FPs caught increase FP recall,
+/// non-FPs (TPs) caught count as suppressions. Stops when TP suppression
+/// exceeds the budget `(1 - min_tp_recall) * total_tp`.
+///
+/// Returns `fp_caught / total_fp`. Returns 0.0 for edge cases: empty input,
+/// no FPs, no TPs, or all tied scores.
+pub fn fp_recall_at_tp_recall(predictions: &[(f64, bool)], min_tp_recall: f64) -> f64 {
+    if predictions.is_empty() {
+        return 0.0;
+    }
+
+    let total_fp = predictions.iter().filter(|(_, is_fp)| *is_fp).count();
+    let total_non_fp = predictions.iter().filter(|(_, is_fp)| !*is_fp).count();
+
+    if total_fp == 0 || total_non_fp == 0 {
+        return 0.0;
+    }
+
+    let mut sorted: Vec<(f64, bool)> = predictions
+        .iter()
+        .filter(|(s, _)| s.is_finite())
+        .copied()
+        .collect();
+    sorted.sort_by(|a, b| b.0.partial_cmp(&a.0).unwrap_or(std::cmp::Ordering::Equal));
+
+    // If all scores are tied, we can't make any distinction
+    if sorted.first().map(|f| f.0) == sorted.last().map(|l| l.0) {
+        return 0.0;
+    }
+
+    #[allow(
+        clippy::cast_possible_truncation,
+        clippy::cast_sign_loss,
+        clippy::cast_precision_loss
+    )]
+    let max_tp_suppressed = ((1.0 - min_tp_recall) * total_non_fp as f64).floor() as usize;
+    let mut fp_caught: usize = 0;
+    let mut tp_suppressed: usize = 0;
+
+    for &(_, is_fp) in &sorted {
+        if is_fp {
+            fp_caught += 1;
+        } else {
+            if tp_suppressed >= max_tp_suppressed {
+                // This TP would push us over budget, stop
+                break;
+            }
+            tp_suppressed += 1;
+        }
+    }
+
+    fp_caught as f64 / total_fp as f64
+}
+
 /// Find the threshold that maximizes F1 score.
 /// Returns `None` if the curve is empty.
 pub fn f1_optimal_threshold(curve: &[(f64, f64, f64)]) -> Option<f64> {
@@ -213,5 +310,132 @@ mod tests {
         // At 0.9: F1=2*(1.0*0.5)/(1.0+0.5)=0.667
         // At 0.5: F1=2*(0.667*1.0)/(0.667+1.0)=0.800
         assert!((t.unwrap() - 0.5).abs() < 1e-9, "threshold 0.5 has best F1");
+    }
+
+    // --- Tests for average_precision_stepwise ---
+
+    #[test]
+    fn ap_stepwise_basic_case() {
+        // Scores: 0.9(TP), 0.8(FP), 0.7(TP), 0.6(FP), 0.5(TP)
+        // Rank 1: TP -> P=1/1=1.0, recall increases -> sum += 1.0
+        // Rank 2: FP -> no recall increase
+        // Rank 3: TP -> P=2/3=0.667, recall increases -> sum += 0.667
+        // Rank 4: FP -> no recall increase
+        // Rank 5: TP -> P=3/5=0.6, recall increases -> sum += 0.6
+        // AP = (1.0 + 2/3 + 3/5) / 3 = (1.0 + 0.6667 + 0.6) / 3 = 2.2667/3 = 0.7556
+        let samples = vec![
+            (0.9, true),
+            (0.8, false),
+            (0.7, true),
+            (0.6, false),
+            (0.5, true),
+        ];
+        let ap = average_precision_stepwise(&samples);
+        let expected = (1.0 + 2.0 / 3.0 + 3.0 / 5.0) / 3.0;
+        assert!(
+            (ap - expected).abs() < 1e-9,
+            "expected {expected}, got {ap}"
+        );
+    }
+
+    #[test]
+    fn ap_stepwise_perfect_separation() {
+        // All positives ranked above all negatives -> AP = 1.0
+        let samples = vec![
+            (0.9, true),
+            (0.8, true),
+            (0.7, true),
+            (0.3, false),
+            (0.2, false),
+        ];
+        let ap = average_precision_stepwise(&samples);
+        assert!(
+            (ap - 1.0).abs() < 1e-9,
+            "perfect separation should give AP=1.0, got {ap}"
+        );
+    }
+
+    #[test]
+    fn ap_stepwise_worst_case() {
+        // All negatives ranked first, then all positives
+        // Scores: 0.9(FP), 0.8(FP), 0.7(TP)
+        // Rank 1: FP -> no recall increase
+        // Rank 2: FP -> no recall increase
+        // Rank 3: TP -> P=1/3, recall increases -> sum += 1/3
+        // AP = (1/3) / 1 = 1/3
+        let samples = vec![(0.9, false), (0.8, false), (0.7, true)];
+        let ap = average_precision_stepwise(&samples);
+        assert!(
+            (ap - 1.0 / 3.0).abs() < 1e-9,
+            "worst case should give AP=1/3, got {ap}"
+        );
+    }
+
+    #[test]
+    fn ap_stepwise_empty() {
+        let ap = average_precision_stepwise(&[]);
+        assert!((ap - 0.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn ap_stepwise_no_positives() {
+        let samples = vec![(0.9, false), (0.5, false)];
+        let ap = average_precision_stepwise(&samples);
+        assert!((ap - 0.0).abs() < 1e-9);
+    }
+
+    // --- Tests for fp_recall_at_tp_recall ---
+
+    #[test]
+    fn fp_recall_perfect_separation() {
+        // FPs scored higher than TPs -> at min_tp_recall=0.95,
+        // we can catch all FPs without suppressing any TPs
+        let predictions = vec![
+            (0.9, true),  // is_fp=true
+            (0.8, true),  // is_fp=true
+            (0.3, false), // is_fp=false (i.e., TP)
+            (0.2, false), // is_fp=false (i.e., TP)
+        ];
+        let recall = fp_recall_at_tp_recall(&predictions, 0.95);
+        assert!(
+            (recall - 1.0).abs() < 1e-9,
+            "perfect FP separation should give recall=1.0, got {recall}"
+        );
+    }
+
+    #[test]
+    fn fp_recall_no_separation() {
+        // All items have the same score -> can't distinguish, return 0.0
+        let predictions = vec![
+            (0.5, true),
+            (0.5, false),
+            (0.5, true),
+            (0.5, false),
+        ];
+        let recall = fp_recall_at_tp_recall(&predictions, 0.95);
+        assert!(
+            (recall - 0.0).abs() < 1e-9,
+            "no separation should give recall=0.0, got {recall}"
+        );
+    }
+
+    #[test]
+    fn fp_recall_empty() {
+        let recall = fp_recall_at_tp_recall(&[], 0.95);
+        assert!((recall - 0.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn fp_recall_no_fps() {
+        let predictions = vec![(0.9, false), (0.5, false)];
+        let recall = fp_recall_at_tp_recall(&predictions, 0.95);
+        assert!((recall - 0.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn fp_recall_no_tps() {
+        let predictions = vec![(0.9, true), (0.5, true)];
+        let recall = fp_recall_at_tp_recall(&predictions, 0.95);
+        assert!((recall - 0.0).abs() < 1e-9);
     }
 }


### PR DESCRIPTION
## Summary

Adds an inline L2-regularized logistic calibrator that models P(FP) from 15 engineered features, using out-of-fold predictions for safe threshold selection.

- **Suppress threshold** (p_fp >= 0.669): findings with high FP probability are suppressed. Only fires when `fp_weight > 0.0` to protect novel findings.
- **Boost threshold** (p_fp <= 0.014): findings with very low FP probability get boosted confidence.
- **65pp neutral zone**: conservative design — model only acts on high-confidence predictions.

### Key metrics (on ~1567-sample feedback corpus)
- Average Precision: 0.236 vs 0.181 baseline (+30% lift)
- 6/15 features selected via consensus (>= 3/5 folds): `log1p_fp_weight`, `log1p_soft_fp_weight`, `log1p_full_suppress_weight`, `category_fp_rate`, `max_word_lor`, `min_word_lor`
- 5-fold GroupKFold by title family with per-fold univariate screening (AP >= baseline + 0.02)

### Files changed (14 files, +3017/-145)
- `src/logistic.rs` — Pure Rust logistic regression (batch GD + Armijo line search)
- `src/metrics.rs` — Stepwise AP and fp_recall_at_tp_recall
- `src/calibrate.rs` — Training pipeline (feature extraction, CV, OOF thresholds)
- `src/calibrator.rs` — Review-time scoring integration
- `src/calibrator_model.rs` — LogisticModel TOML persistence
- `src/main.rs` — CLI `calibrate --learn-weights` and `--feature-importance`
- Multi-source query fan-out with RRF scoring (from merged #372)

### Review cycle verdicts recorded
| Finding | Verdict | Action |
|---------|---------|--------|
| Convergence check comparing loss with itself | tp | Fixed (logistic.rs) |
| FP/non-FP counts from unfiltered vec | tp | Fixed (metrics.rs) |
| In-sample threshold selection | tp | Fixed → OOF predictions |
| Word LOR fold bias (review path) | tp | Fixed (calibrator.rs) |
| Word LOR fold bias (training path) | tp | Fixed (calibrate.rs) |
| OOF threshold empty-vec panic | tp | Fixed (calibrate.rs) |

## Test plan

- [x] `cargo test --bin quorum` — 1578 tests pass
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo build --release` — compiles (31MB binary)
- [x] `quorum calibrate` validates model against feedback corpus
- [x] `quorum review --trace` confirms logistic_p_fp in calibrator traces
- [x] Quorum + CodeRabbit review cycles with all findings triaged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added enhanced calibration model with improved decision-making for suppress/boost actions.
  * Added `--feature-importance` CLI flag to display per-feature diagnostics.
  * Added `--provenance` CLI flag to track feedback origin (post_fix, human).

* **Documentation**
  * Added implementation plan and design specification for calibration improvements.

* **Chores**
  * Bumped version from 0.23.0 to 0.24.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->