### PR TITLE
fix: correctness and reliability bugfix rollup

### DIFF
--- a/src/context/cli.rs
+++ b/src/context/cli.rs
@@ -929,7 +929,13 @@ enum StalenessResult {
 fn check_staleness<D: ContextDeps>(entry: &SourceEntry, deps: &D) -> StalenessResult {
     let layout = SourceLayout::for_source(deps.home_dir(), &entry.name);
     let current_head = match source_repo_root(entry) {
-        Some(root) if root.exists() => deps.git().head_sha(root).ok().flatten(),
+        Some(root) if root.exists() => match deps.git().head_sha(root) {
+            Ok(sha) => sha,
+            Err(e) => {
+                tracing::warn!("Failed to read HEAD sha for {}: {e}", root.display());
+                None
+            }
+        },
         _ => None,
     };
     let current_model = deps.embedder().model_hash();

--- a/src/context/index/builder.rs
+++ b/src/context/index/builder.rs
@@ -511,7 +511,9 @@ impl<'a, C: Clock, E: Embedder> IndexBuilder<'a, C, E> {
                 Ok(())
             }
             Err(e) => {
-                let _ = conn.execute("ROLLBACK", []);
+                if let Err(rb_err) = conn.execute("ROLLBACK", []) {
+                    tracing::warn!("ROLLBACK failed after index error: {rb_err}");
+                }
                 Err(e)
             }
         }

--- a/src/finding.rs
+++ b/src/finding.rs
@@ -161,6 +161,7 @@ impl Finding {
         self.cited_lines
             .map(|(start, _)| start)
             .unwrap_or(self.line_start)
+            .max(1)
     }
 
     pub fn compute_confidence(&mut self) {

--- a/src/finding.rs
+++ b/src/finding.rs
@@ -175,7 +175,13 @@ impl Finding {
                 .grounding_confidence
                 .filter(|c| c.is_finite())
                 .map(|c| c.clamp(0.0, 1.0))
-                .unwrap_or(0.5),
+                .unwrap_or_else(|| match self.grounding_status {
+                    Some(GroundingStatus::Verified) => 0.90,
+                    Some(GroundingStatus::VerifiedElsewhere) => 0.75,
+                    Some(GroundingStatus::LineOutOfRange) => 0.30,
+                    Some(GroundingStatus::SymbolNotFound) => 0.20,
+                    Some(GroundingStatus::NotChecked) | None => 0.50,
+                }),
         };
         let base = self
             .judge_confidence

--- a/src/judge.rs
+++ b/src/judge.rs
@@ -97,12 +97,20 @@ fn truncate_chars(s: &str, max: usize) -> String {
 
 fn extract_json_array(response: &str) -> Option<&str> {
     let trimmed = response.trim();
-    let start = trimmed.find('[')?;
     let end = trimmed.rfind(']')?;
-    if start > end {
-        return None;
+    let mut search_from = 0;
+    while let Some(rel) = trimmed[search_from..].find('[') {
+        let abs_start = search_from + rel;
+        if abs_start > end {
+            return None;
+        }
+        let candidate = &trimmed[abs_start..=end];
+        if serde_json::from_str::<serde_json::Value>(candidate).is_ok() {
+            return Some(candidate);
+        }
+        search_from = abs_start + 1;
     }
-    Some(&trimmed[start..=end])
+    None
 }
 
 /// Map wire-format verdict strings to the `JudgeVerdict` enum.

--- a/src/main.rs
+++ b/src/main.rs
@@ -1720,7 +1720,9 @@ async fn run_review(opts: cli::ReviewOpts) -> i32 {
                 .map(|r| r.judge_metrics.latency_ms)
                 .sum(),
         };
-        let _ = telem_store.record(&telem_entry);
+        if let Err(e) = telem_store.record(&telem_entry) {
+            tracing::warn!("Failed to record telemetry: {e}");
+        }
 
         // Per-review record for dimensional stats (by-repo, by-caller, rolling).
         let review_log = review_log::ReviewLog::with_storage(storage_handle.clone());
@@ -2147,8 +2149,10 @@ fn run_feedback(opts: cli::FeedbackOpts) -> i32 {
             confidence: opts.confidence,
             in_diff: opts.in_diff,
         };
-        if let Some(parent) = feedback_path.parent() {
-            let _ = std::fs::create_dir_all(parent);
+        if let Some(parent) = feedback_path.parent()
+            && let Err(e) = std::fs::create_dir_all(parent)
+        {
+            tracing::warn!("Failed to create feedback directory: {e}");
         }
         let store = feedback::FeedbackStore::new(feedback_path);
         match store.record_external(input) {
@@ -2200,8 +2204,10 @@ fn run_feedback(opts: cli::FeedbackOpts) -> i32 {
             }
         }
     } else {
-        if let Some(parent) = feedback_path.parent() {
-            let _ = std::fs::create_dir_all(parent);
+        if let Some(parent) = feedback_path.parent()
+            && let Err(e) = std::fs::create_dir_all(parent)
+        {
+            tracing::warn!("Failed to create feedback directory: {e}");
         }
         // Derive fp_kind from CLI flags. Errors only when verdict=fp and
         // a kind was specified that requires associated data (e.g.

--- a/src/mcp/handler.rs
+++ b/src/mcp/handler.rs
@@ -272,6 +272,7 @@ impl QuorumHandler {
                 let cwd = match std::env::current_dir() {
                     Ok(p) => p,
                     Err(e) => {
+                        tracing::warn!("MCP catalog domains: cannot determine working directory: {e}");
                         return Ok(CallToolResult::text_content(vec![format!(
                             "Error: cannot determine working directory: {e}"
                         )

--- a/src/mcp/handler.rs
+++ b/src/mcp/handler.rs
@@ -269,7 +269,15 @@ impl QuorumHandler {
                 "Supported languages:\n- Rust (.rs)\n- Python (.py)\n- TypeScript (.ts)\n- TSX (.tsx)\n- Bash (.sh, .bash, .zsh)\n- Dockerfile (Dockerfile*)".to_string()
             }
             "domains" => {
-                let cwd = std::env::current_dir().unwrap_or_default();
+                let cwd = match std::env::current_dir() {
+                    Ok(p) => p,
+                    Err(e) => {
+                        return Ok(CallToolResult::text_content(vec![format!(
+                            "Error: cannot determine working directory: {e}"
+                        )
+                        .into()]));
+                    }
+                };
                 let info = crate::domain::detect_domain(&cwd);
                 let mut result = String::new();
                 if info.languages.is_empty() && info.frameworks.is_empty() {

--- a/src/merge.rs
+++ b/src/merge.rs
@@ -75,7 +75,8 @@ pub fn merge_findings(
         for (idx, finding) in merged.iter_mut().enumerate() {
             let agreeing = llm_model_names[idx].len();
             if agreeing > 0 {
-                finding.model_agreement = Some(agreeing as f32 / num_models as f32);
+                finding.model_agreement =
+                    Some((agreeing as f32 / num_models as f32).min(1.0));
             }
         }
     }

--- a/src/review_log.rs
+++ b/src/review_log.rs
@@ -34,18 +34,22 @@ impl SeverityCounts {
         let mut s = Self::default();
         for sev in iter {
             match sev {
-                Severity::Critical => s.critical += 1,
-                Severity::High => s.high += 1,
-                Severity::Medium => s.medium += 1,
-                Severity::Low => s.low += 1,
-                Severity::Info => s.info += 1,
+                Severity::Critical => s.critical = s.critical.saturating_add(1),
+                Severity::High => s.high = s.high.saturating_add(1),
+                Severity::Medium => s.medium = s.medium.saturating_add(1),
+                Severity::Low => s.low = s.low.saturating_add(1),
+                Severity::Info => s.info = s.info.saturating_add(1),
             }
         }
         s
     }
 
     pub fn total(&self) -> u32 {
-        self.critical + self.high + self.medium + self.low + self.info
+        self.critical
+            .saturating_add(self.high)
+            .saturating_add(self.medium)
+            .saturating_add(self.low)
+            .saturating_add(self.info)
     }
 }
 
@@ -243,20 +247,20 @@ impl LegCounts {
             if legs.is_empty() {
                 continue;
             }
-            c.total_unique += 1;
+            c.total_unique = c.total_unique.saturating_add(1);
             let has_b = legs.contains(&RetrievalLeg::Bm25);
             let has_v = legs.contains(&RetrievalLeg::Vector);
             let has_s = legs.contains(&RetrievalLeg::Structural);
             if has_b {
-                c.bm25 += 1;
+                c.bm25 = c.bm25.saturating_add(1);
             }
             if has_v {
-                c.vector += 1;
+                c.vector = c.vector.saturating_add(1);
             }
             if has_s {
-                c.structural += 1;
+                c.structural = c.structural.saturating_add(1);
                 if !has_b && !has_v {
-                    c.structural_only += 1;
+                    c.structural_only = c.structural_only.saturating_add(1);
                 }
             }
         }

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -164,11 +164,17 @@ pub fn compute_report(
 
     // Rolling windows: only need last N * ROLLING_WINDOWS records.
     let rolling_needed = ROLLING_N.saturating_mul(ROLLING_WINDOWS);
-    let rolling_records = review_log.load_recent(rolling_needed).unwrap_or_default();
+    let rolling_records = review_log.load_recent(rolling_needed).unwrap_or_else(|e| {
+        tracing::warn!("Failed to load recent review records: {e}");
+        Vec::new()
+    });
     let rolling_windows = dimensions::rolling_window(&rolling_records, ROLLING_N, ROLLING_WINDOWS);
 
     // Linkage: only needs finding_ids, not full records.
-    let finding_ids = review_log.load_all_finding_ids().unwrap_or_default();
+    let finding_ids = review_log.load_all_finding_ids().unwrap_or_else(|e| {
+        tracing::warn!("Failed to load finding IDs for linkage: {e}");
+        std::collections::HashSet::new()
+    });
     let link = analytics::linkage_stats_from_ids(&finding_ids, &feedback);
     let linkage_rate = link.rate();
     let headline_trend_uses_finding_id = linkage_rate >= 0.85;

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -76,7 +76,10 @@ pub fn compute_report(
     telemetry_store: &TelemetryStore,
     review_log: &ReviewLog,
 ) -> anyhow::Result<StatsReport> {
-    let feedback = feedback_store.load_all().unwrap_or_default();
+    let feedback = feedback_store.load_all().unwrap_or_else(|e| {
+        tracing::warn!("Failed to load feedback data: {e}");
+        Vec::new()
+    });
     let feedback_count = feedback.len();
     let tier_summary = analytics::compute_tier_stats(&feedback);
 
@@ -99,7 +102,10 @@ pub fn compute_report(
 
     // Telemetry: last 7 days
     let since_7d = chrono::Utc::now() - chrono::Duration::days(7);
-    let recent = telemetry_store.load_since(since_7d).unwrap_or_default();
+    let recent = telemetry_store.load_since(since_7d).unwrap_or_else(|e| {
+        tracing::warn!("Failed to load telemetry data: {e}");
+        Vec::new()
+    });
     let reviews_7d = recent.len();
     let tokens_in_7d: u64 = recent.iter().map(|e| e.tokens_in).sum();
     let tokens_out_7d: u64 = recent.iter().map(|e| e.tokens_out).sum();
@@ -146,7 +152,10 @@ pub fn compute_report(
     // Dimensional highlights: load all for repo/caller bucketing.
     // Best-effort: missing reviews.jsonl yields empty vectors, which
     // the renderer treats as "no data" and hides.
-    let review_records = review_log.load_all().unwrap_or_default();
+    let review_records = review_log.load_all().unwrap_or_else(|e| {
+        tracing::warn!("Failed to load review log: {e}");
+        Vec::new()
+    });
     let top_repos = take_top(dimensions::group_by_repo(&review_records), HIGHLIGHT_TOP_N);
     let top_callers = take_top(
         dimensions::group_by_caller(&review_records),


### PR DESCRIPTION
## Summary

Rolls up 9 bugfixes across two priority groups (correctness + reliability), covering issues #237, #272, #325, #333, #337, #338, #392, #393, #395.

### Correctness fixes
- **#325** `merge.rs` — `model_agreement` clamped to `min(1.0)` to prevent values > 1.0 with duplicate model names
- **#333** `review_log.rs` — `SeverityCounts` and `LegCounts` switched from `+= 1` to `saturating_add(1)`; `total()` uses saturating chain
- **#337** `judge.rs` — `extract_json_array` now scans forward through each `[`, validates with `serde_json`, skipping stray brackets like `[docs]`
- **#395** `finding.rs` — `compute_confidence` falls back to `grounding_status` enum (Verified→0.90, SymbolNotFound→0.20, etc.) instead of flat 0.5

### Reliability fixes (silent error surfacing)
- **#392** `main.rs` — Telemetry `record()` and `create_dir_all` failures now `tracing::warn`
- **#393** `builder.rs` — ROLLBACK failure now warns instead of `let _ =`
- **#272** `stats.rs` — `load_all`/`load_since` errors now warn instead of `unwrap_or_default`
- **#338** `handler.rs` — `current_dir()` failure returns error message to MCP caller
- **#237** `cli.rs` — `head_sha` failure now warns with repo path

### Not included (already fixed / false positive)
- **#391** — `block_on` is inside `spawn_blocking`, which is correct per Tokio docs
- **#197** — Code already uses `strip_prefix("+++ b/")`, not byte indexing

## Test plan
- [x] `cargo test --bin quorum` — 1603 passed, 1 ignored
- [x] `cargo clippy --bin quorum` — clean
- [ ] Quorum self-review
- [ ] CodeRabbit review

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented telemetry counter overflow by using saturating arithmetic.
  * Made JSON array extraction from LLM responses more robust.
  * Capped agreement ratio to 1.0.
  * Ensured anchor line is never below 1.
  * Refined confidence fallback selection based on grounding status.

* **Chores**
  * Improved error handling and added warnings across various operations (IO, migrations, telemetry persistence, feedback storage, directory resolution, data loading).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jsnyder/quorum/pull/402?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->