### PR TITLE
fix: input validation + TS fingerprinter bugfixes

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -145,6 +145,43 @@ pub fn validate_parallel(s: &str) -> Result<usize, String> {
     Ok(n)
 }
 
+const VALID_KINDS: &[&str] = &[
+    "rust",
+    "typescript",
+    "javascript",
+    "python",
+    "go",
+    "terraform",
+    "service",
+    "docs",
+];
+
+/// Validate `--kind` for `quorum context add`.
+pub fn validate_kind(s: &str) -> Result<String, String> {
+    if VALID_KINDS.contains(&s) {
+        Ok(s.to_string())
+    } else {
+        Err(format!(
+            "--kind must be one of: {} (got '{s}')",
+            VALID_KINDS.join(", ")
+        ))
+    }
+}
+
+/// Validate `--reasoning-effort` for `quorum review`.
+/// Accepts the OpenAI-compatible set: none, minimal, low, medium, high, xhigh.
+pub fn validate_reasoning_effort(s: &str) -> Result<String, String> {
+    const VALID: &[&str] = &["none", "minimal", "low", "medium", "high", "xhigh"];
+    if VALID.contains(&s) {
+        Ok(s.to_string())
+    } else {
+        Err(format!(
+            "--reasoning-effort must be one of: {} (got '{s}')",
+            VALID.join(", ")
+        ))
+    }
+}
+
 #[derive(Parser)]
 pub struct ContextAddOpts {
     /// Short unique name for the source (used as a directory key).
@@ -153,7 +190,7 @@ pub struct ContextAddOpts {
     pub name: String,
 
     /// Source kind: rust, typescript, javascript, python, go, terraform, service, docs.
-    #[arg(long)]
+    #[arg(long, value_parser = validate_kind)]
     pub kind: String,
 
     /// Local filesystem path to the source. Mutually exclusive with --git.
@@ -211,7 +248,7 @@ pub struct ContextQueryOpts {
     pub text: String,
 
     /// Restrict results to a single source.
-    #[arg(long)]
+    #[arg(long, value_parser = validate_source_name)]
     pub source: Option<String>,
 
     /// Return up to this many chunks. Range: 1..=100.
@@ -302,6 +339,43 @@ pub struct CalibrateOpts {
     /// Show per-feature univariate AP diagnostics
     #[arg(long)]
     pub feature_importance: bool,
+}
+
+impl Default for CalibrateOpts {
+    fn default() -> Self {
+        Self {
+            dry_run: false,
+            suppress_precision: 0.95,
+            boost_precision: 0.85,
+            trace_version: None,
+            clean_only: false,
+            trace_repo: None,
+            trace_commit: None,
+            trace_run_id: None,
+            disable_fuzzy: false,
+            backfill_paths: false,
+            learn_weights: false,
+            feature_importance: false,
+        }
+    }
+}
+
+impl CalibrateOpts {
+    pub fn validate(&self) -> anyhow::Result<()> {
+        if !(0.0..=1.0).contains(&self.suppress_precision) {
+            anyhow::bail!(
+                "--suppress-precision must be in 0.0..=1.0 (got {})",
+                self.suppress_precision
+            );
+        }
+        if !(0.0..=1.0).contains(&self.boost_precision) {
+            anyhow::bail!(
+                "--boost-precision must be in 0.0..=1.0 (got {})",
+                self.boost_precision
+            );
+        }
+        Ok(())
+    }
 }
 
 #[derive(Parser)]
@@ -440,7 +514,7 @@ pub struct ReviewOpts {
     pub ensemble: bool,
 
     /// Reasoning effort: none, minimal, low, medium, high, xhigh
-    #[arg(long)]
+    #[arg(long, value_parser = validate_reasoning_effort)]
     pub reasoning_effort: Option<String>,
 
     /// Disable color output
@@ -1781,5 +1855,184 @@ mod tests {
             Command::Review(opts) => assert_eq!(opts.parallel, 4),
             _ => panic!("Expected Review command"),
         }
+    }
+
+    // --- Issue #234: --reasoning-effort constrained to known values -----------
+
+    #[test]
+    fn reasoning_effort_rejects_unknown() {
+        use clap::Parser;
+        let r = Args::try_parse_from([
+            "quorum", "review", "/tmp/x.rs", "--reasoning-effort", "turbo",
+        ]);
+        assert!(r.is_err(), "unknown reasoning effort 'turbo' must be rejected");
+    }
+
+    #[test]
+    fn reasoning_effort_rejects_case_mismatch() {
+        use clap::Parser;
+        let r = Args::try_parse_from([
+            "quorum", "review", "/tmp/x.rs", "--reasoning-effort", "HIGH",
+        ]);
+        assert!(r.is_err(), "case-sensitive: 'HIGH' must be rejected");
+    }
+
+    #[test]
+    fn reasoning_effort_accepts_high() {
+        use clap::Parser;
+        let r = Args::try_parse_from([
+            "quorum", "review", "/tmp/x.rs", "--reasoning-effort", "high",
+        ]);
+        assert!(r.is_ok(), "'high' is a valid reasoning effort");
+    }
+
+    #[test]
+    fn reasoning_effort_accepts_none() {
+        use clap::Parser;
+        let r = Args::try_parse_from([
+            "quorum", "review", "/tmp/x.rs", "--reasoning-effort", "none",
+        ]);
+        assert!(r.is_ok(), "'none' is a valid reasoning effort");
+    }
+
+    #[test]
+    fn reasoning_effort_accepts_all_known() {
+        use clap::Parser;
+        for val in &["none", "minimal", "low", "medium", "high", "xhigh"] {
+            let r = Args::try_parse_from([
+                "quorum", "review", "/tmp/x.rs", "--reasoning-effort", val,
+            ]);
+            assert!(r.is_ok(), "'{val}' must be accepted");
+        }
+    }
+
+    // --- Issue #149: --kind constrained to known source kinds -----------------
+
+    #[test]
+    fn context_add_kind_rejects_unknown() {
+        use clap::Parser;
+        let r = Args::try_parse_from([
+            "quorum", "context", "add", "--name", "src", "--kind", "haskell", "--path", "/tmp/x",
+        ]);
+        assert!(r.is_err(), "unknown kind 'haskell' must be rejected");
+    }
+
+    #[test]
+    fn context_add_kind_accepts_rust() {
+        use clap::Parser;
+        let r = Args::try_parse_from([
+            "quorum", "context", "add", "--name", "src", "--kind", "rust", "--path", "/tmp/x",
+        ]);
+        assert!(r.is_ok(), "'rust' is a valid kind");
+    }
+
+    #[test]
+    fn context_add_kind_accepts_all_known() {
+        use clap::Parser;
+        for kind in &[
+            "rust", "typescript", "javascript", "python", "go", "terraform", "service", "docs",
+        ] {
+            let r = Args::try_parse_from([
+                "quorum", "context", "add", "--name", "src", "--kind", kind, "--path", "/tmp/x",
+            ]);
+            assert!(r.is_ok(), "kind '{kind}' must be accepted");
+        }
+    }
+
+    // --- Issue #369: context query --source validated like --name -------------
+
+    #[test]
+    fn context_query_source_rejects_path_traversal() {
+        use clap::Parser;
+        let r = Args::try_parse_from([
+            "quorum", "context", "query", "hello", "--source", "../etc",
+        ]);
+        assert!(r.is_err(), "--source '../etc' must be rejected");
+    }
+
+    #[test]
+    fn context_query_source_rejects_empty() {
+        use clap::Parser;
+        let r = Args::try_parse_from([
+            "quorum", "context", "query", "hello", "--source", "",
+        ]);
+        assert!(r.is_err(), "--source '' must be rejected");
+    }
+
+    #[test]
+    fn context_query_source_rejects_overlong() {
+        use clap::Parser;
+        let long = "a".repeat(65);
+        let r = Args::try_parse_from([
+            "quorum", "context", "query", "hello", "--source", &long,
+        ]);
+        assert!(r.is_err(), "--source with 65 chars must be rejected");
+    }
+
+    #[test]
+    fn context_query_source_accepts_valid() {
+        use clap::Parser;
+        let r = Args::try_parse_from([
+            "quorum", "context", "query", "hello", "--source", "my-source",
+        ]);
+        assert!(r.is_ok(), "'my-source' is a valid source name");
+    }
+
+    // --- Issue #368: CalibrateOpts precision range validation -----------------
+
+    #[test]
+    fn calibrate_opts_validate_rejects_negative_suppress() {
+        let opts = CalibrateOpts {
+            suppress_precision: -0.1,
+            ..Default::default()
+        };
+        assert!(opts.validate().is_err());
+    }
+
+    #[test]
+    fn calibrate_opts_validate_rejects_above_one_boost() {
+        let opts = CalibrateOpts {
+            boost_precision: 1.1,
+            ..Default::default()
+        };
+        assert!(opts.validate().is_err());
+    }
+
+    #[test]
+    fn calibrate_opts_validate_rejects_nan() {
+        let opts = CalibrateOpts {
+            suppress_precision: f64::NAN,
+            ..Default::default()
+        };
+        assert!(opts.validate().is_err(), "NaN must be rejected");
+    }
+
+    #[test]
+    fn calibrate_opts_validate_rejects_infinity() {
+        let opts = CalibrateOpts {
+            boost_precision: f64::INFINITY,
+            ..Default::default()
+        };
+        assert!(opts.validate().is_err(), "infinity must be rejected");
+    }
+
+    #[test]
+    fn calibrate_opts_validate_accepts_valid() {
+        let opts = CalibrateOpts {
+            suppress_precision: 0.95,
+            boost_precision: 0.85,
+            ..Default::default()
+        };
+        assert!(opts.validate().is_ok());
+    }
+
+    #[test]
+    fn calibrate_opts_validate_accepts_boundary() {
+        let opts = CalibrateOpts {
+            suppress_precision: 0.0,
+            boost_precision: 1.0,
+            ..Default::default()
+        };
+        assert!(opts.validate().is_ok());
     }
 }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -147,23 +147,28 @@ pub fn validate_parallel(s: &str) -> Result<usize, String> {
 
 const VALID_KINDS: &[&str] = &[
     "rust",
+    "rs",
     "typescript",
+    "ts",
     "javascript",
+    "js",
     "python",
+    "py",
     "go",
     "terraform",
+    "tf",
     "service",
     "docs",
 ];
 
 /// Validate `--kind` for `quorum context add`.
+/// Accepts canonical names and aliases matching `SourceKind::parse_cli`.
 pub fn validate_kind(s: &str) -> Result<String, String> {
     if VALID_KINDS.contains(&s) {
         Ok(s.to_string())
     } else {
         Err(format!(
-            "--kind must be one of: {} (got '{s}')",
-            VALID_KINDS.join(", ")
+            "--kind must be one of: rust, typescript, javascript, python, go, terraform, service, docs (or aliases: rs, ts, js, py, tf) (got '{s}')",
         ))
     }
 }
@@ -230,7 +235,7 @@ pub struct ContextListOpts {
 #[derive(Parser)]
 pub struct ContextIndexOpts {
     /// Index a single named source. Mutually exclusive with --all.
-    #[arg(long, conflicts_with = "all")]
+    #[arg(long, conflicts_with = "all", value_parser = validate_source_name)]
     pub source: Option<String>,
 
     /// Index every registered source.
@@ -2034,5 +2039,38 @@ mod tests {
             ..Default::default()
         };
         assert!(opts.validate().is_ok());
+    }
+
+    // --- Issue #149 addendum: kind aliases match SourceKind::parse_cli --------
+
+    #[test]
+    fn context_add_kind_accepts_aliases() {
+        use clap::Parser;
+        for alias in &["rs", "ts", "js", "py", "tf"] {
+            let r = Args::try_parse_from([
+                "quorum", "context", "add", "--name", "src", "--kind", alias, "--path", "/tmp/x",
+            ]);
+            assert!(r.is_ok(), "alias '{alias}' must be accepted by --kind");
+        }
+    }
+
+    // --- Issue #369 addendum: context index --source also validated -----------
+
+    #[test]
+    fn context_index_source_rejects_path_traversal() {
+        use clap::Parser;
+        let r = Args::try_parse_from([
+            "quorum", "context", "index", "--source", "../etc",
+        ]);
+        assert!(r.is_err(), "--source '../etc' on index must be rejected");
+    }
+
+    #[test]
+    fn context_index_source_accepts_valid() {
+        use clap::Parser;
+        let r = Args::try_parse_from([
+            "quorum", "context", "index", "--source", "my-source",
+        ]);
+        assert!(r.is_ok(), "'my-source' is a valid source name for index");
     }
 }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1868,16 +1868,27 @@ mod tests {
     fn reasoning_effort_rejects_unknown() {
         use clap::Parser;
         let r = Args::try_parse_from([
-            "quorum", "review", "/tmp/x.rs", "--reasoning-effort", "turbo",
+            "quorum",
+            "review",
+            "/tmp/x.rs",
+            "--reasoning-effort",
+            "turbo",
         ]);
-        assert!(r.is_err(), "unknown reasoning effort 'turbo' must be rejected");
+        assert!(
+            r.is_err(),
+            "unknown reasoning effort 'turbo' must be rejected"
+        );
     }
 
     #[test]
     fn reasoning_effort_rejects_case_mismatch() {
         use clap::Parser;
         let r = Args::try_parse_from([
-            "quorum", "review", "/tmp/x.rs", "--reasoning-effort", "HIGH",
+            "quorum",
+            "review",
+            "/tmp/x.rs",
+            "--reasoning-effort",
+            "HIGH",
         ]);
         assert!(r.is_err(), "case-sensitive: 'HIGH' must be rejected");
     }
@@ -1886,7 +1897,11 @@ mod tests {
     fn reasoning_effort_accepts_high() {
         use clap::Parser;
         let r = Args::try_parse_from([
-            "quorum", "review", "/tmp/x.rs", "--reasoning-effort", "high",
+            "quorum",
+            "review",
+            "/tmp/x.rs",
+            "--reasoning-effort",
+            "high",
         ]);
         assert!(r.is_ok(), "'high' is a valid reasoning effort");
     }
@@ -1895,7 +1910,11 @@ mod tests {
     fn reasoning_effort_accepts_none() {
         use clap::Parser;
         let r = Args::try_parse_from([
-            "quorum", "review", "/tmp/x.rs", "--reasoning-effort", "none",
+            "quorum",
+            "review",
+            "/tmp/x.rs",
+            "--reasoning-effort",
+            "none",
         ]);
         assert!(r.is_ok(), "'none' is a valid reasoning effort");
     }
@@ -1904,9 +1923,8 @@ mod tests {
     fn reasoning_effort_accepts_all_known() {
         use clap::Parser;
         for val in &["none", "minimal", "low", "medium", "high", "xhigh"] {
-            let r = Args::try_parse_from([
-                "quorum", "review", "/tmp/x.rs", "--reasoning-effort", val,
-            ]);
+            let r =
+                Args::try_parse_from(["quorum", "review", "/tmp/x.rs", "--reasoning-effort", val]);
             assert!(r.is_ok(), "'{val}' must be accepted");
         }
     }
@@ -1935,7 +1953,14 @@ mod tests {
     fn context_add_kind_accepts_all_known() {
         use clap::Parser;
         for kind in &[
-            "rust", "typescript", "javascript", "python", "go", "terraform", "service", "docs",
+            "rust",
+            "typescript",
+            "javascript",
+            "python",
+            "go",
+            "terraform",
+            "service",
+            "docs",
         ] {
             let r = Args::try_parse_from([
                 "quorum", "context", "add", "--name", "src", "--kind", kind, "--path", "/tmp/x",
@@ -1949,18 +1974,14 @@ mod tests {
     #[test]
     fn context_query_source_rejects_path_traversal() {
         use clap::Parser;
-        let r = Args::try_parse_from([
-            "quorum", "context", "query", "hello", "--source", "../etc",
-        ]);
+        let r = Args::try_parse_from(["quorum", "context", "query", "hello", "--source", "../etc"]);
         assert!(r.is_err(), "--source '../etc' must be rejected");
     }
 
     #[test]
     fn context_query_source_rejects_empty() {
         use clap::Parser;
-        let r = Args::try_parse_from([
-            "quorum", "context", "query", "hello", "--source", "",
-        ]);
+        let r = Args::try_parse_from(["quorum", "context", "query", "hello", "--source", ""]);
         assert!(r.is_err(), "--source '' must be rejected");
     }
 
@@ -1968,9 +1989,7 @@ mod tests {
     fn context_query_source_rejects_overlong() {
         use clap::Parser;
         let long = "a".repeat(65);
-        let r = Args::try_parse_from([
-            "quorum", "context", "query", "hello", "--source", &long,
-        ]);
+        let r = Args::try_parse_from(["quorum", "context", "query", "hello", "--source", &long]);
         assert!(r.is_err(), "--source with 65 chars must be rejected");
     }
 
@@ -1978,7 +1997,12 @@ mod tests {
     fn context_query_source_accepts_valid() {
         use clap::Parser;
         let r = Args::try_parse_from([
-            "quorum", "context", "query", "hello", "--source", "my-source",
+            "quorum",
+            "context",
+            "query",
+            "hello",
+            "--source",
+            "my-source",
         ]);
         assert!(r.is_ok(), "'my-source' is a valid source name");
     }
@@ -2059,18 +2083,14 @@ mod tests {
     #[test]
     fn context_index_source_rejects_path_traversal() {
         use clap::Parser;
-        let r = Args::try_parse_from([
-            "quorum", "context", "index", "--source", "../etc",
-        ]);
+        let r = Args::try_parse_from(["quorum", "context", "index", "--source", "../etc"]);
         assert!(r.is_err(), "--source '../etc' on index must be rejected");
     }
 
     #[test]
     fn context_index_source_accepts_valid() {
         use clap::Parser;
-        let r = Args::try_parse_from([
-            "quorum", "context", "index", "--source", "my-source",
-        ]);
+        let r = Args::try_parse_from(["quorum", "context", "index", "--source", "my-source"]);
         assert!(r.is_ok(), "'my-source' is a valid source name for index");
     }
 }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -164,6 +164,7 @@ const VALID_KINDS: &[&str] = &[
 /// Validate `--kind` for `quorum context add`.
 /// Accepts canonical names and aliases matching `SourceKind::parse_cli`.
 pub fn validate_kind(s: &str) -> Result<String, String> {
+    let s = s.trim();
     if VALID_KINDS.contains(&s) {
         Ok(s.to_string())
     } else {

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -134,6 +134,17 @@ pub fn validate_k(s: &str) -> Result<usize, String> {
     Ok(n)
 }
 
+/// Validate `--parallel` for `quorum review`. Range: 1..=64.
+pub fn validate_parallel(s: &str) -> Result<usize, String> {
+    let n: usize = s
+        .parse()
+        .map_err(|e| format!("--parallel must be a positive integer: {e}"))?;
+    if !(1..=64).contains(&n) {
+        return Err(format!("--parallel must be in 1..=64 (got {n})"));
+    }
+    Ok(n)
+}
+
 #[derive(Parser)]
 pub struct ContextAddOpts {
     /// Short unique name for the source (used as a directory key).
@@ -477,8 +488,8 @@ pub struct ReviewOpts {
     #[arg(long)]
     pub live_registry: bool,
 
-    /// Max concurrent LLM calls (default: 4, 0 = unlimited, 1 = sequential)
-    #[arg(long, default_value = "4")]
+    /// Max concurrent LLM calls (default: 4, range: 1..=64)
+    #[arg(long, default_value = "4", value_parser = validate_parallel)]
     pub parallel: usize,
 
     /// Enable structured tracing to ~/.quorum/trace.jsonl (also: QUORUM_TRACE=1)
@@ -1730,5 +1741,45 @@ mod tests {
     fn parse_provenance_rejects_unknown() {
         assert!(parse_provenance("external").is_err());
         assert!(parse_provenance("auto_calibrate").is_err());
+    }
+
+    // --- Issue #150: --parallel rejects 0 and caps at 64 ----------------------
+
+    #[test]
+    fn parallel_rejects_zero() {
+        use clap::Parser;
+        let r = Args::try_parse_from(["quorum", "review", "/tmp/x.rs", "--parallel", "0"]);
+        assert!(r.is_err(), "--parallel 0 must be rejected");
+    }
+
+    #[test]
+    fn parallel_rejects_above_64() {
+        use clap::Parser;
+        let r = Args::try_parse_from(["quorum", "review", "/tmp/x.rs", "--parallel", "65"]);
+        assert!(r.is_err(), "--parallel 65 must be rejected (above 64 cap)");
+    }
+
+    #[test]
+    fn parallel_accepts_one() {
+        use clap::Parser;
+        let r = Args::try_parse_from(["quorum", "review", "/tmp/x.rs", "--parallel", "1"]);
+        assert!(r.is_ok(), "--parallel 1 must parse (lower bound)");
+    }
+
+    #[test]
+    fn parallel_accepts_64() {
+        use clap::Parser;
+        let r = Args::try_parse_from(["quorum", "review", "/tmp/x.rs", "--parallel", "64"]);
+        assert!(r.is_ok(), "--parallel 64 must parse (upper bound)");
+    }
+
+    #[test]
+    fn parallel_default_is_4() {
+        use clap::Parser;
+        let args = Args::parse_from(["quorum", "review", "/tmp/x.rs"]);
+        match args.command {
+            Command::Review(opts) => assert_eq!(opts.parallel, 4),
+            _ => panic!("Expected Review command"),
+        }
     }
 }

--- a/src/context/extract/fingerprint_typescript.rs
+++ b/src/context/extract/fingerprint_typescript.rs
@@ -18,6 +18,7 @@ const FUNCTION_KINDS: &[&str] = &[
     "method_definition",
     "arrow_function",
     "function",
+    "function_expression",
 ];
 
 /// Stateless fingerprinter for TypeScript source code.
@@ -49,7 +50,7 @@ impl TypeScriptFingerprinter {
             .collect();
         let mut results = Vec::new();
         for node in &func_nodes {
-            let name = node
+            let mut name = node
                 .children()
                 .find(|c| {
                     let k = c.kind();
@@ -57,6 +58,9 @@ impl TypeScriptFingerprinter {
                 })
                 .map(|c| c.text().into_owned())
                 .unwrap_or_default();
+            if name.is_empty() {
+                name = walk_up_to_variable_name(node);
+            }
             if name.is_empty() {
                 continue;
             }
@@ -110,6 +114,24 @@ fn find_first_function<'a, D: Doc>(
 ) -> Option<ast_grep_core::Node<'a, D>> {
     root.dfs()
         .find(|n| FUNCTION_KINDS.contains(&n.kind().as_ref()))
+}
+
+/// When an arrow_function or function expression has no name child, check if
+/// it's assigned to a variable via `variable_declarator` and extract the
+/// variable name.
+fn walk_up_to_variable_name<D: Doc>(node: &ast_grep_core::Node<'_, D>) -> String {
+    let parent = match node.parent() {
+        Some(p) => p,
+        None => return String::new(),
+    };
+    let pk = parent.kind();
+    let parent_kind = pk.as_ref();
+    if parent_kind == "variable_declarator" {
+        if let Some(name_node) = parent.children().find(|c| c.kind().as_ref() == "identifier") {
+            return name_node.text().into_owned();
+        }
+    }
+    String::new()
 }
 
 /// Extract signature shape from a function/method node.

--- a/src/context/extract/fingerprint_typescript.rs
+++ b/src/context/extract/fingerprint_typescript.rs
@@ -126,21 +126,17 @@ fn walk_up_to_variable_name<D: Doc>(node: &ast_grep_core::Node<'_, D>) -> String
     };
     let pk = parent.kind();
     let parent_kind = pk.as_ref();
-    if parent_kind == "variable_declarator" {
-        if let Some(name_node) = parent.children().find(|c| c.kind().as_ref() == "identifier") {
-            return name_node.text().into_owned();
-        }
+    if parent_kind == "variable_declarator"
+        && let Some(name_node) = parent.children().find(|c| c.kind().as_ref() == "identifier")
+    {
+        return name_node.text().into_owned();
     }
-    // Class field arrow: `validate = (input) => { ... }` has parent
-    // `public_field_definition` (or `field_definition`) with a
-    // `property_identifier` child carrying the name.
-    if parent_kind == "public_field_definition" || parent_kind == "field_definition" {
-        if let Some(name_node) = parent
+    if (parent_kind == "public_field_definition" || parent_kind == "field_definition")
+        && let Some(name_node) = parent
             .children()
             .find(|c| c.kind().as_ref() == "property_identifier")
-        {
-            return name_node.text().into_owned();
-        }
+    {
+        return name_node.text().into_owned();
     }
     String::new()
 }
@@ -217,10 +213,10 @@ fn is_direct_class_member<D: Doc>(node: &ast_grep_core::Node<'_, D>) -> bool {
     if parent_kind == "class_body" {
         return true;
     }
-    if parent_kind == "public_field_definition" || parent_kind == "field_definition" {
-        if let Some(grandparent) = parent.parent() {
-            return grandparent.kind().as_ref() == "class_body";
-        }
+    if (parent_kind == "public_field_definition" || parent_kind == "field_definition")
+        && let Some(grandparent) = parent.parent()
+    {
+        return grandparent.kind().as_ref() == "class_body";
     }
     false
 }

--- a/src/context/extract/fingerprint_typescript.rs
+++ b/src/context/extract/fingerprint_typescript.rs
@@ -127,7 +127,9 @@ fn walk_up_to_variable_name<D: Doc>(node: &ast_grep_core::Node<'_, D>) -> String
     let pk = parent.kind();
     let parent_kind = pk.as_ref();
     if parent_kind == "variable_declarator"
-        && let Some(name_node) = parent.children().find(|c| c.kind().as_ref() == "identifier")
+        && let Some(name_node) = parent
+            .children()
+            .find(|c| c.kind().as_ref() == "identifier")
     {
         return name_node.text().into_owned();
     }

--- a/src/context/extract/fingerprint_typescript.rs
+++ b/src/context/extract/fingerprint_typescript.rs
@@ -50,14 +50,21 @@ impl TypeScriptFingerprinter {
             .collect();
         let mut results = Vec::new();
         for node in &func_nodes {
-            let mut name = node
-                .children()
-                .find(|c| {
-                    let k = c.kind();
-                    k.as_ref() == "identifier" || k.as_ref() == "property_identifier"
-                })
-                .map(|c| c.text().into_owned())
-                .unwrap_or_default();
+            let mut name = if node.kind().as_ref() == "function_expression" {
+                walk_up_to_variable_name(node)
+            } else {
+                String::new()
+            };
+            if name.is_empty() {
+                name = node
+                    .children()
+                    .find(|c| {
+                        let k = c.kind();
+                        k.as_ref() == "identifier" || k.as_ref() == "property_identifier"
+                    })
+                    .map(|c| c.text().into_owned())
+                    .unwrap_or_default();
+            }
             if name.is_empty() {
                 name = walk_up_to_variable_name(node);
             }
@@ -447,10 +454,12 @@ fn count_type_nesting_inner<D: Doc>(node: &ast_grep_core::Node<'_, D>) -> u8 {
         let kind = ck.as_ref();
         if kind == "type_arguments" {
             for arg in child.children() {
-                if arg.kind().as_ref() == "generic_type" {
-                    let inner = 1 + count_type_nesting_inner(&arg);
-                    max_depth = max_depth.max(inner);
-                }
+                let inner = if arg.kind().as_ref() == "generic_type" {
+                    1 + count_type_nesting_inner(&arg)
+                } else {
+                    count_type_nesting(&arg)
+                };
+                max_depth = max_depth.max(inner);
             }
         }
     }

--- a/src/context/extract/fingerprint_typescript.rs
+++ b/src/context/extract/fingerprint_typescript.rs
@@ -423,22 +423,37 @@ fn extract_return_type<'a, D: Doc>(
 }
 
 /// Count the nesting depth of generic type arguments within a type annotation.
+///
+/// `Promise<T>` => 1, `Promise<Result<T>>` => 2, `string` => 0.
 fn count_type_nesting<D: Doc>(node: &ast_grep_core::Node<'_, D>) -> u8 {
     let mut max_depth: u8 = 0;
     for child in node.children() {
         let ck = child.kind();
         let kind = ck.as_ref();
-        if kind == "type_arguments" {
-            let inner_max = child
-                .children()
-                .filter(|c| c.kind().as_ref() == "generic_type")
-                .map(|c| 1 + count_type_nesting(&c))
-                .max()
-                .unwrap_or(1);
-            max_depth = max_depth.max(inner_max);
-        } else if kind == "generic_type" {
+        if kind == "generic_type" {
+            let inner = 1 + count_type_nesting_inner(&child);
+            max_depth = max_depth.max(inner);
+        } else {
             let inner = count_type_nesting(&child);
             max_depth = max_depth.max(inner);
+        }
+    }
+    max_depth
+}
+
+/// Recursive helper: count nesting depth within a `generic_type` node.
+fn count_type_nesting_inner<D: Doc>(node: &ast_grep_core::Node<'_, D>) -> u8 {
+    let mut max_depth: u8 = 0;
+    for child in node.children() {
+        let ck = child.kind();
+        let kind = ck.as_ref();
+        if kind == "type_arguments" {
+            for arg in child.children() {
+                if arg.kind().as_ref() == "generic_type" {
+                    let inner = 1 + count_type_nesting_inner(&arg);
+                    max_depth = max_depth.max(inner);
+                }
+            }
         }
     }
     max_depth

--- a/src/context/extract/fingerprint_typescript.rs
+++ b/src/context/extract/fingerprint_typescript.rs
@@ -117,8 +117,8 @@ fn find_first_function<'a, D: Doc>(
 }
 
 /// When an arrow_function or function expression has no name child, check if
-/// it's assigned to a variable via `variable_declarator` and extract the
-/// variable name.
+/// it's assigned to a variable via `variable_declarator` or a class field via
+/// `public_field_definition` / `field_definition`, and extract the name.
 fn walk_up_to_variable_name<D: Doc>(node: &ast_grep_core::Node<'_, D>) -> String {
     let parent = match node.parent() {
         Some(p) => p,
@@ -128,6 +128,17 @@ fn walk_up_to_variable_name<D: Doc>(node: &ast_grep_core::Node<'_, D>) -> String
     let parent_kind = pk.as_ref();
     if parent_kind == "variable_declarator" {
         if let Some(name_node) = parent.children().find(|c| c.kind().as_ref() == "identifier") {
+            return name_node.text().into_owned();
+        }
+    }
+    // Class field arrow: `validate = (input) => { ... }` has parent
+    // `public_field_definition` (or `field_definition`) with a
+    // `property_identifier` child carrying the name.
+    if parent_kind == "public_field_definition" || parent_kind == "field_definition" {
+        if let Some(name_node) = parent
+            .children()
+            .find(|c| c.kind().as_ref() == "property_identifier")
+        {
             return name_node.text().into_owned();
         }
     }
@@ -145,7 +156,7 @@ fn extract_signature<'a, D: Doc>(
     let kind_str = kind.as_ref();
 
     // Detect if this is a method inside a class.
-    let in_class = is_inside_class(node);
+    let in_class = is_direct_class_member(node);
 
     // Find the formal_parameters node.
     if let Some(params) = node
@@ -191,13 +202,27 @@ fn extract_signature<'a, D: Doc>(
     shape
 }
 
-/// Check if a node is inside a class body.
-fn is_inside_class<D: Doc>(node: &ast_grep_core::Node<'_, D>) -> bool {
-    node.ancestors().any(|a| {
-        let ak = a.kind();
-        let kind = ak.as_ref();
-        kind == "class_declaration" || kind == "class"
-    })
+/// Check if a function node is a direct member of a class body.
+///
+/// For `method_definition`: direct parent is `class_body`.
+/// For `arrow_function`/`function` as class fields: parent chain is
+/// `arrow_function -> public_field_definition -> class_body`.
+fn is_direct_class_member<D: Doc>(node: &ast_grep_core::Node<'_, D>) -> bool {
+    let parent = match node.parent() {
+        Some(p) => p,
+        None => return false,
+    };
+    let pk = parent.kind();
+    let parent_kind = pk.as_ref();
+    if parent_kind == "class_body" {
+        return true;
+    }
+    if parent_kind == "public_field_definition" || parent_kind == "field_definition" {
+        if let Some(grandparent) = parent.parent() {
+            return grandparent.kind().as_ref() == "class_body";
+        }
+    }
+    false
 }
 
 /// Check if a method_definition has a `static` modifier.

--- a/src/context/extract/fingerprint_typescript_tests.rs
+++ b/src/context/extract/fingerprint_typescript_tests.rs
@@ -688,3 +688,51 @@ function buildMap(items: string[]): Map<string, number> {
         fp.signature.return_nesting
     );
 }
+
+#[test]
+fn named_function_expression_uses_binding_name() {
+    let src = r#"
+const handler = function internal(req: Request): Response {
+    const body = req.body;
+    const parsed = JSON.parse(body);
+    const validated = validate(parsed);
+    const processed = process(validated);
+    const serialized = JSON.stringify(processed);
+    const response = new Response(serialized);
+    console.log(response);
+    return response;
+};
+"#;
+    let fprinter = TypeScriptFingerprinter;
+    let results = fprinter.fingerprint_all_functions(src);
+    let names: Vec<&str> = results.iter().map(|(n, _)| n.as_str()).collect();
+    assert!(
+        names.contains(&"handler"),
+        "should use binding name 'handler' not inner name 'internal'; got {:?}",
+        names
+    );
+}
+
+#[test]
+fn type_nesting_union_wrapped_generic_is_two() {
+    let src = r#"
+async function fetchOrNull(url: string): Promise<Result<string> | null> {
+    const response = await fetch(url);
+    const data = await response.json();
+    const validated = validate(data);
+    const wrapped = wrapResult(validated);
+    const checked = checkResult(wrapped);
+    const result = finalizeResult(checked);
+    console.log(result);
+    return result;
+}
+"#;
+    let fp = TypeScriptFingerprinter
+        .fingerprint_source(src)
+        .expect("should fingerprint");
+    assert_eq!(
+        fp.signature.return_nesting, 2,
+        "Promise<Result<string> | null> should have nesting=2, got {}",
+        fp.signature.return_nesting
+    );
+}

--- a/src/context/extract/fingerprint_typescript_tests.rs
+++ b/src/context/extract/fingerprint_typescript_tests.rs
@@ -420,3 +420,99 @@ class Config {
         "static method does not have this"
     );
 }
+
+#[test]
+fn arrow_function_variable_name_extracted() {
+    let src = r#"
+const processData = (input: string): string => {
+    const trimmed = input.trim();
+    const lower = trimmed.toLowerCase();
+    const replaced = lower.replace("-", "_");
+    const padded = replaced.padStart(10, "0");
+    const sliced = padded.slice(0, 8);
+    const result = sliced + "_done";
+    console.log(result);
+    return result;
+};
+"#;
+    let fprinter = TypeScriptFingerprinter;
+    let results = fprinter.fingerprint_all_functions(src);
+    let names: Vec<&str> = results.iter().map(|(n, _)| n.as_str()).collect();
+    assert!(
+        names.contains(&"processData"),
+        "should extract 'processData' from variable declarator; got {:?}",
+        names
+    );
+}
+
+#[test]
+fn async_arrow_variable_name_extracted() {
+    let src = r#"
+const fetchItems = async (url: string): Promise<string[]> => {
+    const response = await fetch(url);
+    const data = await response.json();
+    const items = data.items;
+    const filtered = items.filter((x: string) => x.length > 0);
+    const sorted = filtered.sort();
+    const sliced = sorted.slice(0, 10);
+    console.log(sliced);
+    return sliced;
+};
+"#;
+    let fprinter = TypeScriptFingerprinter;
+    let results = fprinter.fingerprint_all_functions(src);
+    let names: Vec<&str> = results.iter().map(|(n, _)| n.as_str()).collect();
+    assert!(
+        names.contains(&"fetchItems"),
+        "should extract 'fetchItems' from async arrow; got {:?}",
+        names
+    );
+}
+
+#[test]
+fn function_expression_variable_name_extracted() {
+    let src = r#"
+let compute = function(a: number, b: number): number {
+    const sum = a + b;
+    const diff = a - b;
+    const product = sum * diff;
+    const adjusted = product + 1;
+    const clamped = Math.max(0, adjusted);
+    const result = Math.min(100, clamped);
+    console.log(result);
+    return result;
+};
+"#;
+    let fprinter = TypeScriptFingerprinter;
+    let results = fprinter.fingerprint_all_functions(src);
+    let names: Vec<&str> = results.iter().map(|(n, _)| n.as_str()).collect();
+    assert!(
+        names.contains(&"compute"),
+        "should extract 'compute' from function expression; got {:?}",
+        names
+    );
+}
+
+#[test]
+fn export_const_arrow_name_extracted() {
+    let src = r#"
+export const handler = (req: Request): Response => {
+    const body = req.body;
+    const parsed = JSON.parse(body);
+    const validated = validate(parsed);
+    const processed = process(validated);
+    const serialized = JSON.stringify(processed);
+    const response = new Response(serialized);
+    console.log(response);
+    return response;
+};
+"#;
+    let fprinter = TypeScriptFingerprinter;
+    let results = fprinter.fingerprint_all_functions(src);
+    let names: Vec<&str> = results.iter().map(|(n, _)| n.as_str()).collect();
+    assert!(
+        names.contains(&"handler"),
+        "should extract 'handler' from export const arrow; got {:?}",
+        names
+    );
+}

--- a/src/context/extract/fingerprint_typescript_tests.rs
+++ b/src/context/extract/fingerprint_typescript_tests.rs
@@ -516,3 +516,72 @@ export const handler = (req: Request): Response => {
         names
     );
 }
+
+#[test]
+fn nested_arrow_inside_method_not_classified_as_method() {
+    let src = r#"
+class DataService {
+    process(items: string[]): string[] {
+        const result: string[] = [];
+        const helper = (item: string): string => {
+            const trimmed = item.trim();
+            const upper = trimmed.toUpperCase();
+            const prefixed = "PRE_" + upper;
+            const suffixed = prefixed + "_SUF";
+            const final_val = suffixed.slice(0, 20);
+            console.log(final_val);
+            return final_val;
+        };
+        for (const item of items) {
+            result.push(helper(item));
+        }
+        const joined = result.join(",");
+        const wrapped = "[" + joined + "]";
+        console.log(wrapped);
+        return result;
+    }
+}
+"#;
+    let fprinter = TypeScriptFingerprinter;
+    let results = fprinter.fingerprint_all_functions(src);
+
+    let (_, helper_fp) = results.iter().find(|(name, _)| name == "helper")
+        .expect("'helper' must be fingerprinted");
+    assert!(
+        !helper_fp.signature.is_method,
+        "nested arrow 'helper' inside a method body must NOT be classified as a method"
+    );
+
+    let (_, process_fp) = results.iter().find(|(name, _)| name == "process")
+        .expect("'process' must be fingerprinted");
+    assert!(
+        process_fp.signature.is_method,
+        "'process' is a direct class method and must be is_method=true"
+    );
+}
+
+#[test]
+fn class_field_arrow_is_method() {
+    let src = r#"
+class Validator {
+    validate = (input: string): boolean => {
+        const trimmed = input.trim();
+        const hasLength = trimmed.length > 0;
+        const hasAlpha = /[a-z]/.test(trimmed);
+        const hasNum = /[0-9]/.test(trimmed);
+        const isValid = hasLength && hasAlpha && hasNum;
+        const logged = console.log(isValid);
+        return isValid;
+    };
+}
+"#;
+    let fprinter = TypeScriptFingerprinter;
+    let results = fprinter.fingerprint_all_functions(src);
+
+    let (_, validate_fp) = results.iter().find(|(name, _)| name == "validate")
+        .expect("'validate' must be fingerprinted");
+    assert!(
+        validate_fp.signature.is_method,
+        "class field arrow 'validate' should be classified as a method"
+    );
+}

--- a/src/context/extract/fingerprint_typescript_tests.rs
+++ b/src/context/extract/fingerprint_typescript_tests.rs
@@ -585,3 +585,100 @@ class Validator {
         "class field arrow 'validate' should be classified as a method"
     );
 }
+
+#[test]
+fn type_nesting_promise_is_one() {
+    let src = r#"
+async function fetchData(url: string): Promise<string> {
+    const response = await fetch(url);
+    const text = await response.text();
+    const trimmed = text.trim();
+    const lower = trimmed.toLowerCase();
+    const replaced = lower.replace("-", "_");
+    const result = replaced.slice(0, 100);
+    console.log(result);
+    return result;
+}
+"#;
+    let fp = TypeScriptFingerprinter
+        .fingerprint_source(src)
+        .expect("should fingerprint");
+    assert_eq!(
+        fp.signature.return_nesting, 1,
+        "Promise<string> should have nesting=1, got {}",
+        fp.signature.return_nesting
+    );
+}
+
+#[test]
+fn type_nesting_nested_promise_is_two() {
+    let src = r#"
+async function fetchResult(url: string): Promise<Result<string>> {
+    const response = await fetch(url);
+    const data = await response.json();
+    const validated = validate(data);
+    const wrapped = wrapResult(validated);
+    const checked = checkResult(wrapped);
+    const result = finalizeResult(checked);
+    console.log(result);
+    return result;
+}
+"#;
+    let fp = TypeScriptFingerprinter
+        .fingerprint_source(src)
+        .expect("should fingerprint");
+    assert_eq!(
+        fp.signature.return_nesting, 2,
+        "Promise<Result<string>> should have nesting=2, got {}",
+        fp.signature.return_nesting
+    );
+}
+
+#[test]
+fn type_nesting_plain_string_is_zero() {
+    let src = r#"
+function getName(id: number): string {
+    const raw = lookup(id);
+    const trimmed = raw.trim();
+    const validated = validateName(trimmed);
+    const normalized = normalizeName(validated);
+    const formatted = formatName(normalized);
+    const result = finalizeName(formatted);
+    console.log(result);
+    return result;
+}
+"#;
+    let fp = TypeScriptFingerprinter
+        .fingerprint_source(src)
+        .expect("should fingerprint");
+    assert_eq!(
+        fp.signature.return_nesting, 0,
+        "plain string return should have nesting=0, got {}",
+        fp.signature.return_nesting
+    );
+}
+
+#[test]
+fn type_nesting_map_is_one() {
+    let src = r#"
+function buildMap(items: string[]): Map<string, number> {
+    const result = new Map<string, number>();
+    for (const item of items) {
+        const len = item.length;
+        const upper = item.toUpperCase();
+        const key = upper.slice(0, 5);
+        result.set(key, len);
+        console.log(key, len);
+    }
+    return result;
+}
+"#;
+    let fp = TypeScriptFingerprinter
+        .fingerprint_source(src)
+        .expect("should fingerprint");
+    assert_eq!(
+        fp.signature.return_nesting, 1,
+        "Map<string, number> should have nesting=1, got {}",
+        fp.signature.return_nesting
+    );
+}

--- a/src/context/extract/fingerprint_typescript_tests.rs
+++ b/src/context/extract/fingerprint_typescript_tests.rs
@@ -545,14 +545,18 @@ class DataService {
     let fprinter = TypeScriptFingerprinter;
     let results = fprinter.fingerprint_all_functions(src);
 
-    let (_, helper_fp) = results.iter().find(|(name, _)| name == "helper")
+    let (_, helper_fp) = results
+        .iter()
+        .find(|(name, _)| name == "helper")
         .expect("'helper' must be fingerprinted");
     assert!(
         !helper_fp.signature.is_method,
         "nested arrow 'helper' inside a method body must NOT be classified as a method"
     );
 
-    let (_, process_fp) = results.iter().find(|(name, _)| name == "process")
+    let (_, process_fp) = results
+        .iter()
+        .find(|(name, _)| name == "process")
         .expect("'process' must be fingerprinted");
     assert!(
         process_fp.signature.is_method,
@@ -578,7 +582,9 @@ class Validator {
     let fprinter = TypeScriptFingerprinter;
     let results = fprinter.fingerprint_all_functions(src);
 
-    let (_, validate_fp) = results.iter().find(|(name, _)| name == "validate")
+    let (_, validate_fp) = results
+        .iter()
+        .find(|(name, _)| name == "validate")
         .expect("'validate' must be fingerprinted");
     assert!(
         validate_fp.signature.is_method,

--- a/src/finding.rs
+++ b/src/finding.rs
@@ -157,6 +157,14 @@ impl Finding {
         self.line_start >= 1 && self.line_start <= self.line_end
     }
 
+    pub fn normalize_line_range(&mut self) {
+        self.line_start = self.line_start.max(1);
+        self.line_end = self.line_end.max(1);
+        if self.line_start > self.line_end {
+            std::mem::swap(&mut self.line_start, &mut self.line_end);
+        }
+    }
+
     pub fn anchor_line(&self) -> u32 {
         self.cited_lines
             .map(|(start, _)| start)
@@ -1237,5 +1245,63 @@ mod tests {
         let f = FindingBuilder::new().build();
         let json = serde_json::to_string(&f).unwrap();
         assert!(!json.contains("in_diff"));
+    }
+
+    // -- normalize_line_range --
+
+    #[test]
+    fn normalize_clamps_zero_start() {
+        let mut f = FindingBuilder::new().lines(0, 10).build();
+        f.normalize_line_range();
+        assert_eq!(f.line_start, 1);
+        assert_eq!(f.line_end, 10);
+    }
+
+    #[test]
+    fn normalize_swaps_inverted_range() {
+        let mut f = FindingBuilder::new().lines(10, 5).build();
+        f.normalize_line_range();
+        assert_eq!(f.line_start, 5);
+        assert_eq!(f.line_end, 10);
+    }
+
+    #[test]
+    fn normalize_clamps_and_swaps() {
+        let mut f = FindingBuilder::new().lines(0, 0).build();
+        f.normalize_line_range();
+        assert_eq!(f.line_start, 1);
+        assert_eq!(f.line_end, 1);
+    }
+
+    #[test]
+    fn normalize_noop_on_valid() {
+        let mut f = FindingBuilder::new().lines(5, 10).build();
+        f.normalize_line_range();
+        assert_eq!(f.line_start, 5);
+        assert_eq!(f.line_end, 10);
+    }
+
+    #[test]
+    fn normalize_single_line() {
+        let mut f = FindingBuilder::new().lines(7, 7).build();
+        f.normalize_line_range();
+        assert_eq!(f.line_start, 7);
+        assert_eq!(f.line_end, 7);
+    }
+
+    #[test]
+    fn normalize_clamps_zero_end_then_swaps() {
+        let mut f = FindingBuilder::new().lines(5, 0).build();
+        f.normalize_line_range();
+        assert_eq!(f.line_start, 1);
+        assert_eq!(f.line_end, 5);
+    }
+
+    #[test]
+    fn normalize_max_u32() {
+        let mut f = FindingBuilder::new().lines(u32::MAX, u32::MAX).build();
+        f.normalize_line_range();
+        assert_eq!(f.line_start, u32::MAX);
+        assert_eq!(f.line_end, u32::MAX);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -2281,10 +2281,8 @@ fn load_jsonl(path: &std::path::Path) -> Result<Vec<serde_json::Value>, String> 
 
 /// CLI entry point for `quorum calibrate`.
 fn run_calibrate(opts: cli::CalibrateOpts) -> i32 {
-    if !(0.0..=1.0).contains(&opts.suppress_precision)
-        || !(0.0..=1.0).contains(&opts.boost_precision)
-    {
-        eprintln!("error: precision values must be between 0.0 and 1.0");
+    if let Err(e) = opts.validate() {
+        eprintln!("error: {e}");
         return 3;
     }
 

--- a/src/merge.rs
+++ b/src/merge.rs
@@ -75,8 +75,7 @@ pub fn merge_findings(
         for (idx, finding) in merged.iter_mut().enumerate() {
             let agreeing = llm_model_names[idx].len();
             if agreeing > 0 {
-                finding.model_agreement =
-                    Some((agreeing as f32 / num_models as f32).min(1.0));
+                finding.model_agreement = Some((agreeing as f32 / num_models as f32).min(1.0));
             }
         }
     }

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -890,6 +890,9 @@ pub async fn review_file(
                         }
                         match review::parse_llm_response(&resp.content, model) {
                             Ok(mut findings) => {
+                                for f in &mut findings {
+                                    f.normalize_line_range();
+                                }
                                 let n_findings = findings.len();
                                 if let Some(notice) = &file_ctx.truncation_notice {
                                     for f in &mut findings {

--- a/tests/parallel_review.rs
+++ b/tests/parallel_review.rs
@@ -33,7 +33,7 @@ fn parallel_1_sequential() {
 }
 
 #[test]
-fn parallel_0_unlimited() {
+fn parallel_0_rejected() {
     let dir = tempfile::tempdir().unwrap();
     let path = dir.path().join("test.rs");
     std::fs::write(&path, "fn main() {}\n").unwrap();
@@ -45,7 +45,8 @@ fn parallel_0_unlimited() {
         .arg("0")
         .arg(&path)
         .assert()
-        .success();
+        .failure()
+        .code(2);
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Fixes 9 issues across two groups:

**Group A — CLI input validation gaps:**
- **#150**: `--parallel` now constrained to 1..=64 via `validate_parallel` value_parser
- **#234**: `--reasoning-effort` constrained to known values (none/minimal/low/medium/high/xhigh)
- **#149**: `--kind` constrained to known source kinds + aliases (rs, ts, js, py, tf)
- **#369**: `context query --source` and `context index --source` validated with `validate_source_name` (path traversal protection)
- **#368**: `CalibrateOpts::validate()` enforces precision in [0.0, 1.0], rejects NaN/Inf
- **#202**: `Finding::normalize_line_range()` fixes zero/inverted line ranges from LLM output

**Group B — TypeScript fingerprinter traversal bugs:**
- **#346**: Arrow functions and function expressions now extract names from parent `variable_declarator`
- **#347**: `is_direct_class_member` replaces `is_inside_class` — only direct class members classified as methods
- **#348**: `count_type_nesting` rewritten: top-level generic (e.g. `Promise<T>`) counts as depth 1, not 0

## Test Plan
- [x] 36 new tests (1603 -> 1639 passing)
- [x] All `cargo test --bin quorum` pass
- [x] `cargo clippy` clean (zero warnings)
- [x] Quorum diff-scoped review: 0 true positives in changed code (4 FPs recorded)
- [x] CodeRabbit review pending on this PR

## Verification Evidence
```
cargo test: 1639 passed, 1 ignored (1 suite, 11.11s)
cargo clippy: No issues found
```

Closes #149, #150, #202, #234, #346, #347, #348, #368, #369

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added stricter CLI argument validation for `--parallel`, `--reasoning-effort`, and context `--kind` options with improved error messages.
  * Enhanced TypeScript code analysis to better detect functions and accurately classify class methods versus nested functions.

* **Bug Fixes**
  * Improved handling of line ranges in code findings to ensure validity and correct ordering.
  * Strengthened calibration parameter validation with tighter bounds checking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->