### PR TITLE
feat: AST rules + cleanup (#380, #381, #382)

### DIFF
--- a/docs/superpowers/specs/2026-05-17-calibrator-review-time-features-design.md
+++ b/docs/superpowers/specs/2026-05-17-calibrator-review-time-features-design.md
@@ -2,27 +2,38 @@
 
 ## Problem
 
-The logistic calibrator has 22 features in `ExpandedFeatures`. During training, all 22 are populated from the feedback corpus. At review time (`calibrate_core_decision`), 6 features are broken:
+The logistic calibrator has 22 features in `ExpandedFeatures`. During training, all 22 are populated from the feedback corpus. At review time (`calibrate_core_decision`), 7 features are broken:
 
 | Feature | Training value | Review-time value | Problem |
 |---------|---------------|-------------------|---------|
 | `log1p_full_suppress_weight` | `(fp + soft_fp + wontfix).ln_1p()` | `fp_weight.ln_1p()` | Duplicate of `log1p_fp_weight` |
+| `category_fp_rate` | Beta-smoothed FP rate per category | `family_fp_rate` proxy | Wrong proxy |
 | `severity_fp_rate` | Beta-smoothed FP rate per severity | `0.0` | Dead |
 | `model_fp_rate` | Beta-smoothed FP rate per LLM model | `0.0` | Dead |
 | `finding_count_same_file` | `ln_1p(corpus file occurrence count)` | `0.0` | Dead |
 | `file_fp_rate` | Beta-smoothed FP rate per file path | `0.0` | Dead |
 | `finding_span_lines` | `(span_lines as f64).ln_1p()` | `span_lines as f64` (raw) | Wrong scale |
 
-Additionally, the trace emission at review time writes `fp_weight` as `full_suppress_weight`, which corrupts future training data — making the duplicate permanent across retrain cycles.
+Additionally:
+- Trace emission at review time writes `fp_weight` as `full_suppress_weight`, corrupting future training data and making the duplicate permanent across retrain cycles.
+- Word LOR tokenization differs: inference splits on `!is_alphanumeric()`, training uses `[a-z_]+` regex (drops digits). Fix: reuse `tokenize_title()` at inference.
+
+### Historical corpus contamination
+
+Old traces in `calibrator_traces.jsonl` have `full_suppress_weight == fp_weight` even when `soft_fp_weight > 0` or `wontfix_weight > 0`. After fixing trace emission, a `quorum calibrate` retrain will mix old (wrong) and new (correct) data. This is acceptable — the model will progressively improve as new traces dominate. No backfill required.
 
 ## Secondary Goal: Legacy Threshold Cleanup
 
 The old heuristic threshold system (`calibrator_thresholds.toml` with `PathThreshold` suppress/boost using raw composite scores) is fully superseded by the logistic model's P(FP) thresholds. Remove the legacy system:
-- Remove `ThresholdConfig` loading and `calibrator_thresholds.toml` file
-- Remove the "Calibrator Threshold Report" print section from `quorum calibrate`
-- Remove `compute_thresholds()` and `PathThreshold` types
-- Remove `suppress_threshold` / `boost_threshold` fields from `CalibratorConfig` (these were the legacy ones; logistic thresholds live on `LogisticModel`)
-- Simplify `calibrate_core_decision` to only use logistic model thresholds
+- Delete `src/threshold_config.rs` and `pub mod threshold_config` from `lib.rs`
+- Remove `compute_thresholds()` from `calibrate.rs`
+- Remove `suppress_threshold`, `boost_threshold`, `force_threshold` from `CalibratorConfig`
+- Remove `calibrator_thresholds.toml` loading and threshold report output from `main.rs`
+- Remove `--suppress-precision` / `--boost-precision` CLI args from calibrate subcommand
+- Remove the non-logistic threshold decision branches in `calibrate_core_decision` (lines ~564-711)
+- When no `LogisticModel` is loaded, the calibrator falls back to the existing heuristic suppress/boost logic that uses raw `tp_weight / (tp_weight + fp_weight)` ratios with hardcoded cutoffs. This path remains as the "no model" fallback.
+
+**Migration**: When `calibrator_thresholds.toml` exists at startup, emit a one-time `tracing::warn` that it is no longer used and can be deleted. Do not load or apply its contents.
 
 ## Design
 
@@ -30,13 +41,12 @@ The old heuristic threshold system (`calibrator_thresholds.toml` with `PathThres
 
 **Review-time fix** (line 424):
 ```rust
-// Before:
-log1p_full_suppress_weight: fp_weight.ln_1p(),
-// After:
-log1p_full_suppress_weight: (fp_weight + soft_fp_weight + wontfix_weight).ln_1p(),
+let full_suppress_weight = fp_weight + soft_fp_weight + wontfix_weight;
+// ...
+log1p_full_suppress_weight: full_suppress_weight.ln_1p(),
 ```
 
-**Trace emission fix** — all `make_trace_entry` calls pass `fp_weight` as the `full_suppress_weight` argument. Change to pass `fp_weight + soft_fp_weight + wontfix_weight`.
+**Trace emission fix** — all `make_trace_entry` calls currently pass `fp_weight` as the `full_suppress_weight` argument. Change to pass `full_suppress_weight` (the sum computed above).
 
 ### Part B: Fix `finding_span_lines` (calibrator.rs)
 
@@ -47,10 +57,16 @@ finding_span_lines: (finding.line_end.saturating_sub(finding.line_start) + 1) as
 finding_span_lines: ((finding.line_end.saturating_sub(finding.line_start) + 1) as f64).ln_1p(),
 ```
 
-### Part C: Add rate maps to `CalibratorModel` (calibrator_model.rs + calibrate.rs)
+### Part C: Fix word LOR tokenization (calibrator.rs)
 
-Add four new optional fields to `CalibratorModel`:
+Replace the inline `split(|c| ...)` tokenizer in `calibrate_core_decision` with a call to `crate::calibrate::tokenize_title()`, which uses `WORD_RE = r"[a-z_]+"`. This ensures training and inference produce identical token sets for word LOR lookups.
+
+### Part D: Add rate maps to `CalibratorModel` (calibrator_model.rs + calibrate.rs)
+
+Add five new optional fields to `CalibratorModel`:
 ```rust
+#[serde(default, skip_serializing_if = "Option::is_none")]
+pub category_fp_rate_map: Option<HashMap<String, f64>>,
 #[serde(default, skip_serializing_if = "Option::is_none")]
 pub severity_fp_rate: Option<HashMap<String, f64>>,
 #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -61,53 +77,63 @@ pub file_fp_rate: Option<HashMap<String, f64>>,
 pub file_finding_counts: Option<HashMap<String, usize>>,
 ```
 
-**Computation** (in `run_calibrate` / training pipeline): After computing `FoldLocalStats` from the full corpus, store the global stats maps in the model before serialization.
+Note: `category_fp_rate_map` is named differently from the existing `family_fp_rate` field to avoid confusion. The existing `family_fp_rate` remains for backward compat with the non-logistic scoring path.
 
-**Review-time lookup** (in `calibrate_core_decision`): Look up finding's severity/model/file_path in the model's maps, falling back to `0.0` when the map is `None` (backward compat with old model.toml files). A `tracing::info!` fires once per review when maps are missing, prompting recalibration.
+**Computation** (in `run_calibrate`): After computing `FoldLocalStats` from the full corpus (the same `all_stats` used for the final production model refit), store the global stats maps in the model before serialization. File path keys are normalized via `normalize_file_path_deep()` before insertion.
 
-### Part D: Fix `finding_count_same_file` (calibrator.rs)
+**Review-time lookup** (in `calibrate_core_decision`): Look up the finding's category/severity/model/file_path in the model's maps. Fallback semantics match training:
+- When map exists but key is missing: fall back to `model.meta.global_fp_rate`
+- When map is `None` (old model.toml): fall back to `0.0` (preserves current behavior)
+- A `tracing::info_once!` fires when maps are missing, prompting recalibration
 
-Use corpus-level file finding counts from `CalibratorModel.file_finding_counts`, not the current review's count. This matches training semantics.
+### Part E: Fix `finding_count_same_file` (calibrator.rs)
+
+Use corpus-level file finding counts from `CalibratorModel.file_finding_counts`, not the current review's count. This matches training semantics (corpus-level counts, not per-review counts).
 
 ```rust
 finding_count_same_file: config.model.as_ref()
     .and_then(|m| m.file_finding_counts.as_ref())
-    .and_then(|counts| counts.get(file_path))
+    .and_then(|counts| counts.get(&normalized_file_path))
     .map(|&c| (c as f64).ln_1p())
     .unwrap_or(0.0),
 ```
 
-### Part E: Legacy Threshold Removal
+File path is normalized with `normalize_file_path_deep()` before lookup to match the serialized keys.
+
+### Part F: Legacy Threshold Removal
 
 Files affected:
 - `src/threshold_config.rs` — delete entirely
-- `src/calibrate.rs` — remove `compute_thresholds()` function
-- `src/calibrator.rs` — remove `suppress_threshold: Option<f64>`, `boost_threshold: Option<f64>`, `force_threshold: Option<f64>` from `CalibratorConfig`; simplify `calibrate_core_decision` to use only `LogisticModel` thresholds
-- `src/main.rs` — remove `calibrator_thresholds.toml` loading, remove threshold report output, remove `--suppress-precision` / `--boost-precision` CLI args from calibrate subcommand
+- `src/calibrate.rs` — remove `compute_thresholds()` function and `use crate::threshold_config::*`
+- `src/calibrator.rs` — remove `suppress_threshold: Option<f64>`, `boost_threshold: Option<f64>`, `force_threshold: Option<f64>` from `CalibratorConfig`; remove the `sanitize_threshold` calls that reference these fields; remove the non-logistic threshold decision branches; keep the heuristic no-model fallback path
+- `src/main.rs` — remove `calibrator_thresholds.toml` loading, remove threshold report output, remove `--suppress-precision` / `--boost-precision` CLI args; add deprecation warning when old file exists
 - `src/lib.rs` — remove `pub mod threshold_config`
 
-**Migration**: When `calibrator_thresholds.toml` exists, emit a one-time warning that it is no longer used and can be deleted.
+The no-model fallback (when `config.model.logistic_model` is `None`) continues to use the existing hardcoded heuristic logic for suppress/boost. This is not "legacy thresholds" — it's the baseline calibrator behavior that exists independently of the threshold config system.
 
 ### Backward Compatibility
 
-- Old `calibrator_model.toml` files (without rate maps) continue to work — features fall back to `0.0` (same as current behavior). A `tracing::info!` recommends recalibration.
-- Old `calibrator_thresholds.toml` is ignored with a warning.
-- After upgrading, users run `quorum calibrate` to get the new maps and retrain the logistic model with corrected features.
+- Old `calibrator_model.toml` without rate maps: maps deserialize as `None`, features fall back to `0.0` (same as current broken behavior). `tracing::info_once!` recommends recalibration.
+- Old `calibrator_thresholds.toml`: ignored with a warning. No behavioral change for users who have a logistic model (which superseded these thresholds).
+- Users without a logistic model: heuristic calibrator continues to work as before.
+- After upgrading, `quorum calibrate` produces the new maps and retrains the model with corrected features.
 
 ### Files Modified
 
 | File | Changes |
 |------|---------|
-| `src/calibrator.rs` | Fix review-time features, fix trace emission, remove legacy threshold fields, simplify decision logic |
-| `src/calibrator_model.rs` | Add 4 optional map fields |
-| `src/calibrate.rs` | Compute global rate maps for model, remove `compute_thresholds()` |
+| `src/calibrator.rs` | Fix 7 review-time features, fix trace emission, fix tokenization, remove legacy threshold fields, simplify decision logic |
+| `src/calibrator_model.rs` | Add 5 optional map fields |
+| `src/calibrate.rs` | Compute global rate maps for model, remove `compute_thresholds()`, make `tokenize_title` pub |
 | `src/main.rs` | Remove threshold report, remove threshold CLI args, remove thresholds.toml loading, add deprecation warning |
 | `src/threshold_config.rs` | Delete |
 | `src/lib.rs` | Remove `pub mod threshold_config` |
 
 ### Testing
 
-- Unit tests for each fixed feature value (verify training-time and review-time produce equivalent values for known inputs)
+- Unit tests for each fixed feature: verify training-time and review-time produce equivalent values for known inputs (same composite weight, same ln_1p scale, same tokenization, same rate lookups)
+- Serde round-trip tests: old TOML without maps loads with `None`; new TOML serializes and deserializes maps correctly
 - Integration test: run calibrate with test corpus, verify new maps appear in serialized model
-- Regression test: old model.toml without maps still loads and produces valid (zero-fallback) scores
+- Regression test: old model.toml without maps still loads and produces valid scores
 - Test that legacy threshold file triggers deprecation warning
+- Test that `tokenize_title` and inference-time tokenization produce identical tokens

--- a/docs/superpowers/specs/2026-05-17-calibrator-review-time-features-design.md
+++ b/docs/superpowers/specs/2026-05-17-calibrator-review-time-features-design.md
@@ -2,38 +2,27 @@
 
 ## Problem
 
-The logistic calibrator has 22 features in `ExpandedFeatures`. During training, all 22 are populated from the feedback corpus. At review time (`calibrate_core_decision`), 7 features are broken:
+The logistic calibrator has 22 features in `ExpandedFeatures`. During training, all 22 are populated from the feedback corpus. At review time (`calibrate_core_decision`), 6 features are broken:
 
 | Feature | Training value | Review-time value | Problem |
 |---------|---------------|-------------------|---------|
 | `log1p_full_suppress_weight` | `(fp + soft_fp + wontfix).ln_1p()` | `fp_weight.ln_1p()` | Duplicate of `log1p_fp_weight` |
-| `category_fp_rate` | Beta-smoothed FP rate per category | `family_fp_rate` proxy | Wrong proxy |
 | `severity_fp_rate` | Beta-smoothed FP rate per severity | `0.0` | Dead |
 | `model_fp_rate` | Beta-smoothed FP rate per LLM model | `0.0` | Dead |
 | `finding_count_same_file` | `ln_1p(corpus file occurrence count)` | `0.0` | Dead |
 | `file_fp_rate` | Beta-smoothed FP rate per file path | `0.0` | Dead |
 | `finding_span_lines` | `(span_lines as f64).ln_1p()` | `span_lines as f64` (raw) | Wrong scale |
 
-Additionally:
-- Trace emission at review time writes `fp_weight` as `full_suppress_weight`, corrupting future training data and making the duplicate permanent across retrain cycles.
-- Word LOR tokenization differs: inference splits on `!is_alphanumeric()`, training uses `[a-z_]+` regex (drops digits). Fix: reuse `tokenize_title()` at inference.
-
-### Historical corpus contamination
-
-Old traces in `calibrator_traces.jsonl` have `full_suppress_weight == fp_weight` even when `soft_fp_weight > 0` or `wontfix_weight > 0`. After fixing trace emission, a `quorum calibrate` retrain will mix old (wrong) and new (correct) data. This is acceptable — the model will progressively improve as new traces dominate. No backfill required.
+Additionally, the trace emission at review time writes `fp_weight` as `full_suppress_weight`, which corrupts future training data — making the duplicate permanent across retrain cycles.
 
 ## Secondary Goal: Legacy Threshold Cleanup
 
 The old heuristic threshold system (`calibrator_thresholds.toml` with `PathThreshold` suppress/boost using raw composite scores) is fully superseded by the logistic model's P(FP) thresholds. Remove the legacy system:
-- Delete `src/threshold_config.rs` and `pub mod threshold_config` from `lib.rs`
-- Remove `compute_thresholds()` from `calibrate.rs`
-- Remove `suppress_threshold`, `boost_threshold`, `force_threshold` from `CalibratorConfig`
-- Remove `calibrator_thresholds.toml` loading and threshold report output from `main.rs`
-- Remove `--suppress-precision` / `--boost-precision` CLI args from calibrate subcommand
-- Remove the non-logistic threshold decision branches in `calibrate_core_decision` (lines ~564-711)
-- When no `LogisticModel` is loaded, the calibrator falls back to the existing heuristic suppress/boost logic that uses raw `tp_weight / (tp_weight + fp_weight)` ratios with hardcoded cutoffs. This path remains as the "no model" fallback.
-
-**Migration**: When `calibrator_thresholds.toml` exists at startup, emit a one-time `tracing::warn` that it is no longer used and can be deleted. Do not load or apply its contents.
+- Remove `ThresholdConfig` loading and `calibrator_thresholds.toml` file
+- Remove the "Calibrator Threshold Report" print section from `quorum calibrate`
+- Remove `compute_thresholds()` and `PathThreshold` types
+- Remove `suppress_threshold` / `boost_threshold` fields from `CalibratorConfig` (these were the legacy ones; logistic thresholds live on `LogisticModel`)
+- Simplify `calibrate_core_decision` to only use logistic model thresholds
 
 ## Design
 
@@ -41,12 +30,13 @@ The old heuristic threshold system (`calibrator_thresholds.toml` with `PathThres
 
 **Review-time fix** (line 424):
 ```rust
-let full_suppress_weight = fp_weight + soft_fp_weight + wontfix_weight;
-// ...
-log1p_full_suppress_weight: full_suppress_weight.ln_1p(),
+// Before:
+log1p_full_suppress_weight: fp_weight.ln_1p(),
+// After:
+log1p_full_suppress_weight: (fp_weight + soft_fp_weight + wontfix_weight).ln_1p(),
 ```
 
-**Trace emission fix** — all `make_trace_entry` calls currently pass `fp_weight` as the `full_suppress_weight` argument. Change to pass `full_suppress_weight` (the sum computed above).
+**Trace emission fix** — all `make_trace_entry` calls pass `fp_weight` as the `full_suppress_weight` argument. Change to pass `fp_weight + soft_fp_weight + wontfix_weight`.
 
 ### Part B: Fix `finding_span_lines` (calibrator.rs)
 
@@ -57,16 +47,10 @@ finding_span_lines: (finding.line_end.saturating_sub(finding.line_start) + 1) as
 finding_span_lines: ((finding.line_end.saturating_sub(finding.line_start) + 1) as f64).ln_1p(),
 ```
 
-### Part C: Fix word LOR tokenization (calibrator.rs)
+### Part C: Add rate maps to `CalibratorModel` (calibrator_model.rs + calibrate.rs)
 
-Replace the inline `split(|c| ...)` tokenizer in `calibrate_core_decision` with a call to `crate::calibrate::tokenize_title()`, which uses `WORD_RE = r"[a-z_]+"`. This ensures training and inference produce identical token sets for word LOR lookups.
-
-### Part D: Add rate maps to `CalibratorModel` (calibrator_model.rs + calibrate.rs)
-
-Add five new optional fields to `CalibratorModel`:
+Add four new optional fields to `CalibratorModel`:
 ```rust
-#[serde(default, skip_serializing_if = "Option::is_none")]
-pub category_fp_rate_map: Option<HashMap<String, f64>>,
 #[serde(default, skip_serializing_if = "Option::is_none")]
 pub severity_fp_rate: Option<HashMap<String, f64>>,
 #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -77,63 +61,53 @@ pub file_fp_rate: Option<HashMap<String, f64>>,
 pub file_finding_counts: Option<HashMap<String, usize>>,
 ```
 
-Note: `category_fp_rate_map` is named differently from the existing `family_fp_rate` field to avoid confusion. The existing `family_fp_rate` remains for backward compat with the non-logistic scoring path.
+**Computation** (in `run_calibrate` / training pipeline): After computing `FoldLocalStats` from the full corpus, store the global stats maps in the model before serialization.
 
-**Computation** (in `run_calibrate`): After computing `FoldLocalStats` from the full corpus (the same `all_stats` used for the final production model refit), store the global stats maps in the model before serialization. File path keys are normalized via `normalize_file_path_deep()` before insertion.
+**Review-time lookup** (in `calibrate_core_decision`): Look up finding's severity/model/file_path in the model's maps, falling back to `0.0` when the map is `None` (backward compat with old model.toml files). A `tracing::info!` fires once per review when maps are missing, prompting recalibration.
 
-**Review-time lookup** (in `calibrate_core_decision`): Look up the finding's category/severity/model/file_path in the model's maps. Fallback semantics match training:
-- When map exists but key is missing: fall back to `model.meta.global_fp_rate`
-- When map is `None` (old model.toml): fall back to `0.0` (preserves current behavior)
-- A `tracing::info_once!` fires when maps are missing, prompting recalibration
+### Part D: Fix `finding_count_same_file` (calibrator.rs)
 
-### Part E: Fix `finding_count_same_file` (calibrator.rs)
-
-Use corpus-level file finding counts from `CalibratorModel.file_finding_counts`, not the current review's count. This matches training semantics (corpus-level counts, not per-review counts).
+Use corpus-level file finding counts from `CalibratorModel.file_finding_counts`, not the current review's count. This matches training semantics.
 
 ```rust
 finding_count_same_file: config.model.as_ref()
     .and_then(|m| m.file_finding_counts.as_ref())
-    .and_then(|counts| counts.get(&normalized_file_path))
+    .and_then(|counts| counts.get(file_path))
     .map(|&c| (c as f64).ln_1p())
     .unwrap_or(0.0),
 ```
 
-File path is normalized with `normalize_file_path_deep()` before lookup to match the serialized keys.
-
-### Part F: Legacy Threshold Removal
+### Part E: Legacy Threshold Removal
 
 Files affected:
 - `src/threshold_config.rs` — delete entirely
-- `src/calibrate.rs` — remove `compute_thresholds()` function and `use crate::threshold_config::*`
-- `src/calibrator.rs` — remove `suppress_threshold: Option<f64>`, `boost_threshold: Option<f64>`, `force_threshold: Option<f64>` from `CalibratorConfig`; remove the `sanitize_threshold` calls that reference these fields; remove the non-logistic threshold decision branches; keep the heuristic no-model fallback path
-- `src/main.rs` — remove `calibrator_thresholds.toml` loading, remove threshold report output, remove `--suppress-precision` / `--boost-precision` CLI args; add deprecation warning when old file exists
+- `src/calibrate.rs` — remove `compute_thresholds()` function
+- `src/calibrator.rs` — remove `suppress_threshold: Option<f64>`, `boost_threshold: Option<f64>`, `force_threshold: Option<f64>` from `CalibratorConfig`; simplify `calibrate_core_decision` to use only `LogisticModel` thresholds
+- `src/main.rs` — remove `calibrator_thresholds.toml` loading, remove threshold report output, remove `--suppress-precision` / `--boost-precision` CLI args from calibrate subcommand
 - `src/lib.rs` — remove `pub mod threshold_config`
 
-The no-model fallback (when `config.model.logistic_model` is `None`) continues to use the existing hardcoded heuristic logic for suppress/boost. This is not "legacy thresholds" — it's the baseline calibrator behavior that exists independently of the threshold config system.
+**Migration**: When `calibrator_thresholds.toml` exists, emit a one-time warning that it is no longer used and can be deleted.
 
 ### Backward Compatibility
 
-- Old `calibrator_model.toml` without rate maps: maps deserialize as `None`, features fall back to `0.0` (same as current broken behavior). `tracing::info_once!` recommends recalibration.
-- Old `calibrator_thresholds.toml`: ignored with a warning. No behavioral change for users who have a logistic model (which superseded these thresholds).
-- Users without a logistic model: heuristic calibrator continues to work as before.
-- After upgrading, `quorum calibrate` produces the new maps and retrains the model with corrected features.
+- Old `calibrator_model.toml` files (without rate maps) continue to work — features fall back to `0.0` (same as current behavior). A `tracing::info!` recommends recalibration.
+- Old `calibrator_thresholds.toml` is ignored with a warning.
+- After upgrading, users run `quorum calibrate` to get the new maps and retrain the logistic model with corrected features.
 
 ### Files Modified
 
 | File | Changes |
 |------|---------|
-| `src/calibrator.rs` | Fix 7 review-time features, fix trace emission, fix tokenization, remove legacy threshold fields, simplify decision logic |
-| `src/calibrator_model.rs` | Add 5 optional map fields |
-| `src/calibrate.rs` | Compute global rate maps for model, remove `compute_thresholds()`, make `tokenize_title` pub |
+| `src/calibrator.rs` | Fix review-time features, fix trace emission, remove legacy threshold fields, simplify decision logic |
+| `src/calibrator_model.rs` | Add 4 optional map fields |
+| `src/calibrate.rs` | Compute global rate maps for model, remove `compute_thresholds()` |
 | `src/main.rs` | Remove threshold report, remove threshold CLI args, remove thresholds.toml loading, add deprecation warning |
 | `src/threshold_config.rs` | Delete |
 | `src/lib.rs` | Remove `pub mod threshold_config` |
 
 ### Testing
 
-- Unit tests for each fixed feature: verify training-time and review-time produce equivalent values for known inputs (same composite weight, same ln_1p scale, same tokenization, same rate lookups)
-- Serde round-trip tests: old TOML without maps loads with `None`; new TOML serializes and deserializes maps correctly
+- Unit tests for each fixed feature value (verify training-time and review-time produce equivalent values for known inputs)
 - Integration test: run calibrate with test corpus, verify new maps appear in serialized model
-- Regression test: old model.toml without maps still loads and produces valid scores
+- Regression test: old model.toml without maps still loads and produces valid (zero-fallback) scores
 - Test that legacy threshold file triggers deprecation warning
-- Test that `tokenize_title` and inference-time tokenization produce identical tokens

--- a/rules/rust/discarded-fallible-result.yml
+++ b/rules/rust/discarded-fallible-result.yml
@@ -1,0 +1,22 @@
+id: discarded-fallible-result
+language: Rust
+severity: warning
+message: "Fallible result discarded with `let _ = ...`. If this operation fails (lock poisoned, channel closed, I/O error) the error is silently lost. Handle with `?`, `.expect(\"…\")`, or log the error."
+note: "Broadens ignored-io-result to cover lock/send/flush/close/connect/bind patterns. Issue #380."
+metadata:
+  precision: high
+rule:
+  kind: let_declaration
+  all:
+    - has:
+        field: pattern
+        regex: "^_$"
+    - has:
+        field: value
+        kind: call_expression
+        has:
+          field: function
+          kind: field_expression
+          has:
+            field: field
+            regex: "^(lock|send|flush|close|write_all|connect|bind|try_lock|try_send|try_recv|recv|shutdown)$"

--- a/rules/rust/tests/discarded-fallible-result.rs
+++ b/rules/rust/tests/discarded-fallible-result.rs
@@ -1,0 +1,33 @@
+// Fixture: discarded-fallible-result
+use std::sync::Mutex;
+use std::net::TcpStream;
+
+fn bad_examples() {
+    let m = Mutex::new(0);
+    // match: discarded lock result
+    let _ = m.lock();
+
+    // match: discarded send on channel
+    let _ = tx.send(42);
+
+    // match: discarded flush
+    let _ = writer.flush();
+
+    // match: discarded shutdown
+    let _ = stream.shutdown();
+}
+
+fn good_examples() {
+    let m = Mutex::new(0);
+    // no-match: result used
+    let guard = m.lock().unwrap();
+
+    // no-match: propagated
+    tx.send(42)?;
+
+    // no-match: non-fallible method
+    let _ = vec.clone();
+
+    // no-match: named binding (acknowledged)
+    let _guard = m.lock();
+}

--- a/rules/rust/tests/unwrap-after-infallible.rs
+++ b/rules/rust/tests/unwrap-after-infallible.rs
@@ -1,0 +1,24 @@
+// Fixture: unwrap-after-infallible
+
+fn safe_unwraps() {
+    // match: Some(x).unwrap() is always safe
+    let val = Some(42).unwrap();
+
+    // match: Ok(x).unwrap() is always safe
+    let ok = Ok("hello").unwrap();
+
+    // match: Some with expression
+    let computed = Some(vec![1, 2, 3]).unwrap();
+}
+
+fn unsafe_unwraps() {
+    // no-match: unknown option, could be None
+    let maybe: Option<i32> = get_value();
+    let val = maybe.unwrap();
+
+    // no-match: result from fallible operation
+    let data = std::fs::read("file.txt").unwrap();
+
+    // no-match: method call result
+    let item = map.get("key").unwrap();
+}

--- a/rules/rust/unwrap-after-infallible.yml
+++ b/rules/rust/unwrap-after-infallible.yml
@@ -1,0 +1,25 @@
+id: unwrap-after-infallible
+language: Rust
+severity: hint
+message: "`.unwrap()` on a value known to be `Some`/`Ok` at construction site. This is safe but consider using the inner value directly."
+note: "Suppression rule: presence indicates nearby unwrap() findings are likely FP. Issue #382."
+metadata:
+  precision: high
+  judge: suppress_if_matched
+rule:
+  kind: call_expression
+  has:
+    field: function
+    kind: field_expression
+    all:
+      - has:
+          field: field
+          regex: "^unwrap$"
+      - has:
+          field: value
+          kind: call_expression
+          has:
+            field: function
+            any:
+              - regex: "^Some$"
+              - regex: "^Ok$"

--- a/rules/typescript/console-log-non-test.yml
+++ b/rules/typescript/console-log-non-test.yml
@@ -1,0 +1,23 @@
+id: console-log-non-test
+language: TypeScript
+severity: hint
+message: "`console.log()` left in production code. Remove debug artifacts before shipping, or use a structured logger."
+note: "Feedback: 23 FPs from flagging in test code. This rule excludes test contexts. Issue #381."
+metadata:
+  precision: speculative
+rule:
+  any:
+    - pattern: console.log($$$)
+    - pattern: console.debug($$$)
+    - pattern: console.warn($$$)
+  not:
+    any:
+      - inside:
+          kind: call_expression
+          has:
+            field: function
+            regex: "^(describe|it|test|beforeEach|afterEach|beforeAll|afterAll)$"
+          stopBy: end
+      - inside:
+          kind: catch_clause
+          stopBy: end

--- a/rules/typescript/tests/console-log-non-test.ts
+++ b/rules/typescript/tests/console-log-non-test.ts
@@ -1,0 +1,39 @@
+// Fixture: console-log-non-test
+
+// match: top-level console.log in production code
+console.log("debug leftover");
+
+// match: console.debug in a class method
+class Service {
+  init() {
+    console.debug("starting up");
+  }
+}
+
+// match: console.warn in utility function
+function processData(data: any) {
+  console.warn("unexpected format");
+  return data;
+}
+
+// no-match: inside describe block
+describe("MyService", () => {
+  it("should work", () => {
+    console.log("test output");
+  });
+});
+
+// no-match: inside test() block
+test("handles edge case", () => {
+  console.log("checking");
+});
+
+// no-match: inside catch clause
+try {
+  riskyOp();
+} catch (e) {
+  console.log("error caught:", e);
+}
+
+// no-match: console.error is intentional
+console.error("fatal");

--- a/src/analysis.rs
+++ b/src/analysis.rs
@@ -1,6 +1,6 @@
-use crate::finding::{Finding, FindingBuilder, Severity};
 #[cfg(test)]
 use crate::finding::Source;
+use crate::finding::{Finding, FindingBuilder, Severity};
 use crate::parser::Language;
 
 pub fn analyze_complexity(
@@ -237,14 +237,21 @@ fn scan_insecure_rust(node: &tree_sitter::Node, source: &str, findings: &mut Vec
     {
         let field_name = &source[field.byte_range()];
         if field_name == "unwrap" {
-            findings.push(FindingBuilder::new()
-                .title("Use of `.unwrap()` may panic at runtime")
-                .description("Consider using `.expect()` with a message or proper error handling.")
-                .severity(Severity::Low)
-                .category("security".into())
-                .lines(node.start_position().row as u32 + 1, node.end_position().row as u32 + 1)
-                .rule_id("local-ast:rust/unwrap-in-non-test")
-                .build());
+            findings.push(
+                FindingBuilder::new()
+                    .title("Use of `.unwrap()` may panic at runtime")
+                    .description(
+                        "Consider using `.expect()` with a message or proper error handling.",
+                    )
+                    .severity(Severity::Low)
+                    .category("security".into())
+                    .lines(
+                        node.start_position().row as u32 + 1,
+                        node.end_position().row as u32 + 1,
+                    )
+                    .rule_id("local-ast:rust/unwrap-in-non-test")
+                    .build(),
+            );
         }
     }
 }
@@ -258,18 +265,28 @@ fn scan_insecure_python(node: &tree_sitter::Node, source: &str, findings: &mut V
         if let Some(func) = node.child_by_field_name("function") {
             let func_name = &source[func.byte_range()];
             if func_name == "eval" || func_name == "exec" {
-                findings.push(FindingBuilder::new()
-                    .title(&format!("Use of `{}()` is a code injection risk", func_name))
-                    .description(&format!(
-                        "`{}()` executes arbitrary code. Avoid using it with untrusted input.",
-                        func_name
-                    ))
-                    .severity(Severity::Critical)
-                    .category("security".into())
-                    .lines(line, end_line)
-                    .evidence(&source[node.byte_range()].chars().take(200).collect::<String>())
-                    .rule_id("local-ast:python/eval-exec")
-                    .build());
+                findings.push(
+                    FindingBuilder::new()
+                        .title(&format!(
+                            "Use of `{}()` is a code injection risk",
+                            func_name
+                        ))
+                        .description(&format!(
+                            "`{}()` executes arbitrary code. Avoid using it with untrusted input.",
+                            func_name
+                        ))
+                        .severity(Severity::Critical)
+                        .category("security".into())
+                        .lines(line, end_line)
+                        .evidence(
+                            &source[node.byte_range()]
+                                .chars()
+                                .take(200)
+                                .collect::<String>(),
+                        )
+                        .rule_id("local-ast:python/eval-exec")
+                        .build(),
+                );
             }
         }
 
@@ -954,13 +971,15 @@ fn scan_insecure_yaml(node: &tree_sitter::Node, source: &str, findings: &mut Vec
 
             // 4. Missing mode
             if !keys.contains(&"mode") {
-                findings.push(FindingBuilder::new()
-                    .title("Automation has no explicit `mode` (defaults to `single`)")
-                    .description("Automation has no explicit `mode` (defaults to `single`)")
-                    .category("quality".into())
-                    .lines(line, end_line)
-                    .rule_id("local-ast:yaml/ha-no-mode")
-                    .build());
+                findings.push(
+                    FindingBuilder::new()
+                        .title("Automation has no explicit `mode` (defaults to `single`)")
+                        .description("Automation has no explicit `mode` (defaults to `single`)")
+                        .category("quality".into())
+                        .lines(line, end_line)
+                        .rule_id("local-ast:yaml/ha-no-mode")
+                        .build(),
+                );
             }
 
             // 5. Deprecated singular trigger/action/condition
@@ -1146,15 +1165,22 @@ fn scan_insecure_yaml(node: &tree_sitter::Node, source: &str, findings: &mut Vec
         {
             let val_text = source[value.byte_range()].trim();
             if !val_text.is_empty() {
-                findings.push(FindingBuilder::new()
-                    .title(&format!("Hardcoded secret in `{}`", source[key.byte_range()].trim()))
-                    .description("Secrets should use `!secret` references, not hardcoded values.")
-                    .severity(Severity::High)
-                    .category("security".into())
-                    .lines(line, end_line)
-                    .evidence(&format!("{}: [REDACTED]", source[key.byte_range()].trim()))
-                    .rule_id("local-ast:yaml/hardcoded-secret")
-                    .build());
+                findings.push(
+                    FindingBuilder::new()
+                        .title(&format!(
+                            "Hardcoded secret in `{}`",
+                            source[key.byte_range()].trim()
+                        ))
+                        .description(
+                            "Secrets should use `!secret` references, not hardcoded values.",
+                        )
+                        .severity(Severity::High)
+                        .category("security".into())
+                        .lines(line, end_line)
+                        .evidence(&format!("{}: [REDACTED]", source[key.byte_range()].trim()))
+                        .rule_id("local-ast:yaml/hardcoded-secret")
+                        .build(),
+                );
             }
         }
 
@@ -1178,17 +1204,22 @@ fn scan_insecure_yaml(node: &tree_sitter::Node, source: &str, findings: &mut Vec
                                 .trim_start_matches("- ")
                                 .trim();
                             if !item_text.is_empty() && !item_text.contains('.') {
-                                findings.push(FindingBuilder::new()
-                                    .title("entity_id without domain prefix")
-                                    .description(&format!(
-                                        "`{}` is missing a domain prefix (e.g. `sensor.{}`)",
-                                        item_text, item_text
-                                    ))
-                                    .severity(Severity::High)
-                                    .category("bug".into())
-                                    .lines(item.start_position().row as u32 + 1, item.end_position().row as u32 + 1)
-                                    .rule_id("local-ast:yaml/entity-id-no-domain")
-                                    .build());
+                                findings.push(
+                                    FindingBuilder::new()
+                                        .title("entity_id without domain prefix")
+                                        .description(&format!(
+                                            "`{}` is missing a domain prefix (e.g. `sensor.{}`)",
+                                            item_text, item_text
+                                        ))
+                                        .severity(Severity::High)
+                                        .category("bug".into())
+                                        .lines(
+                                            item.start_position().row as u32 + 1,
+                                            item.end_position().row as u32 + 1,
+                                        )
+                                        .rule_id("local-ast:yaml/entity-id-no-domain")
+                                        .build(),
+                                );
                             }
                         }
                     }
@@ -1196,17 +1227,19 @@ fn scan_insecure_yaml(node: &tree_sitter::Node, source: &str, findings: &mut Vec
                 }
             }
             if !is_list && !val_text.is_empty() && !val_text.contains('.') {
-                findings.push(FindingBuilder::new()
-                    .title("entity_id without domain prefix")
-                    .description(&format!(
-                        "`{}` is missing a domain prefix (e.g. `sensor.{}`)",
-                        val_text, val_text
-                    ))
-                    .severity(Severity::High)
-                    .category("bug".into())
-                    .lines(line, end_line)
-                    .rule_id("local-ast:yaml/entity-id-no-domain")
-                    .build());
+                findings.push(
+                    FindingBuilder::new()
+                        .title("entity_id without domain prefix")
+                        .description(&format!(
+                            "`{}` is missing a domain prefix (e.g. `sensor.{}`)",
+                            val_text, val_text
+                        ))
+                        .severity(Severity::High)
+                        .category("bug".into())
+                        .lines(line, end_line)
+                        .rule_id("local-ast:yaml/entity-id-no-domain")
+                        .build(),
+                );
             }
         }
 
@@ -1216,17 +1249,19 @@ fn scan_insecure_yaml(node: &tree_sitter::Node, source: &str, findings: &mut Vec
         {
             let val_text = source[value.byte_range()].trim();
             if !val_text.is_empty() && !val_text.contains('.') {
-                findings.push(FindingBuilder::new()
-                    .title("service without domain prefix")
-                    .description(&format!(
-                        "`{}` is missing a domain prefix (e.g. `light.{}`)",
-                        val_text, val_text
-                    ))
-                    .severity(Severity::Medium)
-                    .category("bug".into())
-                    .lines(line, end_line)
-                    .rule_id("local-ast:yaml/service-no-domain")
-                    .build());
+                findings.push(
+                    FindingBuilder::new()
+                        .title("service without domain prefix")
+                        .description(&format!(
+                            "`{}` is missing a domain prefix (e.g. `light.{}`)",
+                            val_text, val_text
+                        ))
+                        .severity(Severity::Medium)
+                        .category("bug".into())
+                        .lines(line, end_line)
+                        .rule_id("local-ast:yaml/service-no-domain")
+                        .build(),
+                );
             }
         }
 
@@ -1327,15 +1362,17 @@ fn scan_insecure_yaml(node: &tree_sitter::Node, source: &str, findings: &mut Vec
                 "states.alarm_control_panel.",
             ];
             if dot_domains.iter().any(|d| val_text.contains(d)) {
-                findings.push(FindingBuilder::new()
-                    .title("Deprecated dot-notation state access")
-                    .description("Use states('sensor.xxx') instead of states.sensor.xxx.state")
-                    .severity(Severity::Medium)
-                    .category("quality".into())
-                    .lines(line, end_line)
-                    .evidence(&val_text.chars().take(200).collect::<String>())
-                    .rule_id("local-ast:yaml/deprecated-dot-state")
-                    .build());
+                findings.push(
+                    FindingBuilder::new()
+                        .title("Deprecated dot-notation state access")
+                        .description("Use states('sensor.xxx') instead of states.sensor.xxx.state")
+                        .severity(Severity::Medium)
+                        .category("quality".into())
+                        .lines(line, end_line)
+                        .evidence(&val_text.chars().take(200).collect::<String>())
+                        .rule_id("local-ast:yaml/deprecated-dot-state")
+                        .build(),
+                );
             }
         }
     }
@@ -1351,14 +1388,18 @@ fn scan_insecure_typescript(node: &tree_sitter::Node, source: &str, findings: &m
     {
         let func_name = &source[func.byte_range()];
         if func_name == "eval" {
-            findings.push(FindingBuilder::new()
-                .title("Use of `eval()` is a code injection risk")
-                .description("`eval()` executes arbitrary code. Avoid using it with untrusted input.")
-                .severity(Severity::Critical)
-                .category("security".into())
-                .lines(line, end_line)
-                .rule_id("local-ast:typescript/eval")
-                .build());
+            findings.push(
+                FindingBuilder::new()
+                    .title("Use of `eval()` is a code injection risk")
+                    .description(
+                        "`eval()` executes arbitrary code. Avoid using it with untrusted input.",
+                    )
+                    .severity(Severity::Critical)
+                    .category("security".into())
+                    .lines(line, end_line)
+                    .rule_id("local-ast:typescript/eval")
+                    .build(),
+            );
         }
 
         // document.write XSS
@@ -1458,14 +1499,21 @@ fn scan_insecure_typescript(node: &tree_sitter::Node, source: &str, findings: &m
     if node.kind() == "type_annotation" {
         let text = &source[node.byte_range()];
         if text.contains(": any") {
-            findings.push(FindingBuilder::new()
-                .title("Use of `any` type defeats TypeScript's type safety")
-                .description("Prefer `unknown`, generics, or a specific type instead of `any`.")
-                .category("quality".into())
-                .lines(line, end_line)
-                .evidence(&source[node.byte_range()].chars().take(100).collect::<String>())
-                .rule_id("local-ast:typescript/any-type")
-                .build());
+            findings.push(
+                FindingBuilder::new()
+                    .title("Use of `any` type defeats TypeScript's type safety")
+                    .description("Prefer `unknown`, generics, or a specific type instead of `any`.")
+                    .category("quality".into())
+                    .lines(line, end_line)
+                    .evidence(
+                        &source[node.byte_range()]
+                            .chars()
+                            .take(100)
+                            .collect::<String>(),
+                    )
+                    .rule_id("local-ast:typescript/any-type")
+                    .build(),
+            );
         }
     }
 
@@ -1603,14 +1651,18 @@ fn scan_insecure_bash(node: &tree_sitter::Node, source: &str, findings: &mut Vec
             }
         }
         if !found_set_e {
-            findings.push(FindingBuilder::new()
-                .title("Script has no `set -e` -- errors will be silently ignored")
-                .description("Add `set -euo pipefail` near the top of the script to fail on errors.")
-                .severity(Severity::Medium)
-                .category("reliability".into())
-                .lines(1, 1)
-                .rule_id("local-ast:bash/no-set-e")
-                .build());
+            findings.push(
+                FindingBuilder::new()
+                    .title("Script has no `set -e` -- errors will be silently ignored")
+                    .description(
+                        "Add `set -euo pipefail` near the top of the script to fail on errors.",
+                    )
+                    .severity(Severity::Medium)
+                    .category("reliability".into())
+                    .lines(1, 1)
+                    .rule_id("local-ast:bash/no-set-e")
+                    .build(),
+            );
         }
     }
 
@@ -1620,15 +1672,24 @@ fn scan_insecure_bash(node: &tree_sitter::Node, source: &str, findings: &mut Vec
     {
         let name = &source[name_node.byte_range()];
         if name == "eval" {
-            findings.push(FindingBuilder::new()
-                .title("Use of `eval` is a code injection risk")
-                .description("Avoid `eval` -- use arrays, printf, or parameter expansion instead.")
-                .severity(Severity::High)
-                .category("security".into())
-                .lines(line, end_line)
-                .evidence(&source[node.byte_range()].chars().take(200).collect::<String>())
-                .rule_id("local-ast:bash/eval")
-                .build());
+            findings.push(
+                FindingBuilder::new()
+                    .title("Use of `eval` is a code injection risk")
+                    .description(
+                        "Avoid `eval` -- use arrays, printf, or parameter expansion instead.",
+                    )
+                    .severity(Severity::High)
+                    .category("security".into())
+                    .lines(line, end_line)
+                    .evidence(
+                        &source[node.byte_range()]
+                            .chars()
+                            .take(200)
+                            .collect::<String>(),
+                    )
+                    .rule_id("local-ast:bash/eval")
+                    .build(),
+            );
         }
 
         // B9: chmod 777
@@ -1637,15 +1698,22 @@ fn scan_insecure_bash(node: &tree_sitter::Node, source: &str, findings: &mut Vec
                 if let Some(arg) = node.child(i as u32) {
                     let text = &source[arg.byte_range()];
                     if text == "777" {
-                        findings.push(FindingBuilder::new()
-                            .title("`chmod 777` grants world-writable permissions")
-                            .description("Use more restrictive permissions (e.g. 755 or 700).")
-                            .severity(Severity::Medium)
-                            .category("security".into())
-                            .lines(line, end_line)
-                            .evidence(&source[node.byte_range()].chars().take(200).collect::<String>())
-                            .rule_id("local-ast:bash/chmod-777")
-                            .build());
+                        findings.push(
+                            FindingBuilder::new()
+                                .title("`chmod 777` grants world-writable permissions")
+                                .description("Use more restrictive permissions (e.g. 755 or 700).")
+                                .severity(Severity::Medium)
+                                .category("security".into())
+                                .lines(line, end_line)
+                                .evidence(
+                                    &source[node.byte_range()]
+                                        .chars()
+                                        .take(200)
+                                        .collect::<String>(),
+                                )
+                                .rule_id("local-ast:bash/chmod-777")
+                                .build(),
+                        );
                         break;
                     }
                 }
@@ -1665,15 +1733,22 @@ fn scan_insecure_bash(node: &tree_sitter::Node, source: &str, findings: &mut Vec
                 if name == "curl" || name == "wget" {
                     saw_curl = true;
                 } else if saw_curl && (name == "bash" || name == "sh" || name == "zsh") {
-                    findings.push(FindingBuilder::new()
-                        .title("Piping curl/wget to shell executes untrusted remote code")
-                        .description("Download to a file first, inspect it, then execute.")
-                        .severity(Severity::Critical)
-                        .category("security".into())
-                        .lines(line, end_line)
-                        .evidence(&source[node.byte_range()].chars().take(200).collect::<String>())
-                        .rule_id("local-ast:bash/curl-pipe-bash")
-                        .build());
+                    findings.push(
+                        FindingBuilder::new()
+                            .title("Piping curl/wget to shell executes untrusted remote code")
+                            .description("Download to a file first, inspect it, then execute.")
+                            .severity(Severity::Critical)
+                            .category("security".into())
+                            .lines(line, end_line)
+                            .evidence(
+                                &source[node.byte_range()]
+                                    .chars()
+                                    .take(200)
+                                    .collect::<String>(),
+                            )
+                            .rule_id("local-ast:bash/curl-pipe-bash")
+                            .build(),
+                    );
                     break;
                 }
             }
@@ -2118,17 +2193,24 @@ fn check_required_providers(rp_body: tree_sitter::Node, source: &str, findings: 
         walk_for_object_keys(expr, source, &mut has_source, &mut has_version);
 
         if has_source && !has_version {
-            findings.push(FindingBuilder::new()
-                .title(&format!(
-                    "Provider `{}` in required_providers has no version constraint",
-                    provider_name.unwrap_or("unknown")
-                ))
-                .description("Add a `version` constraint to prevent unexpected provider upgrades.")
-                .severity(Severity::Medium)
-                .category("reliability".into())
-                .lines(attr.start_position().row as u32 + 1, attr.end_position().row as u32 + 1)
-                .rule_id("local-ast:terraform/no-provider-version")
-                .build());
+            findings.push(
+                FindingBuilder::new()
+                    .title(&format!(
+                        "Provider `{}` in required_providers has no version constraint",
+                        provider_name.unwrap_or("unknown")
+                    ))
+                    .description(
+                        "Add a `version` constraint to prevent unexpected provider upgrades.",
+                    )
+                    .severity(Severity::Medium)
+                    .category("reliability".into())
+                    .lines(
+                        attr.start_position().row as u32 + 1,
+                        attr.end_position().row as u32 + 1,
+                    )
+                    .rule_id("local-ast:terraform/no-provider-version")
+                    .build(),
+            );
         }
     }
 }
@@ -2231,14 +2313,16 @@ fn analyze_dockerfile_structure(tree: &tree_sitter::Tree, source: &str) -> Vec<F
 
     // D6: No USER instruction
     if !has_user {
-        findings.push(FindingBuilder::new()
-            .title("No USER instruction -- container runs as root")
-            .description("Add a USER instruction to run the container as a non-root user.")
-            .severity(Severity::Medium)
-            .category("security".into())
-            .lines(1, 1)
-            .rule_id("local-ast:dockerfile/no-user")
-            .build());
+        findings.push(
+            FindingBuilder::new()
+                .title("No USER instruction -- container runs as root")
+                .description("Add a USER instruction to run the container as a non-root user.")
+                .severity(Severity::Medium)
+                .category("security".into())
+                .lines(1, 1)
+                .rule_id("local-ast:dockerfile/no-user")
+                .build(),
+        );
     }
 
     // D8: No HEALTHCHECK
@@ -2255,30 +2339,34 @@ fn analyze_dockerfile_structure(tree: &tree_sitter::Tree, source: &str) -> Vec<F
 
     // D11: Multiple CMD/ENTRYPOINT
     if cmd_count > 1 {
-        findings.push(FindingBuilder::new()
-            .title("Multiple CMD instructions -- only the last one takes effect")
-            .description(&format!(
-                "Found {} CMD instructions; only the last one will be used.",
-                cmd_count
-            ))
-            .severity(Severity::Medium)
-            .category("bug".into())
-            .lines(1, 1)
-            .rule_id("local-ast:dockerfile/multiple-cmd")
-            .build());
+        findings.push(
+            FindingBuilder::new()
+                .title("Multiple CMD instructions -- only the last one takes effect")
+                .description(&format!(
+                    "Found {} CMD instructions; only the last one will be used.",
+                    cmd_count
+                ))
+                .severity(Severity::Medium)
+                .category("bug".into())
+                .lines(1, 1)
+                .rule_id("local-ast:dockerfile/multiple-cmd")
+                .build(),
+        );
     }
     if entrypoint_count > 1 {
-        findings.push(FindingBuilder::new()
-            .title("Multiple ENTRYPOINT instructions -- only the last one takes effect")
-            .description(&format!(
-                "Found {} ENTRYPOINT instructions; only the last one will be used.",
-                entrypoint_count
-            ))
-            .severity(Severity::Medium)
-            .category("bug".into())
-            .lines(1, 1)
-            .rule_id("local-ast:dockerfile/multiple-entrypoint")
-            .build());
+        findings.push(
+            FindingBuilder::new()
+                .title("Multiple ENTRYPOINT instructions -- only the last one takes effect")
+                .description(&format!(
+                    "Found {} ENTRYPOINT instructions; only the last one will be used.",
+                    entrypoint_count
+                ))
+                .severity(Severity::Medium)
+                .category("bug".into())
+                .lines(1, 1)
+                .rule_id("local-ast:dockerfile/multiple-entrypoint")
+                .build(),
+        );
     }
 
     findings

--- a/src/analysis.rs
+++ b/src/analysis.rs
@@ -1,4 +1,6 @@
-use crate::finding::{Finding, Severity, Source};
+use crate::finding::{Finding, FindingBuilder, Severity};
+#[cfg(test)]
+use crate::finding::Source;
 use crate::parser::Language;
 
 pub fn analyze_complexity(
@@ -43,37 +45,18 @@ pub fn analyze_complexity(
                 } else {
                     Severity::Low
                 };
-                findings.push(Finding {
-                    id: crate::finding::new_finding_ulid(),
-                    title: format!("Function `{}` has cyclomatic complexity {}", name, cc),
-                    description: format!(
+                findings.push(FindingBuilder::new()
+                    .title(&format!("Function `{}` has cyclomatic complexity {}", name, cc))
+                    .description(&format!(
                         "Cyclomatic complexity of {} exceeds threshold of {}. Consider refactoring.",
                         cc, threshold
-                    ),
-                    severity,
-                    category: "complexity".into(),
-                    source: Source::LocalAst,
-                    line_start: node.start_position().row as u32 + 1,
-                    line_end: node.end_position().row as u32 + 1,
-                    evidence: vec![format!("cyclomatic_complexity={}", cc)],
-                    calibrator_action: None,
-                    similar_precedent: vec![],
-                    canonical_pattern: None,
-                    suggested_fix: None,
-                    based_on_excerpt: None,
-                    reasoning: None,
-                    llm_confidence: None,
-                    confidence: None,
-                    cited_lines: None,
-                    grounding_status: None,
-                    grounding_confidence: None,
-                model_agreement: None,
-                rule_id: Some("local-ast:complexity".into()),
-                judge_verdict: None,
-                judge_confidence: None,
-                precision_tier: None,
-                    in_diff: None,
-                });
+                    ))
+                    .severity(severity)
+                    .category("complexity".into())
+                    .lines(node.start_position().row as u32 + 1, node.end_position().row as u32 + 1)
+                    .evidence(&format!("cyclomatic_complexity={}", cc))
+                    .rule_id("local-ast:complexity")
+                    .build());
             }
         }
     }
@@ -234,34 +217,14 @@ fn has_attribute(node: &tree_sitter::Node, source: &str, attr_name: &str) -> boo
 fn scan_insecure_rust(node: &tree_sitter::Node, source: &str, findings: &mut Vec<Finding>) {
     // unsafe blocks
     if node.kind() == "unsafe_block" {
-        findings.push(Finding {
-            id: crate::finding::new_finding_ulid(),
-            title: "Use of `unsafe` block".into(),
-            description: "Unsafe code bypasses Rust's safety guarantees. Ensure this is necessary and correct.".into(),
-            severity: Severity::Info,
-            category: "security".into(),
-            source: Source::LocalAst,
-            line_start: node.start_position().row as u32 + 1,
-            line_end: node.end_position().row as u32 + 1,
-            evidence: vec![source[node.byte_range()].chars().take(200).collect()],
-            calibrator_action: None,
-            similar_precedent: vec![],
-            canonical_pattern: None,
-            suggested_fix: None,
-            based_on_excerpt: None,
-            reasoning: None,
-            llm_confidence: None,
-            confidence: None,
-            cited_lines: None,
-                    grounding_status: None,
-                    grounding_confidence: None,
-        model_agreement: None,
-        rule_id: Some("local-ast:rust/unsafe-block".into()),
-        judge_verdict: None,
-        judge_confidence: None,
-        precision_tier: None,
-                    in_diff: None,
-        });
+        findings.push(FindingBuilder::new()
+            .title("Use of `unsafe` block")
+            .description("Unsafe code bypasses Rust's safety guarantees. Ensure this is necessary and correct.")
+            .category("security".into())
+            .lines(node.start_position().row as u32 + 1, node.end_position().row as u32 + 1)
+            .evidence(&source[node.byte_range()].chars().take(200).collect::<String>())
+            .rule_id("local-ast:rust/unsafe-block")
+            .build());
     }
 
     // .unwrap() calls — tree-sitter-rust: call_expression with function=field_expression
@@ -274,35 +237,14 @@ fn scan_insecure_rust(node: &tree_sitter::Node, source: &str, findings: &mut Vec
     {
         let field_name = &source[field.byte_range()];
         if field_name == "unwrap" {
-            findings.push(Finding {
-                id: crate::finding::new_finding_ulid(),
-                title: "Use of `.unwrap()` may panic at runtime".into(),
-                description: "Consider using `.expect()` with a message or proper error handling."
-                    .into(),
-                severity: Severity::Low,
-                category: "security".into(),
-                source: Source::LocalAst,
-                line_start: node.start_position().row as u32 + 1,
-                line_end: node.end_position().row as u32 + 1,
-                evidence: vec![],
-                calibrator_action: None,
-                similar_precedent: vec![],
-                canonical_pattern: None,
-                suggested_fix: None,
-                based_on_excerpt: None,
-                reasoning: None,
-                llm_confidence: None,
-                confidence: None,
-                cited_lines: None,
-                grounding_status: None,
-                grounding_confidence: None,
-                model_agreement: None,
-                rule_id: Some("local-ast:rust/unwrap-in-non-test".into()),
-                judge_verdict: None,
-                judge_confidence: None,
-                precision_tier: None,
-                in_diff: None,
-            });
+            findings.push(FindingBuilder::new()
+                .title("Use of `.unwrap()` may panic at runtime")
+                .description("Consider using `.expect()` with a message or proper error handling.")
+                .severity(Severity::Low)
+                .category("security".into())
+                .lines(node.start_position().row as u32 + 1, node.end_position().row as u32 + 1)
+                .rule_id("local-ast:rust/unwrap-in-non-test")
+                .build());
         }
     }
 }
@@ -316,37 +258,18 @@ fn scan_insecure_python(node: &tree_sitter::Node, source: &str, findings: &mut V
         if let Some(func) = node.child_by_field_name("function") {
             let func_name = &source[func.byte_range()];
             if func_name == "eval" || func_name == "exec" {
-                findings.push(Finding {
-                    id: crate::finding::new_finding_ulid(),
-                    title: format!("Use of `{}()` is a code injection risk", func_name),
-                    description: format!(
+                findings.push(FindingBuilder::new()
+                    .title(&format!("Use of `{}()` is a code injection risk", func_name))
+                    .description(&format!(
                         "`{}()` executes arbitrary code. Avoid using it with untrusted input.",
                         func_name
-                    ),
-                    severity: Severity::Critical,
-                    category: "security".into(),
-                    source: Source::LocalAst,
-                    line_start: line,
-                    line_end: end_line,
-                    evidence: vec![source[node.byte_range()].chars().take(200).collect()],
-                    calibrator_action: None,
-                    similar_precedent: vec![],
-                    canonical_pattern: None,
-                    suggested_fix: None,
-                    based_on_excerpt: None,
-                    reasoning: None,
-                    llm_confidence: None,
-                    confidence: None,
-                    cited_lines: None,
-                    grounding_status: None,
-                    grounding_confidence: None,
-                    model_agreement: None,
-                    rule_id: Some("local-ast:python/eval-exec".into()),
-                    judge_verdict: None,
-                    judge_confidence: None,
-                    precision_tier: None,
-                    in_diff: None,
-                });
+                    ))
+                    .severity(Severity::Critical)
+                    .category("security".into())
+                    .lines(line, end_line)
+                    .evidence(&source[node.byte_range()].chars().take(200).collect::<String>())
+                    .rule_id("local-ast:python/eval-exec")
+                    .build());
             }
         }
 
@@ -354,64 +277,26 @@ fn scan_insecure_python(node: &tree_sitter::Node, source: &str, findings: &mut V
         if let Some(args) = node.child_by_field_name("arguments") {
             let args_text = &source[args.byte_range()];
             if args_text.contains("debug=True") || args_text.contains("debug = True") {
-                findings.push(Finding {
-                    id: crate::finding::new_finding_ulid(),
-                    title: "Server running with debug=True".into(),
-                    description: "Debug mode exposes detailed error pages and may enable a debugger. Disable in production.".into(),
-                    severity: Severity::High,
-                    category: "security".into(),
-                    source: Source::LocalAst,
-                    line_start: line,
-                    line_end: end_line,
-                    evidence: vec![source[node.byte_range()].chars().take(200).collect()],
-                    calibrator_action: None,
-                    similar_precedent: vec![],
-                    canonical_pattern: None,
-                    suggested_fix: None,
-                    based_on_excerpt: None,
-                    reasoning: None,
-                    llm_confidence: None,
-                    confidence: None,
-                    cited_lines: None,
-                    grounding_status: None,
-                    grounding_confidence: None,
-                model_agreement: None,
-                rule_id: Some("local-ast:python/debug-true".into()),
-                judge_verdict: None,
-                judge_confidence: None,
-                precision_tier: None,
-                    in_diff: None,
-                });
+                findings.push(FindingBuilder::new()
+                    .title("Server running with debug=True")
+                    .description("Debug mode exposes detailed error pages and may enable a debugger. Disable in production.")
+                    .severity(Severity::High)
+                    .category("security".into())
+                    .lines(line, end_line)
+                    .evidence(&source[node.byte_range()].chars().take(200).collect::<String>())
+                    .rule_id("local-ast:python/debug-true")
+                    .build());
             }
             if args_text.contains("host=\"0.0.0.0\"") || args_text.contains("host='0.0.0.0'") {
-                findings.push(Finding {
-                    id: crate::finding::new_finding_ulid(),
-                    title: "Server binding to 0.0.0.0 exposes all network interfaces".into(),
-                    description: "Binding to 0.0.0.0 makes the server accessible from any network interface. Use 127.0.0.1 for local-only access.".into(),
-                    severity: Severity::Medium,
-                    category: "security".into(),
-                    source: Source::LocalAst,
-                    line_start: line,
-                    line_end: end_line,
-                    evidence: vec![source[node.byte_range()].chars().take(200).collect()],
-                    calibrator_action: None,
-                    similar_precedent: vec![],
-                    canonical_pattern: None,
-                    suggested_fix: None,
-                    based_on_excerpt: None,
-                    reasoning: None,
-                    llm_confidence: None,
-                    confidence: None,
-                    cited_lines: None,
-                    grounding_status: None,
-                    grounding_confidence: None,
-                model_agreement: None,
-                rule_id: Some("local-ast:python/bind-all-interfaces".into()),
-                judge_verdict: None,
-                judge_confidence: None,
-                precision_tier: None,
-                    in_diff: None,
-                });
+                findings.push(FindingBuilder::new()
+                    .title("Server binding to 0.0.0.0 exposes all network interfaces")
+                    .description("Binding to 0.0.0.0 makes the server accessible from any network interface. Use 127.0.0.1 for local-only access.")
+                    .severity(Severity::Medium)
+                    .category("security".into())
+                    .lines(line, end_line)
+                    .evidence(&source[node.byte_range()].chars().take(200).collect::<String>())
+                    .rule_id("local-ast:python/bind-all-interfaces")
+                    .build());
             }
         }
 
@@ -428,63 +313,25 @@ fn scan_insecure_python(node: &tree_sitter::Node, source: &str, findings: &mut V
                     if arg_kind == "string"
                         && (arg_text.starts_with("f\"") || arg_text.starts_with("f'"))
                     {
-                        findings.push(Finding {
-                                id: crate::finding::new_finding_ulid(),
-                                title: "Potential SQL injection via f-string in execute()".into(),
-                                description: "String interpolation in SQL queries allows injection. Use parameterized queries instead.".into(),
-                                severity: Severity::Critical,
-                                category: "security".into(),
-                                source: Source::LocalAst,
-                                line_start: line,
-                                line_end: end_line,
-                                evidence: vec![source[node.byte_range()].chars().take(200).collect()],
-                                calibrator_action: None,
-                                similar_precedent: vec![],
-                                canonical_pattern: None,
-                                suggested_fix: None,
-                                based_on_excerpt: None,
-                                reasoning: None,
-                                llm_confidence: None,
-                    confidence: None,
-                                cited_lines: None,
-                    grounding_status: None,
-                    grounding_confidence: None,
-                            model_agreement: None,
-                            rule_id: Some("local-ast:python/sql-injection".into()),
-                            judge_verdict: None,
-                            judge_confidence: None,
-                            precision_tier: None,
-                    in_diff: None,
-                            });
+                        findings.push(FindingBuilder::new()
+                            .title("Potential SQL injection via f-string in execute()")
+                            .description("String interpolation in SQL queries allows injection. Use parameterized queries instead.")
+                            .severity(Severity::Critical)
+                            .category("security".into())
+                            .lines(line, end_line)
+                            .evidence(&source[node.byte_range()].chars().take(200).collect::<String>())
+                            .rule_id("local-ast:python/sql-injection")
+                            .build());
                     } else if arg_text.contains(".format(") {
-                        findings.push(Finding {
-                                id: crate::finding::new_finding_ulid(),
-                                title: "Potential SQL injection via .format() in execute()".into(),
-                                description: "String formatting in SQL queries allows injection. Use parameterized queries instead.".into(),
-                                severity: Severity::Critical,
-                                category: "security".into(),
-                                source: Source::LocalAst,
-                                line_start: line,
-                                line_end: end_line,
-                                evidence: vec![source[node.byte_range()].chars().take(200).collect()],
-                                calibrator_action: None,
-                                similar_precedent: vec![],
-                                canonical_pattern: None,
-                                suggested_fix: None,
-                                based_on_excerpt: None,
-                                reasoning: None,
-                                llm_confidence: None,
-                    confidence: None,
-                                cited_lines: None,
-                    grounding_status: None,
-                    grounding_confidence: None,
-                            model_agreement: None,
-                            rule_id: Some("local-ast:python/sql-injection".into()),
-                            judge_verdict: None,
-                            judge_confidence: None,
-                            precision_tier: None,
-                    in_diff: None,
-                            });
+                        findings.push(FindingBuilder::new()
+                            .title("Potential SQL injection via .format() in execute()")
+                            .description("String formatting in SQL queries allows injection. Use parameterized queries instead.")
+                            .severity(Severity::Critical)
+                            .category("security".into())
+                            .lines(line, end_line)
+                            .evidence(&source[node.byte_range()].chars().take(200).collect::<String>())
+                            .rule_id("local-ast:python/sql-injection")
+                            .build());
                     }
                 }
             }
@@ -506,34 +353,15 @@ fn scan_insecure_python(node: &tree_sitter::Node, source: &str, findings: &mut V
                 let has_encoding =
                     args_text.contains("encoding=") || args_text.contains("encoding =");
                 if !is_binary && !has_encoding {
-                    findings.push(Finding {
-                            id: crate::finding::new_finding_ulid(),
-                            title: "`open()` without explicit `encoding` parameter".into(),
-                            description: "Without `encoding=`, open() uses the system default which varies by platform. Specify `encoding='utf-8'` for portable behavior.".into(),
-                            severity: Severity::Low,
-                            category: "reliability".into(),
-                            source: Source::LocalAst,
-                            line_start: line,
-                            line_end: end_line,
-                            evidence: vec![source[node.byte_range()].chars().take(200).collect()],
-                            calibrator_action: None,
-                            similar_precedent: vec![],
-                            canonical_pattern: None,
-                            suggested_fix: None,
-                            based_on_excerpt: None,
-                            reasoning: None,
-                            llm_confidence: None,
-                    confidence: None,
-                            cited_lines: None,
-                    grounding_status: None,
-                    grounding_confidence: None,
-                        model_agreement: None,
-                        rule_id: Some("local-ast:python/open-no-encoding".into()),
-                        judge_verdict: None,
-                        judge_confidence: None,
-                        precision_tier: None,
-                    in_diff: None,
-                        });
+                    findings.push(FindingBuilder::new()
+                        .title("`open()` without explicit `encoding` parameter")
+                        .description("Without `encoding=`, open() uses the system default which varies by platform. Specify `encoding='utf-8'` for portable behavior.")
+                        .severity(Severity::Low)
+                        .category("reliability".into())
+                        .lines(line, end_line)
+                        .evidence(&source[node.byte_range()].chars().take(200).collect::<String>())
+                        .rule_id("local-ast:python/open-no-encoding")
+                        .build());
                 }
             }
         }
@@ -572,34 +400,15 @@ fn scan_insecure_python(node: &tree_sitter::Node, source: &str, findings: &mut V
             let body_has_only_pass = body.named_child_count() == 1
                 && body.named_child(0).map(|c| c.kind()) == Some("pass_statement");
             if body_has_only_pass {
-                findings.push(Finding {
-                        id: crate::finding::new_finding_ulid(),
-                        title: "Catch-all `except: pass` silently swallows errors".into(),
-                        description: "Catching all exceptions with `pass` hides bugs. Log the error or catch a specific exception type.".into(),
-                        severity: Severity::Medium,
-                        category: "reliability".into(),
-                        source: Source::LocalAst,
-                        line_start: line,
-                        line_end: end_line,
-                        evidence: vec![source[node.byte_range()].chars().take(200).collect()],
-                        calibrator_action: None,
-                        similar_precedent: vec![],
-                        canonical_pattern: None,
-                        suggested_fix: None,
-                        based_on_excerpt: None,
-                        reasoning: None,
-                        llm_confidence: None,
-                    confidence: None,
-                        cited_lines: None,
-                    grounding_status: None,
-                    grounding_confidence: None,
-                    model_agreement: None,
-                    rule_id: Some("local-ast:python/bare-except-pass".into()),
-                    judge_verdict: None,
-                    judge_confidence: None,
-                    precision_tier: None,
-                    in_diff: None,
-                    });
+                findings.push(FindingBuilder::new()
+                    .title("Catch-all `except: pass` silently swallows errors")
+                    .description("Catching all exceptions with `pass` hides bugs. Log the error or catch a specific exception type.")
+                    .severity(Severity::Medium)
+                    .category("reliability".into())
+                    .lines(line, end_line)
+                    .evidence(&source[node.byte_range()].chars().take(200).collect::<String>())
+                    .rule_id("local-ast:python/bare-except-pass")
+                    .build());
             }
         }
     }
@@ -654,34 +463,15 @@ fn scan_insecure_python(node: &tree_sitter::Node, source: &str, findings: &mut V
                 && !inner.starts_with("http://")
                 && !inner.starts_with("https://")
             {
-                findings.push(Finding {
-                            id: crate::finding::new_finding_ulid(),
-                            title: format!("Hardcoded secret in `{}`", &source[left.byte_range()]),
-                            description: "Secrets should be loaded from environment variables or a secrets manager, not hardcoded in source.".into(),
-                            severity: Severity::High,
-                            category: "security".into(),
-                            source: Source::LocalAst,
-                            line_start: line,
-                            line_end: end_line,
-                            evidence: vec![format!("{} = [REDACTED]", &source[left.byte_range()])],
-                            calibrator_action: None,
-                            similar_precedent: vec![],
-                            canonical_pattern: None,
-                            suggested_fix: None,
-                            based_on_excerpt: None,
-                            reasoning: None,
-                            llm_confidence: None,
-                    confidence: None,
-                            cited_lines: None,
-                    grounding_status: None,
-                    grounding_confidence: None,
-                        model_agreement: None,
-                        rule_id: Some("local-ast:python/hardcoded-secret".into()),
-                        judge_verdict: None,
-                        judge_confidence: None,
-                        precision_tier: None,
-                    in_diff: None,
-                        });
+                findings.push(FindingBuilder::new()
+                    .title(&format!("Hardcoded secret in `{}`", &source[left.byte_range()]))
+                    .description("Secrets should be loaded from environment variables or a secrets manager, not hardcoded in source.")
+                    .severity(Severity::High)
+                    .category("security".into())
+                    .lines(line, end_line)
+                    .evidence(&format!("{} = [REDACTED]", &source[left.byte_range()]))
+                    .rule_id("local-ast:python/hardcoded-secret")
+                    .build());
             }
         }
     }
@@ -697,34 +487,15 @@ fn scan_insecure_python(node: &tree_sitter::Node, source: &str, findings: &mut V
                 if let Some(body) = node.child_by_field_name("body")
                     && has_mutating_call(&body, source, iterable_name)
                 {
-                    findings.push(Finding {
-                            id: crate::finding::new_finding_ulid(),
-                            title: format!("Mutating `{}` while iterating over it", iterable_name),
-                            description: "Modifying a collection while iterating over it leads to skipped elements or RuntimeError. Iterate over a copy instead.".into(),
-                            severity: Severity::High,
-                            category: "bug".into(),
-                            source: Source::LocalAst,
-                            line_start: line,
-                            line_end: end_line,
-                            evidence: vec![source[node.byte_range()].chars().take(200).collect()],
-                            calibrator_action: None,
-                            similar_precedent: vec![],
-                            canonical_pattern: None,
-                            suggested_fix: None,
-                            based_on_excerpt: None,
-                            reasoning: None,
-                            llm_confidence: None,
-                    confidence: None,
-                            cited_lines: None,
-                    grounding_status: None,
-                    grounding_confidence: None,
-                        model_agreement: None,
-                        rule_id: Some("local-ast:python/mutation-during-iteration".into()),
-                        judge_verdict: None,
-                        judge_confidence: None,
-                        precision_tier: None,
-                    in_diff: None,
-                        });
+                    findings.push(FindingBuilder::new()
+                        .title(&format!("Mutating `{}` while iterating over it", iterable_name))
+                        .description("Modifying a collection while iterating over it leads to skipped elements or RuntimeError. Iterate over a copy instead.")
+                        .severity(Severity::High)
+                        .category("bug".into())
+                        .lines(line, end_line)
+                        .evidence(&source[node.byte_range()].chars().take(200).collect::<String>())
+                        .rule_id("local-ast:python/mutation-during-iteration")
+                        .build());
                 }
             }
         }
@@ -755,37 +526,18 @@ fn scan_insecure_python(node: &tree_sitter::Node, source: &str, findings: &mut V
         if let Some(var_name) = exc_var {
             // Look for return statements that expose the exception
             if has_exception_in_return(node, source, var_name) {
-                findings.push(Finding {
-                    id: crate::finding::new_finding_ulid(),
-                    title: "Exception details disclosed in API response".into(),
-                    description: format!(
+                findings.push(FindingBuilder::new()
+                    .title("Exception details disclosed in API response")
+                    .description(&format!(
                         "Returning `str({0})` or `repr({0})` in an API response leaks internal details to clients. Log the exception and return a generic error message.",
                         var_name
-                    ),
-                    severity: Severity::Medium,
-                    category: "security".into(),
-                    source: Source::LocalAst,
-                    line_start: line,
-                    line_end: end_line,
-                    evidence: vec![source[node.byte_range()].chars().take(200).collect()],
-                    calibrator_action: None,
-                    similar_precedent: vec![],
-                    canonical_pattern: None,
-                    suggested_fix: None,
-                    based_on_excerpt: None,
-                    reasoning: None,
-                    llm_confidence: None,
-                    confidence: None,
-                    cited_lines: None,
-                    grounding_status: None,
-                    grounding_confidence: None,
-                model_agreement: None,
-                rule_id: Some("local-ast:python/exception-disclosure".into()),
-                judge_verdict: None,
-                judge_confidence: None,
-                precision_tier: None,
-                    in_diff: None,
-                });
+                    ))
+                    .severity(Severity::Medium)
+                    .category("security".into())
+                    .lines(line, end_line)
+                    .evidence(&source[node.byte_range()].chars().take(200).collect::<String>())
+                    .rule_id("local-ast:python/exception-disclosure")
+                    .build());
             }
         }
     }
@@ -797,34 +549,15 @@ fn scan_insecure_python(node: &tree_sitter::Node, source: &str, findings: &mut V
         // the node text starts with "async"
         let func_text = &source[node.byte_range()];
         if func_text.starts_with("async ") && has_result_call(node, source) {
-            findings.push(Finding {
-                    id: crate::finding::new_finding_ulid(),
-                    title: "Blocking `.result()` call in async function".into(),
-                    description: "Calling `.result()` on a future inside an async function blocks the event loop. Use `await` or run in an executor.".into(),
-                    severity: Severity::High,
-                    category: "concurrency".into(),
-                    source: Source::LocalAst,
-                    line_start: line,
-                    line_end: end_line,
-                    evidence: vec![source[node.byte_range()].chars().take(200).collect()],
-                    calibrator_action: None,
-                    similar_precedent: vec![],
-                    canonical_pattern: None,
-                    suggested_fix: None,
-                    based_on_excerpt: None,
-                    reasoning: None,
-                    llm_confidence: None,
-                    confidence: None,
-                    cited_lines: None,
-                    grounding_status: None,
-                    grounding_confidence: None,
-                model_agreement: None,
-                rule_id: Some("local-ast:python/blocking-in-async".into()),
-                judge_verdict: None,
-                judge_confidence: None,
-                precision_tier: None,
-                    in_diff: None,
-                });
+            findings.push(FindingBuilder::new()
+                .title("Blocking `.result()` call in async function")
+                .description("Calling `.result()` on a future inside an async function blocks the event loop. Use `await` or run in an executor.")
+                .severity(Severity::High)
+                .category("concurrency".into())
+                .lines(line, end_line)
+                .evidence(&source[node.byte_range()].chars().take(200).collect::<String>())
+                .rule_id("local-ast:python/blocking-in-async")
+                .build());
         }
     }
 
@@ -838,34 +571,15 @@ fn scan_insecure_python(node: &tree_sitter::Node, source: &str, findings: &mut V
                 .child_by_field_name("name")
                 .map(|n| &source[n.byte_range()])
                 .unwrap_or("parameter");
-            findings.push(Finding {
-                    id: crate::finding::new_finding_ulid(),
-                    title: format!("Mutable default argument `{}`", param_name),
-                    description: "Mutable default arguments are shared across calls and cause subtle bugs. Use None and initialize inside the function.".into(),
-                    severity: Severity::Medium,
-                    category: "bug".into(),
-                    source: Source::LocalAst,
-                    line_start: line,
-                    line_end: end_line,
-                    evidence: vec![source[node.byte_range()].chars().take(100).collect()],
-                    calibrator_action: None,
-                    similar_precedent: vec![],
-                    canonical_pattern: None,
-                    suggested_fix: None,
-                    based_on_excerpt: None,
-                    reasoning: None,
-                    llm_confidence: None,
-                    confidence: None,
-                    cited_lines: None,
-                    grounding_status: None,
-                    grounding_confidence: None,
-                model_agreement: None,
-                rule_id: Some("local-ast:python/mutable-default-arg".into()),
-                judge_verdict: None,
-                judge_confidence: None,
-                precision_tier: None,
-                    in_diff: None,
-                });
+            findings.push(FindingBuilder::new()
+                .title(&format!("Mutable default argument `{}`", param_name))
+                .description("Mutable default arguments are shared across calls and cause subtle bugs. Use None and initialize inside the function.")
+                .severity(Severity::Medium)
+                .category("bug".into())
+                .lines(line, end_line)
+                .evidence(&source[node.byte_range()].chars().take(100).collect::<String>())
+                .rule_id("local-ast:python/mutable-default-arg")
+                .build());
         }
     }
 }
@@ -1205,37 +919,17 @@ fn scan_insecure_yaml(node: &tree_sitter::Node, source: &str, findings: &mut Vec
                 let key_text = source[key.byte_range()].trim();
                 let key_line = key.start_position().row as u32 + 1;
                 if let Some((_, first_line)) = seen_keys.iter().find(|(k, _)| *k == key_text) {
-                    findings.push(Finding {
-                                id: crate::finding::new_finding_ulid(),
-                                title: format!("Duplicate key `{}` in mapping", key_text),
-                                description: format!(
+                    findings.push(FindingBuilder::new()
+                        .title(&format!("Duplicate key `{}` in mapping", key_text))
+                        .description(&format!(
                                     "Key `{}` appears multiple times in the same mapping (first at line {}). The last value silently wins.",
                                     key_text, first_line
-                                ),
-                                severity: Severity::High,
-                                category: "bug".into(),
-                                source: Source::LocalAst,
-                                line_start: key_line,
-                                line_end: key_line,
-                                evidence: vec![],
-                                calibrator_action: None,
-                                similar_precedent: vec![],
-                                canonical_pattern: None,
-                                suggested_fix: None,
-                                based_on_excerpt: None,
-                                reasoning: None,
-                                llm_confidence: None,
-                    confidence: None,
-                                cited_lines: None,
-                    grounding_status: None,
-                    grounding_confidence: None,
-                            model_agreement: None,
-                            rule_id: Some("local-ast:yaml/duplicate-key".into()),
-                            judge_verdict: None,
-                            judge_confidence: None,
-                            precision_tier: None,
-                    in_diff: None,
-                            });
+                                ))
+                        .severity(Severity::High)
+                        .category("bug".into())
+                        .lines(key_line, key_line)
+                        .rule_id("local-ast:yaml/duplicate-key")
+                        .build());
                 } else {
                     seen_keys.push((key_text, key_line));
                 }
@@ -1248,69 +942,25 @@ fn scan_insecure_yaml(node: &tree_sitter::Node, source: &str, findings: &mut Vec
 
             // 3. Missing id
             if !keys.contains(&"id") {
-                findings.push(Finding {
-                    id: crate::finding::new_finding_ulid(),
-                    title: "Automation missing `id` -- UI management and debug traces are disabled"
-                        .into(),
-                    description:
-                        "Automation missing `id` -- UI management and debug traces are disabled"
-                            .into(),
-                    severity: Severity::Medium,
-                    category: "quality".into(),
-                    source: Source::LocalAst,
-                    line_start: line,
-                    line_end: end_line,
-                    evidence: vec![],
-                    calibrator_action: None,
-                    similar_precedent: vec![],
-                    canonical_pattern: None,
-                    suggested_fix: None,
-                    based_on_excerpt: None,
-                    reasoning: None,
-                    llm_confidence: None,
-                    confidence: None,
-                    cited_lines: None,
-                    grounding_status: None,
-                    grounding_confidence: None,
-                    model_agreement: None,
-                    rule_id: Some("local-ast:yaml/ha-no-id".into()),
-                    judge_verdict: None,
-                    judge_confidence: None,
-                    precision_tier: None,
-                    in_diff: None,
-                });
+                findings.push(FindingBuilder::new()
+                    .title("Automation missing `id` -- UI management and debug traces are disabled")
+                    .description("Automation missing `id` -- UI management and debug traces are disabled")
+                    .severity(Severity::Medium)
+                    .category("quality".into())
+                    .lines(line, end_line)
+                    .rule_id("local-ast:yaml/ha-no-id")
+                    .build());
             }
 
             // 4. Missing mode
             if !keys.contains(&"mode") {
-                findings.push(Finding {
-                    id: crate::finding::new_finding_ulid(),
-                    title: "Automation has no explicit `mode` (defaults to `single`)".into(),
-                    description: "Automation has no explicit `mode` (defaults to `single`)".into(),
-                    severity: Severity::Info,
-                    category: "quality".into(),
-                    source: Source::LocalAst,
-                    line_start: line,
-                    line_end: end_line,
-                    evidence: vec![],
-                    calibrator_action: None,
-                    similar_precedent: vec![],
-                    canonical_pattern: None,
-                    suggested_fix: None,
-                    based_on_excerpt: None,
-                    reasoning: None,
-                    llm_confidence: None,
-                    confidence: None,
-                    cited_lines: None,
-                    grounding_status: None,
-                    grounding_confidence: None,
-                    model_agreement: None,
-                    rule_id: Some("local-ast:yaml/ha-no-mode".into()),
-                    judge_verdict: None,
-                    judge_confidence: None,
-                    precision_tier: None,
-                    in_diff: None,
-                });
+                findings.push(FindingBuilder::new()
+                    .title("Automation has no explicit `mode` (defaults to `single`)")
+                    .description("Automation has no explicit `mode` (defaults to `single`)")
+                    .category("quality".into())
+                    .lines(line, end_line)
+                    .rule_id("local-ast:yaml/ha-no-mode")
+                    .build());
             }
 
             // 5. Deprecated singular trigger/action/condition
@@ -1321,37 +971,17 @@ fn scan_insecure_yaml(node: &tree_sitter::Node, source: &str, findings: &mut Vec
             ];
             for (singular, plural) in &deprecated {
                 if keys.contains(singular) && !keys.contains(plural) {
-                    findings.push(Finding {
-                        id: crate::finding::new_finding_ulid(),
-                        title: format!("Deprecated singular `{}:` -- use `{}:` instead", singular, plural),
-                        description: format!(
+                    findings.push(FindingBuilder::new()
+                        .title(&format!("Deprecated singular `{}:` -- use `{}:` instead", singular, plural))
+                        .description(&format!(
                             "Home Assistant deprecated the singular `{}:` key. Use `{}:` (plural) for forward compatibility.",
                             singular, plural
-                        ),
-                        severity: Severity::Medium,
-                        category: "quality".into(),
-                        source: Source::LocalAst,
-                        line_start: line,
-                        line_end: end_line,
-                        evidence: vec![],
-                        calibrator_action: None,
-                        similar_precedent: vec![],
-                        canonical_pattern: None,
-                        suggested_fix: None,
-                        based_on_excerpt: None,
-                        reasoning: None,
-                        llm_confidence: None,
-                    confidence: None,
-                        cited_lines: None,
-                    grounding_status: None,
-                    grounding_confidence: None,
-                    model_agreement: None,
-                    rule_id: Some("local-ast:yaml/ha-deprecated-singular".into()),
-                    judge_verdict: None,
-                    judge_confidence: None,
-                    precision_tier: None,
-                    in_diff: None,
-                    });
+                        ))
+                        .severity(Severity::Medium)
+                        .category("quality".into())
+                        .lines(line, end_line)
+                        .rule_id("local-ast:yaml/ha-deprecated-singular")
+                        .build());
                 }
             }
 
@@ -1365,37 +995,17 @@ fn scan_insecure_yaml(node: &tree_sitter::Node, source: &str, findings: &mut Vec
                     if (key_text == "triggers" || key_text == "actions")
                         && yaml_value_is_empty(&child, source)
                     {
-                        findings.push(Finding {
-                                    id: crate::finding::new_finding_ulid(),
-                                    title: format!("Empty `{}:` in automation", key_text),
-                                    description: format!(
+                        findings.push(FindingBuilder::new()
+                            .title(&format!("Empty `{}:` in automation", key_text))
+                            .description(&format!(
                                         "The `{}:` key has no items. This automation will not function correctly.",
                                         key_text
-                                    ),
-                                    severity: Severity::High,
-                                    category: "bug".into(),
-                                    source: Source::LocalAst,
-                                    line_start: child.start_position().row as u32 + 1,
-                                    line_end: child.end_position().row as u32 + 1,
-                                    evidence: vec![],
-                                    calibrator_action: None,
-                                    similar_precedent: vec![],
-                                    canonical_pattern: None,
-                                    suggested_fix: None,
-                                    based_on_excerpt: None,
-                                    reasoning: None,
-                                    llm_confidence: None,
-                    confidence: None,
-                                    cited_lines: None,
-                    grounding_status: None,
-                    grounding_confidence: None,
-                                model_agreement: None,
-                                rule_id: Some("local-ast:yaml/ha-empty-section".into()),
-                                judge_verdict: None,
-                                judge_confidence: None,
-                                precision_tier: None,
-                    in_diff: None,
-                                });
+                                    ))
+                            .severity(Severity::High)
+                            .category("bug".into())
+                            .lines(child.start_position().row as u32 + 1, child.end_position().row as u32 + 1)
+                            .rule_id("local-ast:yaml/ha-empty-section")
+                            .build());
                     }
                 }
             }
@@ -1416,34 +1026,14 @@ fn scan_insecure_yaml(node: &tree_sitter::Node, source: &str, findings: &mut Vec
                             false
                         };
                     if !has_password {
-                        findings.push(Finding {
-                            id: crate::finding::new_finding_ulid(),
-                            title: "ESPHome OTA section has no password -- firmware updates are unprotected".into(),
-                            description: "ESPHome OTA section has no password -- firmware updates are unprotected. Add a password to prevent unauthorized firmware uploads.".into(),
-                            severity: Severity::Medium,
-                            category: "security".into(),
-                            source: Source::LocalAst,
-                            line_start: line,
-                            line_end: end_line,
-                            evidence: vec![],
-                            calibrator_action: None,
-                            similar_precedent: vec![],
-                            canonical_pattern: None,
-                            suggested_fix: None,
-                            based_on_excerpt: None,
-                            reasoning: None,
-                            llm_confidence: None,
-                    confidence: None,
-                            cited_lines: None,
-                    grounding_status: None,
-                    grounding_confidence: None,
-                        model_agreement: None,
-                        rule_id: Some("local-ast:yaml/esphome-ota-no-password".into()),
-                        judge_verdict: None,
-                        judge_confidence: None,
-                        precision_tier: None,
-                    in_diff: None,
-                        });
+                        findings.push(FindingBuilder::new()
+                            .title("ESPHome OTA section has no password -- firmware updates are unprotected")
+                            .description("ESPHome OTA section has no password -- firmware updates are unprotected. Add a password to prevent unauthorized firmware uploads.")
+                            .severity(Severity::Medium)
+                            .category("security".into())
+                            .lines(line, end_line)
+                            .rule_id("local-ast:yaml/esphome-ota-no-password")
+                            .build());
                     }
                 }
 
@@ -1457,34 +1047,14 @@ fn scan_insecure_yaml(node: &tree_sitter::Node, source: &str, findings: &mut Vec
                             false
                         };
                     if !has_encryption {
-                        findings.push(Finding {
-                            id: crate::finding::new_finding_ulid(),
-                            title: "ESPHome API has no encryption configured".into(),
-                            description: "ESPHome API has no encryption configured. Add an encryption key to secure communication.".into(),
-                            severity: Severity::Medium,
-                            category: "security".into(),
-                            source: Source::LocalAst,
-                            line_start: line,
-                            line_end: end_line,
-                            evidence: vec![],
-                            calibrator_action: None,
-                            similar_precedent: vec![],
-                            canonical_pattern: None,
-                            suggested_fix: None,
-                            based_on_excerpt: None,
-                            reasoning: None,
-                            llm_confidence: None,
-                    confidence: None,
-                            cited_lines: None,
-                    grounding_status: None,
-                    grounding_confidence: None,
-                        model_agreement: None,
-                        rule_id: Some("local-ast:yaml/esphome-api-no-encryption".into()),
-                        judge_verdict: None,
-                        judge_confidence: None,
-                        precision_tier: None,
-                    in_diff: None,
-                        });
+                        findings.push(FindingBuilder::new()
+                            .title("ESPHome API has no encryption configured")
+                            .description("ESPHome API has no encryption configured. Add an encryption key to secure communication.")
+                            .severity(Severity::Medium)
+                            .category("security".into())
+                            .lines(line, end_line)
+                            .rule_id("local-ast:yaml/esphome-api-no-encryption")
+                            .build());
                     }
                 }
             }
@@ -1532,66 +1102,28 @@ fn scan_insecure_yaml(node: &tree_sitter::Node, source: &str, findings: &mut Vec
                                 false
                             };
                             if !has_no_new_privs {
-                                findings.push(Finding {
-                                            id: crate::finding::new_finding_ulid(),
-                                            title: format!("Docker Compose service `{}` missing `no-new-privileges` security option", svc_name),
-                                            description: "Without `security_opt: [no-new-privileges:true]`, containers can escalate privileges via setuid binaries.".into(),
-                                            severity: Severity::Medium,
-                                            category: "security".into(),
-                                            source: Source::LocalAst,
-                                            line_start: svc_line,
-                                            line_end: svc_end,
-                                            evidence: vec![],
-                                            calibrator_action: None,
-                                            similar_precedent: vec![],
-                                            canonical_pattern: None,
-                                            suggested_fix: Some(format!("Add `security_opt: [no-new-privileges:true]` to the `{}` service.", svc_name)),
-                                            based_on_excerpt: None,
-                                            reasoning: None,
-                                            llm_confidence: None,
-                    confidence: None,
-                                            cited_lines: None,
-                    grounding_status: None,
-                    grounding_confidence: None,
-                                        model_agreement: None,
-                                        rule_id: Some("local-ast:yaml/compose-no-new-privileges".into()),
-                                        judge_verdict: None,
-                                        judge_confidence: None,
-                                        precision_tier: None,
-                    in_diff: None,
-                                        });
+                                findings.push(FindingBuilder::new()
+                                    .title(&format!("Docker Compose service `{}` missing `no-new-privileges` security option", svc_name))
+                                    .description("Without `security_opt: [no-new-privileges:true]`, containers can escalate privileges via setuid binaries.")
+                                    .severity(Severity::Medium)
+                                    .category("security".into())
+                                    .lines(svc_line, svc_end)
+                                    .rule_id("local-ast:yaml/compose-no-new-privileges")
+                                    .suggested_fix(&format!("Add `security_opt: [no-new-privileges:true]` to the `{}` service.", svc_name))
+                                    .build());
                             }
 
                             // Pattern: Docker Compose service missing read_only
                             if !svc_keys.contains(&"read_only") {
-                                findings.push(Finding {
-                                            id: crate::finding::new_finding_ulid(),
-                                            title: format!("Docker Compose service `{}` has writable root filesystem", svc_name),
-                                            description: "Without `read_only: true`, the container root filesystem is writable, which allows malicious payload download.".into(),
-                                            severity: Severity::Low,
-                                            category: "security".into(),
-                                            source: Source::LocalAst,
-                                            line_start: svc_line,
-                                            line_end: svc_end,
-                                            evidence: vec![],
-                                            calibrator_action: None,
-                                            similar_precedent: vec![],
-                                            canonical_pattern: None,
-                                            suggested_fix: Some(format!("Add `read_only: true` to the `{}` service and use tmpfs mounts for writable paths.", svc_name)),
-                                            based_on_excerpt: None,
-                                            reasoning: None,
-                                            llm_confidence: None,
-                    confidence: None,
-                                            cited_lines: None,
-                    grounding_status: None,
-                    grounding_confidence: None,
-                                        model_agreement: None,
-                                        rule_id: Some("local-ast:yaml/compose-writable-rootfs".into()),
-                                        judge_verdict: None,
-                                        judge_confidence: None,
-                                        precision_tier: None,
-                    in_diff: None,
-                                        });
+                                findings.push(FindingBuilder::new()
+                                    .title(&format!("Docker Compose service `{}` has writable root filesystem", svc_name))
+                                    .description("Without `read_only: true`, the container root filesystem is writable, which allows malicious payload download.")
+                                    .severity(Severity::Low)
+                                    .category("security".into())
+                                    .lines(svc_line, svc_end)
+                                    .rule_id("local-ast:yaml/compose-writable-rootfs")
+                                    .suggested_fix(&format!("Add `read_only: true` to the `{}` service and use tmpfs mounts for writable paths.", svc_name))
+                                    .build());
                             }
                         }
                     }
@@ -1614,35 +1146,15 @@ fn scan_insecure_yaml(node: &tree_sitter::Node, source: &str, findings: &mut Vec
         {
             let val_text = source[value.byte_range()].trim();
             if !val_text.is_empty() {
-                findings.push(Finding {
-                    id: crate::finding::new_finding_ulid(),
-                    title: format!("Hardcoded secret in `{}`", source[key.byte_range()].trim()),
-                    description: "Secrets should use `!secret` references, not hardcoded values."
-                        .into(),
-                    severity: Severity::High,
-                    category: "security".into(),
-                    source: Source::LocalAst,
-                    line_start: line,
-                    line_end: end_line,
-                    evidence: vec![format!("{}: [REDACTED]", source[key.byte_range()].trim())],
-                    calibrator_action: None,
-                    similar_precedent: vec![],
-                    canonical_pattern: None,
-                    suggested_fix: None,
-                    based_on_excerpt: None,
-                    reasoning: None,
-                    llm_confidence: None,
-                    confidence: None,
-                    cited_lines: None,
-                    grounding_status: None,
-                    grounding_confidence: None,
-                    model_agreement: None,
-                    rule_id: Some("local-ast:yaml/hardcoded-secret".into()),
-                    judge_verdict: None,
-                    judge_confidence: None,
-                    precision_tier: None,
-                    in_diff: None,
-                });
+                findings.push(FindingBuilder::new()
+                    .title(&format!("Hardcoded secret in `{}`", source[key.byte_range()].trim()))
+                    .description("Secrets should use `!secret` references, not hardcoded values.")
+                    .severity(Severity::High)
+                    .category("security".into())
+                    .lines(line, end_line)
+                    .evidence(&format!("{}: [REDACTED]", source[key.byte_range()].trim()))
+                    .rule_id("local-ast:yaml/hardcoded-secret")
+                    .build());
             }
         }
 
@@ -1666,37 +1178,17 @@ fn scan_insecure_yaml(node: &tree_sitter::Node, source: &str, findings: &mut Vec
                                 .trim_start_matches("- ")
                                 .trim();
                             if !item_text.is_empty() && !item_text.contains('.') {
-                                findings.push(Finding {
-                                    id: crate::finding::new_finding_ulid(),
-                                    title: "entity_id without domain prefix".into(),
-                                    description: format!(
+                                findings.push(FindingBuilder::new()
+                                    .title("entity_id without domain prefix")
+                                    .description(&format!(
                                         "`{}` is missing a domain prefix (e.g. `sensor.{}`)",
                                         item_text, item_text
-                                    ),
-                                    severity: Severity::High,
-                                    category: "bug".into(),
-                                    source: Source::LocalAst,
-                                    line_start: item.start_position().row as u32 + 1,
-                                    line_end: item.end_position().row as u32 + 1,
-                                    evidence: vec![],
-                                    calibrator_action: None,
-                                    similar_precedent: vec![],
-                                    canonical_pattern: None,
-                                    suggested_fix: None,
-                                    based_on_excerpt: None,
-                                    reasoning: None,
-                                    llm_confidence: None,
-                                    confidence: None,
-                                    cited_lines: None,
-                                    grounding_status: None,
-                                    grounding_confidence: None,
-                                    model_agreement: None,
-                                    rule_id: Some("local-ast:yaml/entity-id-no-domain".into()),
-                                    judge_verdict: None,
-                                    judge_confidence: None,
-                                    precision_tier: None,
-                                    in_diff: None,
-                                });
+                                    ))
+                                    .severity(Severity::High)
+                                    .category("bug".into())
+                                    .lines(item.start_position().row as u32 + 1, item.end_position().row as u32 + 1)
+                                    .rule_id("local-ast:yaml/entity-id-no-domain")
+                                    .build());
                             }
                         }
                     }
@@ -1704,37 +1196,17 @@ fn scan_insecure_yaml(node: &tree_sitter::Node, source: &str, findings: &mut Vec
                 }
             }
             if !is_list && !val_text.is_empty() && !val_text.contains('.') {
-                findings.push(Finding {
-                    id: crate::finding::new_finding_ulid(),
-                    title: "entity_id without domain prefix".into(),
-                    description: format!(
+                findings.push(FindingBuilder::new()
+                    .title("entity_id without domain prefix")
+                    .description(&format!(
                         "`{}` is missing a domain prefix (e.g. `sensor.{}`)",
                         val_text, val_text
-                    ),
-                    severity: Severity::High,
-                    category: "bug".into(),
-                    source: Source::LocalAst,
-                    line_start: line,
-                    line_end: end_line,
-                    evidence: vec![],
-                    calibrator_action: None,
-                    similar_precedent: vec![],
-                    canonical_pattern: None,
-                    suggested_fix: None,
-                    based_on_excerpt: None,
-                    reasoning: None,
-                    llm_confidence: None,
-                    confidence: None,
-                    cited_lines: None,
-                    grounding_status: None,
-                    grounding_confidence: None,
-                    model_agreement: None,
-                    rule_id: Some("local-ast:yaml/entity-id-no-domain".into()),
-                    judge_verdict: None,
-                    judge_confidence: None,
-                    precision_tier: None,
-                    in_diff: None,
-                });
+                    ))
+                    .severity(Severity::High)
+                    .category("bug".into())
+                    .lines(line, end_line)
+                    .rule_id("local-ast:yaml/entity-id-no-domain")
+                    .build());
             }
         }
 
@@ -1744,37 +1216,17 @@ fn scan_insecure_yaml(node: &tree_sitter::Node, source: &str, findings: &mut Vec
         {
             let val_text = source[value.byte_range()].trim();
             if !val_text.is_empty() && !val_text.contains('.') {
-                findings.push(Finding {
-                    id: crate::finding::new_finding_ulid(),
-                    title: "service without domain prefix".into(),
-                    description: format!(
+                findings.push(FindingBuilder::new()
+                    .title("service without domain prefix")
+                    .description(&format!(
                         "`{}` is missing a domain prefix (e.g. `light.{}`)",
                         val_text, val_text
-                    ),
-                    severity: Severity::Medium,
-                    category: "bug".into(),
-                    source: Source::LocalAst,
-                    line_start: line,
-                    line_end: end_line,
-                    evidence: vec![],
-                    calibrator_action: None,
-                    similar_precedent: vec![],
-                    canonical_pattern: None,
-                    suggested_fix: None,
-                    based_on_excerpt: None,
-                    reasoning: None,
-                    llm_confidence: None,
-                    confidence: None,
-                    cited_lines: None,
-                    grounding_status: None,
-                    grounding_confidence: None,
-                    model_agreement: None,
-                    rule_id: Some("local-ast:yaml/service-no-domain".into()),
-                    judge_verdict: None,
-                    judge_confidence: None,
-                    precision_tier: None,
-                    in_diff: None,
-                });
+                    ))
+                    .severity(Severity::Medium)
+                    .category("bug".into())
+                    .lines(line, end_line)
+                    .rule_id("local-ast:yaml/service-no-domain")
+                    .build());
             }
         }
 
@@ -1784,34 +1236,14 @@ fn scan_insecure_yaml(node: &tree_sitter::Node, source: &str, findings: &mut Vec
         {
             let val_text = source[value.byte_range()].trim();
             if val_text.contains("0.0.0.0") {
-                findings.push(Finding {
-                            id: crate::finding::new_finding_ulid(),
-                            title: "Server binding to 0.0.0.0 exposes all interfaces".into(),
-                            description: "Binding to 0.0.0.0 makes the server accessible from any network interface. Use 127.0.0.1 for local-only access.".into(),
-                            severity: Severity::Medium,
-                            category: "security".into(),
-                            source: Source::LocalAst,
-                            line_start: line,
-                            line_end: end_line,
-                            evidence: vec![],
-                            calibrator_action: None,
-                            similar_precedent: vec![],
-                            canonical_pattern: None,
-                            suggested_fix: None,
-                            based_on_excerpt: None,
-                            reasoning: None,
-                            llm_confidence: None,
-                    confidence: None,
-                            cited_lines: None,
-                    grounding_status: None,
-                    grounding_confidence: None,
-                        model_agreement: None,
-                        rule_id: Some("local-ast:yaml/bind-all-interfaces".into()),
-                        judge_verdict: None,
-                        judge_confidence: None,
-                        precision_tier: None,
-                    in_diff: None,
-                        });
+                findings.push(FindingBuilder::new()
+                    .title("Server binding to 0.0.0.0 exposes all interfaces")
+                    .description("Binding to 0.0.0.0 makes the server accessible from any network interface. Use 127.0.0.1 for local-only access.")
+                    .severity(Severity::Medium)
+                    .category("security".into())
+                    .lines(line, end_line)
+                    .rule_id("local-ast:yaml/bind-all-interfaces")
+                    .build());
             }
         }
 
@@ -1823,34 +1255,15 @@ fn scan_insecure_yaml(node: &tree_sitter::Node, source: &str, findings: &mut Vec
                 && val_text.contains("://")
                 && yaml_url_has_credentials(val_text)
             {
-                findings.push(Finding {
-                            id: crate::finding::new_finding_ulid(),
-                            title: "URL contains embedded credentials".into(),
-                            description: "URLs with embedded user:password credentials are a security risk. Use environment variables or secret references.".into(),
-                            severity: Severity::High,
-                            category: "security".into(),
-                            source: Source::LocalAst,
-                            line_start: line,
-                            line_end: end_line,
-                            evidence: vec![format!("{}: [REDACTED]", source[key.byte_range()].trim())],
-                            calibrator_action: None,
-                            similar_precedent: vec![],
-                            canonical_pattern: None,
-                            suggested_fix: None,
-                            based_on_excerpt: None,
-                            reasoning: None,
-                            llm_confidence: None,
-                    confidence: None,
-                            cited_lines: None,
-                    grounding_status: None,
-                    grounding_confidence: None,
-                        model_agreement: None,
-                        rule_id: Some("local-ast:yaml/url-credentials".into()),
-                        judge_verdict: None,
-                        judge_confidence: None,
-                        precision_tier: None,
-                    in_diff: None,
-                        });
+                findings.push(FindingBuilder::new()
+                    .title("URL contains embedded credentials")
+                    .description("URLs with embedded user:password credentials are a security risk. Use environment variables or secret references.")
+                    .severity(Severity::High)
+                    .category("security".into())
+                    .lines(line, end_line)
+                    .evidence(&format!("{}: [REDACTED]", source[key.byte_range()].trim()))
+                    .rule_id("local-ast:yaml/url-credentials")
+                    .build());
             }
         }
     }
@@ -1869,34 +1282,14 @@ fn scan_insecure_yaml(node: &tree_sitter::Node, source: &str, findings: &mut Vec
                 let has_availability =
                     val_text.contains("unavailable") || val_text.contains("unknown");
                 if !has_availability {
-                    findings.push(Finding {
-                        id: crate::finding::new_finding_ulid(),
-                        title: "Template uses `states()` without availability check".into(),
-                        description: "Templates using states() should check for 'unavailable' and 'unknown' to avoid errors when entities are offline".into(),
-                        severity: Severity::Info,
-                        category: "quality".into(),
-                        source: Source::LocalAst,
-                        line_start: line,
-                        line_end: end_line,
-                        evidence: vec![val_text.chars().take(200).collect()],
-                        calibrator_action: None,
-                        similar_precedent: vec![],
-                        canonical_pattern: None,
-                        suggested_fix: None,
-                        based_on_excerpt: None,
-                        reasoning: None,
-                        llm_confidence: None,
-                    confidence: None,
-                        cited_lines: None,
-                    grounding_status: None,
-                    grounding_confidence: None,
-                    model_agreement: None,
-                    rule_id: Some("local-ast:yaml/states-no-availability-check".into()),
-                    judge_verdict: None,
-                    judge_confidence: None,
-                    precision_tier: None,
-                    in_diff: None,
-                    });
+                    findings.push(FindingBuilder::new()
+                        .title("Template uses `states()` without availability check")
+                        .description("Templates using states() should check for 'unavailable' and 'unknown' to avoid errors when entities are offline")
+                        .category("quality".into())
+                        .lines(line, end_line)
+                        .evidence(&val_text.chars().take(200).collect::<String>())
+                        .rule_id("local-ast:yaml/states-no-availability-check")
+                        .build());
                 }
             }
 
@@ -1934,35 +1327,15 @@ fn scan_insecure_yaml(node: &tree_sitter::Node, source: &str, findings: &mut Vec
                 "states.alarm_control_panel.",
             ];
             if dot_domains.iter().any(|d| val_text.contains(d)) {
-                findings.push(Finding {
-                    id: crate::finding::new_finding_ulid(),
-                    title: "Deprecated dot-notation state access".into(),
-                    description: "Use states('sensor.xxx') instead of states.sensor.xxx.state"
-                        .into(),
-                    severity: Severity::Medium,
-                    category: "quality".into(),
-                    source: Source::LocalAst,
-                    line_start: line,
-                    line_end: end_line,
-                    evidence: vec![val_text.chars().take(200).collect()],
-                    calibrator_action: None,
-                    similar_precedent: vec![],
-                    canonical_pattern: None,
-                    suggested_fix: None,
-                    based_on_excerpt: None,
-                    reasoning: None,
-                    llm_confidence: None,
-                    confidence: None,
-                    cited_lines: None,
-                    grounding_status: None,
-                    grounding_confidence: None,
-                    model_agreement: None,
-                    rule_id: Some("local-ast:yaml/deprecated-dot-state".into()),
-                    judge_verdict: None,
-                    judge_confidence: None,
-                    precision_tier: None,
-                    in_diff: None,
-                });
+                findings.push(FindingBuilder::new()
+                    .title("Deprecated dot-notation state access")
+                    .description("Use states('sensor.xxx') instead of states.sensor.xxx.state")
+                    .severity(Severity::Medium)
+                    .category("quality".into())
+                    .lines(line, end_line)
+                    .evidence(&val_text.chars().take(200).collect::<String>())
+                    .rule_id("local-ast:yaml/deprecated-dot-state")
+                    .build());
             }
         }
     }
@@ -1978,99 +1351,39 @@ fn scan_insecure_typescript(node: &tree_sitter::Node, source: &str, findings: &m
     {
         let func_name = &source[func.byte_range()];
         if func_name == "eval" {
-            findings.push(Finding {
-                id: crate::finding::new_finding_ulid(),
-                title: "Use of `eval()` is a code injection risk".into(),
-                description:
-                    "`eval()` executes arbitrary code. Avoid using it with untrusted input.".into(),
-                severity: Severity::Critical,
-                category: "security".into(),
-                source: Source::LocalAst,
-                line_start: line,
-                line_end: end_line,
-                evidence: vec![],
-                calibrator_action: None,
-                similar_precedent: vec![],
-                canonical_pattern: None,
-                suggested_fix: None,
-                based_on_excerpt: None,
-                reasoning: None,
-                llm_confidence: None,
-                confidence: None,
-                cited_lines: None,
-                grounding_status: None,
-                grounding_confidence: None,
-                model_agreement: None,
-                rule_id: Some("local-ast:typescript/eval".into()),
-                judge_verdict: None,
-                judge_confidence: None,
-                precision_tier: None,
-                in_diff: None,
-            });
+            findings.push(FindingBuilder::new()
+                .title("Use of `eval()` is a code injection risk")
+                .description("`eval()` executes arbitrary code. Avoid using it with untrusted input.")
+                .severity(Severity::Critical)
+                .category("security".into())
+                .lines(line, end_line)
+                .rule_id("local-ast:typescript/eval")
+                .build());
         }
 
         // document.write XSS
         if func_name == "document.write" {
-            findings.push(Finding {
-                    id: crate::finding::new_finding_ulid(),
-                    title: "Use of `document.write()` is an XSS risk".into(),
-                    description: "`document.write()` injects raw HTML into the page. Use DOM APIs or a framework's safe rendering instead.".into(),
-                    severity: Severity::Critical,
-                    category: "security".into(),
-                    source: Source::LocalAst,
-                    line_start: line,
-                    line_end: end_line,
-                    evidence: vec![source[node.byte_range()].chars().take(200).collect()],
-                    calibrator_action: None,
-                    similar_precedent: vec![],
-                    canonical_pattern: None,
-                    suggested_fix: None,
-                    based_on_excerpt: None,
-                    reasoning: None,
-                    llm_confidence: None,
-                    confidence: None,
-                    cited_lines: None,
-                    grounding_status: None,
-                    grounding_confidence: None,
-                model_agreement: None,
-                rule_id: Some("local-ast:typescript/document-write-xss".into()),
-                judge_verdict: None,
-                judge_confidence: None,
-                precision_tier: None,
-                    in_diff: None,
-                });
+            findings.push(FindingBuilder::new()
+                .title("Use of `document.write()` is an XSS risk")
+                .description("`document.write()` injects raw HTML into the page. Use DOM APIs or a framework's safe rendering instead.")
+                .severity(Severity::Critical)
+                .category("security".into())
+                .lines(line, end_line)
+                .evidence(&source[node.byte_range()].chars().take(200).collect::<String>())
+                .rule_id("local-ast:typescript/document-write-xss")
+                .build());
         }
 
         // console.log / console.debug debug artifacts
         if func_name == "console.log" || func_name == "console.debug" {
-            findings.push(Finding {
-                    id: crate::finding::new_finding_ulid(),
-                    title: format!("`{}` debug artifact left in code", func_name),
-                    description: "Debug logging should be removed or replaced with a proper logging framework before production.".into(),
-                    severity: Severity::Info,
-                    category: "quality".into(),
-                    source: Source::LocalAst,
-                    line_start: line,
-                    line_end: end_line,
-                    evidence: vec![source[node.byte_range()].chars().take(200).collect()],
-                    calibrator_action: None,
-                    similar_precedent: vec![],
-                    canonical_pattern: None,
-                    suggested_fix: None,
-                    based_on_excerpt: None,
-                    reasoning: None,
-                    llm_confidence: None,
-                    confidence: None,
-                    cited_lines: None,
-                    grounding_status: None,
-                    grounding_confidence: None,
-                model_agreement: None,
-                rule_id: Some("local-ast:typescript/console-log-artifact".into()),
-                judge_verdict: None,
-                judge_confidence: None,
-                precision_tier: None,
-                    in_diff: None,
-                });
+            findings.push(FindingBuilder::new()
+                .title(&format!("`{}` debug artifact left in code", func_name))
+                .description("Debug logging should be removed or replaced with a proper logging framework before production.")
+                .category("quality".into())
+                .lines(line, end_line)
+                .evidence(&source[node.byte_range()].chars().take(200).collect::<String>())
+                .rule_id("local-ast:typescript/console-log-artifact")
+                .build());
         }
     }
 
@@ -2104,34 +1417,15 @@ fn scan_insecure_typescript(node: &tree_sitter::Node, source: &str, findings: &m
                 let has_special = inner.chars().any(|c| matches!(c, '-' | '/' | '+' | '='));
                 let looks_like_secret = (has_upper || has_digit || has_special) && inner_len > 8;
                 if looks_like_secret && !val_text.contains("process.env") {
-                    findings.push(Finding {
-                                id: crate::finding::new_finding_ulid(),
-                                title: format!("Hardcoded secret in `{}`", &source[name_node.byte_range()]),
-                                description: "Secrets should be loaded from environment variables or a secrets manager, not hardcoded in source.".into(),
-                                severity: Severity::High,
-                                category: "security".into(),
-                                source: Source::LocalAst,
-                                line_start: line,
-                                line_end: end_line,
-                                evidence: vec![format!("{} = [REDACTED]", &source[name_node.byte_range()])],
-                                calibrator_action: None,
-                                similar_precedent: vec![],
-                                canonical_pattern: None,
-                                suggested_fix: None,
-                                based_on_excerpt: None,
-                                reasoning: None,
-                                llm_confidence: None,
-                    confidence: None,
-                                cited_lines: None,
-                    grounding_status: None,
-                    grounding_confidence: None,
-                            model_agreement: None,
-                            rule_id: Some("local-ast:typescript/hardcoded-secret".into()),
-                            judge_verdict: None,
-                            judge_confidence: None,
-                            precision_tier: None,
-                    in_diff: None,
-                            });
+                    findings.push(FindingBuilder::new()
+                        .title(&format!("Hardcoded secret in `{}`", &source[name_node.byte_range()]))
+                        .description("Secrets should be loaded from environment variables or a secrets manager, not hardcoded in source.")
+                        .severity(Severity::High)
+                        .category("security".into())
+                        .lines(line, end_line)
+                        .evidence(&format!("{} = [REDACTED]", &source[name_node.byte_range()]))
+                        .rule_id("local-ast:typescript/hardcoded-secret")
+                        .build());
                 }
             }
         }
@@ -2148,34 +1442,15 @@ fn scan_insecure_typescript(node: &tree_sitter::Node, source: &str, findings: &m
             } else {
                 "outerHTML"
             };
-            findings.push(Finding {
-                    id: crate::finding::new_finding_ulid(),
-                    title: format!("Direct `{}` assignment is an XSS risk", prop),
-                    description: format!("Setting `{}` with untrusted data enables XSS. Use `textContent` or a sanitization library.", prop),
-                    severity: Severity::High,
-                    category: "security".into(),
-                    source: Source::LocalAst,
-                    line_start: line,
-                    line_end: end_line,
-                    evidence: vec![source[node.byte_range()].chars().take(200).collect()],
-                    calibrator_action: None,
-                    similar_precedent: vec![],
-                    canonical_pattern: None,
-                    suggested_fix: None,
-                    based_on_excerpt: None,
-                    reasoning: None,
-                    llm_confidence: None,
-                    confidence: None,
-                    cited_lines: None,
-                    grounding_status: None,
-                    grounding_confidence: None,
-                model_agreement: None,
-                rule_id: Some("local-ast:typescript/innerhtml-xss".into()),
-                judge_verdict: None,
-                judge_confidence: None,
-                precision_tier: None,
-                    in_diff: None,
-                });
+            findings.push(FindingBuilder::new()
+                .title(&format!("Direct `{}` assignment is an XSS risk", prop))
+                .description(&format!("Setting `{}` with untrusted data enables XSS. Use `textContent` or a sanitization library.", prop))
+                .severity(Severity::High)
+                .category("security".into())
+                .lines(line, end_line)
+                .evidence(&source[node.byte_range()].chars().take(200).collect::<String>())
+                .rule_id("local-ast:typescript/innerhtml-xss")
+                .build());
         }
     }
 
@@ -2183,35 +1458,14 @@ fn scan_insecure_typescript(node: &tree_sitter::Node, source: &str, findings: &m
     if node.kind() == "type_annotation" {
         let text = &source[node.byte_range()];
         if text.contains(": any") {
-            findings.push(Finding {
-                id: crate::finding::new_finding_ulid(),
-                title: "Use of `any` type defeats TypeScript's type safety".into(),
-                description: "Prefer `unknown`, generics, or a specific type instead of `any`."
-                    .into(),
-                severity: Severity::Info,
-                category: "quality".into(),
-                source: Source::LocalAst,
-                line_start: line,
-                line_end: end_line,
-                evidence: vec![source[node.byte_range()].chars().take(100).collect()],
-                calibrator_action: None,
-                similar_precedent: vec![],
-                canonical_pattern: None,
-                suggested_fix: None,
-                based_on_excerpt: None,
-                reasoning: None,
-                llm_confidence: None,
-                confidence: None,
-                cited_lines: None,
-                grounding_status: None,
-                grounding_confidence: None,
-                model_agreement: None,
-                rule_id: Some("local-ast:typescript/any-type".into()),
-                judge_verdict: None,
-                judge_confidence: None,
-                precision_tier: None,
-                in_diff: None,
-            });
+            findings.push(FindingBuilder::new()
+                .title("Use of `any` type defeats TypeScript's type safety")
+                .description("Prefer `unknown`, generics, or a specific type instead of `any`.")
+                .category("quality".into())
+                .lines(line, end_line)
+                .evidence(&source[node.byte_range()].chars().take(100).collect::<String>())
+                .rule_id("local-ast:typescript/any-type")
+                .build());
         }
     }
 
@@ -2225,36 +1479,15 @@ fn scan_insecure_typescript(node: &tree_sitter::Node, source: &str, findings: &m
                 .unwrap_or(false)
         });
         if !has_statements {
-            findings.push(Finding {
-                id: crate::finding::new_finding_ulid(),
-                title: "Empty `catch` block silently swallows errors".into(),
-                description:
-                    "An empty catch block hides failures. Log the error, handle it, or rethrow."
-                        .into(),
-                severity: Severity::Medium,
-                category: "reliability".into(),
-                source: Source::LocalAst,
-                line_start: line,
-                line_end: end_line,
-                evidence: vec![source[node.byte_range()].chars().take(200).collect()],
-                calibrator_action: None,
-                similar_precedent: vec![],
-                canonical_pattern: None,
-                suggested_fix: None,
-                based_on_excerpt: None,
-                reasoning: None,
-                llm_confidence: None,
-                confidence: None,
-                cited_lines: None,
-                grounding_status: None,
-                grounding_confidence: None,
-                model_agreement: None,
-                rule_id: Some("local-ast:typescript/empty-catch".into()),
-                judge_verdict: None,
-                judge_confidence: None,
-                precision_tier: None,
-                in_diff: None,
-            });
+            findings.push(FindingBuilder::new()
+                .title("Empty `catch` block silently swallows errors")
+                .description("An empty catch block hides failures. Log the error, handle it, or rethrow.")
+                .severity(Severity::Medium)
+                .category("reliability".into())
+                .lines(line, end_line)
+                .evidence(&source[node.byte_range()].chars().take(200).collect::<String>())
+                .rule_id("local-ast:typescript/empty-catch")
+                .build());
         }
     }
 
@@ -2278,37 +1511,18 @@ fn scan_insecure_typescript(node: &tree_sitter::Node, source: &str, findings: &m
         ];
         for api in &sync_apis {
             if func_name.ends_with(api) && is_in_async_function(node, source) {
-                findings.push(Finding {
-                            id: crate::finding::new_finding_ulid(),
-                            title: format!("`{}` blocks the event loop in async function", api),
-                            description: format!(
+                findings.push(FindingBuilder::new()
+                    .title(&format!("`{}` blocks the event loop in async function", api))
+                    .description(&format!(
                                 "Calling synchronous `{}` inside an async function blocks the event loop. Use the async equivalent from `fs/promises`.",
                                 api
-                            ),
-                            severity: Severity::Medium,
-                            category: "concurrency".into(),
-                            source: Source::LocalAst,
-                            line_start: line,
-                            line_end: end_line,
-                            evidence: vec![source[node.byte_range()].chars().take(200).collect()],
-                            calibrator_action: None,
-                            similar_precedent: vec![],
-                            canonical_pattern: None,
-                            suggested_fix: None,
-                            based_on_excerpt: None,
-                            reasoning: None,
-                            llm_confidence: None,
-                    confidence: None,
-                            cited_lines: None,
-                    grounding_status: None,
-                    grounding_confidence: None,
-                        model_agreement: None,
-                        rule_id: Some("local-ast:typescript/sync-in-async".into()),
-                        judge_verdict: None,
-                        judge_confidence: None,
-                        precision_tier: None,
-                    in_diff: None,
-                        });
+                            ))
+                    .severity(Severity::Medium)
+                    .category("concurrency".into())
+                    .lines(line, end_line)
+                    .evidence(&source[node.byte_range()].chars().take(200).collect::<String>())
+                    .rule_id("local-ast:typescript/sync-in-async")
+                    .build());
                 break;
             }
         }
@@ -2330,68 +1544,29 @@ fn scan_insecure_typescript(node: &tree_sitter::Node, source: &str, findings: &m
                     .map(|p| &source[p.byte_range()] == "length")
                     .unwrap_or(false);
             if is_length_access && right_text.trim() == "0" {
-                findings.push(Finding {
-                                id: crate::finding::new_finding_ulid(),
-                                title: "`.length >= 0` is always true".into(),
-                                description: "Array and string `.length` is always >= 0. This condition is tautological. Did you mean `.length > 0`?".into(),
-                                severity: Severity::Medium,
-                                category: "correctness".into(),
-                                source: Source::LocalAst,
-                                line_start: line,
-                                line_end: end_line,
-                                evidence: vec![source[node.byte_range()].chars().take(200).collect()],
-                                calibrator_action: None,
-                                similar_precedent: vec![],
-                                canonical_pattern: None,
-                                suggested_fix: None,
-                                based_on_excerpt: None,
-                                reasoning: None,
-                                llm_confidence: None,
-                    confidence: None,
-                                cited_lines: None,
-                    grounding_status: None,
-                    grounding_confidence: None,
-                            model_agreement: None,
-                            rule_id: Some("local-ast:typescript/tautological-length".into()),
-                            judge_verdict: None,
-                            judge_confidence: None,
-                            precision_tier: None,
-                    in_diff: None,
-                            });
+                findings.push(FindingBuilder::new()
+                    .title("`.length >= 0` is always true")
+                    .description("Array and string `.length` is always >= 0. This condition is tautological. Did you mean `.length > 0`?")
+                    .severity(Severity::Medium)
+                    .category("correctness".into())
+                    .lines(line, end_line)
+                    .evidence(&source[node.byte_range()].chars().take(200).collect::<String>())
+                    .rule_id("local-ast:typescript/tautological-length")
+                    .build());
             }
         }
     }
 
     // Non-null assertion operator (!)
     if node.kind() == "non_null_expression" {
-        findings.push(Finding {
-            id: crate::finding::new_finding_ulid(),
-            title: "Use of non-null assertion operator `!` bypasses type safety".into(),
-            description: "The non-null assertion operator tells TypeScript to ignore possible null/undefined. Use proper null checks instead.".into(),
-            severity: Severity::Info,
-            category: "quality".into(),
-            source: Source::LocalAst,
-            line_start: line,
-            line_end: end_line,
-            evidence: vec![source[node.byte_range()].chars().take(100).collect()],
-            calibrator_action: None,
-            similar_precedent: vec![],
-            canonical_pattern: None,
-            suggested_fix: None,
-            based_on_excerpt: None,
-            reasoning: None,
-            llm_confidence: None,
-            confidence: None,
-            cited_lines: None,
-                    grounding_status: None,
-                    grounding_confidence: None,
-        model_agreement: None,
-        rule_id: Some("local-ast:typescript/non-null-assertion".into()),
-        judge_verdict: None,
-        judge_confidence: None,
-        precision_tier: None,
-                    in_diff: None,
-        });
+        findings.push(FindingBuilder::new()
+            .title("Use of non-null assertion operator `!` bypasses type safety")
+            .description("The non-null assertion operator tells TypeScript to ignore possible null/undefined. Use proper null checks instead.")
+            .category("quality".into())
+            .lines(line, end_line)
+            .evidence(&source[node.byte_range()].chars().take(100).collect::<String>())
+            .rule_id("local-ast:typescript/non-null-assertion")
+            .build());
     }
 }
 
@@ -2402,34 +1577,14 @@ fn scan_insecure_bash(node: &tree_sitter::Node, source: &str, findings: &mut Vec
 
     // B11: Missing shebang (root program node only)
     if kind == "program" && !source.starts_with("#!") {
-        findings.push(Finding {
-                id: crate::finding::new_finding_ulid(),
-                title: "Script has no shebang line".into(),
-                description: "Add a shebang (e.g. #!/usr/bin/env bash) so the script runs with the intended interpreter.".into(),
-                severity: Severity::Low,
-                category: "quality".into(),
-                source: Source::LocalAst,
-                line_start: 1,
-                line_end: 1,
-                evidence: vec![],
-                calibrator_action: None,
-                similar_precedent: vec![],
-                canonical_pattern: None,
-                suggested_fix: None,
-                based_on_excerpt: None,
-                reasoning: None,
-                llm_confidence: None,
-                confidence: None,
-                cited_lines: None,
-                    grounding_status: None,
-                grounding_confidence: None,
-            model_agreement: None,
-            rule_id: Some("local-ast:bash/no-shebang".into()),
-            judge_verdict: None,
-            judge_confidence: None,
-            precision_tier: None,
-                    in_diff: None,
-            });
+        findings.push(FindingBuilder::new()
+            .title("Script has no shebang line")
+            .description("Add a shebang (e.g. #!/usr/bin/env bash) so the script runs with the intended interpreter.")
+            .severity(Severity::Low)
+            .category("quality".into())
+            .lines(1, 1)
+            .rule_id("local-ast:bash/no-shebang")
+            .build());
     }
 
     // B4: Missing set -e (root program node only)
@@ -2448,35 +1603,14 @@ fn scan_insecure_bash(node: &tree_sitter::Node, source: &str, findings: &mut Vec
             }
         }
         if !found_set_e {
-            findings.push(Finding {
-                id: crate::finding::new_finding_ulid(),
-                title: "Script has no `set -e` -- errors will be silently ignored".into(),
-                description:
-                    "Add `set -euo pipefail` near the top of the script to fail on errors.".into(),
-                severity: Severity::Medium,
-                category: "reliability".into(),
-                source: Source::LocalAst,
-                line_start: 1,
-                line_end: 1,
-                evidence: vec![],
-                calibrator_action: None,
-                similar_precedent: vec![],
-                canonical_pattern: None,
-                suggested_fix: None,
-                based_on_excerpt: None,
-                reasoning: None,
-                llm_confidence: None,
-                confidence: None,
-                cited_lines: None,
-                grounding_status: None,
-                grounding_confidence: None,
-                model_agreement: None,
-                rule_id: Some("local-ast:bash/no-set-e".into()),
-                judge_verdict: None,
-                judge_confidence: None,
-                precision_tier: None,
-                in_diff: None,
-            });
+            findings.push(FindingBuilder::new()
+                .title("Script has no `set -e` -- errors will be silently ignored")
+                .description("Add `set -euo pipefail` near the top of the script to fail on errors.")
+                .severity(Severity::Medium)
+                .category("reliability".into())
+                .lines(1, 1)
+                .rule_id("local-ast:bash/no-set-e")
+                .build());
         }
     }
 
@@ -2486,35 +1620,15 @@ fn scan_insecure_bash(node: &tree_sitter::Node, source: &str, findings: &mut Vec
     {
         let name = &source[name_node.byte_range()];
         if name == "eval" {
-            findings.push(Finding {
-                id: crate::finding::new_finding_ulid(),
-                title: "Use of `eval` is a code injection risk".into(),
-                description: "Avoid `eval` -- use arrays, printf, or parameter expansion instead."
-                    .into(),
-                severity: Severity::High,
-                category: "security".into(),
-                source: Source::LocalAst,
-                line_start: line,
-                line_end: end_line,
-                evidence: vec![source[node.byte_range()].chars().take(200).collect()],
-                calibrator_action: None,
-                similar_precedent: vec![],
-                canonical_pattern: None,
-                suggested_fix: None,
-                based_on_excerpt: None,
-                reasoning: None,
-                llm_confidence: None,
-                confidence: None,
-                cited_lines: None,
-                grounding_status: None,
-                grounding_confidence: None,
-                model_agreement: None,
-                rule_id: Some("local-ast:bash/eval".into()),
-                judge_verdict: None,
-                judge_confidence: None,
-                precision_tier: None,
-                in_diff: None,
-            });
+            findings.push(FindingBuilder::new()
+                .title("Use of `eval` is a code injection risk")
+                .description("Avoid `eval` -- use arrays, printf, or parameter expansion instead.")
+                .severity(Severity::High)
+                .category("security".into())
+                .lines(line, end_line)
+                .evidence(&source[node.byte_range()].chars().take(200).collect::<String>())
+                .rule_id("local-ast:bash/eval")
+                .build());
         }
 
         // B9: chmod 777
@@ -2523,35 +1637,15 @@ fn scan_insecure_bash(node: &tree_sitter::Node, source: &str, findings: &mut Vec
                 if let Some(arg) = node.child(i as u32) {
                     let text = &source[arg.byte_range()];
                     if text == "777" {
-                        findings.push(Finding {
-                            id: crate::finding::new_finding_ulid(),
-                            title: "`chmod 777` grants world-writable permissions".into(),
-                            description: "Use more restrictive permissions (e.g. 755 or 700)."
-                                .into(),
-                            severity: Severity::Medium,
-                            category: "security".into(),
-                            source: Source::LocalAst,
-                            line_start: line,
-                            line_end: end_line,
-                            evidence: vec![source[node.byte_range()].chars().take(200).collect()],
-                            calibrator_action: None,
-                            similar_precedent: vec![],
-                            canonical_pattern: None,
-                            suggested_fix: None,
-                            based_on_excerpt: None,
-                            reasoning: None,
-                            llm_confidence: None,
-                            confidence: None,
-                            cited_lines: None,
-                            grounding_status: None,
-                            grounding_confidence: None,
-                            model_agreement: None,
-                            rule_id: Some("local-ast:bash/chmod-777".into()),
-                            judge_verdict: None,
-                            judge_confidence: None,
-                            precision_tier: None,
-                            in_diff: None,
-                        });
+                        findings.push(FindingBuilder::new()
+                            .title("`chmod 777` grants world-writable permissions")
+                            .description("Use more restrictive permissions (e.g. 755 or 700).")
+                            .severity(Severity::Medium)
+                            .category("security".into())
+                            .lines(line, end_line)
+                            .evidence(&source[node.byte_range()].chars().take(200).collect::<String>())
+                            .rule_id("local-ast:bash/chmod-777")
+                            .build());
                         break;
                     }
                 }
@@ -2571,34 +1665,15 @@ fn scan_insecure_bash(node: &tree_sitter::Node, source: &str, findings: &mut Vec
                 if name == "curl" || name == "wget" {
                     saw_curl = true;
                 } else if saw_curl && (name == "bash" || name == "sh" || name == "zsh") {
-                    findings.push(Finding {
-                        id: crate::finding::new_finding_ulid(),
-                        title: "Piping curl/wget to shell executes untrusted remote code".into(),
-                        description: "Download to a file first, inspect it, then execute.".into(),
-                        severity: Severity::Critical,
-                        category: "security".into(),
-                        source: Source::LocalAst,
-                        line_start: line,
-                        line_end: end_line,
-                        evidence: vec![source[node.byte_range()].chars().take(200).collect()],
-                        calibrator_action: None,
-                        similar_precedent: vec![],
-                        canonical_pattern: None,
-                        suggested_fix: None,
-                        based_on_excerpt: None,
-                        reasoning: None,
-                        llm_confidence: None,
-                        confidence: None,
-                        cited_lines: None,
-                        grounding_status: None,
-                        grounding_confidence: None,
-                        model_agreement: None,
-                        rule_id: Some("local-ast:bash/curl-pipe-bash".into()),
-                        judge_verdict: None,
-                        judge_confidence: None,
-                        precision_tier: None,
-                        in_diff: None,
-                    });
+                    findings.push(FindingBuilder::new()
+                        .title("Piping curl/wget to shell executes untrusted remote code")
+                        .description("Download to a file first, inspect it, then execute.")
+                        .severity(Severity::Critical)
+                        .category("security".into())
+                        .lines(line, end_line)
+                        .evidence(&source[node.byte_range()].chars().take(200).collect::<String>())
+                        .rule_id("local-ast:bash/curl-pipe-bash")
+                        .build());
                     break;
                 }
             }
@@ -2627,34 +1702,14 @@ fn scan_insecure_bash(node: &tree_sitter::Node, source: &str, findings: &mut Vec
                 let val_text = &source[value_node.byte_range()];
                 // Skip if value contains $ (env var reference)
                 if !val_text.contains('$') {
-                    findings.push(Finding {
-                                id: crate::finding::new_finding_ulid(),
-                                title: format!("Hardcoded secret in shell variable `{}`", var_name),
-                                description: "Use environment variables or a secrets manager instead of hardcoded values.".into(),
-                                severity: Severity::High,
-                                category: "security".into(),
-                                source: Source::LocalAst,
-                                line_start: line,
-                                line_end: end_line,
-                                evidence: vec![],
-                                calibrator_action: None,
-                                similar_precedent: vec![],
-                                canonical_pattern: None,
-                                suggested_fix: None,
-                                based_on_excerpt: None,
-                                reasoning: None,
-                                llm_confidence: None,
-                    confidence: None,
-                                cited_lines: None,
-                    grounding_status: None,
-                    grounding_confidence: None,
-                            model_agreement: None,
-                            rule_id: Some("local-ast:bash/hardcoded-secret".into()),
-                            judge_verdict: None,
-                            judge_confidence: None,
-                            precision_tier: None,
-                    in_diff: None,
-                            });
+                    findings.push(FindingBuilder::new()
+                        .title(&format!("Hardcoded secret in shell variable `{}`", var_name))
+                        .description("Use environment variables or a secrets manager instead of hardcoded values.")
+                        .severity(Severity::High)
+                        .category("security".into())
+                        .lines(line, end_line)
+                        .rule_id("local-ast:bash/hardcoded-secret")
+                        .build());
                 }
             }
         }
@@ -2669,34 +1724,15 @@ fn scan_insecure_dockerfile(node: &tree_sitter::Node, source: &str, findings: &m
         "add_instruction" => {
             let text = &source[node.byte_range()];
             if !text.contains("http://") && !text.contains("https://") {
-                findings.push(Finding {
-                    id: crate::finding::new_finding_ulid(),
-                    title: "Use COPY instead of ADD for local files".into(),
-                    description: "ADD has extra functionality (tar extraction, remote URLs) that can be surprising. Use COPY for simple file copies.".into(),
-                    severity: Severity::Medium,
-                    category: "quality".into(),
-                    source: Source::LocalAst,
-                    line_start: node.start_position().row as u32 + 1,
-                    line_end: node.end_position().row as u32 + 1,
-                    evidence: vec![text.trim().to_string()],
-                    calibrator_action: None,
-                    similar_precedent: vec![],
-                    canonical_pattern: None,
-                    suggested_fix: None,
-                    based_on_excerpt: None,
-                    reasoning: None,
-                    llm_confidence: None,
-                    confidence: None,
-                    cited_lines: None,
-                    grounding_status: None,
-                    grounding_confidence: None,
-                model_agreement: None,
-                rule_id: Some("local-ast:dockerfile/add-vs-copy".into()),
-                judge_verdict: None,
-                judge_confidence: None,
-                precision_tier: None,
-                    in_diff: None,
-                });
+                findings.push(FindingBuilder::new()
+                    .title("Use COPY instead of ADD for local files")
+                    .description("ADD has extra functionality (tar extraction, remote URLs) that can be surprising. Use COPY for simple file copies.")
+                    .severity(Severity::Medium)
+                    .category("quality".into())
+                    .lines(node.start_position().row as u32 + 1, node.end_position().row as u32 + 1)
+                    .evidence(&text.trim().to_string())
+                    .rule_id("local-ast:dockerfile/add-vs-copy")
+                    .build());
             }
         }
 
@@ -2722,34 +1758,14 @@ fn scan_insecure_dockerfile(node: &tree_sitter::Node, source: &str, findings: &m
                     if let Some(eq_pos) = line.find('=') {
                         let value = line[eq_pos + 1..].trim().trim_matches('"');
                         if !value.is_empty() && !value.starts_with('$') {
-                            findings.push(Finding {
-                                id: crate::finding::new_finding_ulid(),
-                                title: "Secret hardcoded in Dockerfile ENV/ARG".into(),
-                                description: "Secrets should not be hardcoded in Dockerfiles. Use build secrets (--mount=type=secret) or runtime environment variables instead.".into(),
-                                severity: Severity::High,
-                                category: "security".into(),
-                                source: Source::LocalAst,
-                                line_start: node.start_position().row as u32 + 1,
-                                line_end: node.end_position().row as u32 + 1,
-                                evidence: vec![],
-                                calibrator_action: None,
-                                similar_precedent: vec![],
-                                canonical_pattern: None,
-                                suggested_fix: None,
-                                based_on_excerpt: None,
-                                reasoning: None,
-                                llm_confidence: None,
-                    confidence: None,
-                                cited_lines: None,
-                    grounding_status: None,
-                    grounding_confidence: None,
-                            model_agreement: None,
-                            rule_id: Some("local-ast:dockerfile/hardcoded-secret".into()),
-                            judge_verdict: None,
-                            judge_confidence: None,
-                            precision_tier: None,
-                    in_diff: None,
-                            });
+                            findings.push(FindingBuilder::new()
+                                .title("Secret hardcoded in Dockerfile ENV/ARG")
+                                .description("Secrets should not be hardcoded in Dockerfiles. Use build secrets (--mount=type=secret) or runtime environment variables instead.")
+                                .severity(Severity::High)
+                                .category("security".into())
+                                .lines(node.start_position().row as u32 + 1, node.end_position().row as u32 + 1)
+                                .rule_id("local-ast:dockerfile/hardcoded-secret")
+                                .build());
                             break;
                         }
                     }
@@ -2764,34 +1780,15 @@ fn scan_insecure_dockerfile(node: &tree_sitter::Node, source: &str, findings: &m
             let has_pipe = text.contains('|');
             let has_shell = text.contains("bash") || text.contains("/sh") || text.contains("| sh");
             if has_downloader && has_pipe && has_shell {
-                findings.push(Finding {
-                    id: crate::finding::new_finding_ulid(),
-                    title: "RUN pipes curl/wget to shell -- executes untrusted remote code".into(),
-                    description: "Piping downloaded scripts directly to a shell is dangerous. Download the script first, verify its checksum, then execute.".into(),
-                    severity: Severity::Critical,
-                    category: "security".into(),
-                    source: Source::LocalAst,
-                    line_start: node.start_position().row as u32 + 1,
-                    line_end: node.end_position().row as u32 + 1,
-                    evidence: vec![text.trim().to_string()],
-                    calibrator_action: None,
-                    similar_precedent: vec![],
-                    canonical_pattern: None,
-                    suggested_fix: None,
-                    based_on_excerpt: None,
-                    reasoning: None,
-                    llm_confidence: None,
-                    confidence: None,
-                    cited_lines: None,
-                    grounding_status: None,
-                    grounding_confidence: None,
-                model_agreement: None,
-                rule_id: Some("local-ast:dockerfile/curl-pipe-bash".into()),
-                judge_verdict: None,
-                judge_confidence: None,
-                precision_tier: None,
-                    in_diff: None,
-                });
+                findings.push(FindingBuilder::new()
+                    .title("RUN pipes curl/wget to shell -- executes untrusted remote code")
+                    .description("Piping downloaded scripts directly to a shell is dangerous. Download the script first, verify its checksum, then execute.")
+                    .severity(Severity::Critical)
+                    .category("security".into())
+                    .lines(node.start_position().row as u32 + 1, node.end_position().row as u32 + 1)
+                    .evidence(&text.trim().to_string())
+                    .rule_id("local-ast:dockerfile/curl-pipe-bash")
+                    .build());
             }
         }
 
@@ -2875,34 +1872,15 @@ fn scan_insecure_terraform(node: &tree_sitter::Node, source: &str, findings: &mu
                 && !inner.starts_with("${var.")
                 && !inner.starts_with("${")
             {
-                findings.push(Finding {
-                                    id: crate::finding::new_finding_ulid(),
-                                    title: format!("Hardcoded secret in `{}`", &source[name_node.byte_range()]),
-                                    description: "Secrets should be loaded from variables or a secrets manager, not hardcoded in Terraform files.".into(),
-                                    severity: Severity::High,
-                                    category: "security".into(),
-                                    source: Source::LocalAst,
-                                    line_start: line,
-                                    line_end: end_line,
-                                    evidence: vec![format!("{} = [REDACTED]", &source[name_node.byte_range()])],
-                                    calibrator_action: None,
-                                    similar_precedent: vec![],
-                                    canonical_pattern: None,
-                                    suggested_fix: None,
-                                    based_on_excerpt: None,
-                                    reasoning: None,
-                                    llm_confidence: None,
-                    confidence: None,
-                                    cited_lines: None,
-                    grounding_status: None,
-                    grounding_confidence: None,
-                                model_agreement: None,
-                                rule_id: Some("local-ast:terraform/hardcoded-secret".into()),
-                                judge_verdict: None,
-                                judge_confidence: None,
-                                precision_tier: None,
-                    in_diff: None,
-                                });
+                findings.push(FindingBuilder::new()
+                    .title(&format!("Hardcoded secret in `{}`", &source[name_node.byte_range()]))
+                    .description("Secrets should be loaded from variables or a secrets manager, not hardcoded in Terraform files.")
+                    .severity(Severity::High)
+                    .category("security".into())
+                    .lines(line, end_line)
+                    .evidence(&format!("{} = [REDACTED]", &source[name_node.byte_range()]))
+                    .rule_id("local-ast:terraform/hardcoded-secret")
+                    .build());
             }
         }
     }
@@ -2923,34 +1901,15 @@ fn scan_insecure_terraform(node: &tree_sitter::Node, source: &str, findings: &mu
                     let val_text = source[val_expr.byte_range()].trim();
                     let inner = val_text.trim_matches('"');
                     if inner == "*" {
-                        findings.push(Finding {
-                                    id: crate::finding::new_finding_ulid(),
-                                    title: "Wildcard IAM action grants unrestricted permissions".into(),
-                                    description: "Using `Action = \"*\"` grants all permissions. Follow the principle of least privilege.".into(),
-                                    severity: Severity::High,
-                                    category: "security".into(),
-                                    source: Source::LocalAst,
-                                    line_start: line,
-                                    line_end: end_line,
-                                    evidence: vec![source[node.byte_range()].chars().take(200).collect()],
-                                    calibrator_action: None,
-                                    similar_precedent: vec![],
-                                    canonical_pattern: None,
-                                    suggested_fix: None,
-                                    based_on_excerpt: None,
-                                    reasoning: None,
-                                    llm_confidence: None,
-                    confidence: None,
-                                    cited_lines: None,
-                    grounding_status: None,
-                    grounding_confidence: None,
-                                model_agreement: None,
-                                rule_id: Some("local-ast:terraform/wildcard-iam".into()),
-                                judge_verdict: None,
-                                judge_confidence: None,
-                                precision_tier: None,
-                    in_diff: None,
-                                });
+                        findings.push(FindingBuilder::new()
+                            .title("Wildcard IAM action grants unrestricted permissions")
+                            .description("Using `Action = \"*\"` grants all permissions. Follow the principle of least privilege.")
+                            .severity(Severity::High)
+                            .category("security".into())
+                            .lines(line, end_line)
+                            .evidence(&source[node.byte_range()].chars().take(200).collect::<String>())
+                            .rule_id("local-ast:terraform/wildcard-iam")
+                            .build());
                     }
                 }
             }
@@ -2999,34 +1958,15 @@ fn scan_insecure_terraform(node: &tree_sitter::Node, source: &str, findings: &mu
         }
 
         if has_open_cidr && port_is_sensitive && found_port {
-            findings.push(Finding {
-                        id: crate::finding::new_finding_ulid(),
-                        title: "Security group open to 0.0.0.0/0 on sensitive port".into(),
-                        description: "Allowing ingress from 0.0.0.0/0 on non-HTTP(S) ports exposes the service to the internet. Restrict to specific CIDR ranges.".into(),
-                        severity: Severity::High,
-                        category: "security".into(),
-                        source: Source::LocalAst,
-                        line_start: line,
-                        line_end: end_line,
-                        evidence: vec![source[node.byte_range()].chars().take(200).collect()],
-                        calibrator_action: None,
-                        similar_precedent: vec![],
-                        canonical_pattern: None,
-                        suggested_fix: None,
-                        based_on_excerpt: None,
-                        reasoning: None,
-                        llm_confidence: None,
-                    confidence: None,
-                        cited_lines: None,
-                    grounding_status: None,
-                    grounding_confidence: None,
-                    model_agreement: None,
-                    rule_id: Some("local-ast:terraform/open-security-group".into()),
-                    judge_verdict: None,
-                    judge_confidence: None,
-                    precision_tier: None,
-                    in_diff: None,
-                    });
+            findings.push(FindingBuilder::new()
+                .title("Security group open to 0.0.0.0/0 on sensitive port")
+                .description("Allowing ingress from 0.0.0.0/0 on non-HTTP(S) ports exposes the service to the internet. Restrict to specific CIDR ranges.")
+                .severity(Severity::High)
+                .category("security".into())
+                .lines(line, end_line)
+                .evidence(&source[node.byte_range()].chars().take(200).collect::<String>())
+                .rule_id("local-ast:terraform/open-security-group")
+                .build());
         }
     }
 }
@@ -3100,34 +2040,14 @@ fn analyze_terraform_structure(tree: &tree_sitter::Tree, source: &str) -> Vec<Fi
 
     // S1: Missing required_version
     if (!has_terraform_block || !has_required_version) && has_resource_or_data {
-        findings.push(Finding {
-            id: crate::finding::new_finding_ulid(),
-            title: "Missing required_version in terraform block".into(),
-            description: "Add a `terraform { required_version = \">= X.Y\" }` block to pin the Terraform version and prevent unexpected upgrades.".into(),
-            severity: Severity::Medium,
-            category: "reliability".into(),
-            source: Source::LocalAst,
-            line_start: 1,
-            line_end: 1,
-            evidence: vec![],
-            calibrator_action: None,
-            similar_precedent: vec![],
-            canonical_pattern: None,
-            suggested_fix: None,
-            based_on_excerpt: None,
-            reasoning: None,
-            llm_confidence: None,
-            confidence: None,
-            cited_lines: None,
-                    grounding_status: None,
-                    grounding_confidence: None,
-        model_agreement: None,
-        rule_id: Some("local-ast:terraform/no-version-pin".into()),
-        judge_verdict: None,
-        judge_confidence: None,
-        precision_tier: None,
-                    in_diff: None,
-        });
+        findings.push(FindingBuilder::new()
+            .title("Missing required_version in terraform block")
+            .description("Add a `terraform { required_version = \">= X.Y\" }` block to pin the Terraform version and prevent unexpected upgrades.")
+            .severity(Severity::Medium)
+            .category("reliability".into())
+            .lines(1, 1)
+            .rule_id("local-ast:terraform/no-version-pin")
+            .build());
     }
 
     findings
@@ -3198,38 +2118,17 @@ fn check_required_providers(rp_body: tree_sitter::Node, source: &str, findings: 
         walk_for_object_keys(expr, source, &mut has_source, &mut has_version);
 
         if has_source && !has_version {
-            findings.push(Finding {
-                id: crate::finding::new_finding_ulid(),
-                title: format!(
+            findings.push(FindingBuilder::new()
+                .title(&format!(
                     "Provider `{}` in required_providers has no version constraint",
                     provider_name.unwrap_or("unknown")
-                ),
-                description: "Add a `version` constraint to prevent unexpected provider upgrades."
-                    .into(),
-                severity: Severity::Medium,
-                category: "reliability".into(),
-                source: Source::LocalAst,
-                line_start: attr.start_position().row as u32 + 1,
-                line_end: attr.end_position().row as u32 + 1,
-                evidence: vec![],
-                calibrator_action: None,
-                similar_precedent: vec![],
-                canonical_pattern: None,
-                suggested_fix: None,
-                based_on_excerpt: None,
-                reasoning: None,
-                llm_confidence: None,
-                confidence: None,
-                cited_lines: None,
-                grounding_status: None,
-                grounding_confidence: None,
-                model_agreement: None,
-                rule_id: Some("local-ast:terraform/no-provider-version".into()),
-                judge_verdict: None,
-                judge_confidence: None,
-                precision_tier: None,
-                in_diff: None,
-            });
+                ))
+                .description("Add a `version` constraint to prevent unexpected provider upgrades.")
+                .severity(Severity::Medium)
+                .category("reliability".into())
+                .lines(attr.start_position().row as u32 + 1, attr.end_position().row as u32 + 1)
+                .rule_id("local-ast:terraform/no-provider-version")
+                .build());
         }
     }
 }
@@ -3309,34 +2208,15 @@ fn analyze_dockerfile_structure(tree: &tree_sitter::Tree, source: &str) -> Vec<F
                     let has_tag = image_ref.contains(':');
                     let uses_latest = image_ref.ends_with(":latest");
                     if !has_tag || uses_latest {
-                        findings.push(Finding {
-                            id: crate::finding::new_finding_ulid(),
-                            title: "FROM uses `latest` or untagged image -- builds are not reproducible".into(),
-                            description: format!("Pin the image to a specific tag or digest: {}", image_ref),
-                            severity: Severity::Medium,
-                            category: "reliability".into(),
-                            source: Source::LocalAst,
-                            line_start: child.start_position().row as u32 + 1,
-                            line_end: child.end_position().row as u32 + 1,
-                            evidence: vec![image_ref.to_string()],
-                            calibrator_action: None,
-                            similar_precedent: vec![],
-                            canonical_pattern: None,
-                            suggested_fix: None,
-                            based_on_excerpt: None,
-                            reasoning: None,
-                            llm_confidence: None,
-                    confidence: None,
-                            cited_lines: None,
-                    grounding_status: None,
-                    grounding_confidence: None,
-                        model_agreement: None,
-                        rule_id: Some("local-ast:dockerfile/from-latest".into()),
-                        judge_verdict: None,
-                        judge_confidence: None,
-                        precision_tier: None,
-                    in_diff: None,
-                        });
+                        findings.push(FindingBuilder::new()
+                            .title("FROM uses `latest` or untagged image -- builds are not reproducible")
+                            .description(&format!("Pin the image to a specific tag or digest: {}", image_ref))
+                            .severity(Severity::Medium)
+                            .category("reliability".into())
+                            .lines(child.start_position().row as u32 + 1, child.end_position().row as u32 + 1)
+                            .evidence(&image_ref.to_string())
+                            .rule_id("local-ast:dockerfile/from-latest")
+                            .build());
                     }
                 }
             }
@@ -3351,134 +2231,54 @@ fn analyze_dockerfile_structure(tree: &tree_sitter::Tree, source: &str) -> Vec<F
 
     // D6: No USER instruction
     if !has_user {
-        findings.push(Finding {
-            id: crate::finding::new_finding_ulid(),
-            title: "No USER instruction -- container runs as root".into(),
-            description: "Add a USER instruction to run the container as a non-root user.".into(),
-            severity: Severity::Medium,
-            category: "security".into(),
-            source: Source::LocalAst,
-            line_start: 1,
-            line_end: 1,
-            evidence: vec![],
-            calibrator_action: None,
-            similar_precedent: vec![],
-            canonical_pattern: None,
-            suggested_fix: None,
-            based_on_excerpt: None,
-            reasoning: None,
-            llm_confidence: None,
-            confidence: None,
-            cited_lines: None,
-            grounding_status: None,
-            grounding_confidence: None,
-            model_agreement: None,
-            rule_id: Some("local-ast:dockerfile/no-user".into()),
-            judge_verdict: None,
-            judge_confidence: None,
-            precision_tier: None,
-            in_diff: None,
-        });
+        findings.push(FindingBuilder::new()
+            .title("No USER instruction -- container runs as root")
+            .description("Add a USER instruction to run the container as a non-root user.")
+            .severity(Severity::Medium)
+            .category("security".into())
+            .lines(1, 1)
+            .rule_id("local-ast:dockerfile/no-user")
+            .build());
     }
 
     // D8: No HEALTHCHECK
     if !has_healthcheck {
-        findings.push(Finding {
-            id: crate::finding::new_finding_ulid(),
-            title: "No HEALTHCHECK instruction".into(),
-            description: "Add a HEALTHCHECK instruction so the container runtime can detect unhealthy containers.".into(),
-            severity: Severity::Low,
-            category: "reliability".into(),
-            source: Source::LocalAst,
-            line_start: 1,
-            line_end: 1,
-            evidence: vec![],
-            calibrator_action: None,
-            similar_precedent: vec![],
-            canonical_pattern: None,
-            suggested_fix: None,
-            based_on_excerpt: None,
-            reasoning: None,
-            llm_confidence: None,
-            confidence: None,
-            cited_lines: None,
-                    grounding_status: None,
-                    grounding_confidence: None,
-        model_agreement: None,
-        rule_id: Some("local-ast:dockerfile/no-healthcheck".into()),
-        judge_verdict: None,
-        judge_confidence: None,
-        precision_tier: None,
-                    in_diff: None,
-        });
+        findings.push(FindingBuilder::new()
+            .title("No HEALTHCHECK instruction")
+            .description("Add a HEALTHCHECK instruction so the container runtime can detect unhealthy containers.")
+            .severity(Severity::Low)
+            .category("reliability".into())
+            .lines(1, 1)
+            .rule_id("local-ast:dockerfile/no-healthcheck")
+            .build());
     }
 
     // D11: Multiple CMD/ENTRYPOINT
     if cmd_count > 1 {
-        findings.push(Finding {
-            id: crate::finding::new_finding_ulid(),
-            title: "Multiple CMD instructions -- only the last one takes effect".into(),
-            description: format!(
+        findings.push(FindingBuilder::new()
+            .title("Multiple CMD instructions -- only the last one takes effect")
+            .description(&format!(
                 "Found {} CMD instructions; only the last one will be used.",
                 cmd_count
-            ),
-            severity: Severity::Medium,
-            category: "bug".into(),
-            source: Source::LocalAst,
-            line_start: 1,
-            line_end: 1,
-            evidence: vec![],
-            calibrator_action: None,
-            similar_precedent: vec![],
-            canonical_pattern: None,
-            suggested_fix: None,
-            based_on_excerpt: None,
-            reasoning: None,
-            llm_confidence: None,
-            confidence: None,
-            cited_lines: None,
-            grounding_status: None,
-            grounding_confidence: None,
-            model_agreement: None,
-            rule_id: Some("local-ast:dockerfile/multiple-cmd".into()),
-            judge_verdict: None,
-            judge_confidence: None,
-            precision_tier: None,
-            in_diff: None,
-        });
+            ))
+            .severity(Severity::Medium)
+            .category("bug".into())
+            .lines(1, 1)
+            .rule_id("local-ast:dockerfile/multiple-cmd")
+            .build());
     }
     if entrypoint_count > 1 {
-        findings.push(Finding {
-            id: crate::finding::new_finding_ulid(),
-            title: "Multiple ENTRYPOINT instructions -- only the last one takes effect".into(),
-            description: format!(
+        findings.push(FindingBuilder::new()
+            .title("Multiple ENTRYPOINT instructions -- only the last one takes effect")
+            .description(&format!(
                 "Found {} ENTRYPOINT instructions; only the last one will be used.",
                 entrypoint_count
-            ),
-            severity: Severity::Medium,
-            category: "bug".into(),
-            source: Source::LocalAst,
-            line_start: 1,
-            line_end: 1,
-            evidence: vec![],
-            calibrator_action: None,
-            similar_precedent: vec![],
-            canonical_pattern: None,
-            suggested_fix: None,
-            based_on_excerpt: None,
-            reasoning: None,
-            llm_confidence: None,
-            confidence: None,
-            cited_lines: None,
-            grounding_status: None,
-            grounding_confidence: None,
-            model_agreement: None,
-            rule_id: Some("local-ast:dockerfile/multiple-entrypoint".into()),
-            judge_verdict: None,
-            judge_confidence: None,
-            precision_tier: None,
-            in_diff: None,
-        });
+            ))
+            .severity(Severity::Medium)
+            .category("bug".into())
+            .lines(1, 1)
+            .rule_id("local-ast:dockerfile/multiple-entrypoint")
+            .build());
     }
 
     findings

--- a/src/analysis.rs
+++ b/src/analysis.rs
@@ -1730,7 +1730,7 @@ fn scan_insecure_dockerfile(node: &tree_sitter::Node, source: &str, findings: &m
                     .severity(Severity::Medium)
                     .category("quality".into())
                     .lines(node.start_position().row as u32 + 1, node.end_position().row as u32 + 1)
-                    .evidence(&text.trim().to_string())
+                    .evidence(text.trim())
                     .rule_id("local-ast:dockerfile/add-vs-copy")
                     .build());
             }
@@ -1786,7 +1786,7 @@ fn scan_insecure_dockerfile(node: &tree_sitter::Node, source: &str, findings: &m
                     .severity(Severity::Critical)
                     .category("security".into())
                     .lines(node.start_position().row as u32 + 1, node.end_position().row as u32 + 1)
-                    .evidence(&text.trim().to_string())
+                    .evidence(text.trim())
                     .rule_id("local-ast:dockerfile/curl-pipe-bash")
                     .build());
             }
@@ -2214,7 +2214,7 @@ fn analyze_dockerfile_structure(tree: &tree_sitter::Tree, source: &str) -> Vec<F
                             .severity(Severity::Medium)
                             .category("reliability".into())
                             .lines(child.start_position().row as u32 + 1, child.end_position().row as u32 + 1)
-                            .evidence(&image_ref.to_string())
+                            .evidence(image_ref)
                             .rule_id("local-ast:dockerfile/from-latest")
                             .build());
                     }

--- a/src/ast_grep.rs
+++ b/src/ast_grep.rs
@@ -1255,6 +1255,24 @@ rule:
                 "ts-regex-word-merge",
                 2,
             ),
+            (
+                "rules/rust/tests/discarded-fallible-result.rs",
+                "rs",
+                "discarded-fallible-result",
+                4,
+            ),
+            (
+                "rules/typescript/tests/console-log-non-test.ts",
+                "ts",
+                "console-log-non-test",
+                3,
+            ),
+            (
+                "rules/rust/tests/unwrap-after-infallible.rs",
+                "rs",
+                "unwrap-after-infallible",
+                3,
+            ),
         ];
 
         let mut failures = Vec::new();

--- a/src/context/index/builder.rs
+++ b/src/context/index/builder.rs
@@ -111,12 +111,12 @@ impl<'a, C: Clock, E: Embedder> IndexBuilder<'a, C, E> {
         Ok(stored.as_deref() != Some(self.embedder.model_hash().as_str()))
     }
 
-    #[allow(dead_code)]
+    #[cfg(test)]
     pub(crate) fn conn(&self) -> &Connection {
         &self.conn
     }
 
-    #[allow(dead_code)]
+    #[cfg(test)]
     pub(crate) fn conn_mut(&mut self) -> &mut Connection {
         &mut self.conn
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,3 @@
-#![allow(dead_code)]
-
 // Library half of the bin/lib hybrid split: re-export `quorum::foo` modules
 // at the binary crate root so existing `crate::foo` paths inside main.rs and
 // its submodules continue to resolve unchanged. See `src/lib.rs` for the
@@ -28,36 +26,55 @@ pub use quorum::redact;
 pub use quorum::review_mode;
 pub use quorum::storage;
 
+#[allow(dead_code)]
 mod agent;
+#[allow(dead_code)]
 mod analytics;
+#[allow(dead_code)]
 mod cache;
 mod cli;
 mod cli_io;
 mod config;
+#[allow(dead_code)]
 mod context;
+#[allow(dead_code)]
 mod context_enrichment;
+#[allow(dead_code)]
 mod daemon;
 mod dep_manifest;
 mod dimensions;
+#[allow(dead_code)]
 mod enrichment_policy;
+#[allow(dead_code)]
 mod formatting;
 mod glyphs;
+#[allow(dead_code)]
 mod http_server;
 mod judge;
+#[allow(dead_code)]
 mod linter;
+#[allow(dead_code)]
 mod llm_client;
+#[allow(dead_code)]
 mod mcp;
+#[allow(dead_code)]
 mod output;
+#[allow(dead_code)]
 mod pipeline;
+#[allow(dead_code)]
 mod progress;
 mod review;
+#[allow(dead_code)]
 mod review_log;
+#[allow(dead_code)]
 mod stats;
 mod stats_math;
 mod suppress;
+#[allow(dead_code)]
 mod telemetry;
 #[cfg(test)]
 mod test_support;
+#[allow(dead_code)]
 mod tools;
 mod trace_subscriber;
 

--- a/src/test_support.rs
+++ b/src/test_support.rs
@@ -22,6 +22,7 @@ pub mod fakes {
             }
         }
 
+        #[allow(dead_code)]
         pub fn sequence(responses: Vec<&str>) -> Self {
             Self {
                 responses: Mutex::new(responses.into_iter().map(|r| Ok(r.to_string())).collect()),


### PR DESCRIPTION
## Summary

- **Cleanup**: Removed crate-wide `#![allow(dead_code)]` blanket from `src/main.rs`, applied targeted suppressions on 16 designed-but-not-yet-wired modules, gated `conn()`/`conn_mut()` behind `#[cfg(test)]`, and adopted `FindingBuilder` across all 61 raw `Finding{}` construction sites in `analysis.rs` (net -998 lines)
- **3 new ast-grep rules**:
  - `discarded-fallible-result` (Rust) — catches `let _ =` on `.lock()`, `.send()`, `.flush()`, `.close()`, `.connect()`, `.bind()`, `.recv()`, `.shutdown()`. Broadens `ignored-io-result` beyond std::fs (#380)
  - `console-log-non-test` (TypeScript) — flags `console.log/debug/warn` outside test contexts (`describe`/`it`/`test` blocks) and catch clauses (#381)
  - `unwrap-after-infallible` (Rust) — suppression rule marking `Some(x).unwrap()` and `Ok(x).unwrap()` as safe, reducing FP signal for calibrator (#382)
- **Clippy fix**: Removed 3 unnecessary `.to_string()` calls surfaced by clippy after FindingBuilder adoption

## Verification

- `cargo clippy --all-targets -- -D warnings`: clean
- `cargo test --bin quorum`: 1581 passed, 1 ignored
- `cargo test --lib`: 985 passed (includes all ast-grep rule fixture tests)
- `cargo build --release`: succeeds
- Quorum self-review: 0 in-branch bugs found; all in-diff findings are pre-existing (string-byte-slice-broad FPs on array indexing, complexity on scan dispatchers)

## Quorum Verdicts Recorded

- FP: `string-byte-slice-broad` in analysis.rs (pattern-overgeneralization: array indexing, not string slicing)
- Wontfix: cyclomatic complexity on `scan_insecure_*` dispatchers (structural, not refactorable)

## Test Plan

- [x] Each rule has test fixtures with positive + negative cases
- [x] Integrated into `mining_2026_04_rules_scan_correctly` test harness
- [x] `all_bundled_rules_match_fixtures` passes
- [x] FindingBuilder adoption verified by full test suite (no behavioral change)
- [x] Dead code removal verified by clippy with zero warnings

Closes #380, #381, #382

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Rust linting rule detecting discarded results from fallible operations (lock, send, flush, close, write_all, connect, bind, try_lock, try_send, try_recv, recv, shutdown).
  * Added Rust linting rule identifying safe unwrap calls on infallible values constructed at call site (Some/Ok).
  * Added TypeScript linting rule detecting debug logging outside test contexts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jsnyder/quorum/pull/390?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->