### PR TITLE
fix(calibrator): align 7 review-time features with training

### DIFF
--- a/docs/superpowers/plans/2026-05-17-calibrator-review-time-features.md
+++ b/docs/superpowers/plans/2026-05-17-calibrator-review-time-features.md
@@ -1,0 +1,886 @@
+# Calibrator Review-Time Feature Fix — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix 7 broken logistic calibrator features at review time, fix trace emission corruption, align tokenization, add rate maps to the model, and remove the legacy threshold system.
+
+**Architecture:** Add rate/count maps to `CalibratorModel` (serialized in model.toml), populate them from the full corpus during `quorum calibrate`, and look them up at review time. Fix feature scale mismatches (`ln_1p`, tokenization). Remove the legacy `ThresholdConfig` system and simplify the non-logistic decision path to magic-number heuristics only.
+
+**Tech Stack:** Rust, serde (TOML serialization), cargo test
+
+**Spec:** `docs/superpowers/specs/2026-05-17-calibrator-review-time-features-design.md`
+
+---
+
+### Task 1: Add rate map fields to CalibratorModel
+
+**Files:**
+- Modify: `src/calibrator_model.rs:56-66`
+
+- [ ] **Step 1: Write failing serde round-trip test for new fields**
+
+Add to the existing test section in `src/calibrator_model.rs` (after the existing round-trip tests around line ~344):
+
+```rust
+#[test]
+fn rate_maps_round_trip() {
+    let mut model = CalibratorModel {
+        meta: ModelMeta {
+            computed_at: "2026-01-01T00:00:00Z".to_string(),
+            feedback_count: 100,
+            global_fp_rate: 0.3,
+            learned_weights: None,
+        },
+        weights: ScoreWeights {
+            score: 1.0,
+            word_lor: 0.5,
+            family_fp_inv: 0.3,
+            language_fp_inv: 0.2,
+        },
+        logistic_model: None,
+        word_lor: HashMap::new(),
+        family_fp_rate: HashMap::new(),
+        language_fp_rate: HashMap::new(),
+        category_fp_rate_map: None,
+        severity_fp_rate: None,
+        model_fp_rate: None,
+        file_fp_rate: None,
+        file_finding_counts: None,
+    };
+
+    // Round-trip with None maps
+    let toml_str = model.to_toml();
+    let loaded = CalibratorModel::from_toml(&toml_str).unwrap();
+    assert!(loaded.category_fp_rate_map.is_none());
+    assert!(loaded.severity_fp_rate.is_none());
+    assert!(loaded.model_fp_rate.is_none());
+    assert!(loaded.file_fp_rate.is_none());
+    assert!(loaded.file_finding_counts.is_none());
+
+    // Round-trip with populated maps
+    let mut cat_map = HashMap::new();
+    cat_map.insert("security".to_string(), 0.25);
+    cat_map.insert("correctness".to_string(), 0.4);
+    model.category_fp_rate_map = Some(cat_map);
+
+    let mut sev_map = HashMap::new();
+    sev_map.insert("critical".to_string(), 0.1);
+    model.severity_fp_rate = Some(sev_map);
+
+    let mut model_map = HashMap::new();
+    model_map.insert("gpt-5.4".to_string(), 0.35);
+    model.model_fp_rate = Some(model_map);
+
+    let mut file_map = HashMap::new();
+    file_map.insert("src/main.rs".to_string(), 0.5);
+    model.file_fp_rate = Some(file_map);
+
+    let mut count_map = HashMap::new();
+    count_map.insert("src/main.rs".to_string(), 42);
+    model.file_finding_counts = Some(count_map);
+
+    let toml_str = model.to_toml();
+    let loaded = CalibratorModel::from_toml(&toml_str).unwrap();
+    assert_eq!(
+        loaded.category_fp_rate_map.as_ref().unwrap().get("security"),
+        Some(&0.25)
+    );
+    assert_eq!(
+        loaded.severity_fp_rate.as_ref().unwrap().get("critical"),
+        Some(&0.1)
+    );
+    assert_eq!(
+        loaded.model_fp_rate.as_ref().unwrap().get("gpt-5.4"),
+        Some(&0.35)
+    );
+    assert_eq!(
+        loaded.file_fp_rate.as_ref().unwrap().get("src/main.rs"),
+        Some(&0.5)
+    );
+    assert_eq!(
+        loaded.file_finding_counts.as_ref().unwrap().get("src/main.rs"),
+        Some(&42)
+    );
+}
+
+#[test]
+fn old_toml_without_rate_maps_loads() {
+    // Simulate a pre-upgrade model.toml that lacks the new fields
+    let old_toml = r#"
+[meta]
+computed_at = "2026-01-01T00:00:00Z"
+feedback_count = 100
+global_fp_rate = 0.3
+
+[weights]
+score = 1.0
+word_lor = 0.5
+family_fp_inv = 0.3
+language_fp_inv = 0.2
+
+[word_lor]
+
+[family_fp_rate]
+
+[language_fp_rate]
+"#;
+    let loaded = CalibratorModel::from_toml(old_toml).unwrap();
+    assert!(loaded.category_fp_rate_map.is_none());
+    assert!(loaded.severity_fp_rate.is_none());
+    assert!(loaded.model_fp_rate.is_none());
+    assert!(loaded.file_fp_rate.is_none());
+    assert!(loaded.file_finding_counts.is_none());
+    assert!((loaded.meta.global_fp_rate - 0.3).abs() < f64::EPSILON);
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test --bin quorum rate_maps_round_trip -- --nocapture`
+Expected: Compilation error — `CalibratorModel` has no field `category_fp_rate_map`
+
+- [ ] **Step 3: Add the 5 new fields to CalibratorModel struct**
+
+In `src/calibrator_model.rs`, add after the `language_fp_rate` field (line ~65):
+
+```rust
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub category_fp_rate_map: Option<HashMap<String, f64>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub severity_fp_rate: Option<HashMap<String, f64>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub model_fp_rate: Option<HashMap<String, f64>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub file_fp_rate: Option<HashMap<String, f64>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub file_finding_counts: Option<HashMap<String, usize>>,
+```
+
+- [ ] **Step 4: Fix all existing CalibratorModel initializations**
+
+Search for all `CalibratorModel {` struct literals across the codebase and add the 5 new fields as `None`. Key locations:
+- `src/calibrate.rs` — where the model is built during `run_calibrate`
+- `src/calibrator.rs` — any test fixtures
+- `src/calibrator_model.rs` — existing test fixtures
+
+For each, append:
+```rust
+    category_fp_rate_map: None,
+    severity_fp_rate: None,
+    model_fp_rate: None,
+    file_fp_rate: None,
+    file_finding_counts: None,
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `cargo test --bin quorum rate_maps_round_trip old_toml_without_rate_maps_loads -- --nocapture`
+Expected: PASS for both tests
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/calibrator_model.rs src/calibrate.rs src/calibrator.rs
+git commit -m "feat(calibrator): add rate map fields to CalibratorModel"
+```
+
+---
+
+### Task 2: Make tokenize_title public and add parity test
+
+**Files:**
+- Modify: `src/calibrate.rs:1518-1525` (visibility change)
+
+- [ ] **Step 1: Write failing test for tokenize_title parity**
+
+Add to `src/calibrate.rs` test section:
+
+```rust
+#[test]
+fn tokenize_title_drops_digits_and_lowercases() {
+    let tokens = tokenize_title("Buffer overflow in parse123 at L42");
+    // [a-z_]+ regex: keeps alpha+underscore, drops digits, lowercases
+    assert!(tokens.contains(&"buffer".to_string()));
+    assert!(tokens.contains(&"overflow".to_string()));
+    assert!(tokens.contains(&"parse".to_string()));
+    assert!(tokens.contains(&"at".to_string()));
+    // Digits-only tokens are excluded
+    assert!(!tokens.iter().any(|t| t == "123" || t == "42"));
+    // Single-char tokens filtered by len >= 2
+    assert!(!tokens.iter().any(|t| t.len() < 2));
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test --bin quorum tokenize_title_drops_digits -- --nocapture`
+Expected: Compilation error if `tokenize_title` is not accessible in test module, or PASS if already accessible (it's in the same file).
+
+- [ ] **Step 3: Change tokenize_title visibility to pub**
+
+In `src/calibrate.rs`, change `fn tokenize_title` (line ~1518) to:
+
+```rust
+pub fn tokenize_title(title: &str) -> Vec<String> {
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cargo test --bin quorum tokenize_title_drops_digits -- --nocapture`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/calibrate.rs
+git commit -m "feat(calibrate): make tokenize_title pub for inference reuse"
+```
+
+---
+
+### Task 3: Populate rate maps during `quorum calibrate`
+
+**Files:**
+- Modify: `src/calibrate.rs` — `compute_fold_local_stats` result extraction
+- Modify: `src/main.rs:2400-2500` — store maps in model after `all_stats` computation
+
+- [ ] **Step 1: Write failing test for rate map population**
+
+Add to `src/calibrate.rs` test section:
+
+```rust
+#[test]
+fn compute_fold_local_stats_returns_all_rate_maps() {
+    let samples = vec![
+        JoinedSample {
+            title: "SQL injection".to_string(),
+            category: "security".to_string(),
+            severity: "critical".to_string(),
+            model: "gpt-5.4".to_string(),
+            tp_weight: 0.0,
+            fp_weight: 1.0,
+            soft_fp_weight: 0.0,
+            full_suppress_weight: 1.0,
+            wontfix_weight: 0.0,
+            precedent_count: 1,
+            max_similarity: 0.9,
+            mean_similarity: 0.9,
+            is_fp: true,
+            family: "sql".to_string(),
+            file_path: "src/db.rs".to_string(),
+            source_is_ast: false,
+            finding_span_lines: 5,
+        },
+        JoinedSample {
+            title: "Buffer overflow".to_string(),
+            category: "correctness".to_string(),
+            severity: "warning".to_string(),
+            model: "gpt-5.4".to_string(),
+            tp_weight: 1.0,
+            fp_weight: 0.0,
+            soft_fp_weight: 0.0,
+            full_suppress_weight: 0.0,
+            wontfix_weight: 0.0,
+            precedent_count: 1,
+            max_similarity: 0.8,
+            mean_similarity: 0.8,
+            is_fp: false,
+            family: "memory".to_string(),
+            file_path: "src/db.rs".to_string(),
+            source_is_ast: true,
+            finding_span_lines: 10,
+        },
+    ];
+    let refs: Vec<&JoinedSample> = samples.iter().collect();
+    let stats = compute_fold_local_stats(&refs);
+
+    // Category rates exist
+    assert!(stats.category_fp_rates.contains_key("security"));
+    assert!(stats.category_fp_rates.contains_key("correctness"));
+    // Severity rates exist
+    assert!(stats.severity_fp_rates.contains_key("critical"));
+    assert!(stats.severity_fp_rates.contains_key("warning"));
+    // Model rates exist
+    assert!(stats.model_fp_rates.contains_key("gpt-5.4"));
+    // File rates and counts exist
+    assert!(stats.file_fp_rates.contains_key("src/db.rs"));
+    assert_eq!(stats.file_finding_counts.get("src/db.rs"), Some(&2));
+}
+```
+
+- [ ] **Step 2: Run test to verify it passes (stats already computed)**
+
+Run: `cargo test --bin quorum compute_fold_local_stats_returns_all_rate_maps -- --nocapture`
+Expected: PASS (the stats function already computes these maps — we just need to store them in the model)
+
+- [ ] **Step 3: Add `store_rate_maps` helper to calibrate.rs**
+
+Add a new public function in `src/calibrate.rs`:
+
+```rust
+/// Copy global rate maps from `FoldLocalStats` into a `CalibratorModel` so they
+/// are available at review time. File path keys are normalized via
+/// `normalize_file_path_deep`. Called after final full-corpus stats are computed.
+pub fn store_rate_maps_in_model(
+    model: &mut crate::calibrator_model::CalibratorModel,
+    stats: &FoldLocalStats,
+) {
+    model.category_fp_rate_map = Some(stats.category_fp_rates.clone());
+    model.severity_fp_rate = Some(stats.severity_fp_rates.clone());
+    model.model_fp_rate = Some(stats.model_fp_rates.clone());
+
+    // Normalize file paths before storing
+    let file_fp: std::collections::HashMap<String, f64> = stats
+        .file_fp_rates
+        .iter()
+        .map(|(k, &v)| (crate::file_util::normalize_file_path_deep(k), v))
+        .collect();
+    model.file_fp_rate = Some(file_fp);
+
+    let file_counts: std::collections::HashMap<String, usize> = stats
+        .file_finding_counts
+        .iter()
+        .map(|(k, &v)| (crate::file_util::normalize_file_path_deep(k), v))
+        .collect();
+    model.file_finding_counts = Some(file_counts);
+}
+```
+
+- [ ] **Step 4: Wire store_rate_maps_in_model into run_calibrate in main.rs**
+
+In `src/main.rs`, after the `all_stats` computation (around line 2408, after `let all_stats = compute_fold_local_stats(&all_refs);`), add the call to store maps into the composite model before it's serialized. Find where `composite_model` is mutated and add:
+
+```rust
+if let Some(ref mut model) = composite_model {
+    quorum::calibrate::store_rate_maps_in_model(model, &all_stats);
+}
+```
+
+This must be placed AFTER `all_stats` is computed and BEFORE the model is written to `calibrator_model.toml`.
+
+- [ ] **Step 5: Run tests and build to verify**
+
+Run: `cargo test --bin quorum compute_fold_local_stats_returns -- --nocapture && cargo build`
+Expected: PASS + clean build
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/calibrate.rs src/main.rs
+git commit -m "feat(calibrate): store global rate maps in CalibratorModel"
+```
+
+---
+
+### Task 4: Fix review-time feature computation
+
+**Files:**
+- Modify: `src/calibrator.rs:338-450` — `calibrate_core_decision` feature extraction
+
+- [ ] **Step 1: Write failing tests for corrected feature values**
+
+Add to `src/calibrator.rs` test section:
+
+```rust
+#[test]
+fn review_features_full_suppress_weight_is_composite() {
+    // full_suppress_weight should be (fp + soft_fp + wontfix).ln_1p()
+    // not just fp.ln_1p()
+    let fp = 1.0_f64;
+    let soft_fp = 0.5_f64;
+    let wontfix = 0.3_f64;
+    let expected = (fp + soft_fp + wontfix).ln_1p();
+    let wrong = fp.ln_1p();
+    assert!(
+        (expected - wrong).abs() > 0.01,
+        "composite and fp-only must differ for this test to be meaningful"
+    );
+    // The actual feature computation is inside calibrate_core_decision,
+    // which is private. We test via the trace output.
+}
+
+#[test]
+fn review_features_finding_span_lines_uses_ln1p() {
+    // A 50-line finding should produce ln_1p(50) ≈ 3.93, not 50.0
+    let span = 50_u32;
+    let expected = (span as f64).ln_1p();
+    assert!((expected - 3.932).abs() < 0.01);
+    assert!((expected - 50.0).abs() > 1.0, "must differ from raw");
+}
+```
+
+- [ ] **Step 2: Run tests to verify they pass (these are value sanity checks)**
+
+Run: `cargo test --bin quorum review_features_full_suppress review_features_finding_span -- --nocapture`
+Expected: PASS (these verify the math, not the wiring yet)
+
+- [ ] **Step 3: Fix all 7 features in calibrate_core_decision**
+
+In `src/calibrator.rs`, in the `calibrate_core_decision` function (lines ~350-450):
+
+**3a. Compute full_suppress_weight at the top of the function** (after weights are available, around line ~355):
+```rust
+    let full_suppress_weight = fp_weight + soft_fp_weight + wontfix_weight;
+```
+
+**3b. Fix tokenization** (replace lines ~362-367):
+```rust
+    // Before:
+    let lower = finding.title.to_lowercase();
+    let word_lors: Vec<f64> = lower
+        .split(|c: char| !c.is_alphanumeric() && c != '_')
+        .filter(|w| w.len() >= 2)
+        .filter_map(|w| model.word_lor.get(w).copied())
+        .collect();
+
+    // After:
+    let words = crate::calibrate::tokenize_title(&finding.title);
+    let word_lors: Vec<f64> = words
+        .iter()
+        .filter_map(|w| model.word_lor.get(w.as_str()).copied())
+        .collect();
+```
+
+**3c. Fix feature values** (in the `ReviewFeatures` struct literal, lines ~404-447):
+
+```rust
+    let normalized_file_path = crate::file_util::normalize_file_path_deep(file_path);
+    let global_fp_rate = config
+        .model
+        .as_ref()
+        .map(|m| m.meta.global_fp_rate)
+        .unwrap_or(0.0);
+
+    let review_features = ReviewFeatures {
+        log1p_tp_weight: tp_weight.ln_1p(),
+        log1p_fp_weight: fp_weight.ln_1p(),
+        precedent_count: (matched_precedents.len() as f64).min(10.0),
+        max_similarity: matched_precedents
+            .iter()
+            .map(|p| p.similarity)
+            .fold(0.0_f64, f64::max),
+        mean_similarity: if matched_precedents.is_empty() {
+            0.0
+        } else {
+            matched_precedents.iter().map(|p| p.similarity).sum::<f64>()
+                / matched_precedents.len() as f64
+        },
+        has_no_precedents: if matched_precedents.is_empty() {
+            1.0
+        } else {
+            0.0
+        },
+        log1p_soft_fp_weight: soft_fp_weight.ln_1p(),
+        log1p_full_suppress_weight: full_suppress_weight.ln_1p(),
+        log1p_wontfix_weight: wontfix_weight.ln_1p(),
+        category_fp_rate: config
+            .model
+            .as_ref()
+            .and_then(|m| m.category_fp_rate_map.as_ref())
+            .and_then(|map| map.get(&finding.category.to_string()).copied())
+            .unwrap_or(global_fp_rate),
+        severity_fp_rate: config
+            .model
+            .as_ref()
+            .and_then(|m| m.severity_fp_rate.as_ref())
+            .and_then(|map| map.get(&finding.severity.to_string()).copied())
+            .unwrap_or(global_fp_rate),
+        model_fp_rate: config
+            .model
+            .as_ref()
+            .and_then(|m| m.model_fp_rate.as_ref())
+            .and_then(|map| {
+                let model_name = finding.model.as_deref().unwrap_or("unknown");
+                map.get(model_name).copied()
+            })
+            .unwrap_or(global_fp_rate),
+        max_word_lor,
+        min_word_lor,
+        count_negative_lor_tokens,
+        is_test_file,
+        source_is_ast: if source_is_ast { 1.0 } else { 0.0 },
+        finding_count_same_file: config
+            .model
+            .as_ref()
+            .and_then(|m| m.file_finding_counts.as_ref())
+            .and_then(|counts| counts.get(&normalized_file_path))
+            .map(|&c| (c as f64).ln_1p())
+            .unwrap_or(0.0),
+        file_fp_rate: config
+            .model
+            .as_ref()
+            .and_then(|m| m.file_fp_rate.as_ref())
+            .and_then(|map| map.get(&normalized_file_path).copied())
+            .unwrap_or(global_fp_rate),
+        finding_span_lines: ((finding.line_end.saturating_sub(finding.line_start) + 1)
+            as f64)
+            .ln_1p(),
+        is_mock_or_fixture: if crate::calibrate::is_mock_or_fixture_path(file_path) {
+            1.0
+        } else {
+            0.0
+        },
+        is_generated_or_vendor: if crate::calibrate::is_generated_or_vendor_path(file_path)
+        {
+            1.0
+        } else {
+            0.0
+        },
+    };
+```
+
+Note: `finding.model` — check if `Finding` has a `model` field. If not, use `"unknown"` unconditionally for the model_fp_rate lookup.
+
+- [ ] **Step 4: Run tests to verify it compiles and existing tests pass**
+
+Run: `cargo test --bin quorum -- --nocapture 2>&1 | tail -5`
+Expected: All existing tests pass
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/calibrator.rs
+git commit -m "fix(calibrator): align 7 review-time features with training"
+```
+
+---
+
+### Task 5: Fix trace emission for full_suppress_weight
+
+**Files:**
+- Modify: `src/calibrator.rs` — all `make_trace_entry` call sites
+
+- [ ] **Step 1: Write failing test for trace full_suppress_weight**
+
+Add to `src/calibrator.rs` test section:
+
+```rust
+#[test]
+fn trace_full_suppress_weight_includes_soft_fp_and_wontfix() {
+    use crate::finding::{Finding, Severity};
+    use crate::calibrator_trace::CalibratorTraceEntry;
+
+    let mut finding = Finding {
+        title: "test finding".to_string(),
+        category: "test".to_string(),
+        severity: Severity::Warning,
+        ..Finding::default()
+    };
+
+    let trace = make_trace_entry(
+        &finding,
+        1.0,   // tp_weight
+        2.0,   // fp_weight
+        0.5,   // wontfix_weight
+        3.5,   // full_suppress_weight = fp(2.0) + soft_fp(1.0) + wontfix(0.5)
+        1.0,   // soft_fp_weight
+        vec![],
+        None,
+        Severity::Warning,
+        None,
+        "src/test.rs",
+    );
+
+    // full_suppress_weight in trace should be the composite, not just fp_weight
+    assert!(
+        (trace.full_suppress_weight - 3.5).abs() < f64::EPSILON,
+        "trace.full_suppress_weight should be composite (3.5), got {}",
+        trace.full_suppress_weight
+    );
+}
+```
+
+- [ ] **Step 2: Run test — should pass since make_trace_entry is a pass-through**
+
+Run: `cargo test --bin quorum trace_full_suppress_weight_includes -- --nocapture`
+Expected: PASS (make_trace_entry just stores what it receives; the bug is in the CALLER)
+
+- [ ] **Step 3: Fix all make_trace_entry call sites**
+
+In `src/calibrator.rs`, find every call to `make_trace_entry` and ensure the `full_suppress_weight` argument is the composite sum. The `full_suppress_weight` local variable was already computed in Task 4 Step 3a.
+
+**Logistic suppress path** (line ~463): Change `fp_weight` → `full_suppress_weight`
+```rust
+    // Before:
+    fp_weight, // full_suppress_weight = fp_weight
+    // After:
+    full_suppress_weight,
+```
+
+**Logistic boost path** (line ~498): Change `fp_weight` → `full_suppress_weight`
+
+**Logistic fall-through path** (line ~522): Remove `let full_suppress_weight = fp_weight;` — this shadows the correct composite. The function-scoped `full_suppress_weight` from Task 4 Step 3a is already correct.
+
+**Non-logistic suppress path** (line ~596): Already uses `full_suppress_weight` variable — but in the non-logistic path this was set to `fp_weight` at line ~583. Remove `let full_suppress_weight = fp_weight;` at line 583 — the function-scoped variable is correct.
+
+**All remaining call sites**: Verify they use the function-scoped `full_suppress_weight` (the composite).
+
+- [ ] **Step 4: Run tests**
+
+Run: `cargo test --bin quorum -- --nocapture 2>&1 | tail -5`
+Expected: All tests pass
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/calibrator.rs
+git commit -m "fix(calibrator): emit composite full_suppress_weight in traces"
+```
+
+---
+
+### Task 6: Delete threshold_config.rs and remove compute_thresholds
+
+**Files:**
+- Delete: `src/threshold_config.rs`
+- Modify: `src/lib.rs:92` — remove `pub mod threshold_config`
+- Modify: `src/calibrate.rs:12,728-786` — remove import and `compute_thresholds` function
+
+- [ ] **Step 1: Delete threshold_config.rs**
+
+```bash
+rm src/threshold_config.rs
+```
+
+- [ ] **Step 2: Remove pub mod from lib.rs**
+
+In `src/lib.rs`, remove the line:
+```rust
+pub mod threshold_config;
+```
+
+- [ ] **Step 3: Remove import and compute_thresholds from calibrate.rs**
+
+In `src/calibrate.rs`:
+- Remove `use crate::threshold_config::{PathThreshold, ThresholdConfig};` (line 12)
+- Remove the entire `compute_thresholds` function (lines 728-786)
+
+- [ ] **Step 4: Attempt to build — collect all dependent compilation errors**
+
+Run: `cargo build 2>&1 | head -60`
+Expected: Compilation errors in `src/main.rs` and `src/calibrator.rs` referencing removed types
+
+- [ ] **Step 5: Commit (partial — compilation will fail until Task 7)**
+
+```bash
+git add -A
+git commit -m "refactor(calibrator): remove threshold_config module and compute_thresholds"
+```
+
+---
+
+### Task 7: Remove legacy threshold fields from CalibratorConfig and main.rs
+
+**Files:**
+- Modify: `src/calibrator.rs:24-66` — remove 3 fields from `CalibratorConfig`, remove `sanitize_threshold`, simplify non-logistic path
+- Modify: `src/cli/mod.rs:251-257` — remove `--suppress-precision` and `--boost-precision` args
+- Modify: `src/main.rs` — remove threshold loading, threshold report, force_threshold env var handling
+
+- [ ] **Step 1: Remove threshold fields from CalibratorConfig**
+
+In `src/calibrator.rs`, remove these fields from `CalibratorConfig` (lines ~44-53):
+```rust
+    // REMOVE these three:
+    pub suppress_threshold: Option<f64>,
+    pub boost_threshold: Option<f64>,
+    pub force_threshold: Option<f64>,
+```
+
+Also remove them from the `Default` impl (lines ~68-90).
+
+Remove the `sanitize_threshold` function (lines 319-335).
+
+- [ ] **Step 2: Simplify the non-logistic decision path**
+
+In `calibrate_core_decision`, replace the data-driven + magic-number interleaved path (lines ~564-711) with the magic-number-only path:
+
+```rust
+    // --- Non-logistic fallback: heuristic magic numbers ---
+
+    let has_composite = config.model.is_some();
+    let total = tp_weight + fp_weight;
+    let precedent_score = if total > 0.0 { tp_weight / total } else { 0.5 };
+    let lang = CalibratorModel::file_ext_language(file_path);
+    let composite = config
+        .model
+        .as_ref()
+        .map(|m| m.composite_score(precedent_score, &finding.title, lang));
+
+    // Full suppress: magic number heuristic
+    if full_suppress_weight >= 1.5 && fp_weight > 0.0 && full_suppress_weight > tp_weight * 2.0 {
+        finding.calibrator_action = Some(CalibratorAction::Disputed);
+        suppressed = true;
+        let mut trace = make_trace_entry(
+            finding, tp_weight, fp_weight, wontfix_weight,
+            full_suppress_weight, soft_fp_weight, matched_precedents,
+            finding.calibrator_action.clone(), input_severity,
+            Some(crate::calibrator_trace::SeverityChangeReason::Disputed),
+            file_path,
+        );
+        trace.composite_score = composite;
+        return CoreDecision { suppressed, boosted, trace };
+    }
+
+    // Soft suppress
+    let soft_suppressed = (soft_fp_weight >= 1.0 && soft_fp_weight > tp_weight * 2.0)
+        || (soft_fp_weight >= 0.5 && tp_weight < 0.1);
+    if soft_suppressed {
+        finding.severity = Severity::Info;
+        finding.calibrator_action = Some(CalibratorAction::Disputed);
+        reason = Some(crate::calibrator_trace::SeverityChangeReason::Disputed);
+    }
+
+    // Boost: magic number heuristic
+    let boost_triggered = if soft_suppressed {
+        false
+    } else {
+        config.boost_tp && tp_weight >= 1.5 && tp_weight > fp_weight * 2.0
+    };
+
+    if boost_triggered {
+        let proposed = boost_severity(&finding.severity);
+        let gate_on = std::env::var("QUORUM_RUBRIC_GATE")
+            .map(|v| v != "off" && v != "0")
+            .unwrap_or(true);
+        if !gate_on || rubric_supports_severity_bump(&proposed, finding) {
+            finding.severity = proposed;
+            boosted = true;
+            reason = Some(crate::calibrator_trace::SeverityChangeReason::Boosted);
+        } else {
+            reason = Some(crate::calibrator_trace::SeverityChangeReason::BoostBlockedByGate);
+        }
+        finding.calibrator_action = Some(CalibratorAction::Confirmed);
+    } else if tp_weight > fp_weight * 1.5 {
+        finding.calibrator_action = Some(CalibratorAction::Confirmed);
+        if reason.is_none() {
+            reason = Some(crate::calibrator_trace::SeverityChangeReason::BoostWeightTooLow);
+        }
+    }
+
+    if reason.is_none() {
+        reason = Some(crate::calibrator_trace::SeverityChangeReason::BoostWeightTooLow);
+    }
+
+    let mut trace = make_trace_entry(
+        finding, tp_weight, fp_weight, wontfix_weight,
+        full_suppress_weight, soft_fp_weight, matched_precedents,
+        finding.calibrator_action.clone(), input_severity, reason, file_path,
+    );
+    trace.composite_score = composite;
+
+    CoreDecision { suppressed, boosted, trace }
+```
+
+- [ ] **Step 3: Remove CLI args from cli/mod.rs**
+
+In `src/cli/mod.rs`, remove the `suppress_precision` and `boost_precision` fields (lines 251-257):
+```rust
+    // REMOVE:
+    #[arg(long, default_value = "0.95")]
+    pub suppress_precision: f64,
+    #[arg(long, default_value = "0.85")]
+    pub boost_precision: f64,
+```
+
+- [ ] **Step 4: Remove threshold loading and report from main.rs**
+
+In `src/main.rs`:
+
+**Remove threshold loading** (lines ~1070-1082): Remove the block that loads `calibrator_thresholds.toml` and maps its values into `calibrator_config.suppress_threshold` and `calibrator_config.boost_threshold`.
+
+**Replace with deprecation warning:**
+```rust
+    let thresholds_path = qhome.join("calibrator_thresholds.toml");
+    if thresholds_path.exists() {
+        tracing::warn!(
+            path = %thresholds_path.display(),
+            "calibrator_thresholds.toml is deprecated and no longer used; \
+             the logistic model's P(FP) thresholds supersede it. \
+             You can safely delete this file."
+        );
+    }
+```
+
+**Remove force_threshold env var** (lines ~1108-1139): Remove the `QUORUM_FORCE_THRESHOLD` parsing block.
+
+**Remove threshold report** (lines ~2583-2618): Remove the `compute_thresholds()` call and the `println!` block that reports suppress/boost thresholds and precision targets.
+
+**Remove precision validation** (lines ~2259-2264): Remove the check on `opts.suppress_precision` and `opts.boost_precision` since these fields no longer exist.
+
+- [ ] **Step 5: Fix all remaining compilation errors**
+
+Run `cargo build` and fix any remaining references to removed fields. Common locations:
+- Test fixtures that set `suppress_threshold`, `boost_threshold`, `force_threshold` on `CalibratorConfig`
+- Any env var references to `QUORUM_FORCE_THRESHOLD` in tests
+
+For each test fixture, simply remove the fields (they'll use the `Default` impl).
+
+- [ ] **Step 6: Run full test suite**
+
+Run: `cargo test --bin quorum -- --nocapture 2>&1 | tail -5`
+Expected: All tests pass
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add -A
+git commit -m "refactor(calibrator): remove legacy threshold system
+
+Remove ThresholdConfig, compute_thresholds, CLI precision args,
+and data-driven threshold branches. Non-logistic path retains
+magic-number heuristics. Logistic model thresholds are the
+primary suppress/boost mechanism.
+
+Closes #375"
+```
+
+---
+
+### Task 8: Add missing-maps diagnostic logging
+
+**Files:**
+- Modify: `src/calibrator.rs` — add once-per-review logging when rate maps are absent
+
+- [ ] **Step 1: Add diagnostic logging at model load time**
+
+In `src/calibrator.rs`, at the top of the `calibrate` function (line ~811), after the early-return for disabled calibrator, add:
+
+```rust
+    if let Some(ref model) = config.model {
+        if model.category_fp_rate_map.is_none()
+            || model.severity_fp_rate.is_none()
+            || model.file_fp_rate.is_none()
+        {
+            tracing::info!(
+                "calibrator model lacks rate maps; run `quorum calibrate` to improve accuracy"
+            );
+        }
+    }
+```
+
+This fires once per `calibrate()` call (once per file), not once per finding. For truly once-per-review, the caller in `pipeline.rs` could log it, but once-per-file is acceptable.
+
+- [ ] **Step 2: Run tests**
+
+Run: `cargo test --bin quorum -- --nocapture 2>&1 | tail -5`
+Expected: All tests pass
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/calibrator.rs
+git commit -m "feat(calibrator): log when rate maps are missing from model"
+```
+
+---
+
+### Post-Implementation Checklist
+
+After all tasks are complete:
+
+- [ ] `cargo test --bin quorum` — all tests pass
+- [ ] `cargo clippy` — no warnings
+- [ ] `cargo build --release` — compiles cleanly
+- [ ] Run `quorum calibrate` locally — verify new maps appear in `~/.quorum/calibrator_model.toml`
+- [ ] Run `quorum review src/calibrator.rs` — verify features are populated (check trace output)
+- [ ] Verify `calibrator_thresholds.toml` deprecation warning appears if file exists

--- a/docs/superpowers/specs/2026-05-17-calibrator-review-time-features-design.md
+++ b/docs/superpowers/specs/2026-05-17-calibrator-review-time-features-design.md
@@ -2,27 +2,38 @@
 
 ## Problem
 
-The logistic calibrator has 22 features in `ExpandedFeatures`. During training, all 22 are populated from the feedback corpus. At review time (`calibrate_core_decision`), 6 features are broken:
+The logistic calibrator has 22 features in `ExpandedFeatures`. During training, all 22 are populated from the feedback corpus. At review time (`calibrate_core_decision`), 7 features are broken:
 
 | Feature | Training value | Review-time value | Problem |
 |---------|---------------|-------------------|---------|
 | `log1p_full_suppress_weight` | `(fp + soft_fp + wontfix).ln_1p()` | `fp_weight.ln_1p()` | Duplicate of `log1p_fp_weight` |
+| `category_fp_rate` | Beta-smoothed FP rate per category | `family_fp_rate` proxy | Wrong proxy |
 | `severity_fp_rate` | Beta-smoothed FP rate per severity | `0.0` | Dead |
 | `model_fp_rate` | Beta-smoothed FP rate per LLM model | `0.0` | Dead |
 | `finding_count_same_file` | `ln_1p(corpus file occurrence count)` | `0.0` | Dead |
 | `file_fp_rate` | Beta-smoothed FP rate per file path | `0.0` | Dead |
 | `finding_span_lines` | `(span_lines as f64).ln_1p()` | `span_lines as f64` (raw) | Wrong scale |
 
-Additionally, the trace emission at review time writes `fp_weight` as `full_suppress_weight`, which corrupts future training data — making the duplicate permanent across retrain cycles.
+Additionally:
+- Trace emission at review time writes `fp_weight` as `full_suppress_weight`, corrupting future training data and making the duplicate permanent across retrain cycles.
+- Word LOR tokenization differs: inference splits on `!is_alphanumeric()`, training uses `[a-z_]+` regex (drops digits). Fix: reuse `tokenize_title()` at inference.
+
+### Historical corpus contamination
+
+Old traces in `calibrator_traces.jsonl` have `full_suppress_weight == fp_weight` even when `soft_fp_weight > 0` or `wontfix_weight > 0`. After fixing trace emission, a `quorum calibrate` retrain will mix old (wrong) and new (correct) data. This is acceptable — the model will progressively improve as new traces dominate. No backfill required.
 
 ## Secondary Goal: Legacy Threshold Cleanup
 
 The old heuristic threshold system (`calibrator_thresholds.toml` with `PathThreshold` suppress/boost using raw composite scores) is fully superseded by the logistic model's P(FP) thresholds. Remove the legacy system:
-- Remove `ThresholdConfig` loading and `calibrator_thresholds.toml` file
-- Remove the "Calibrator Threshold Report" print section from `quorum calibrate`
-- Remove `compute_thresholds()` and `PathThreshold` types
-- Remove `suppress_threshold` / `boost_threshold` fields from `CalibratorConfig` (these were the legacy ones; logistic thresholds live on `LogisticModel`)
-- Simplify `calibrate_core_decision` to only use logistic model thresholds
+- Delete `src/threshold_config.rs` and `pub mod threshold_config` from `lib.rs`
+- Remove `compute_thresholds()` from `calibrate.rs`
+- Remove `suppress_threshold`, `boost_threshold`, `force_threshold` from `CalibratorConfig`
+- Remove `calibrator_thresholds.toml` loading and threshold report output from `main.rs`
+- Remove `--suppress-precision` / `--boost-precision` CLI args from calibrate subcommand
+- Remove the non-logistic threshold decision branches in `calibrate_core_decision` (lines ~564-711)
+- When no `LogisticModel` is loaded, the calibrator falls back to the existing heuristic suppress/boost logic that uses raw `tp_weight / (tp_weight + fp_weight)` ratios with hardcoded cutoffs. This path remains as the "no model" fallback.
+
+**Migration**: When `calibrator_thresholds.toml` exists at startup, emit a one-time `tracing::warn` that it is no longer used and can be deleted. Do not load or apply its contents.
 
 ## Design
 
@@ -30,13 +41,12 @@ The old heuristic threshold system (`calibrator_thresholds.toml` with `PathThres
 
 **Review-time fix** (line 424):
 ```rust
-// Before:
-log1p_full_suppress_weight: fp_weight.ln_1p(),
-// After:
-log1p_full_suppress_weight: (fp_weight + soft_fp_weight + wontfix_weight).ln_1p(),
+let full_suppress_weight = fp_weight + soft_fp_weight + wontfix_weight;
+// ...
+log1p_full_suppress_weight: full_suppress_weight.ln_1p(),
 ```
 
-**Trace emission fix** — all `make_trace_entry` calls pass `fp_weight` as the `full_suppress_weight` argument. Change to pass `fp_weight + soft_fp_weight + wontfix_weight`.
+**Trace emission fix** — all `make_trace_entry` calls currently pass `fp_weight` as the `full_suppress_weight` argument. Change to pass `full_suppress_weight` (the sum computed above).
 
 ### Part B: Fix `finding_span_lines` (calibrator.rs)
 
@@ -47,10 +57,16 @@ finding_span_lines: (finding.line_end.saturating_sub(finding.line_start) + 1) as
 finding_span_lines: ((finding.line_end.saturating_sub(finding.line_start) + 1) as f64).ln_1p(),
 ```
 
-### Part C: Add rate maps to `CalibratorModel` (calibrator_model.rs + calibrate.rs)
+### Part C: Fix word LOR tokenization (calibrator.rs)
 
-Add four new optional fields to `CalibratorModel`:
+Replace the inline `split(|c| ...)` tokenizer in `calibrate_core_decision` with a call to `crate::calibrate::tokenize_title()`, which uses `WORD_RE = r"[a-z_]+"`. This ensures training and inference produce identical token sets for word LOR lookups.
+
+### Part D: Add rate maps to `CalibratorModel` (calibrator_model.rs + calibrate.rs)
+
+Add five new optional fields to `CalibratorModel`:
 ```rust
+#[serde(default, skip_serializing_if = "Option::is_none")]
+pub category_fp_rate_map: Option<HashMap<String, f64>>,
 #[serde(default, skip_serializing_if = "Option::is_none")]
 pub severity_fp_rate: Option<HashMap<String, f64>>,
 #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -61,53 +77,63 @@ pub file_fp_rate: Option<HashMap<String, f64>>,
 pub file_finding_counts: Option<HashMap<String, usize>>,
 ```
 
-**Computation** (in `run_calibrate` / training pipeline): After computing `FoldLocalStats` from the full corpus, store the global stats maps in the model before serialization.
+Note: `category_fp_rate_map` is named differently from the existing `family_fp_rate` field to avoid confusion. The existing `family_fp_rate` remains for backward compat with the non-logistic scoring path.
 
-**Review-time lookup** (in `calibrate_core_decision`): Look up finding's severity/model/file_path in the model's maps, falling back to `0.0` when the map is `None` (backward compat with old model.toml files). A `tracing::info!` fires once per review when maps are missing, prompting recalibration.
+**Computation** (in `run_calibrate`): After computing `FoldLocalStats` from the full corpus (the same `all_stats` used for the final production model refit), store the global stats maps in the model before serialization. File path keys are normalized via `normalize_file_path_deep()` before insertion.
 
-### Part D: Fix `finding_count_same_file` (calibrator.rs)
+**Review-time lookup** (in `calibrate_core_decision`): Look up the finding's category/severity/model/file_path in the model's maps. Fallback semantics match training:
+- When map exists but key is missing: fall back to `model.meta.global_fp_rate`
+- When map is `None` (old model.toml): fall back to `0.0` (preserves current behavior)
+- A `tracing::info_once!` fires when maps are missing, prompting recalibration
 
-Use corpus-level file finding counts from `CalibratorModel.file_finding_counts`, not the current review's count. This matches training semantics.
+### Part E: Fix `finding_count_same_file` (calibrator.rs)
+
+Use corpus-level file finding counts from `CalibratorModel.file_finding_counts`, not the current review's count. This matches training semantics (corpus-level counts, not per-review counts).
 
 ```rust
 finding_count_same_file: config.model.as_ref()
     .and_then(|m| m.file_finding_counts.as_ref())
-    .and_then(|counts| counts.get(file_path))
+    .and_then(|counts| counts.get(&normalized_file_path))
     .map(|&c| (c as f64).ln_1p())
     .unwrap_or(0.0),
 ```
 
-### Part E: Legacy Threshold Removal
+File path is normalized with `normalize_file_path_deep()` before lookup to match the serialized keys.
+
+### Part F: Legacy Threshold Removal
 
 Files affected:
 - `src/threshold_config.rs` — delete entirely
-- `src/calibrate.rs` — remove `compute_thresholds()` function
-- `src/calibrator.rs` — remove `suppress_threshold: Option<f64>`, `boost_threshold: Option<f64>`, `force_threshold: Option<f64>` from `CalibratorConfig`; simplify `calibrate_core_decision` to use only `LogisticModel` thresholds
-- `src/main.rs` — remove `calibrator_thresholds.toml` loading, remove threshold report output, remove `--suppress-precision` / `--boost-precision` CLI args from calibrate subcommand
+- `src/calibrate.rs` — remove `compute_thresholds()` function and `use crate::threshold_config::*`
+- `src/calibrator.rs` — remove `suppress_threshold: Option<f64>`, `boost_threshold: Option<f64>`, `force_threshold: Option<f64>` from `CalibratorConfig`; remove the `sanitize_threshold` calls that reference these fields; remove the non-logistic threshold decision branches; keep the heuristic no-model fallback path
+- `src/main.rs` — remove `calibrator_thresholds.toml` loading, remove threshold report output, remove `--suppress-precision` / `--boost-precision` CLI args; add deprecation warning when old file exists
 - `src/lib.rs` — remove `pub mod threshold_config`
 
-**Migration**: When `calibrator_thresholds.toml` exists, emit a one-time warning that it is no longer used and can be deleted.
+The no-model fallback (when `config.model.logistic_model` is `None`) continues to use the existing hardcoded heuristic logic for suppress/boost. This is not "legacy thresholds" — it's the baseline calibrator behavior that exists independently of the threshold config system.
 
 ### Backward Compatibility
 
-- Old `calibrator_model.toml` files (without rate maps) continue to work — features fall back to `0.0` (same as current behavior). A `tracing::info!` recommends recalibration.
-- Old `calibrator_thresholds.toml` is ignored with a warning.
-- After upgrading, users run `quorum calibrate` to get the new maps and retrain the logistic model with corrected features.
+- Old `calibrator_model.toml` without rate maps: maps deserialize as `None`, features fall back to `0.0` (same as current broken behavior). `tracing::info_once!` recommends recalibration.
+- Old `calibrator_thresholds.toml`: ignored with a warning. No behavioral change for users who have a logistic model (which superseded these thresholds).
+- Users without a logistic model: heuristic calibrator continues to work as before.
+- After upgrading, `quorum calibrate` produces the new maps and retrains the model with corrected features.
 
 ### Files Modified
 
 | File | Changes |
 |------|---------|
-| `src/calibrator.rs` | Fix review-time features, fix trace emission, remove legacy threshold fields, simplify decision logic |
-| `src/calibrator_model.rs` | Add 4 optional map fields |
-| `src/calibrate.rs` | Compute global rate maps for model, remove `compute_thresholds()` |
+| `src/calibrator.rs` | Fix 7 review-time features, fix trace emission, fix tokenization, remove legacy threshold fields, simplify decision logic |
+| `src/calibrator_model.rs` | Add 5 optional map fields |
+| `src/calibrate.rs` | Compute global rate maps for model, remove `compute_thresholds()`, make `tokenize_title` pub |
 | `src/main.rs` | Remove threshold report, remove threshold CLI args, remove thresholds.toml loading, add deprecation warning |
 | `src/threshold_config.rs` | Delete |
 | `src/lib.rs` | Remove `pub mod threshold_config` |
 
 ### Testing
 
-- Unit tests for each fixed feature value (verify training-time and review-time produce equivalent values for known inputs)
+- Unit tests for each fixed feature: verify training-time and review-time produce equivalent values for known inputs (same composite weight, same ln_1p scale, same tokenization, same rate lookups)
+- Serde round-trip tests: old TOML without maps loads with `None`; new TOML serializes and deserializes maps correctly
 - Integration test: run calibrate with test corpus, verify new maps appear in serialized model
-- Regression test: old model.toml without maps still loads and produces valid (zero-fallback) scores
+- Regression test: old model.toml without maps still loads and produces valid scores
 - Test that legacy threshold file triggers deprecation warning
+- Test that `tokenize_title` and inference-time tokenization produce identical tokens

--- a/docs/superpowers/specs/2026-05-17-calibrator-review-time-features-design.md
+++ b/docs/superpowers/specs/2026-05-17-calibrator-review-time-features-design.md
@@ -1,0 +1,113 @@
+# Calibrator Review-Time Feature Fix
+
+## Problem
+
+The logistic calibrator has 22 features in `ExpandedFeatures`. During training, all 22 are populated from the feedback corpus. At review time (`calibrate_core_decision`), 6 features are broken:
+
+| Feature | Training value | Review-time value | Problem |
+|---------|---------------|-------------------|---------|
+| `log1p_full_suppress_weight` | `(fp + soft_fp + wontfix).ln_1p()` | `fp_weight.ln_1p()` | Duplicate of `log1p_fp_weight` |
+| `severity_fp_rate` | Beta-smoothed FP rate per severity | `0.0` | Dead |
+| `model_fp_rate` | Beta-smoothed FP rate per LLM model | `0.0` | Dead |
+| `finding_count_same_file` | `ln_1p(corpus file occurrence count)` | `0.0` | Dead |
+| `file_fp_rate` | Beta-smoothed FP rate per file path | `0.0` | Dead |
+| `finding_span_lines` | `(span_lines as f64).ln_1p()` | `span_lines as f64` (raw) | Wrong scale |
+
+Additionally, the trace emission at review time writes `fp_weight` as `full_suppress_weight`, which corrupts future training data — making the duplicate permanent across retrain cycles.
+
+## Secondary Goal: Legacy Threshold Cleanup
+
+The old heuristic threshold system (`calibrator_thresholds.toml` with `PathThreshold` suppress/boost using raw composite scores) is fully superseded by the logistic model's P(FP) thresholds. Remove the legacy system:
+- Remove `ThresholdConfig` loading and `calibrator_thresholds.toml` file
+- Remove the "Calibrator Threshold Report" print section from `quorum calibrate`
+- Remove `compute_thresholds()` and `PathThreshold` types
+- Remove `suppress_threshold` / `boost_threshold` fields from `CalibratorConfig` (these were the legacy ones; logistic thresholds live on `LogisticModel`)
+- Simplify `calibrate_core_decision` to only use logistic model thresholds
+
+## Design
+
+### Part A: Fix `log1p_full_suppress_weight` (calibrator.rs)
+
+**Review-time fix** (line 424):
+```rust
+// Before:
+log1p_full_suppress_weight: fp_weight.ln_1p(),
+// After:
+log1p_full_suppress_weight: (fp_weight + soft_fp_weight + wontfix_weight).ln_1p(),
+```
+
+**Trace emission fix** — all `make_trace_entry` calls pass `fp_weight` as the `full_suppress_weight` argument. Change to pass `fp_weight + soft_fp_weight + wontfix_weight`.
+
+### Part B: Fix `finding_span_lines` (calibrator.rs)
+
+```rust
+// Before:
+finding_span_lines: (finding.line_end.saturating_sub(finding.line_start) + 1) as f64,
+// After:
+finding_span_lines: ((finding.line_end.saturating_sub(finding.line_start) + 1) as f64).ln_1p(),
+```
+
+### Part C: Add rate maps to `CalibratorModel` (calibrator_model.rs + calibrate.rs)
+
+Add four new optional fields to `CalibratorModel`:
+```rust
+#[serde(default, skip_serializing_if = "Option::is_none")]
+pub severity_fp_rate: Option<HashMap<String, f64>>,
+#[serde(default, skip_serializing_if = "Option::is_none")]
+pub model_fp_rate: Option<HashMap<String, f64>>,
+#[serde(default, skip_serializing_if = "Option::is_none")]
+pub file_fp_rate: Option<HashMap<String, f64>>,
+#[serde(default, skip_serializing_if = "Option::is_none")]
+pub file_finding_counts: Option<HashMap<String, usize>>,
+```
+
+**Computation** (in `run_calibrate` / training pipeline): After computing `FoldLocalStats` from the full corpus, store the global stats maps in the model before serialization.
+
+**Review-time lookup** (in `calibrate_core_decision`): Look up finding's severity/model/file_path in the model's maps, falling back to `0.0` when the map is `None` (backward compat with old model.toml files). A `tracing::info!` fires once per review when maps are missing, prompting recalibration.
+
+### Part D: Fix `finding_count_same_file` (calibrator.rs)
+
+Use corpus-level file finding counts from `CalibratorModel.file_finding_counts`, not the current review's count. This matches training semantics.
+
+```rust
+finding_count_same_file: config.model.as_ref()
+    .and_then(|m| m.file_finding_counts.as_ref())
+    .and_then(|counts| counts.get(file_path))
+    .map(|&c| (c as f64).ln_1p())
+    .unwrap_or(0.0),
+```
+
+### Part E: Legacy Threshold Removal
+
+Files affected:
+- `src/threshold_config.rs` — delete entirely
+- `src/calibrate.rs` — remove `compute_thresholds()` function
+- `src/calibrator.rs` — remove `suppress_threshold: Option<f64>`, `boost_threshold: Option<f64>`, `force_threshold: Option<f64>` from `CalibratorConfig`; simplify `calibrate_core_decision` to use only `LogisticModel` thresholds
+- `src/main.rs` — remove `calibrator_thresholds.toml` loading, remove threshold report output, remove `--suppress-precision` / `--boost-precision` CLI args from calibrate subcommand
+- `src/lib.rs` — remove `pub mod threshold_config`
+
+**Migration**: When `calibrator_thresholds.toml` exists, emit a one-time warning that it is no longer used and can be deleted.
+
+### Backward Compatibility
+
+- Old `calibrator_model.toml` files (without rate maps) continue to work — features fall back to `0.0` (same as current behavior). A `tracing::info!` recommends recalibration.
+- Old `calibrator_thresholds.toml` is ignored with a warning.
+- After upgrading, users run `quorum calibrate` to get the new maps and retrain the logistic model with corrected features.
+
+### Files Modified
+
+| File | Changes |
+|------|---------|
+| `src/calibrator.rs` | Fix review-time features, fix trace emission, remove legacy threshold fields, simplify decision logic |
+| `src/calibrator_model.rs` | Add 4 optional map fields |
+| `src/calibrate.rs` | Compute global rate maps for model, remove `compute_thresholds()` |
+| `src/main.rs` | Remove threshold report, remove threshold CLI args, remove thresholds.toml loading, add deprecation warning |
+| `src/threshold_config.rs` | Delete |
+| `src/lib.rs` | Remove `pub mod threshold_config` |
+
+### Testing
+
+- Unit tests for each fixed feature value (verify training-time and review-time produce equivalent values for known inputs)
+- Integration test: run calibrate with test corpus, verify new maps appear in serialized model
+- Regression test: old model.toml without maps still loads and produces valid (zero-fallback) scores
+- Test that legacy threshold file triggers deprecation warning

--- a/src/calibrate.rs
+++ b/src/calibrate.rs
@@ -1520,7 +1520,7 @@ struct TraceInfo {
     fp_weight: f64,
 }
 
-fn tokenize_title(title: &str) -> Vec<String> {
+pub fn tokenize_title(title: &str) -> Vec<String> {
     let lower = title.to_lowercase();
     crate::calibrator_model::WORD_RE
         .find_iter(&lower)
@@ -4753,5 +4753,38 @@ mod tests {
             .map(|(_, fold)| *fold)
             .collect();
         assert!(b_folds.iter().all(|f| *f == b_folds[0]));
+    }
+
+    #[test]
+    fn tokenize_title_drops_digits_and_lowercases() {
+        let tokens = tokenize_title("Buffer overflow in parse123 at L42");
+        assert!(tokens.contains(&"buffer".to_string()));
+        assert!(tokens.contains(&"overflow".to_string()));
+        assert!(tokens.contains(&"parse".to_string()));
+        assert!(tokens.contains(&"at".to_string()));
+        assert!(!tokens.iter().any(|t| t == "123" || t == "42" || t == "parse123"));
+        assert!(!tokens.iter().any(|t| t.len() < 2));
+    }
+
+    #[test]
+    fn tokenize_title_keeps_underscores() {
+        let tokens = tokenize_title("buffer_overflow detected in my_func");
+        assert!(tokens.contains(&"buffer_overflow".to_string()));
+        assert!(tokens.contains(&"detected".to_string()));
+        assert!(tokens.contains(&"my_func".to_string()));
+    }
+
+    #[test]
+    fn tokenize_title_matches_word_re_regex() {
+        use crate::calibrator_model::WORD_RE;
+        let title = "SQL injection in `process_data` at line 42";
+        let tokens = tokenize_title(title);
+        let lower = title.to_lowercase();
+        let regex_tokens: Vec<String> = WORD_RE
+            .find_iter(&lower)
+            .map(|m| m.as_str().to_string())
+            .filter(|w| w.len() >= 2)
+            .collect();
+        assert_eq!(tokens, regex_tokens);
     }
 }

--- a/src/calibrate.rs
+++ b/src/calibrate.rs
@@ -4792,7 +4792,11 @@ mod tests {
         assert!(tokens.contains(&"overflow".to_string()));
         assert!(tokens.contains(&"parse".to_string()));
         assert!(tokens.contains(&"at".to_string()));
-        assert!(!tokens.iter().any(|t| t == "123" || t == "42" || t == "parse123"));
+        assert!(
+            !tokens
+                .iter()
+                .any(|t| t == "123" || t == "42" || t == "parse123")
+        );
         assert!(!tokens.iter().any(|t| t.len() < 2));
     }
 

--- a/src/calibrate.rs
+++ b/src/calibrate.rs
@@ -2004,7 +2004,11 @@ pub fn extract_joined_samples(
             .unwrap_or("unknown")
             .to_string();
         let severity = t["input_severity"].as_str().unwrap_or("medium").to_string();
-        let model_name = t["model"].as_str().unwrap_or("unknown").to_string();
+        let model_name = t["provenance"]["review_model"]
+            .as_str()
+            .or_else(|| t["model"].as_str())
+            .unwrap_or("unknown")
+            .to_string();
         let span_lines = t["finding_span_lines"].as_u64().unwrap_or(1) as u32;
 
         let norm = normalize_title(&title);

--- a/src/calibrate.rs
+++ b/src/calibrate.rs
@@ -4824,7 +4824,7 @@ mod tests {
 
     #[test]
     fn store_rate_maps_populates_model() {
-        let samples = vec![
+        let samples = [
             JoinedSample {
                 title: "SQL injection".to_string(),
                 category: "security".to_string(),

--- a/src/calibrate.rs
+++ b/src/calibrate.rs
@@ -1051,6 +1051,11 @@ pub fn compute_calibrator_model(feedback: &[serde_json::Value]) -> Option<Calibr
         word_lor: word_lor_map,
         family_fp_rate: family_fp_rate_map,
         language_fp_rate: lang_fp_rate_map,
+        category_fp_rate_map: None,
+        severity_fp_rate: None,
+        model_fp_rate: None,
+        file_fp_rate: None,
+        file_finding_counts: None,
     })
 }
 
@@ -4413,6 +4418,11 @@ mod tests {
             word_lor: HashMap::new(),
             family_fp_rate: HashMap::new(),
             language_fp_rate: HashMap::new(),
+            category_fp_rate_map: None,
+            severity_fp_rate: None,
+            model_fp_rate: None,
+            file_fp_rate: None,
+            file_finding_counts: None,
         }
     }
 

--- a/src/calibrate.rs
+++ b/src/calibrate.rs
@@ -1712,6 +1712,32 @@ pub fn compute_fold_local_stats(samples: &[&JoinedSample]) -> FoldLocalStats {
     }
 }
 
+/// Populate the rate-map fields on a [`CalibratorModel`] from full-corpus
+/// [`FoldLocalStats`].  File paths are deep-normalized so the keys match
+/// review-time lookups regardless of leading `./` or `../` prefixes.
+pub fn store_rate_maps_in_model(
+    model: &mut crate::calibrator_model::CalibratorModel,
+    stats: &FoldLocalStats,
+) {
+    model.category_fp_rate_map = Some(stats.category_fp_rates.clone());
+    model.severity_fp_rate = Some(stats.severity_fp_rates.clone());
+    model.model_fp_rate = Some(stats.model_fp_rates.clone());
+
+    let file_fp: std::collections::HashMap<String, f64> = stats
+        .file_fp_rates
+        .iter()
+        .map(|(k, &v)| (crate::file_util::normalize_file_path_deep(k), v))
+        .collect();
+    model.file_fp_rate = Some(file_fp);
+
+    let file_counts: std::collections::HashMap<String, usize> = stats
+        .file_finding_counts
+        .iter()
+        .map(|(k, &v)| (crate::file_util::normalize_file_path_deep(k), v))
+        .collect();
+    model.file_finding_counts = Some(file_counts);
+}
+
 /// Extract expanded features for a single sample using fold-local stats.
 ///
 /// Returns the feature vector and the label (`true` = FP for logistic regression).
@@ -4786,5 +4812,81 @@ mod tests {
             .filter(|w| w.len() >= 2)
             .collect();
         assert_eq!(tokens, regex_tokens);
+    }
+
+    #[test]
+    fn store_rate_maps_populates_model() {
+        let samples = vec![
+            JoinedSample {
+                title: "SQL injection".to_string(),
+                category: "security".to_string(),
+                severity: "critical".to_string(),
+                model: "gpt-5.4".to_string(),
+                tp_weight: 0.0,
+                fp_weight: 1.0,
+                soft_fp_weight: 0.0,
+                full_suppress_weight: 1.0,
+                wontfix_weight: 0.0,
+                precedent_count: 1,
+                max_similarity: 0.9,
+                mean_similarity: 0.9,
+                is_fp: true,
+                family: "sql".to_string(),
+                file_path: "./src/db.rs".to_string(),
+                source_is_ast: false,
+                finding_span_lines: 5,
+            },
+            JoinedSample {
+                title: "Buffer overflow".to_string(),
+                category: "correctness".to_string(),
+                severity: "warning".to_string(),
+                model: "gpt-5.4".to_string(),
+                tp_weight: 1.0,
+                fp_weight: 0.0,
+                soft_fp_weight: 0.0,
+                full_suppress_weight: 0.0,
+                wontfix_weight: 0.0,
+                precedent_count: 1,
+                max_similarity: 0.8,
+                mean_similarity: 0.8,
+                is_fp: false,
+                family: "memory".to_string(),
+                file_path: "./src/db.rs".to_string(),
+                source_is_ast: true,
+                finding_span_lines: 10,
+            },
+        ];
+        let refs: Vec<&JoinedSample> = samples.iter().collect();
+        let stats = compute_fold_local_stats(&refs);
+
+        let mut model = make_test_model();
+        store_rate_maps_in_model(&mut model, &stats);
+
+        // Maps populated
+        assert!(model.category_fp_rate_map.is_some());
+        assert!(model.severity_fp_rate.is_some());
+        assert!(model.model_fp_rate.is_some());
+        assert!(model.file_fp_rate.is_some());
+        assert!(model.file_finding_counts.is_some());
+
+        // Category rates are correct (beta-smoothed)
+        let cat = model.category_fp_rate_map.unwrap();
+        assert!(cat.contains_key("security"));
+        assert!(cat.contains_key("correctness"));
+
+        // File path normalized: ./src/db.rs -> src/db.rs
+        let file_fp = model.file_fp_rate.unwrap();
+        assert!(
+            file_fp.contains_key("src/db.rs"),
+            "file path should be normalized"
+        );
+        assert!(
+            !file_fp.contains_key("./src/db.rs"),
+            "raw path should not be key"
+        );
+
+        // File finding counts normalized too
+        let counts = model.file_finding_counts.unwrap();
+        assert_eq!(counts.get("src/db.rs"), Some(&2));
     }
 }

--- a/src/calibrator.rs
+++ b/src/calibrator.rs
@@ -60,6 +60,9 @@ pub struct CalibratorConfig {
     /// uses only raw exact + raw title-only fallback. `None` or `Some(false)`
     /// keeps all tiers active (default).
     pub disable_fuzzy_matching: Option<bool>,
+    /// LLM model used for this review (e.g. "gpt-5.4"). Used for
+    /// `model_fp_rate` feature lookup in the logistic calibrator.
+    pub review_model: Option<String>,
     /// Composite scoring model. When present, threshold comparisons use
     /// composite scores instead of raw `tp_weight / total`.
     pub model: Option<CalibratorModel>,
@@ -79,6 +82,7 @@ impl Default for CalibratorConfig {
             force_threshold: None,
             trace_provenance: None,
             disable_fuzzy_matching: None,
+            review_model: None,
             model: None,
         }
     }
@@ -440,7 +444,10 @@ fn calibrate_core_decision(
                 .model
                 .as_ref()
                 .and_then(|m| m.model_fp_rate.as_ref())
-                .and_then(|map| map.get("unknown").copied())
+                .and_then(|map| {
+                    let key = config.review_model.as_deref().unwrap_or("unknown");
+                    map.get(key).copied()
+                })
                 .unwrap_or(global_fp_rate),
             max_word_lor,
             min_word_lor,

--- a/src/calibrator.rs
+++ b/src/calibrator.rs
@@ -5435,6 +5435,11 @@ mod tests {
             ]),
             family_fp_rate: HashMap::from([("use of `` may panic at runtime".into(), 0.90)]),
             language_fp_rate: HashMap::from([("rust".into(), 0.328), ("python".into(), 0.208)]),
+            category_fp_rate_map: None,
+            severity_fp_rate: None,
+            model_fp_rate: None,
+            file_fp_rate: None,
+            file_finding_counts: None,
         }
     }
 
@@ -5664,6 +5669,11 @@ mod tests {
             word_lor: HashMap::new(),
             family_fp_rate: HashMap::new(),
             language_fp_rate: HashMap::new(),
+            category_fp_rate_map: None,
+            severity_fp_rate: None,
+            model_fp_rate: None,
+            file_fp_rate: None,
+            file_finding_counts: None,
         };
         let mut finding = finding_at(
             "hardcoded secret in API_KEY",
@@ -5737,6 +5747,11 @@ mod tests {
             word_lor: HashMap::new(),
             family_fp_rate: HashMap::new(),
             language_fp_rate: HashMap::new(),
+            category_fp_rate_map: None,
+            severity_fp_rate: None,
+            model_fp_rate: None,
+            file_fp_rate: None,
+            file_finding_counts: None,
         };
         let mut finding = finding_at(
             "SQL injection via user input",
@@ -5808,6 +5823,11 @@ mod tests {
             word_lor: HashMap::new(),
             family_fp_rate: HashMap::new(),
             language_fp_rate: HashMap::new(),
+            category_fp_rate_map: None,
+            severity_fp_rate: None,
+            model_fp_rate: None,
+            file_fp_rate: None,
+            file_finding_counts: None,
         };
         let mut finding = finding_at(
             "unused variable x",

--- a/src/calibrator.rs
+++ b/src/calibrator.rs
@@ -5915,10 +5915,10 @@ mod tests {
         let decision = calibrate_core_decision(
             &mut finding,
             &config,
-            0.1,  // tp_weight
-            2.0,  // fp_weight
-            0.3,  // wontfix_weight
-            0.5,  // soft_fp_weight
+            0.1, // tp_weight
+            2.0, // fp_weight
+            0.3, // wontfix_weight
+            0.5, // soft_fp_weight
             vec![],
             Severity::Medium,
             "config.rs",
@@ -5989,10 +5989,10 @@ mod tests {
         let decision = calibrate_core_decision(
             &mut finding,
             &config,
-            0.1,  // tp_weight (low)
-            2.0,  // fp_weight (high -> suppress)
-            0.3,  // wontfix_weight
-            0.5,  // soft_fp_weight
+            0.1, // tp_weight (low)
+            2.0, // fp_weight (high -> suppress)
+            0.3, // wontfix_weight
+            0.5, // soft_fp_weight
             vec![],
             Severity::High,
             "test.rs",
@@ -6050,21 +6050,11 @@ mod tests {
             word_lor: HashMap::new(),
             family_fp_rate: HashMap::new(),
             language_fp_rate: HashMap::new(),
-            category_fp_rate_map: Some(HashMap::from([
-                ("security".to_string(), 0.15),
-            ])),
-            severity_fp_rate: Some(HashMap::from([
-                ("high".to_string(), 0.35),
-            ])),
-            model_fp_rate: Some(HashMap::from([
-                ("unknown".to_string(), 0.42),
-            ])),
-            file_fp_rate: Some(HashMap::from([
-                ("src/app.py".to_string(), 0.55),
-            ])),
-            file_finding_counts: Some(HashMap::from([
-                ("src/app.py".to_string(), 7),
-            ])),
+            category_fp_rate_map: Some(HashMap::from([("security".to_string(), 0.15)])),
+            severity_fp_rate: Some(HashMap::from([("high".to_string(), 0.35)])),
+            model_fp_rate: Some(HashMap::from([("unknown".to_string(), 0.42)])),
+            file_fp_rate: Some(HashMap::from([("src/app.py".to_string(), 0.55)])),
+            file_finding_counts: Some(HashMap::from([("src/app.py".to_string(), 7)])),
         };
         let mut finding = finding_at(
             "SQL injection risk",

--- a/src/calibrator.rs
+++ b/src/calibrator.rs
@@ -349,6 +349,7 @@ fn calibrate_core_decision(
     let mut reason: Option<crate::calibrator_trace::SeverityChangeReason> = None;
     let mut suppressed = false;
     let mut boosted = false;
+    let full_suppress_weight = fp_weight + soft_fp_weight + wontfix_weight;
 
     // Logistic model path: when present, P(FP) directly drives suppress/boost decisions.
     if let Some(logistic) = config
@@ -359,11 +360,10 @@ fn calibrate_core_decision(
         // Compute word LOR features from the model's vocabulary
         let (max_word_lor, min_word_lor, count_negative_lor_tokens) =
             if let Some(model) = config.model.as_ref() {
-                let lower = finding.title.to_lowercase();
-                let word_lors: Vec<f64> = lower
-                    .split(|c: char| !c.is_alphanumeric() && c != '_')
-                    .filter(|w| w.len() >= 2)
-                    .filter_map(|w| model.word_lor.get(w).copied())
+                let words = crate::calibrate::tokenize_title(&finding.title);
+                let word_lors: Vec<f64> = words
+                    .iter()
+                    .filter_map(|w| model.word_lor.get(w.as_str()).copied())
                     .collect();
                 if word_lors.is_empty() {
                     (0.0, 0.0, 0.0)
@@ -378,18 +378,19 @@ fn calibrate_core_decision(
                 (0.0, 0.0, 0.0)
             };
 
-        // Compute category FP rate from family_fp_rate (closest available proxy)
-        let category_fp_rate = config
+        let normalized_file_path = crate::file_util::normalize_file_path_deep(file_path);
+        let global_fp_rate = config
             .model
             .as_ref()
-            .map(|m| {
-                let family = CalibratorModel::title_family(&finding.title);
-                m.family_fp_rate
-                    .get(&family)
-                    .copied()
-                    .unwrap_or(m.meta.global_fp_rate)
-            })
+            .map(|m| m.meta.global_fp_rate)
             .unwrap_or(0.0);
+        let severity_str = match input_severity {
+            Severity::Info => "info",
+            Severity::Low => "low",
+            Severity::Medium => "medium",
+            Severity::High => "high",
+            Severity::Critical => "critical",
+        };
 
         let is_test_file = if crate::calibrate::is_test_file_path(file_path) {
             1.0
@@ -421,19 +422,46 @@ fn calibrate_core_decision(
                 0.0
             },
             log1p_soft_fp_weight: soft_fp_weight.ln_1p(),
-            log1p_full_suppress_weight: fp_weight.ln_1p(),
+            log1p_full_suppress_weight: full_suppress_weight.ln_1p(),
             log1p_wontfix_weight: wontfix_weight.ln_1p(),
-            category_fp_rate,
-            severity_fp_rate: 0.0,
-            model_fp_rate: 0.0,
+            category_fp_rate: config
+                .model
+                .as_ref()
+                .and_then(|m| m.category_fp_rate_map.as_ref())
+                .and_then(|map| map.get(finding.category.as_str()).copied())
+                .unwrap_or(global_fp_rate),
+            severity_fp_rate: config
+                .model
+                .as_ref()
+                .and_then(|m| m.severity_fp_rate.as_ref())
+                .and_then(|map| map.get(severity_str).copied())
+                .unwrap_or(global_fp_rate),
+            model_fp_rate: config
+                .model
+                .as_ref()
+                .and_then(|m| m.model_fp_rate.as_ref())
+                .and_then(|map| map.get("unknown").copied())
+                .unwrap_or(global_fp_rate),
             max_word_lor,
             min_word_lor,
             count_negative_lor_tokens,
             is_test_file,
             source_is_ast: if source_is_ast { 1.0 } else { 0.0 },
-            finding_count_same_file: 0.0,
-            file_fp_rate: 0.0,
-            finding_span_lines: (finding.line_end.saturating_sub(finding.line_start) + 1) as f64,
+            finding_count_same_file: config
+                .model
+                .as_ref()
+                .and_then(|m| m.file_finding_counts.as_ref())
+                .and_then(|counts| counts.get(&normalized_file_path))
+                .map(|&c| (c as f64).ln_1p())
+                .unwrap_or(0.0),
+            file_fp_rate: config
+                .model
+                .as_ref()
+                .and_then(|m| m.file_fp_rate.as_ref())
+                .and_then(|map| map.get(&normalized_file_path).copied())
+                .unwrap_or(global_fp_rate),
+            finding_span_lines: ((finding.line_end.saturating_sub(finding.line_start) + 1) as f64)
+                .ln_1p(),
             is_mock_or_fixture: if crate::calibrate::is_mock_or_fixture_path(file_path) {
                 1.0
             } else {
@@ -465,7 +493,7 @@ fn calibrate_core_decision(
                 tp_weight,
                 fp_weight,
                 wontfix_weight,
-                fp_weight, // full_suppress_weight = fp_weight
+                full_suppress_weight,
                 soft_fp_weight,
                 matched_precedents,
                 finding.calibrator_action.clone(),
@@ -500,7 +528,7 @@ fn calibrate_core_decision(
                 tp_weight,
                 fp_weight,
                 wontfix_weight,
-                fp_weight,
+                full_suppress_weight,
                 soft_fp_weight,
                 matched_precedents,
                 finding.calibrator_action.clone(),
@@ -518,8 +546,6 @@ fn calibrate_core_decision(
 
         // Neither threshold triggered: pass through (no data-driven action).
         // Fall through to legacy soft-suppress path only.
-        // Record logistic_p_fp on trace but don't use composite/data-driven thresholds.
-        let full_suppress_weight = fp_weight;
 
         // Legacy soft suppress still applies even with logistic model present.
         let soft_suppressed = (soft_fp_weight >= 1.0 && soft_fp_weight > tp_weight * 2.0)
@@ -579,8 +605,6 @@ fn calibrate_core_decision(
         .map(|m| m.composite_score(precedent_score, &finding.title, lang));
     let score = composite.unwrap_or(precedent_score);
 
-    // Full suppress: FP weight only. Wontfix no longer contributes.
-    let full_suppress_weight = fp_weight;
     let suppress_thresh = force_threshold.or(suppress_threshold);
     if let Some(thresh) = suppress_thresh {
         // Data-driven path: suppress when score is below the threshold and
@@ -609,9 +633,9 @@ fn calibrate_core_decision(
             };
         }
     } else {
-        // Legacy fallback: magic numbers.
-        if full_suppress_weight >= 1.5 && fp_weight > 0.0 && full_suppress_weight > tp_weight * 2.0
-        {
+        // Legacy fallback: magic numbers. Threshold uses fp_weight only
+        // (wontfix/soft_fp do not contribute to the legacy suppress decision).
+        if fp_weight >= 1.5 && fp_weight > tp_weight * 2.0 {
             finding.calibrator_action = Some(CalibratorAction::Disputed);
             suppressed = true;
             let mut trace = make_trace_entry(
@@ -5863,6 +5887,245 @@ mod tests {
         assert!(
             decision.trace.logistic_p_fp.is_some(),
             "logistic_p_fp should still be recorded on trace"
+        );
+    }
+
+    #[test]
+    fn trace_full_suppress_weight_is_composite() {
+        // When soft_fp_weight > 0 or wontfix_weight > 0, the trace's
+        // full_suppress_weight must be fp + soft_fp + wontfix (composite),
+        // not just fp_weight alone.
+        let mut finding = finding_at(
+            "hardcoded secret in config",
+            "security",
+            Severity::Medium,
+            "secret in config file",
+        );
+        let config = CalibratorConfig {
+            suppress_threshold: Some(0.3),
+            ..Default::default()
+        };
+        let decision = calibrate_core_decision(
+            &mut finding,
+            &config,
+            0.1,  // tp_weight
+            2.0,  // fp_weight
+            0.3,  // wontfix_weight
+            0.5,  // soft_fp_weight
+            vec![],
+            Severity::Medium,
+            "config.rs",
+        );
+        let expected = 2.0 + 0.5 + 0.3; // fp + soft_fp + wontfix = 2.8
+        assert!(
+            (decision.trace.full_suppress_weight - expected).abs() < 1e-9,
+            "full_suppress_weight should be composite (fp + soft_fp + wontfix = {}), got {}",
+            expected,
+            decision.trace.full_suppress_weight,
+        );
+    }
+
+    #[test]
+    fn trace_full_suppress_weight_composite_in_logistic_path() {
+        // Verify the logistic path also passes the composite full_suppress_weight
+        // to the trace, not just fp_weight.
+        use crate::calibrator_model::{CalibratorModel, LogisticModel, ModelMeta, ScoreWeights};
+        use std::collections::HashMap;
+        let lm = LogisticModel {
+            computed_at: "2026-05-16T12:00:00Z".to_string(),
+            n_samples: 1000,
+            n_fp: 200,
+            selected_features: vec!["log1p_fp_weight".to_string()],
+            coefficients: vec![3.0],
+            intercept: 0.0,
+            feature_means: vec![0.3],
+            feature_stddevs: vec![0.2],
+            suppress_threshold: 0.7,
+            boost_threshold: 0.1,
+            ap_score: 0.6,
+            fp_recall_at_99_tp_recall: 0.3,
+            baseline_ap: 0.15,
+        };
+        let model = CalibratorModel {
+            meta: ModelMeta {
+                computed_at: "2026-05-16".into(),
+                feedback_count: 100,
+                global_fp_rate: 0.2,
+                learned_weights: None,
+            },
+            weights: ScoreWeights {
+                score: 0.5,
+                word_lor: 1.0,
+                family_fp_inv: 1.0,
+                language_fp_inv: 0.5,
+            },
+            logistic_model: Some(lm),
+            word_lor: HashMap::new(),
+            family_fp_rate: HashMap::new(),
+            language_fp_rate: HashMap::new(),
+            category_fp_rate_map: None,
+            severity_fp_rate: None,
+            model_fp_rate: None,
+            file_fp_rate: None,
+            file_finding_counts: None,
+        };
+        let mut finding = finding_at(
+            "hardcoded API key",
+            "security",
+            Severity::High,
+            "API key exposed",
+        );
+        let config = CalibratorConfig {
+            model: Some(model),
+            ..Default::default()
+        };
+        let decision = calibrate_core_decision(
+            &mut finding,
+            &config,
+            0.1,  // tp_weight (low)
+            2.0,  // fp_weight (high -> suppress)
+            0.3,  // wontfix_weight
+            0.5,  // soft_fp_weight
+            vec![],
+            Severity::High,
+            "test.rs",
+        );
+        let expected = 2.0 + 0.5 + 0.3; // 2.8
+        assert!(
+            decision.suppressed,
+            "should be suppressed with high fp_weight in logistic path"
+        );
+        assert!(
+            (decision.trace.full_suppress_weight - expected).abs() < 1e-9,
+            "logistic suppress path: full_suppress_weight should be composite {}, got {}",
+            expected,
+            decision.trace.full_suppress_weight,
+        );
+    }
+
+    #[test]
+    fn review_features_use_rate_maps_from_model() {
+        // Verify that when the model has rate maps populated, the ReviewFeatures
+        // struct picks them up instead of defaulting to 0.0.
+        use crate::calibrator_model::{CalibratorModel, LogisticModel, ModelMeta, ScoreWeights};
+        use std::collections::HashMap;
+        let lm = LogisticModel {
+            computed_at: "2026-05-16T12:00:00Z".to_string(),
+            n_samples: 1000,
+            n_fp: 200,
+            // Use a feature that doesn't trigger suppress or boost so we can
+            // inspect the passthrough trace.
+            selected_features: vec!["log1p_fp_weight".to_string()],
+            coefficients: vec![1.0],
+            intercept: 0.0,
+            feature_means: vec![0.5],
+            feature_stddevs: vec![0.5],
+            suppress_threshold: 0.95,
+            boost_threshold: 0.01,
+            ap_score: 0.6,
+            fp_recall_at_99_tp_recall: 0.3,
+            baseline_ap: 0.15,
+        };
+        let model = CalibratorModel {
+            meta: ModelMeta {
+                computed_at: "2026-05-16".into(),
+                feedback_count: 100,
+                global_fp_rate: 0.25,
+                learned_weights: None,
+            },
+            weights: ScoreWeights {
+                score: 0.5,
+                word_lor: 1.0,
+                family_fp_inv: 1.0,
+                language_fp_inv: 0.5,
+            },
+            logistic_model: Some(lm),
+            word_lor: HashMap::new(),
+            family_fp_rate: HashMap::new(),
+            language_fp_rate: HashMap::new(),
+            category_fp_rate_map: Some(HashMap::from([
+                ("security".to_string(), 0.15),
+            ])),
+            severity_fp_rate: Some(HashMap::from([
+                ("high".to_string(), 0.35),
+            ])),
+            model_fp_rate: Some(HashMap::from([
+                ("unknown".to_string(), 0.42),
+            ])),
+            file_fp_rate: Some(HashMap::from([
+                ("src/app.py".to_string(), 0.55),
+            ])),
+            file_finding_counts: Some(HashMap::from([
+                ("src/app.py".to_string(), 7),
+            ])),
+        };
+        let mut finding = finding_at(
+            "SQL injection risk",
+            "security",
+            Severity::High,
+            "unsanitized user input",
+        );
+        // Set line span to 10 lines so we can verify ln_1p transform
+        finding.line_start = 10;
+        finding.line_end = 19;
+
+        let config = CalibratorConfig {
+            model: Some(model),
+            ..Default::default()
+        };
+        let decision = calibrate_core_decision(
+            &mut finding,
+            &config,
+            0.5,
+            0.3,
+            0.1,
+            0.2,
+            vec![],
+            Severity::High,
+            "src/app.py",
+        );
+        // The trace itself doesn't expose ReviewFeatures directly, but we
+        // can verify full_suppress_weight is composite and the function
+        // didn't panic — the feature lookups worked.
+        let expected_fsw = 0.3 + 0.2 + 0.1; // 0.6
+        assert!(
+            (decision.trace.full_suppress_weight - expected_fsw).abs() < 1e-9,
+            "full_suppress_weight should be {} (composite), got {}",
+            expected_fsw,
+            decision.trace.full_suppress_weight,
+        );
+        // Verify finding_span_lines on trace is raw span (10), while the
+        // ReviewFeatures internally used ln_1p(10) for the logistic model.
+        assert_eq!(
+            decision.trace.finding_span_lines,
+            Some(10),
+            "trace finding_span_lines should be raw span",
+        );
+    }
+
+    #[test]
+    fn tokenize_title_drops_digits_matching_training() {
+        // The inline tokenizer used to include digits (e.g. "v2", "123").
+        // Training uses tokenize_title() which drops digits via [a-z_]+ regex.
+        // Verify the fix by checking that digit-only tokens are excluded.
+        let words = crate::calibrate::tokenize_title("Use v2 API for 403 errors");
+        // "v2" contains a digit -> dropped by [a-z_]+ regex
+        // "403" is all digits -> dropped
+        // Expected tokens: "use", "api", "for", "errors"
+        assert!(
+            !words.contains(&"v2".to_string()),
+            "tokenize_title should drop tokens containing digits, got: {:?}",
+            words,
+        );
+        assert!(
+            !words.contains(&"403".to_string()),
+            "tokenize_title should drop all-digit tokens, got: {:?}",
+            words,
+        );
+        assert!(
+            words.contains(&"use".to_string()),
+            "tokenize_title should include alphabetic tokens, got: {:?}",
+            words,
         );
     }
 }

--- a/src/calibrator_model.rs
+++ b/src/calibrator_model.rs
@@ -400,16 +400,15 @@ mod tests {
 
         // Populated maps survive round-trip
         let mut model2 = make_model();
-        model2.category_fp_rate_map =
-            Some(HashMap::from([("security".into(), 0.15), ("quality".into(), 0.42)]));
+        model2.category_fp_rate_map = Some(HashMap::from([
+            ("security".into(), 0.15),
+            ("quality".into(), 0.42),
+        ]));
         model2.severity_fp_rate =
             Some(HashMap::from([("high".into(), 0.10), ("low".into(), 0.55)]));
-        model2.model_fp_rate =
-            Some(HashMap::from([("gpt-5.4".into(), 0.22)]));
-        model2.file_fp_rate =
-            Some(HashMap::from([("src/main.rs".into(), 0.33)]));
-        model2.file_finding_counts =
-            Some(HashMap::from([("src/main.rs".into(), 7)]));
+        model2.model_fp_rate = Some(HashMap::from([("gpt-5.4".into(), 0.22)]));
+        model2.file_fp_rate = Some(HashMap::from([("src/main.rs".into(), 0.33)]));
+        model2.file_finding_counts = Some(HashMap::from([("src/main.rs".into(), 7)]));
 
         let toml_str2 = model2.to_toml();
         assert!(toml_str2.contains("category_fp_rate_map"));

--- a/src/calibrator_model.rs
+++ b/src/calibrator_model.rs
@@ -63,6 +63,16 @@ pub struct CalibratorModel {
     pub word_lor: HashMap<String, f64>,
     pub family_fp_rate: HashMap<String, f64>,
     pub language_fp_rate: HashMap<String, f64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub category_fp_rate_map: Option<HashMap<String, f64>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub severity_fp_rate: Option<HashMap<String, f64>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub model_fp_rate: Option<HashMap<String, f64>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub file_fp_rate: Option<HashMap<String, f64>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub file_finding_counts: Option<HashMap<String, usize>>,
 }
 
 impl CalibratorModel {
@@ -187,6 +197,11 @@ mod tests {
                 0.30,
             )]),
             language_fp_rate: HashMap::from([("rust".into(), 0.328), ("python".into(), 0.208)]),
+            category_fp_rate_map: None,
+            severity_fp_rate: None,
+            model_fp_rate: None,
+            file_fp_rate: None,
+            file_finding_counts: None,
         }
     }
 
@@ -362,5 +377,104 @@ mod tests {
         assert!(!toml_str.contains("[logistic_model]"));
         let parsed = CalibratorModel::from_toml(&toml_str).unwrap();
         assert!(parsed.logistic_model.is_none());
+    }
+
+    #[test]
+    fn rate_maps_round_trip() {
+        // None maps should be absent from TOML output
+        let model = make_model();
+        let toml_str = model.to_toml();
+        assert!(!toml_str.contains("category_fp_rate_map"));
+        assert!(!toml_str.contains("severity_fp_rate"));
+        assert!(!toml_str.contains("model_fp_rate"));
+        assert!(!toml_str.contains("file_fp_rate"));
+        assert!(!toml_str.contains("file_finding_counts"));
+
+        // Round-trip with None maps
+        let parsed = CalibratorModel::from_toml(&toml_str).unwrap();
+        assert!(parsed.category_fp_rate_map.is_none());
+        assert!(parsed.severity_fp_rate.is_none());
+        assert!(parsed.model_fp_rate.is_none());
+        assert!(parsed.file_fp_rate.is_none());
+        assert!(parsed.file_finding_counts.is_none());
+
+        // Populated maps survive round-trip
+        let mut model2 = make_model();
+        model2.category_fp_rate_map =
+            Some(HashMap::from([("security".into(), 0.15), ("quality".into(), 0.42)]));
+        model2.severity_fp_rate =
+            Some(HashMap::from([("high".into(), 0.10), ("low".into(), 0.55)]));
+        model2.model_fp_rate =
+            Some(HashMap::from([("gpt-5.4".into(), 0.22)]));
+        model2.file_fp_rate =
+            Some(HashMap::from([("src/main.rs".into(), 0.33)]));
+        model2.file_finding_counts =
+            Some(HashMap::from([("src/main.rs".into(), 7)]));
+
+        let toml_str2 = model2.to_toml();
+        assert!(toml_str2.contains("category_fp_rate_map"));
+        assert!(toml_str2.contains("file_finding_counts"));
+
+        let parsed2 = CalibratorModel::from_toml(&toml_str2).unwrap();
+        let cat_map = parsed2.category_fp_rate_map.unwrap();
+        assert_eq!(cat_map.len(), 2);
+        assert!((cat_map["security"] - 0.15).abs() < 1e-9);
+        assert!((cat_map["quality"] - 0.42).abs() < 1e-9);
+
+        let sev_map = parsed2.severity_fp_rate.unwrap();
+        assert!((sev_map["high"] - 0.10).abs() < 1e-9);
+
+        let model_map = parsed2.model_fp_rate.unwrap();
+        assert!((model_map["gpt-5.4"] - 0.22).abs() < 1e-9);
+
+        let file_map = parsed2.file_fp_rate.unwrap();
+        assert!((file_map["src/main.rs"] - 0.33).abs() < 1e-9);
+
+        let count_map = parsed2.file_finding_counts.unwrap();
+        assert_eq!(count_map["src/main.rs"], 7);
+
+        // Some(empty map) vs None: empty map IS serialized (not skipped)
+        let mut model3 = make_model();
+        model3.category_fp_rate_map = Some(HashMap::new());
+        let toml_str3 = model3.to_toml();
+        assert!(toml_str3.contains("category_fp_rate_map"));
+        let parsed3 = CalibratorModel::from_toml(&toml_str3).unwrap();
+        assert!(parsed3.category_fp_rate_map.is_some());
+        assert!(parsed3.category_fp_rate_map.unwrap().is_empty());
+    }
+
+    #[test]
+    fn old_toml_without_rate_maps_loads() {
+        // Simulates a pre-upgrade model.toml that lacks the new fields
+        let old_toml = r#"
+[meta]
+computed_at = "2026-01-01T00:00:00Z"
+feedback_count = 50
+global_fp_rate = 0.25
+
+[weights]
+score = 0.5
+word_lor = 1.5
+family_fp_inv = 1.0
+language_fp_inv = 0.5
+
+[word_lor]
+hardcoded = -1.88
+
+[family_fp_rate]
+
+[language_fp_rate]
+rust = 0.33
+"#;
+        let parsed = CalibratorModel::from_toml(old_toml).unwrap();
+        assert!(parsed.category_fp_rate_map.is_none());
+        assert!(parsed.severity_fp_rate.is_none());
+        assert!(parsed.model_fp_rate.is_none());
+        assert!(parsed.file_fp_rate.is_none());
+        assert!(parsed.file_finding_counts.is_none());
+        assert_eq!(parsed.meta.feedback_count, 50);
+        assert!((parsed.meta.global_fp_rate - 0.25).abs() < 1e-9);
+        assert_eq!(parsed.word_lor.len(), 1);
+        assert_eq!(parsed.language_fp_rate.len(), 1);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -2617,6 +2617,29 @@ fn run_calibrate(opts: cli::CalibrateOpts) -> i32 {
         println!("Boost:    not computed (insufficient data or precision target unachievable)");
     }
 
+    // Populate rate maps from full corpus stats
+    {
+        let joined_for_maps = composite_model.as_ref().map(|model| {
+            quorum::calibrate::extract_joined_samples(
+                &feedback, &traces, model, &filter, disable_fuzzy,
+            )
+        });
+        if let (Some(model), Some(joined)) = (&mut composite_model, joined_for_maps) {
+            if !joined.is_empty() {
+                let refs: Vec<&quorum::calibrate::JoinedSample> = joined.iter().collect();
+                let all_stats = quorum::calibrate::compute_fold_local_stats(&refs);
+                quorum::calibrate::store_rate_maps_in_model(model, &all_stats);
+                eprintln!(
+                    "Rate maps: {} categories, {} severities, {} models, {} files",
+                    model.category_fp_rate_map.as_ref().map_or(0, |m| m.len()),
+                    model.severity_fp_rate.as_ref().map_or(0, |m| m.len()),
+                    model.model_fp_rate.as_ref().map_or(0, |m| m.len()),
+                    model.file_fp_rate.as_ref().map_or(0, |m| m.len()),
+                );
+            }
+        }
+    }
+
     let has_logistic = composite_model
         .as_ref()
         .is_some_and(|m| m.logistic_model.is_some());

--- a/src/main.rs
+++ b/src/main.rs
@@ -1064,6 +1064,7 @@ async fn run_review(opts: cli::ReviewOpts) -> i32 {
 
     // Build calibrator config, loading data-driven thresholds if available.
     let mut calibrator_config = calibrator::CalibratorConfig {
+        review_model: models.first().cloned(),
         trace_provenance: Some(trace_provenance),
         ..Default::default()
     };

--- a/src/main.rs
+++ b/src/main.rs
@@ -2622,7 +2622,11 @@ fn run_calibrate(opts: cli::CalibrateOpts) -> i32 {
     {
         let joined_for_maps = composite_model.as_ref().map(|model| {
             quorum::calibrate::extract_joined_samples(
-                &feedback, &traces, model, &filter, disable_fuzzy,
+                &feedback,
+                &traces,
+                model,
+                &filter,
+                disable_fuzzy,
             )
         });
         if let (Some(model), Some(joined)) = (&mut composite_model, joined_for_maps)

--- a/src/main.rs
+++ b/src/main.rs
@@ -2624,19 +2624,19 @@ fn run_calibrate(opts: cli::CalibrateOpts) -> i32 {
                 &feedback, &traces, model, &filter, disable_fuzzy,
             )
         });
-        if let (Some(model), Some(joined)) = (&mut composite_model, joined_for_maps) {
-            if !joined.is_empty() {
-                let refs: Vec<&quorum::calibrate::JoinedSample> = joined.iter().collect();
-                let all_stats = quorum::calibrate::compute_fold_local_stats(&refs);
-                quorum::calibrate::store_rate_maps_in_model(model, &all_stats);
-                eprintln!(
-                    "Rate maps: {} categories, {} severities, {} models, {} files",
-                    model.category_fp_rate_map.as_ref().map_or(0, |m| m.len()),
-                    model.severity_fp_rate.as_ref().map_or(0, |m| m.len()),
-                    model.model_fp_rate.as_ref().map_or(0, |m| m.len()),
-                    model.file_fp_rate.as_ref().map_or(0, |m| m.len()),
-                );
-            }
+        if let (Some(model), Some(joined)) = (&mut composite_model, joined_for_maps)
+            && !joined.is_empty()
+        {
+            let refs: Vec<&quorum::calibrate::JoinedSample> = joined.iter().collect();
+            let all_stats = quorum::calibrate::compute_fold_local_stats(&refs);
+            quorum::calibrate::store_rate_maps_in_model(model, &all_stats);
+            eprintln!(
+                "Rate maps: {} categories, {} severities, {} models, {} files",
+                model.category_fp_rate_map.as_ref().map_or(0, |m| m.len()),
+                model.severity_fp_rate.as_ref().map_or(0, |m| m.len()),
+                model.model_fp_rate.as_ref().map_or(0, |m| m.len()),
+                model.file_fp_rate.as_ref().map_or(0, |m| m.len()),
+            );
         }
     }
 


### PR DESCRIPTION
## Summary

- **Fix 7 broken logistic calibrator features** at review time that had train/inference mismatch: `log1p_full_suppress_weight` (duplicate of fp_weight), `category_fp_rate` (wrong proxy), `severity_fp_rate` (dead zero), `model_fp_rate` (dead zero), `finding_count_same_file` (dead zero), `file_fp_rate` (dead zero), `finding_span_lines` (missing ln_1p transform)
- **Fix trace emission corruption**: `full_suppress_weight` in calibrator traces was always written as `fp_weight` instead of the composite `fp + soft_fp + wontfix`. This contaminated training data across retrain cycles.
- **Fix tokenization mismatch**: inference used inline `split(!is_alphanumeric)` (keeps digits), training used `[a-z_]+` regex (drops digits). Now both use `tokenize_title()`.
- **Add rate maps to CalibratorModel**: 5 new optional fields (`category_fp_rate_map`, `severity_fp_rate`, `model_fp_rate`, `file_fp_rate`, `file_finding_counts`) populated from the full corpus during `quorum calibrate`, looked up at review time with proper fallback semantics.

## Design

See `docs/superpowers/specs/2026-05-17-calibrator-review-time-features-design.md` for the full design spec (reviewed by GPT-5.4 and GPT-5.2 before implementation).

### Backward compatibility

- Old `calibrator_model.toml` without rate maps: fields deserialize as `None`, features fall back to `0.0` (same as current broken behavior). A `tracing::info` recommends recalibration.
- After upgrading, `quorum calibrate` produces the new maps and retrains with corrected features.

### Not in this PR (follow-up)

- Legacy threshold removal (`calibrator_thresholds.toml`, `ThresholdConfig`, `compute_thresholds`, CLI precision args) — separate PR to keep this focused on the feature fix.

## Test plan

- [x] Serde round-trip tests for new CalibratorModel fields (None, populated, empty map vs None distinction)
- [x] Backward compat test: old TOML without rate maps loads correctly
- [x] `tokenize_title` parity tests (drops digits, keeps underscores, matches WORD_RE regex)
- [x] `store_rate_maps_in_model` unit test (correct values, file path normalization)
- [x] Trace emission test: `full_suppress_weight` is composite in both logistic and non-logistic paths
- [x] Rate map lookup test via `calibrate_core_decision` with populated model
- [x] Full suite: 1581 bin tests pass, clippy clean, release build OK

Closes #375

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added optional rate/count lookup maps to calibrator model for improved accuracy tracking.
  * Implemented rate map population in calibration workflow.

* **Bug Fixes**
  * Fixed logistic calibrator feature computation with proper title tokenization.
  * Corrected seven review-time feature computations (scaling, tokenization, and composite values).
  * Fixed trace reporting for full-suppress metrics.

* **Documentation**
  * Added calibrator review-time features planning and design documentation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jsnyder/quorum/pull/379?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->