### PR TITLE
feat(skills): Foundation B — JSON output contract + audit infrastructure

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -117,3 +117,6 @@ pub mod storage;
 
 // Skill manifest schema and two-tier loader (#404).
 pub mod skill_manifest;
+
+pub mod skill_audit;
+pub mod skill_output;

--- a/src/skill_audit.rs
+++ b/src/skill_audit.rs
@@ -485,7 +485,8 @@ impl SkillsLock {
         }
     }
 
-    /// Save the lock file to disk. Creates parent directories if needed.
+    /// Save the lock file to disk atomically (write-to-temp, then rename).
+    /// Creates parent directories if needed.
     pub fn save(&self, path: &Path) -> anyhow::Result<()> {
         if let Some(parent) = path.parent().filter(|p| !p.as_os_str().is_empty()) {
             std::fs::create_dir_all(parent).with_context(|| {
@@ -497,8 +498,20 @@ impl SkillsLock {
         }
         let content =
             toml::to_string_pretty(self).context("Failed to serialize skills lock to TOML")?;
-        std::fs::write(path, content)
-            .with_context(|| format!("Failed to write skills lock file: {}", path.display()))?;
+
+        let tmp_path = path.with_extension("toml.tmp");
+        std::fs::write(&tmp_path, &content).with_context(|| {
+            format!(
+                "Failed to write temporary lock file: {}",
+                tmp_path.display()
+            )
+        })?;
+        std::fs::rename(&tmp_path, path).with_context(|| {
+            format!(
+                "Failed to rename temporary lock file to: {}",
+                path.display()
+            )
+        })?;
         Ok(())
     }
 

--- a/src/skill_audit.rs
+++ b/src/skill_audit.rs
@@ -1,0 +1,1234 @@
+//! Audit log infrastructure for the skills framework.
+//!
+//! Provides shared append-only JSONL infrastructure and schema definitions for
+//! the skills framework audit trail. Other issues (#410, #411) will write rows
+//! to these files; this module defines the schemas, the writer, the reader,
+//! and the `skills.lock` mechanism.
+//!
+//! ## Design
+//!
+//! - `AuditWriter<T: Serialize>`: cross-process safe JSONL appender using
+//!   `fs2` exclusive advisory locks (mirrors `src/feedback.rs` pattern).
+//! - `AuditReader<T: DeserializeOwned>`: bounded-line JSONL reader using
+//!   `fs2` shared locks (per #233, no `BufRead::lines()`).
+//! - `SkillInvocationRecord`: one row per (skill x model x file x review) cell.
+//! - `IntegratorDecisionRecord`: one row per integrator merge/suppress decision.
+//! - `SkillsLock`: TOML-based tamper-detection lock file.
+
+use std::collections::HashMap;
+use std::marker::PhantomData;
+use std::path::{Path, PathBuf};
+
+use anyhow::Context;
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize, de::DeserializeOwned};
+
+use crate::skill_manifest::LoadedSkill;
+
+// ---------------------------------------------------------------------------
+// Default file paths (relative to ~/.quorum/)
+// ---------------------------------------------------------------------------
+
+/// Default basename for the skill invocation audit log.
+pub const SKILL_INVOCATIONS_FILE: &str = "skill_invocations.jsonl";
+
+/// Default basename for the integrator decision audit log.
+pub const INTEGRATOR_DECISIONS_FILE: &str = "integrator_decisions.jsonl";
+
+/// Default basename for the skills lock file.
+pub const SKILLS_LOCK_FILE: &str = "skills.lock";
+
+// ---------------------------------------------------------------------------
+// Bounded-read constants
+// ---------------------------------------------------------------------------
+
+/// Maximum bytes per JSONL line before the line is considered oversized and
+/// skipped. Skill invocation and integrator records are typically a few
+/// hundred bytes; 1 MiB is a generous ceiling.
+const MAX_JSONL_LINE_BYTES: usize = 1 << 20;
+
+// ---------------------------------------------------------------------------
+// AuditReadStats
+// ---------------------------------------------------------------------------
+
+/// Statistics returned alongside parsed records from `AuditReader::load_all`.
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct AuditReadStats {
+    /// Total non-empty lines encountered.
+    pub total_lines: usize,
+    /// Lines that parsed successfully.
+    pub parsed_ok: usize,
+    /// Lines that failed to parse (malformed JSON, schema mismatch, oversized).
+    pub parse_errors: usize,
+}
+
+// ---------------------------------------------------------------------------
+// AuditWriter<T>
+// ---------------------------------------------------------------------------
+
+/// Cross-process-safe append-only JSONL writer.
+///
+/// Opens a file with `O_APPEND | O_CREAT`, takes an exclusive `fs2` lock
+/// before writing, serializes `T` to JSON + newline, and unlocks after write
+/// (even on error). Creates parent directories if needed.
+pub struct AuditWriter<T: Serialize> {
+    path: PathBuf,
+    _marker: PhantomData<T>,
+}
+
+impl<T: Serialize> AuditWriter<T> {
+    pub fn new(path: PathBuf) -> Self {
+        Self {
+            path,
+            _marker: PhantomData,
+        }
+    }
+
+    /// Append a single record to the JSONL file.
+    pub fn write(&self, record: &T) -> anyhow::Result<()> {
+        use fs2::FileExt;
+        use std::io::Write;
+
+        // Create parent directories if needed (mirrors feedback.rs #100).
+        if let Some(parent) = self.path.parent().filter(|p| !p.as_os_str().is_empty()) {
+            std::fs::create_dir_all(parent).with_context(|| {
+                format!(
+                    "Failed to create audit log parent dir: {}",
+                    parent.display()
+                )
+            })?;
+        }
+
+        let mut file = std::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&self.path)
+            .with_context(|| format!("Failed to open audit log file: {}", self.path.display()))?;
+
+        // Exclusive advisory lock (issue #185: cross-process append safety).
+        FileExt::lock_exclusive(&file)
+            .with_context(|| format!("Failed to lock audit log file: {}", self.path.display()))?;
+
+        let mut buf = serde_json::to_string(record)?;
+        buf.push('\n');
+        let write_result = file.write_all(buf.as_bytes());
+
+        // Always attempt unlock, even if write failed.
+        let unlock_result = FileExt::unlock(&file);
+        write_result?;
+        unlock_result
+            .with_context(|| format!("Failed to unlock audit log file: {}", self.path.display()))?;
+
+        Ok(())
+    }
+
+    /// Read-only access to the underlying path.
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+}
+
+// ---------------------------------------------------------------------------
+// AuditReader<T>
+// ---------------------------------------------------------------------------
+
+/// Bounded-line JSONL reader with shared locking.
+///
+/// Uses `BufRead::read_until` with a per-line byte cap (per #233 — no
+/// `BufRead::lines()` which is unbounded). Malformed rows are skipped with
+/// a warning counter rather than aborting.
+pub struct AuditReader<T: DeserializeOwned> {
+    path: PathBuf,
+    _marker: PhantomData<T>,
+}
+
+impl<T: DeserializeOwned> AuditReader<T> {
+    pub fn new(path: PathBuf) -> Self {
+        Self {
+            path,
+            _marker: PhantomData,
+        }
+    }
+
+    /// Load all records from the JSONL file.
+    ///
+    /// Returns the successfully parsed records together with structured
+    /// read statistics. Malformed or oversized lines increment
+    /// `stats.parse_errors` rather than aborting.
+    pub fn load_all(&self) -> anyhow::Result<(Vec<T>, AuditReadStats)> {
+        use fs2::FileExt;
+        use std::io::{BufRead, BufReader, Read};
+
+        let file = match std::fs::OpenOptions::new().read(true).open(&self.path) {
+            Ok(f) => f,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                return Ok((vec![], AuditReadStats::default()));
+            }
+            Err(e) => {
+                return Err(e).with_context(|| {
+                    format!("Failed to open audit log file: {}", self.path.display())
+                });
+            }
+        };
+
+        // Shared advisory lock (pairs with exclusive lock in AuditWriter).
+        FileExt::lock_shared(&file).with_context(|| {
+            format!(
+                "Failed to lock audit log file for read: {}",
+                self.path.display()
+            )
+        })?;
+
+        let mut reader = BufReader::new(&file);
+        let mut entries: Vec<T> = Vec::new();
+        let mut stats = AuditReadStats::default();
+        let mut buf = Vec::with_capacity(4096);
+
+        loop {
+            buf.clear();
+            // Bounded read: take at most MAX + 2 bytes (to accommodate
+            // trailing \r\n on a line of exactly MAX payload bytes).
+            let mut limited = (&mut reader).take((MAX_JSONL_LINE_BYTES + 2) as u64);
+            let n = limited.read_until(b'\n', &mut buf)?;
+            if n == 0 {
+                break;
+            }
+
+            // Detect oversized line.
+            let payload_len = if buf.ends_with(b"\n") {
+                let end = buf.len() - 1;
+                if end > 0 && buf[end - 1] == b'\r' {
+                    end - 1
+                } else {
+                    end
+                }
+            } else {
+                buf.len()
+            };
+
+            let oversized = payload_len > MAX_JSONL_LINE_BYTES;
+            if oversized {
+                // Drain the rest of the oversized line so we resync to the
+                // next newline without unbounded allocation.
+                let mut sink = Vec::with_capacity(64);
+                while !buf.ends_with(b"\n") {
+                    sink.clear();
+                    let mut tail = (&mut reader).take(64 * 1024);
+                    let drained = tail.read_until(b'\n', &mut sink)?;
+                    if drained == 0 {
+                        break;
+                    }
+                    if sink.ends_with(b"\n") {
+                        buf.push(b'\n');
+                        break;
+                    }
+                }
+                stats.total_lines += 1;
+                stats.parse_errors += 1;
+                tracing::warn!(
+                    target: "quorum::skill_audit",
+                    path = %self.path.display(),
+                    "oversized line ({payload_len} bytes) skipped in audit log"
+                );
+                continue;
+            }
+
+            // Trim trailing newline / CRLF.
+            let line_bytes = if buf.ends_with(b"\n") {
+                let end = buf.len() - 1;
+                let end = if end > 0 && buf[end - 1] == b'\r' {
+                    end - 1
+                } else {
+                    end
+                };
+                &buf[..end]
+            } else {
+                &buf[..]
+            };
+
+            // Skip empty / whitespace-only lines.
+            if line_bytes.iter().all(|b| b.is_ascii_whitespace()) {
+                continue;
+            }
+
+            stats.total_lines += 1;
+
+            // Strict UTF-8 validation.
+            let line = match std::str::from_utf8(line_bytes) {
+                Ok(s) => s,
+                Err(_) => {
+                    stats.parse_errors += 1;
+                    tracing::warn!(
+                        target: "quorum::skill_audit",
+                        path = %self.path.display(),
+                        "invalid UTF-8 in audit log line; skipping"
+                    );
+                    continue;
+                }
+            };
+
+            match serde_json::from_str(line) {
+                Ok(entry) => {
+                    entries.push(entry);
+                    stats.parsed_ok += 1;
+                }
+                Err(_) => {
+                    stats.parse_errors += 1;
+                    tracing::warn!(
+                        target: "quorum::skill_audit",
+                        path = %self.path.display(),
+                        "malformed JSON in audit log line; skipping"
+                    );
+                }
+            }
+        }
+
+        // Unlock after reading.
+        let unlock_result = FileExt::unlock(&file);
+        unlock_result
+            .with_context(|| format!("Failed to unlock audit log file: {}", self.path.display()))?;
+
+        Ok((entries, stats))
+    }
+
+    /// Read-only access to the underlying path.
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Schema enums
+// ---------------------------------------------------------------------------
+
+/// How the review axis set was selected for this invocation.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AxisSelectionSource {
+    ExplicitAxes,
+    ModeMacro,
+    Default,
+    AutoDiscovery,
+}
+
+/// Terminal exit status for a skill invocation.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ExitStatus {
+    Ok,
+    Error,
+}
+
+/// Reason a skill invocation failed.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum FailureReason {
+    ModelTimeout,
+    ModelRateLimit,
+    BudgetCapHit,
+    CapabilityDenied,
+    NetworkError,
+    Other,
+}
+
+/// Integrator decision for a finding cluster.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum IntegratorDecision {
+    Merged,
+    Suppressed,
+    PassThrough,
+}
+
+// ---------------------------------------------------------------------------
+// SkillInvocationRecord
+// ---------------------------------------------------------------------------
+
+/// One record per (skill x model x file x review) cell.
+///
+/// See design doc section 5.2.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct SkillInvocationRecord {
+    /// ULID for this specific skill run.
+    pub skill_run_id: String,
+    /// Parent review ULID.
+    pub run_id: String,
+    pub ts: DateTime<Utc>,
+    pub skill_name: String,
+    pub skill_version: String,
+    pub manifest_sha256: String,
+    pub prompt_family: String,
+    pub prompt_sha256: String,
+    pub model: String,
+    pub model_was_fallback: bool,
+    pub axis_selection_source: AxisSelectionSource,
+    /// "pure" in v1.
+    pub capability_mode: String,
+    /// "bundled" | "user" | "untrusted".
+    pub trust_tier: String,
+    pub file_path: String,
+    pub file_sha256: String,
+    pub tokens_in: u64,
+    pub tokens_out: u64,
+    #[serde(default)]
+    pub tokens_cache_read: u64,
+    #[serde(default)]
+    pub llm_cache_hit: bool,
+    pub duration_ms: u64,
+    pub findings_emitted: u32,
+    #[serde(default)]
+    pub findings_clamped: u32,
+    #[serde(default)]
+    pub findings_dropped_invalid_json: u32,
+    /// From #407's `ParseErrorClass`, if applicable.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub parse_error_class: Option<String>,
+    pub exit_status: ExitStatus,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub failure_reason: Option<FailureReason>,
+    #[serde(default)]
+    pub calibrator_suppressions: u32,
+    #[serde(default)]
+    pub calibrator_precedents_matched: u32,
+}
+
+// ---------------------------------------------------------------------------
+// ClusterKey
+// ---------------------------------------------------------------------------
+
+/// Identifies a finding cluster by file location and kind.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ClusterKey {
+    pub file_path: String,
+    pub line_range: (u32, u32),
+    pub finding_kind: String,
+}
+
+// ---------------------------------------------------------------------------
+// IntegratorDecisionRecord
+// ---------------------------------------------------------------------------
+
+/// One record per integrator merge/suppress/pass-through decision.
+///
+/// See design doc section 5.2.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct IntegratorDecisionRecord {
+    pub run_id: String,
+    pub ts: DateTime<Utc>,
+    pub decision: IntegratorDecision,
+    pub cluster_key: ClusterKey,
+    pub input_finding_ids: Vec<String>,
+    pub input_confidences: Vec<f64>,
+    pub input_severities: Vec<String>,
+    pub calibrator_weights: HashMap<String, f64>,
+    pub confidence_floor: f64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub output_finding_id: Option<String>,
+    pub output_confidence: f64,
+    pub severity_pre_clamp: String,
+    pub severity_post_clamp: String,
+    pub reason: String,
+    pub originating_skills: Vec<String>,
+}
+
+// ---------------------------------------------------------------------------
+// SkillsLock
+// ---------------------------------------------------------------------------
+
+/// A single entry in the skills lock file.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct LockEntry {
+    pub name: String,
+    pub source: String,
+    pub manifest_sha256: String,
+    pub version: String,
+    pub first_seen_at: DateTime<Utc>,
+    pub last_seen_at: DateTime<Utc>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub previous_manifest_sha256: Option<String>,
+}
+
+/// Warning emitted when the lock detects a silent manifest edit.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LockWarning {
+    /// Name of the skill whose hash changed without a version bump.
+    pub skill_name: String,
+    /// The hash recorded in the lock before this update.
+    pub previous_sha256: String,
+    /// The new hash from the loaded skill.
+    pub current_sha256: String,
+    /// The version that stayed the same.
+    pub version: String,
+}
+
+/// TOML-serializable wrapper for the lock file.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SkillsLock {
+    #[serde(default)]
+    pub skills: Vec<LockEntry>,
+}
+
+impl SkillsLock {
+    /// Load an existing lock file, or return an empty lock if the file does
+    /// not exist.
+    pub fn load(path: &Path) -> anyhow::Result<Self> {
+        match std::fs::read_to_string(path) {
+            Ok(content) => {
+                let lock: SkillsLock = toml::from_str(&content).with_context(|| {
+                    format!("Failed to parse skills lock file: {}", path.display())
+                })?;
+                Ok(lock)
+            }
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(Self::default()),
+            Err(e) => Err(e)
+                .with_context(|| format!("Failed to read skills lock file: {}", path.display())),
+        }
+    }
+
+    /// Save the lock file to disk. Creates parent directories if needed.
+    pub fn save(&self, path: &Path) -> anyhow::Result<()> {
+        if let Some(parent) = path.parent().filter(|p| !p.as_os_str().is_empty()) {
+            std::fs::create_dir_all(parent).with_context(|| {
+                format!(
+                    "Failed to create lock file parent dir: {}",
+                    parent.display()
+                )
+            })?;
+        }
+        let content =
+            toml::to_string_pretty(self).context("Failed to serialize skills lock to TOML")?;
+        std::fs::write(path, content)
+            .with_context(|| format!("Failed to write skills lock file: {}", path.display()))?;
+        Ok(())
+    }
+
+    /// Compare currently loaded skills against the lock state.
+    ///
+    /// Returns warnings for silent edits: same version but different
+    /// manifest hash. Updates the lock in place:
+    /// - New skills are added.
+    /// - Existing skills are updated (`last_seen_at`, and version/hash
+    ///   if changed).
+    /// - Skills present in the lock but absent from `loaded` are preserved
+    ///   (they may be temporarily absent if a user directory is unavailable).
+    pub fn update(&mut self, loaded: &[LoadedSkill]) -> Vec<LockWarning> {
+        let now = Utc::now();
+        let mut warnings = Vec::new();
+
+        // Index existing lock entries by name for O(1) lookup.
+        let mut by_name: HashMap<String, usize> = self
+            .skills
+            .iter()
+            .enumerate()
+            .map(|(i, e)| (e.name.clone(), i))
+            .collect();
+
+        for skill in loaded {
+            let name = &skill.manifest.name;
+            let new_sha = &skill.manifest_sha256;
+            let new_version = &skill.manifest.version;
+            let source = skill.source_path.display().to_string();
+
+            if let Some(&idx) = by_name.get(name) {
+                let entry = &mut self.skills[idx];
+                entry.last_seen_at = now;
+                entry.source = source;
+
+                if entry.version == *new_version && entry.manifest_sha256 != *new_sha {
+                    // Silent edit: same version, different hash.
+                    warnings.push(LockWarning {
+                        skill_name: name.clone(),
+                        previous_sha256: entry.manifest_sha256.clone(),
+                        current_sha256: new_sha.clone(),
+                        version: new_version.clone(),
+                    });
+                    entry.previous_manifest_sha256 = Some(entry.manifest_sha256.clone());
+                    entry.manifest_sha256 = new_sha.clone();
+                } else if entry.version != *new_version {
+                    // Version change: clean update, no warning.
+                    entry.previous_manifest_sha256 = Some(entry.manifest_sha256.clone());
+                    entry.manifest_sha256 = new_sha.clone();
+                    entry.version = new_version.clone();
+                }
+                // If both version and hash match, only last_seen_at is bumped.
+            } else {
+                // New skill, not previously in the lock.
+                let entry = LockEntry {
+                    name: name.clone(),
+                    source,
+                    manifest_sha256: new_sha.clone(),
+                    version: new_version.clone(),
+                    first_seen_at: now,
+                    last_seen_at: now,
+                    previous_manifest_sha256: None,
+                };
+                by_name.insert(name.clone(), self.skills.len());
+                self.skills.push(entry);
+            }
+        }
+
+        // Skills present in the lock but absent from `loaded` are preserved
+        // (not removed) — they may be temporarily absent.
+
+        warnings
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    // ── Helpers ──────────────────────────────────────────────────────────
+
+    fn sample_invocation_record() -> SkillInvocationRecord {
+        SkillInvocationRecord {
+            skill_run_id: "01HZ0000000000000000000001".into(),
+            run_id: "01HZ0000000000000000000000".into(),
+            ts: Utc::now(),
+            skill_name: "security".into(),
+            skill_version: "1.0.0".into(),
+            manifest_sha256: "abcd1234".repeat(8),
+            prompt_family: "default".into(),
+            prompt_sha256: "ef567890".repeat(8),
+            model: "gpt-5.4".into(),
+            model_was_fallback: false,
+            axis_selection_source: AxisSelectionSource::Default,
+            capability_mode: "pure".into(),
+            trust_tier: "bundled".into(),
+            file_path: "src/main.rs".into(),
+            file_sha256: "1111aaaa".repeat(8),
+            tokens_in: 1500,
+            tokens_out: 300,
+            tokens_cache_read: 100,
+            llm_cache_hit: false,
+            duration_ms: 2500,
+            findings_emitted: 3,
+            findings_clamped: 1,
+            findings_dropped_invalid_json: 0,
+            parse_error_class: None,
+            exit_status: ExitStatus::Ok,
+            failure_reason: None,
+            calibrator_suppressions: 0,
+            calibrator_precedents_matched: 2,
+        }
+    }
+
+    fn sample_integrator_record() -> IntegratorDecisionRecord {
+        IntegratorDecisionRecord {
+            run_id: "01HZ0000000000000000000000".into(),
+            ts: Utc::now(),
+            decision: IntegratorDecision::Merged,
+            cluster_key: ClusterKey {
+                file_path: "src/lib.rs".into(),
+                line_range: (10, 15),
+                finding_kind: "sql-injection".into(),
+            },
+            input_finding_ids: vec!["f1".into(), "f2".into()],
+            input_confidences: vec![0.85, 0.72],
+            input_severities: vec!["high".into(), "medium".into()],
+            calibrator_weights: HashMap::from([
+                ("security".into(), 1.2),
+                ("correctness".into(), 0.8),
+            ]),
+            confidence_floor: 0.5,
+            output_finding_id: Some("merged-f1".into()),
+            output_confidence: 0.9,
+            severity_pre_clamp: "high".into(),
+            severity_post_clamp: "high".into(),
+            reason: "Two skills agree on SQL injection at same location".into(),
+            originating_skills: vec!["security".into(), "correctness".into()],
+        }
+    }
+
+    fn sample_loaded_skill(name: &str, version: &str, sha: &str) -> LoadedSkill {
+        use crate::skill_manifest::*;
+        LoadedSkill {
+            manifest: SkillManifest {
+                name: name.into(),
+                version: version.into(),
+                display_name: format!("Test {name}"),
+                description: "A test skill.".into(),
+                preferred_model: None,
+                fallback_models: None,
+                calibration_namespace: None,
+                axis: Axis::Security,
+                max_severity: crate::finding::Severity::Critical,
+                target_findings: None,
+                capability: Capability {
+                    mode: CapabilityMode::Pure,
+                },
+                prompts: Prompts {
+                    primary: "Review for issues.".into(),
+                    anthropic: None,
+                    openai: None,
+                    google: None,
+                },
+                checklist: vec![],
+                ast_rules: vec![],
+            },
+            trust_tier: TrustTier::Bundled,
+            source_path: PathBuf::from(format!("/skills/{name}.toml")),
+            manifest_sha256: sha.into(),
+        }
+    }
+
+    // ── AuditWriter / AuditReader tests ─────────────────────────────────
+
+    #[test]
+    fn write_single_record_read_back() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("test.jsonl");
+
+        let writer = AuditWriter::<SkillInvocationRecord>::new(path.clone());
+        let record = sample_invocation_record();
+        writer.write(&record).unwrap();
+
+        let reader = AuditReader::<SkillInvocationRecord>::new(path);
+        let (entries, stats) = reader.load_all().unwrap();
+
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].skill_name, "security");
+        assert_eq!(stats.total_lines, 1);
+        assert_eq!(stats.parsed_ok, 1);
+        assert_eq!(stats.parse_errors, 0);
+    }
+
+    #[test]
+    fn write_multiple_records_read_all_back() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("multi.jsonl");
+
+        let writer = AuditWriter::<SkillInvocationRecord>::new(path.clone());
+        for i in 0..5 {
+            let mut record = sample_invocation_record();
+            record.skill_name = format!("skill-{i}");
+            writer.write(&record).unwrap();
+        }
+
+        let reader = AuditReader::<SkillInvocationRecord>::new(path);
+        let (entries, stats) = reader.load_all().unwrap();
+
+        assert_eq!(entries.len(), 5);
+        assert_eq!(stats.total_lines, 5);
+        assert_eq!(stats.parsed_ok, 5);
+        assert_eq!(stats.parse_errors, 0);
+        for (i, entry) in entries.iter().enumerate() {
+            assert_eq!(entry.skill_name, format!("skill-{i}"));
+        }
+    }
+
+    #[test]
+    fn malformed_row_skipped_with_error_count() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("malformed.jsonl");
+
+        // Write a valid record, then a malformed line, then another valid one.
+        let writer = AuditWriter::<SkillInvocationRecord>::new(path.clone());
+        writer.write(&sample_invocation_record()).unwrap();
+
+        // Manually append a malformed line.
+        std::fs::OpenOptions::new()
+            .append(true)
+            .open(&path)
+            .and_then(|mut f| {
+                use std::io::Write;
+                writeln!(f, "{{this is not valid json}}")
+            })
+            .unwrap();
+
+        let mut record2 = sample_invocation_record();
+        record2.skill_name = "second".into();
+        writer.write(&record2).unwrap();
+
+        let reader = AuditReader::<SkillInvocationRecord>::new(path);
+        let (entries, stats) = reader.load_all().unwrap();
+
+        assert_eq!(entries.len(), 2);
+        assert_eq!(stats.total_lines, 3);
+        assert_eq!(stats.parsed_ok, 2);
+        assert_eq!(stats.parse_errors, 1);
+    }
+
+    #[test]
+    fn empty_file_returns_empty_vec() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("empty.jsonl");
+        std::fs::write(&path, "").unwrap();
+
+        let reader = AuditReader::<SkillInvocationRecord>::new(path);
+        let (entries, stats) = reader.load_all().unwrap();
+
+        assert!(entries.is_empty());
+        assert_eq!(stats, AuditReadStats::default());
+    }
+
+    #[test]
+    fn nonexistent_file_returns_empty_vec() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("does-not-exist.jsonl");
+
+        let reader = AuditReader::<SkillInvocationRecord>::new(path);
+        let (entries, stats) = reader.load_all().unwrap();
+
+        assert!(entries.is_empty());
+        assert_eq!(stats, AuditReadStats::default());
+    }
+
+    #[test]
+    fn audit_read_stats_counts_correct() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("stats.jsonl");
+
+        // 3 valid, 2 malformed, 1 blank line.
+        let writer = AuditWriter::<SkillInvocationRecord>::new(path.clone());
+        writer.write(&sample_invocation_record()).unwrap();
+        writer.write(&sample_invocation_record()).unwrap();
+
+        {
+            use std::io::Write;
+            let mut f = std::fs::OpenOptions::new()
+                .append(true)
+                .open(&path)
+                .unwrap();
+            writeln!(f, "bad line 1").unwrap();
+            writeln!(f).unwrap(); // blank line
+            writeln!(f, "bad line 2").unwrap();
+        }
+
+        writer.write(&sample_invocation_record()).unwrap();
+
+        let reader = AuditReader::<SkillInvocationRecord>::new(path);
+        let (entries, stats) = reader.load_all().unwrap();
+
+        assert_eq!(entries.len(), 3);
+        assert_eq!(stats.total_lines, 5); // 3 valid + 2 malformed; blank skipped
+        assert_eq!(stats.parsed_ok, 3);
+        assert_eq!(stats.parse_errors, 2);
+    }
+
+    #[test]
+    fn writer_creates_parent_directories() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("deep").join("nested").join("audit.jsonl");
+
+        let writer = AuditWriter::<SkillInvocationRecord>::new(path.clone());
+        writer.write(&sample_invocation_record()).unwrap();
+
+        assert!(path.exists());
+        let reader = AuditReader::<SkillInvocationRecord>::new(path);
+        let (entries, _) = reader.load_all().unwrap();
+        assert_eq!(entries.len(), 1);
+    }
+
+    // ── Schema roundtrip tests ──────────────────────────────────────────
+
+    #[test]
+    fn skill_invocation_record_full_roundtrip() {
+        let record = sample_invocation_record();
+        let json = serde_json::to_string(&record).unwrap();
+        let deserialized: SkillInvocationRecord = serde_json::from_str(&json).unwrap();
+        assert_eq!(record, deserialized);
+    }
+
+    #[test]
+    fn skill_invocation_record_with_failure() {
+        let mut record = sample_invocation_record();
+        record.exit_status = ExitStatus::Error;
+        record.failure_reason = Some(FailureReason::ModelTimeout);
+        record.parse_error_class = Some("truncated_json".into());
+
+        let json = serde_json::to_string(&record).unwrap();
+        let deserialized: SkillInvocationRecord = serde_json::from_str(&json).unwrap();
+        assert_eq!(deserialized.exit_status, ExitStatus::Error);
+        assert_eq!(
+            deserialized.failure_reason,
+            Some(FailureReason::ModelTimeout)
+        );
+        assert_eq!(
+            deserialized.parse_error_class.as_deref(),
+            Some("truncated_json")
+        );
+    }
+
+    #[test]
+    fn integrator_decision_merged_roundtrip() {
+        let record = sample_integrator_record();
+        let json = serde_json::to_string(&record).unwrap();
+        let deserialized: IntegratorDecisionRecord = serde_json::from_str(&json).unwrap();
+        assert_eq!(record, deserialized);
+    }
+
+    #[test]
+    fn integrator_decision_suppressed_roundtrip() {
+        let mut record = sample_integrator_record();
+        record.decision = IntegratorDecision::Suppressed;
+        record.output_finding_id = None;
+        record.output_confidence = 0.0;
+        record.reason = "Below confidence floor".into();
+
+        let json = serde_json::to_string(&record).unwrap();
+        let deserialized: IntegratorDecisionRecord = serde_json::from_str(&json).unwrap();
+        assert_eq!(deserialized.decision, IntegratorDecision::Suppressed);
+        assert!(deserialized.output_finding_id.is_none());
+    }
+
+    #[test]
+    fn integrator_decision_pass_through_roundtrip() {
+        let mut record = sample_integrator_record();
+        record.decision = IntegratorDecision::PassThrough;
+        record.input_finding_ids = vec!["solo-f1".into()];
+        record.input_confidences = vec![0.95];
+        record.input_severities = vec!["critical".into()];
+        record.originating_skills = vec!["security".into()];
+        record.reason = "Single skill, no merge needed".into();
+
+        let json = serde_json::to_string(&record).unwrap();
+        let deserialized: IntegratorDecisionRecord = serde_json::from_str(&json).unwrap();
+        assert_eq!(deserialized.decision, IntegratorDecision::PassThrough);
+        assert_eq!(deserialized.input_finding_ids.len(), 1);
+    }
+
+    #[test]
+    fn cluster_key_roundtrip() {
+        let key = ClusterKey {
+            file_path: "src/main.rs".into(),
+            line_range: (42, 50),
+            finding_kind: "buffer-overflow".into(),
+        };
+        let json = serde_json::to_string(&key).unwrap();
+        let deserialized: ClusterKey = serde_json::from_str(&json).unwrap();
+        assert_eq!(key, deserialized);
+    }
+
+    // ── Enum variant serde roundtrips ───────────────────────────────────
+
+    #[test]
+    fn axis_selection_source_all_variants_roundtrip() {
+        let variants = [
+            AxisSelectionSource::ExplicitAxes,
+            AxisSelectionSource::ModeMacro,
+            AxisSelectionSource::Default,
+            AxisSelectionSource::AutoDiscovery,
+        ];
+        for variant in variants {
+            let json = serde_json::to_string(&variant).unwrap();
+            let deserialized: AxisSelectionSource = serde_json::from_str(&json).unwrap();
+            assert_eq!(variant, deserialized, "failed roundtrip for {json}");
+        }
+    }
+
+    #[test]
+    fn exit_status_all_variants_roundtrip() {
+        let variants = [ExitStatus::Ok, ExitStatus::Error];
+        for variant in variants {
+            let json = serde_json::to_string(&variant).unwrap();
+            let deserialized: ExitStatus = serde_json::from_str(&json).unwrap();
+            assert_eq!(variant, deserialized, "failed roundtrip for {json}");
+        }
+    }
+
+    #[test]
+    fn failure_reason_all_variants_roundtrip() {
+        let variants = [
+            FailureReason::ModelTimeout,
+            FailureReason::ModelRateLimit,
+            FailureReason::BudgetCapHit,
+            FailureReason::CapabilityDenied,
+            FailureReason::NetworkError,
+            FailureReason::Other,
+        ];
+        for variant in variants {
+            let json = serde_json::to_string(&variant).unwrap();
+            let deserialized: FailureReason = serde_json::from_str(&json).unwrap();
+            assert_eq!(variant, deserialized, "failed roundtrip for {json}");
+        }
+    }
+
+    #[test]
+    fn integrator_decision_all_variants_roundtrip() {
+        let variants = [
+            IntegratorDecision::Merged,
+            IntegratorDecision::Suppressed,
+            IntegratorDecision::PassThrough,
+        ];
+        for variant in variants {
+            let json = serde_json::to_string(&variant).unwrap();
+            let deserialized: IntegratorDecision = serde_json::from_str(&json).unwrap();
+            assert_eq!(variant, deserialized, "failed roundtrip for {json}");
+        }
+    }
+
+    // ── Integrator record writer/reader roundtrip ───────────────────────
+
+    #[test]
+    fn integrator_record_write_read_roundtrip() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("integrator.jsonl");
+
+        let writer = AuditWriter::<IntegratorDecisionRecord>::new(path.clone());
+        let record = sample_integrator_record();
+        writer.write(&record).unwrap();
+
+        let reader = AuditReader::<IntegratorDecisionRecord>::new(path);
+        let (entries, stats) = reader.load_all().unwrap();
+
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0], record);
+        assert_eq!(stats.parsed_ok, 1);
+    }
+
+    // ── SkillsLock tests ────────────────────────────────────────────────
+
+    #[test]
+    fn fresh_load_from_nonexistent_path() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("nonexistent.lock");
+        let lock = SkillsLock::load(&path).unwrap();
+        assert!(lock.skills.is_empty());
+    }
+
+    #[test]
+    fn save_and_reload_roundtrip() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("skills.lock");
+
+        let mut lock = SkillsLock::default();
+        lock.skills.push(LockEntry {
+            name: "security".into(),
+            source: "/skills/security.toml".into(),
+            manifest_sha256: "aaaa".repeat(16),
+            version: "1.0.0".into(),
+            first_seen_at: Utc::now(),
+            last_seen_at: Utc::now(),
+            previous_manifest_sha256: None,
+        });
+
+        lock.save(&path).unwrap();
+        let reloaded = SkillsLock::load(&path).unwrap();
+
+        assert_eq!(reloaded.skills.len(), 1);
+        assert_eq!(reloaded.skills[0].name, "security");
+        assert_eq!(reloaded.skills[0].version, "1.0.0");
+    }
+
+    #[test]
+    fn silent_edit_detection_same_version_different_hash() {
+        let mut lock = SkillsLock {
+            skills: vec![LockEntry {
+                name: "security".into(),
+                source: "/skills/security.toml".into(),
+                manifest_sha256: "old_hash_aaa".into(),
+                version: "1.0.0".into(),
+                first_seen_at: Utc::now(),
+                last_seen_at: Utc::now(),
+                previous_manifest_sha256: None,
+            }],
+        };
+
+        let loaded = [sample_loaded_skill("security", "1.0.0", "new_hash_bbb")];
+        let warnings = lock.update(&loaded);
+
+        assert_eq!(warnings.len(), 1);
+        assert_eq!(warnings[0].skill_name, "security");
+        assert_eq!(warnings[0].previous_sha256, "old_hash_aaa");
+        assert_eq!(warnings[0].current_sha256, "new_hash_bbb");
+        assert_eq!(warnings[0].version, "1.0.0");
+    }
+
+    #[test]
+    fn version_change_no_warning() {
+        let mut lock = SkillsLock {
+            skills: vec![LockEntry {
+                name: "security".into(),
+                source: "/skills/security.toml".into(),
+                manifest_sha256: "old_hash".into(),
+                version: "1.0.0".into(),
+                first_seen_at: Utc::now(),
+                last_seen_at: Utc::now(),
+                previous_manifest_sha256: None,
+            }],
+        };
+
+        let loaded = [sample_loaded_skill("security", "2.0.0", "new_hash")];
+        let warnings = lock.update(&loaded);
+
+        assert!(
+            warnings.is_empty(),
+            "version change should not produce a warning"
+        );
+        assert_eq!(lock.skills[0].version, "2.0.0");
+        assert_eq!(lock.skills[0].manifest_sha256, "new_hash");
+        assert_eq!(
+            lock.skills[0].previous_manifest_sha256.as_deref(),
+            Some("old_hash")
+        );
+    }
+
+    #[test]
+    fn new_skill_added_no_warning() {
+        let mut lock = SkillsLock::default();
+
+        let loaded = [sample_loaded_skill("security", "1.0.0", "sha_aaa")];
+        let warnings = lock.update(&loaded);
+
+        assert!(
+            warnings.is_empty(),
+            "new skill should not produce a warning"
+        );
+        assert_eq!(lock.skills.len(), 1);
+        assert_eq!(lock.skills[0].name, "security");
+        assert!(lock.skills[0].previous_manifest_sha256.is_none());
+    }
+
+    #[test]
+    fn removed_skill_preserved_in_lock() {
+        let mut lock = SkillsLock {
+            skills: vec![
+                LockEntry {
+                    name: "security".into(),
+                    source: "/skills/security.toml".into(),
+                    manifest_sha256: "sha_sec".into(),
+                    version: "1.0.0".into(),
+                    first_seen_at: Utc::now(),
+                    last_seen_at: Utc::now(),
+                    previous_manifest_sha256: None,
+                },
+                LockEntry {
+                    name: "performance".into(),
+                    source: "/skills/performance.toml".into(),
+                    manifest_sha256: "sha_perf".into(),
+                    version: "1.0.0".into(),
+                    first_seen_at: Utc::now(),
+                    last_seen_at: Utc::now(),
+                    previous_manifest_sha256: None,
+                },
+            ],
+        };
+
+        // Only "security" is loaded; "performance" is absent.
+        let loaded = [sample_loaded_skill("security", "1.0.0", "sha_sec")];
+        let warnings = lock.update(&loaded);
+
+        assert!(warnings.is_empty());
+        assert_eq!(
+            lock.skills.len(),
+            2,
+            "absent skill should be preserved in lock"
+        );
+        assert!(lock.skills.iter().any(|e| e.name == "performance"));
+    }
+
+    #[test]
+    fn previous_manifest_sha256_preserved_on_edit() {
+        let mut lock = SkillsLock {
+            skills: vec![LockEntry {
+                name: "security".into(),
+                source: "/skills/security.toml".into(),
+                manifest_sha256: "hash_v1".into(),
+                version: "1.0.0".into(),
+                first_seen_at: Utc::now(),
+                last_seen_at: Utc::now(),
+                previous_manifest_sha256: None,
+            }],
+        };
+
+        // First edit: version bump.
+        let loaded_v2 = [sample_loaded_skill("security", "2.0.0", "hash_v2")];
+        lock.update(&loaded_v2);
+        assert_eq!(
+            lock.skills[0].previous_manifest_sha256.as_deref(),
+            Some("hash_v1")
+        );
+
+        // Second edit: another version bump.
+        let loaded_v3 = [sample_loaded_skill("security", "3.0.0", "hash_v3")];
+        lock.update(&loaded_v3);
+        assert_eq!(
+            lock.skills[0].previous_manifest_sha256.as_deref(),
+            Some("hash_v2"),
+            "previous_manifest_sha256 should track the immediately prior hash"
+        );
+    }
+
+    #[test]
+    fn unchanged_skill_no_warning_no_previous_hash_change() {
+        let mut lock = SkillsLock {
+            skills: vec![LockEntry {
+                name: "security".into(),
+                source: "/skills/security.toml".into(),
+                manifest_sha256: "same_hash".into(),
+                version: "1.0.0".into(),
+                first_seen_at: Utc::now(),
+                last_seen_at: Utc::now(),
+                previous_manifest_sha256: None,
+            }],
+        };
+
+        let loaded = [sample_loaded_skill("security", "1.0.0", "same_hash")];
+        let warnings = lock.update(&loaded);
+
+        assert!(
+            warnings.is_empty(),
+            "no change should not produce a warning"
+        );
+        assert!(
+            lock.skills[0].previous_manifest_sha256.is_none(),
+            "unchanged skill should not set previous_manifest_sha256"
+        );
+    }
+
+    #[test]
+    fn lock_save_creates_parent_directories() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("deep").join("nested").join("skills.lock");
+
+        let lock = SkillsLock::default();
+        lock.save(&path).unwrap();
+
+        assert!(path.exists());
+    }
+
+    #[test]
+    fn lock_multiple_skills_update() {
+        let mut lock = SkillsLock::default();
+
+        let loaded = [
+            sample_loaded_skill("security", "1.0.0", "sha_sec"),
+            sample_loaded_skill("performance", "1.0.0", "sha_perf"),
+            sample_loaded_skill("correctness", "1.0.0", "sha_corr"),
+        ];
+        let warnings = lock.update(&loaded);
+
+        assert!(warnings.is_empty());
+        assert_eq!(lock.skills.len(), 3);
+    }
+
+    // ── Serde snake_case verification ───────────────────────────────────
+
+    #[test]
+    fn enum_serde_uses_snake_case() {
+        // Verify the serde representation matches the spec.
+        assert_eq!(
+            serde_json::to_string(&AxisSelectionSource::ExplicitAxes).unwrap(),
+            "\"explicit_axes\""
+        );
+        assert_eq!(
+            serde_json::to_string(&AxisSelectionSource::AutoDiscovery).unwrap(),
+            "\"auto_discovery\""
+        );
+        assert_eq!(serde_json::to_string(&ExitStatus::Ok).unwrap(), "\"ok\"");
+        assert_eq!(
+            serde_json::to_string(&FailureReason::ModelRateLimit).unwrap(),
+            "\"model_rate_limit\""
+        );
+        assert_eq!(
+            serde_json::to_string(&IntegratorDecision::PassThrough).unwrap(),
+            "\"pass_through\""
+        );
+    }
+}

--- a/src/skill_audit.rs
+++ b/src/skill_audit.rs
@@ -24,6 +24,7 @@ use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize, de::DeserializeOwned};
 
 use crate::skill_manifest::LoadedSkill;
+use crate::skill_output::ParseErrorClass;
 
 // ---------------------------------------------------------------------------
 // Default file paths (relative to ~/.quorum/)
@@ -110,6 +111,14 @@ impl<T: Serialize> AuditWriter<T> {
             .with_context(|| format!("Failed to lock audit log file: {}", self.path.display()))?;
 
         let mut buf = serde_json::to_string(record)?;
+        if buf.len() > MAX_JSONL_LINE_BYTES {
+            anyhow::bail!(
+                "serialized record ({} bytes) exceeds MAX_JSONL_LINE_BYTES ({}) — \
+                 the reader would silently drop this line",
+                buf.len(),
+                MAX_JSONL_LINE_BYTES
+            );
+        }
         buf.push('\n');
         let write_result = file.write_all(buf.as_bytes());
 
@@ -380,9 +389,8 @@ pub struct SkillInvocationRecord {
     pub findings_clamped: u32,
     #[serde(default)]
     pub findings_dropped_invalid_json: u32,
-    /// From #407's `ParseErrorClass`, if applicable.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub parse_error_class: Option<String>,
+    pub parse_error_class: Option<ParseErrorClass>,
     pub exit_status: ExitStatus,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub failure_reason: Option<FailureReason>,
@@ -853,7 +861,7 @@ mod tests {
         let mut record = sample_invocation_record();
         record.exit_status = ExitStatus::Error;
         record.failure_reason = Some(FailureReason::ModelTimeout);
-        record.parse_error_class = Some("truncated_json".into());
+        record.parse_error_class = Some(ParseErrorClass::Truncated);
 
         let json = serde_json::to_string(&record).unwrap();
         let deserialized: SkillInvocationRecord = serde_json::from_str(&json).unwrap();
@@ -863,8 +871,8 @@ mod tests {
             Some(FailureReason::ModelTimeout)
         );
         assert_eq!(
-            deserialized.parse_error_class.as_deref(),
-            Some("truncated_json")
+            deserialized.parse_error_class,
+            Some(ParseErrorClass::Truncated)
         );
     }
 

--- a/src/skill_output.rs
+++ b/src/skill_output.rs
@@ -1,0 +1,918 @@
+//! Strict JSON review output contract for skill-based reviews.
+//!
+//! Owns the `ParseErrorClass` taxonomy for telemetry, `ModelCapabilities`
+//! for per-family JSON mode detection, and `SkillResponseOutcome` for
+//! carrying either parsed findings or classified parse failures.
+//!
+//! The `classify_response` function reuses the existing multi-strategy
+//! extraction logic from `review::parse_llm_response` where possible,
+//! wrapping it with `ParseErrorClass` classification. The actual wiring
+//! into the LLM client happens in issue #410 — this module provides the
+//! building blocks.
+
+use crate::finding::Finding;
+use crate::model_family::ModelFamily;
+use serde::{Deserialize, Serialize};
+use std::fmt;
+
+// ---------------------------------------------------------------------------
+// ParseErrorClass
+// ---------------------------------------------------------------------------
+
+/// Classification of why a skill response could not be parsed into findings.
+///
+/// Used for telemetry bucketing and retry decisions. Each variant maps to a
+/// distinct remediation path: `Truncated` allows one internal retry with a
+/// continuation prompt, while other classes are terminal drops.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ParseErrorClass {
+    /// Response body is empty or whitespace-only.
+    Empty,
+    /// Response contains text but cannot be parsed as JSON at all.
+    NotJson,
+    /// Valid JSON but does not match the `Finding[]` schema.
+    WrongSchema,
+    /// The model's `finish_reason` was `"length"` — response was cut off by
+    /// the token limit.
+    Truncated,
+}
+
+impl fmt::Display for ParseErrorClass {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Empty => f.write_str("empty"),
+            Self::NotJson => f.write_str("not_json"),
+            Self::WrongSchema => f.write_str("wrong_schema"),
+            Self::Truncated => f.write_str("truncated"),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// ModelCapabilities
+// ---------------------------------------------------------------------------
+
+/// Per-model-family capability flags.
+///
+/// Today this only tracks `response_format` support (`json_object` mode).
+/// Future flags (tool use, vision, reasoning tokens, etc.) will land here
+/// as the skill framework expands.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ModelCapabilities {
+    /// Whether the model supports `response_format: { "type": "json_object" }`
+    /// via the OpenAI-compatible API surface that quorum uses.
+    pub supports_json_mode: bool,
+}
+
+/// Return the capability flags for a given model family.
+///
+/// - **OpenAI (GPT)**: supports `response_format: { "type": "json_object" }`.
+/// - **Google (Gemini)**: supports the same via OpenAI-compatible endpoints.
+/// - **Anthropic (Claude)**: does NOT support `response_format` in the
+///   OpenAI-compatible API format. Prompt-based JSON only.
+/// - **Other**: no structured output support; prompt-based only.
+#[must_use]
+pub fn capabilities_for(family: ModelFamily) -> ModelCapabilities {
+    let supports_json_mode = matches!(family, ModelFamily::OpenAi | ModelFamily::Google);
+    ModelCapabilities { supports_json_mode }
+}
+
+// ---------------------------------------------------------------------------
+// build_json_mode_params
+// ---------------------------------------------------------------------------
+
+/// Return the `response_format` JSON value to merge into the request body
+/// for models that support JSON mode, or `None` if the family does not
+/// support structured output.
+///
+/// The caller (issue #410 wiring) is responsible for merging this into the
+/// request body when `Some`.
+#[must_use]
+pub fn build_json_mode_params(family: ModelFamily) -> Option<serde_json::Value> {
+    if capabilities_for(family).supports_json_mode {
+        Some(serde_json::json!({
+            "type": "json_object"
+        }))
+    } else {
+        None
+    }
+}
+
+// ---------------------------------------------------------------------------
+// SkillResponseOutcome
+// ---------------------------------------------------------------------------
+
+/// Result of attempting to parse a skill's LLM response into findings.
+///
+/// Carries either the successfully parsed findings (with optional parse
+/// warnings for non-fatal issues), a terminal parse error, or a retryable
+/// error with a continuation prompt.
+#[derive(Debug, Clone)]
+pub enum SkillResponseOutcome {
+    /// Parsing succeeded. `parse_warnings` captures non-fatal issues like
+    /// sanitized JSON escapes or unknown severity values.
+    Ok {
+        findings: Vec<Finding>,
+        parse_warnings: Vec<String>,
+    },
+    /// Terminal parse failure. The response could not be converted to
+    /// findings. `raw_snippet` carries up to 200 chars of the original
+    /// response for telemetry / debugging.
+    ParseError {
+        class: ParseErrorClass,
+        raw_snippet: String,
+    },
+    /// Retryable parse failure. The caller should issue one internal retry
+    /// with `continuation_prompt` appended. Only `Truncated` uses this
+    /// path today.
+    Retry {
+        class: ParseErrorClass,
+        continuation_prompt: String,
+    },
+}
+
+/// Maximum length of the raw snippet stored in `ParseError` for telemetry.
+const RAW_SNIPPET_MAX_LEN: usize = 200;
+
+/// Truncate a string to at most `RAW_SNIPPET_MAX_LEN` chars, appending
+/// "..." if truncated.
+fn snippet(raw: &str) -> String {
+    if raw.len() <= RAW_SNIPPET_MAX_LEN {
+        raw.to_owned()
+    } else {
+        // Truncate at a char boundary.
+        let end = raw
+            .char_indices()
+            .nth(RAW_SNIPPET_MAX_LEN)
+            .map_or(raw.len(), |(i, _)| i);
+        format!("{}...", &raw[..end])
+    }
+}
+
+// ---------------------------------------------------------------------------
+// classify_response
+// ---------------------------------------------------------------------------
+
+/// Classify an LLM response, attempting to parse it into `Finding[]`.
+///
+/// Decision tree:
+/// 1. If `finish_reason` is `"length"`, return `Retry { Truncated, ... }`.
+/// 2. If the raw body is empty/whitespace, return `ParseError { Empty, ... }`.
+/// 3. Attempt multi-strategy JSON extraction (reusing logic from
+///    `review::parse_llm_response`'s 4-strategy fallback).
+/// 4. If extraction yields valid `Finding[]`, return `Ok`.
+/// 5. If the text is valid JSON but the wrong shape, return
+///    `ParseError { WrongSchema, ... }`.
+/// 6. Otherwise, return `ParseError { NotJson, ... }`.
+#[must_use]
+pub fn classify_response(raw: &str, finish_reason: Option<&str>) -> SkillResponseOutcome {
+    // 1. Truncation check (finish_reason == "length").
+    if finish_reason == Some("length") {
+        return SkillResponseOutcome::Retry {
+            class: ParseErrorClass::Truncated,
+            continuation_prompt: "Your previous response was truncated. \
+                Please continue the JSON array from where you left off."
+                .to_owned(),
+        };
+    }
+
+    // 2. Empty check.
+    if raw.trim().is_empty() {
+        return SkillResponseOutcome::ParseError {
+            class: ParseErrorClass::Empty,
+            raw_snippet: String::new(),
+        };
+    }
+
+    // 3. Attempt to parse as Finding[] using the same strategies as
+    //    review::parse_llm_response. We inline a simplified version here
+    //    to avoid a circular dependency on the binary-only review module.
+    //    The strategies are:
+    //    a) Strip markdown fences + extract JSON array bracket-scan
+    //    b) Try as bare Vec<Finding>
+    //    c) Try as {"findings": [...]} envelope
+    //    d) Sanitize invalid JSON escapes and retry both shapes
+
+    let stripped = strip_control_chars(raw);
+    let extracted = extract_json_block(&stripped);
+
+    // Try bare array.
+    if let Some(findings) = try_parse_findings(&extracted) {
+        return SkillResponseOutcome::Ok {
+            findings,
+            parse_warnings: vec![],
+        };
+    }
+
+    // Try envelope shape on the full (fence-stripped) payload.
+    let defenced = strip_markdown_fence(&stripped);
+    if let Some(findings) = try_parse_envelope(&defenced) {
+        return SkillResponseOutcome::Ok {
+            findings,
+            parse_warnings: vec![],
+        };
+    }
+
+    // Sanitize invalid JSON escapes and retry.
+    let sanitized_extracted = sanitize_json_escapes(&extracted);
+    if let Some(findings) = try_parse_findings(&sanitized_extracted) {
+        return SkillResponseOutcome::Ok {
+            findings,
+            parse_warnings: vec!["sanitized invalid JSON escapes".to_owned()],
+        };
+    }
+
+    let sanitized_defenced = sanitize_json_escapes(&defenced);
+    if let Some(findings) = try_parse_envelope(&sanitized_defenced) {
+        return SkillResponseOutcome::Ok {
+            findings,
+            parse_warnings: vec!["sanitized invalid JSON escapes".to_owned()],
+        };
+    }
+
+    // 4-5. Classify failure: valid JSON but wrong shape vs not JSON at all.
+    //
+    // Check the extracted text first (likely the most JSON-like portion),
+    // then fall back to the full payload.
+    if is_valid_json(&sanitized_extracted) || is_valid_json(&sanitized_defenced) {
+        return SkillResponseOutcome::ParseError {
+            class: ParseErrorClass::WrongSchema,
+            raw_snippet: snippet(raw),
+        };
+    }
+
+    SkillResponseOutcome::ParseError {
+        class: ParseErrorClass::NotJson,
+        raw_snippet: snippet(raw),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Internal parsing helpers
+// ---------------------------------------------------------------------------
+
+/// Try to deserialize a string as `Vec<Finding>`. Returns `None` on failure.
+fn try_parse_findings(s: &str) -> Option<Vec<Finding>> {
+    serde_json::from_str::<Vec<Finding>>(s).ok()
+}
+
+/// Wrapper envelope shape: `{"findings": [...]}`.
+#[derive(Deserialize)]
+struct FindingsEnvelope {
+    findings: Vec<Finding>,
+}
+
+/// Try to deserialize a string as a `{"findings": [...]}` envelope.
+fn try_parse_envelope(s: &str) -> Option<Vec<Finding>> {
+    serde_json::from_str::<FindingsEnvelope>(s.trim())
+        .ok()
+        .map(|e| e.findings)
+}
+
+/// Check whether a string is valid JSON of any shape.
+fn is_valid_json(s: &str) -> bool {
+    serde_json::from_str::<serde_json::Value>(s.trim()).is_ok()
+}
+
+/// Strip raw control characters from LLM output while preserving JSON
+/// structure. Mirrors `review::strip_control_chars`.
+fn strip_control_chars(s: &str) -> String {
+    s.chars()
+        .map(|c| {
+            if c.is_control() && c != '\n' && c != '\r' && c != '\t' {
+                ' '
+            } else {
+                c
+            }
+        })
+        .collect()
+}
+
+/// Strip surrounding ````json` / ```` markdown fences if present.
+/// Mirrors `review::strip_markdown_fence`.
+fn strip_markdown_fence(text: &str) -> String {
+    let t = text.trim();
+    let after_prefix = if let Some(rest) = t.strip_prefix("```json") {
+        rest
+    } else if let Some(rest) = t.strip_prefix("```") {
+        rest
+    } else {
+        return t.to_string();
+    };
+    let trimmed = after_prefix.trim_end();
+    let inner = trimmed.strip_suffix("```").unwrap_or(trimmed);
+    inner.trim().to_string()
+}
+
+/// Extract the outermost JSON array from text using bracket-depth tracking.
+/// If no balanced array is found, returns the fence-stripped text as-is.
+/// Mirrors `review::extract_json_array`.
+fn extract_json_block(text: &str) -> String {
+    let text = strip_markdown_fence(text);
+    let text = text.trim();
+    let bytes = text.as_bytes();
+    let mut start = None;
+    let mut depth: i32 = 0;
+    let mut in_string = false;
+    let mut escape = false;
+
+    for (i, &b) in bytes.iter().enumerate() {
+        if escape {
+            escape = false;
+            continue;
+        }
+        if b == b'\\' && in_string {
+            escape = true;
+            continue;
+        }
+        if b == b'"' {
+            in_string = !in_string;
+            continue;
+        }
+        if in_string {
+            continue;
+        }
+        if b == b'[' {
+            if depth == 0 {
+                start = Some(i);
+            }
+            depth += 1;
+        } else if b == b']' && depth > 0 {
+            depth -= 1;
+            if depth == 0
+                && let Some(s) = start
+            {
+                return text[s..=i].to_string();
+            }
+        }
+    }
+
+    text.to_string()
+}
+
+/// Fix invalid JSON escape sequences that LLMs sometimes emit (e.g. `\d`,
+/// `\s`). Converts them to `\\d`, `\\s`. Mirrors `review::sanitize_json_escapes`.
+fn sanitize_json_escapes(json: &str) -> String {
+    let mut result = String::with_capacity(json.len());
+    let mut chars = json.chars().peekable();
+    let mut in_string = false;
+
+    while let Some(c) = chars.next() {
+        if c == '"' && in_string {
+            // Check if this quote is escaped by counting preceding backslashes.
+            // We already emitted those backslashes, so just toggle.
+            in_string = false;
+            result.push(c);
+            continue;
+        }
+        if c == '"' {
+            in_string = true;
+            result.push(c);
+            continue;
+        }
+        if c == '\\' && in_string {
+            if let Some(&next) = chars.peek() {
+                // Valid JSON escapes: " \ / b f n r t u
+                if matches!(next, '"' | '\\' | '/' | 'b' | 'f' | 'n' | 'r' | 't' | 'u') {
+                    result.push(c);
+                    result.push(chars.next().unwrap());
+                } else {
+                    // Invalid escape like \d, \s — double the backslash.
+                    result.push('\\');
+                    result.push(c);
+                    result.push(chars.next().unwrap());
+                }
+            } else {
+                result.push(c);
+            }
+            continue;
+        }
+        result.push(c);
+    }
+    result
+}
+
+// ===========================================================================
+// Tests
+// ===========================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::category::Category;
+    use crate::finding::{FindingBuilder, Severity, Source};
+
+    // -----------------------------------------------------------------------
+    // ParseErrorClass serde roundtrip
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn parse_error_class_serde_roundtrip() {
+        for class in [
+            ParseErrorClass::Empty,
+            ParseErrorClass::NotJson,
+            ParseErrorClass::WrongSchema,
+            ParseErrorClass::Truncated,
+        ] {
+            let json = serde_json::to_string(&class).unwrap();
+            let back: ParseErrorClass = serde_json::from_str(&json).unwrap();
+            assert_eq!(back, class, "serde roundtrip failed for {class}");
+        }
+    }
+
+    #[test]
+    fn parse_error_class_serializes_as_snake_case() {
+        assert_eq!(
+            serde_json::to_value(ParseErrorClass::Empty).unwrap(),
+            "empty"
+        );
+        assert_eq!(
+            serde_json::to_value(ParseErrorClass::NotJson).unwrap(),
+            "not_json"
+        );
+        assert_eq!(
+            serde_json::to_value(ParseErrorClass::WrongSchema).unwrap(),
+            "wrong_schema"
+        );
+        assert_eq!(
+            serde_json::to_value(ParseErrorClass::Truncated).unwrap(),
+            "truncated"
+        );
+    }
+
+    #[test]
+    fn parse_error_class_display_matches_serde() {
+        for class in [
+            ParseErrorClass::Empty,
+            ParseErrorClass::NotJson,
+            ParseErrorClass::WrongSchema,
+            ParseErrorClass::Truncated,
+        ] {
+            let display = class.to_string();
+            let serde_str = serde_json::to_value(class)
+                .unwrap()
+                .as_str()
+                .unwrap()
+                .to_owned();
+            assert_eq!(
+                display, serde_str,
+                "Display and serde disagree for {class:?}"
+            );
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // ModelCapabilities
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn capabilities_openai_supports_json_mode() {
+        let caps = capabilities_for(ModelFamily::OpenAi);
+        assert!(caps.supports_json_mode);
+    }
+
+    #[test]
+    fn capabilities_google_supports_json_mode() {
+        let caps = capabilities_for(ModelFamily::Google);
+        assert!(caps.supports_json_mode);
+    }
+
+    #[test]
+    fn capabilities_anthropic_no_json_mode() {
+        let caps = capabilities_for(ModelFamily::Anthropic);
+        assert!(!caps.supports_json_mode);
+    }
+
+    #[test]
+    fn capabilities_other_no_json_mode() {
+        let caps = capabilities_for(ModelFamily::Other);
+        assert!(!caps.supports_json_mode);
+    }
+
+    // -----------------------------------------------------------------------
+    // build_json_mode_params
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn json_mode_params_openai_returns_some() {
+        let params = build_json_mode_params(ModelFamily::OpenAi);
+        assert!(params.is_some());
+        let val = params.unwrap();
+        assert_eq!(val["type"], "json_object");
+    }
+
+    #[test]
+    fn json_mode_params_google_returns_some() {
+        let params = build_json_mode_params(ModelFamily::Google);
+        assert!(params.is_some());
+        let val = params.unwrap();
+        assert_eq!(val["type"], "json_object");
+    }
+
+    #[test]
+    fn json_mode_params_anthropic_returns_none() {
+        assert!(build_json_mode_params(ModelFamily::Anthropic).is_none());
+    }
+
+    #[test]
+    fn json_mode_params_other_returns_none() {
+        assert!(build_json_mode_params(ModelFamily::Other).is_none());
+    }
+
+    // -----------------------------------------------------------------------
+    // SkillResponseOutcome construction
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn outcome_ok_variant() {
+        let findings = vec![
+            FindingBuilder::new()
+                .title("test")
+                .severity(Severity::High)
+                .build(),
+        ];
+        let outcome = SkillResponseOutcome::Ok {
+            findings: findings.clone(),
+            parse_warnings: vec!["warning1".into()],
+        };
+        match outcome {
+            SkillResponseOutcome::Ok {
+                findings: f,
+                parse_warnings: w,
+            } => {
+                assert_eq!(f.len(), 1);
+                assert_eq!(f[0].title, "test");
+                assert_eq!(w, vec!["warning1"]);
+            }
+            other => panic!("expected Ok, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn outcome_parse_error_variant() {
+        let outcome = SkillResponseOutcome::ParseError {
+            class: ParseErrorClass::NotJson,
+            raw_snippet: "garbled text".into(),
+        };
+        match outcome {
+            SkillResponseOutcome::ParseError { class, raw_snippet } => {
+                assert_eq!(class, ParseErrorClass::NotJson);
+                assert_eq!(raw_snippet, "garbled text");
+            }
+            other => panic!("expected ParseError, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn outcome_retry_variant() {
+        let outcome = SkillResponseOutcome::Retry {
+            class: ParseErrorClass::Truncated,
+            continuation_prompt: "continue please".into(),
+        };
+        match outcome {
+            SkillResponseOutcome::Retry {
+                class,
+                continuation_prompt,
+            } => {
+                assert_eq!(class, ParseErrorClass::Truncated);
+                assert_eq!(continuation_prompt, "continue please");
+            }
+            other => panic!("expected Retry, got {other:?}"),
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // classify_response: empty input
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn classify_empty_string() {
+        let outcome = classify_response("", None);
+        match outcome {
+            SkillResponseOutcome::ParseError { class, .. } => {
+                assert_eq!(class, ParseErrorClass::Empty);
+            }
+            other => panic!("expected Empty ParseError, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn classify_whitespace_only() {
+        let outcome = classify_response("   \n\t  ", None);
+        match outcome {
+            SkillResponseOutcome::ParseError { class, .. } => {
+                assert_eq!(class, ParseErrorClass::Empty);
+            }
+            other => panic!("expected Empty ParseError, got {other:?}"),
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // classify_response: truncated (finish_reason == "length")
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn classify_truncated_finish_reason() {
+        let outcome = classify_response("[{\"partial\": true", Some("length"));
+        match outcome {
+            SkillResponseOutcome::Retry {
+                class,
+                continuation_prompt,
+            } => {
+                assert_eq!(class, ParseErrorClass::Truncated);
+                assert!(!continuation_prompt.is_empty());
+            }
+            other => panic!("expected Retry/Truncated, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn classify_truncated_even_if_empty_body() {
+        // finish_reason takes priority over body analysis.
+        let outcome = classify_response("", Some("length"));
+        match outcome {
+            SkillResponseOutcome::Retry { class, .. } => {
+                assert_eq!(class, ParseErrorClass::Truncated);
+            }
+            other => panic!("expected Retry/Truncated, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn classify_stop_finish_reason_does_not_trigger_truncation() {
+        let outcome = classify_response("not json at all", Some("stop"));
+        match outcome {
+            SkillResponseOutcome::ParseError { class, .. } => {
+                assert_eq!(class, ParseErrorClass::NotJson);
+            }
+            other => panic!("expected NotJson, got {other:?}"),
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // classify_response: not JSON
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn classify_garbage_text() {
+        let outcome = classify_response("Here are my thoughts on the code...", None);
+        match outcome {
+            SkillResponseOutcome::ParseError { class, raw_snippet } => {
+                assert_eq!(class, ParseErrorClass::NotJson);
+                assert!(raw_snippet.contains("Here are my thoughts"));
+            }
+            other => panic!("expected NotJson, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn classify_partial_json() {
+        let outcome = classify_response("[{\"title\": \"incomplete", None);
+        match outcome {
+            SkillResponseOutcome::ParseError { class, .. } => {
+                assert_eq!(class, ParseErrorClass::NotJson);
+            }
+            other => panic!("expected NotJson, got {other:?}"),
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // classify_response: wrong schema
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn classify_valid_json_wrong_shape_object() {
+        let outcome = classify_response("{\"message\": \"no findings here\"}", None);
+        match outcome {
+            SkillResponseOutcome::ParseError { class, .. } => {
+                assert_eq!(class, ParseErrorClass::WrongSchema);
+            }
+            other => panic!("expected WrongSchema, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn classify_valid_json_wrong_shape_array_of_strings() {
+        let outcome = classify_response("[\"foo\", \"bar\"]", None);
+        match outcome {
+            SkillResponseOutcome::ParseError { class, .. } => {
+                assert_eq!(class, ParseErrorClass::WrongSchema);
+            }
+            other => panic!("expected WrongSchema, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn classify_valid_json_wrong_shape_array_of_wrong_objects() {
+        let outcome = classify_response("[{\"name\": \"foo\", \"age\": 42}]", None);
+        match outcome {
+            SkillResponseOutcome::ParseError { class, .. } => {
+                assert_eq!(class, ParseErrorClass::WrongSchema);
+            }
+            other => panic!("expected WrongSchema, got {other:?}"),
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // classify_response: valid Finding array
+    // -----------------------------------------------------------------------
+
+    fn make_finding_json(title: &str) -> String {
+        let f = FindingBuilder::new()
+            .title(title)
+            .severity(Severity::High)
+            .category(Category::Security)
+            .source(Source::Llm("gpt-5.4".into()))
+            .lines(10, 20)
+            .build();
+        serde_json::to_string(&f).unwrap()
+    }
+
+    #[test]
+    fn classify_valid_bare_array() {
+        let json = format!("[{}]", make_finding_json("SQL injection"));
+        let outcome = classify_response(&json, None);
+        match outcome {
+            SkillResponseOutcome::Ok {
+                findings,
+                parse_warnings,
+            } => {
+                assert_eq!(findings.len(), 1);
+                assert_eq!(findings[0].title, "SQL injection");
+                assert!(parse_warnings.is_empty());
+            }
+            other => panic!("expected Ok, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn classify_valid_envelope() {
+        let json = format!(
+            "{{\"findings\": [{}]}}",
+            make_finding_json("Buffer overflow")
+        );
+        let outcome = classify_response(&json, None);
+        match outcome {
+            SkillResponseOutcome::Ok { findings, .. } => {
+                assert_eq!(findings.len(), 1);
+                assert_eq!(findings[0].title, "Buffer overflow");
+            }
+            other => panic!("expected Ok, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn classify_valid_array_in_markdown_fence() {
+        let json = format!("```json\n[{}]\n```", make_finding_json("XSS"));
+        let outcome = classify_response(&json, None);
+        match outcome {
+            SkillResponseOutcome::Ok { findings, .. } => {
+                assert_eq!(findings.len(), 1);
+                assert_eq!(findings[0].title, "XSS");
+            }
+            other => panic!("expected Ok, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn classify_empty_findings_array() {
+        let outcome = classify_response("[]", None);
+        match outcome {
+            SkillResponseOutcome::Ok { findings, .. } => {
+                assert!(findings.is_empty());
+            }
+            other => panic!("expected Ok with empty findings, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn classify_empty_findings_envelope() {
+        let outcome = classify_response("{\"findings\": []}", None);
+        match outcome {
+            SkillResponseOutcome::Ok { findings, .. } => {
+                assert!(findings.is_empty());
+            }
+            other => panic!("expected Ok with empty findings, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn classify_multiple_findings() {
+        let json = format!(
+            "[{}, {}]",
+            make_finding_json("Finding A"),
+            make_finding_json("Finding B")
+        );
+        let outcome = classify_response(&json, Some("stop"));
+        match outcome {
+            SkillResponseOutcome::Ok { findings, .. } => {
+                assert_eq!(findings.len(), 2);
+            }
+            other => panic!("expected Ok, got {other:?}"),
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // classify_response: sanitized JSON escapes
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn classify_with_invalid_json_escapes() {
+        // Build a valid finding JSON, then inject an invalid escape in a
+        // string field to force the sanitize path.
+        let base = make_finding_json("Regex issue");
+        // Replace "Regex issue" with "Regex \d+ issue" (invalid \d escape).
+        let broken = base.replace("Regex issue", "Regex \\d+ issue");
+        let json = format!("[{}]", broken);
+        let outcome = classify_response(&json, None);
+        match outcome {
+            SkillResponseOutcome::Ok { parse_warnings, .. } => {
+                assert!(
+                    parse_warnings.iter().any(|w| w.contains("sanitized")),
+                    "expected sanitization warning, got {parse_warnings:?}"
+                );
+            }
+            other => panic!("expected Ok with sanitization warning, got {other:?}"),
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // snippet truncation
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn snippet_short_text_not_truncated() {
+        let s = snippet("hello");
+        assert_eq!(s, "hello");
+    }
+
+    #[test]
+    fn snippet_long_text_truncated() {
+        let long = "x".repeat(300);
+        let s = snippet(&long);
+        assert!(s.len() < 300);
+        assert!(s.ends_with("..."));
+    }
+
+    // -----------------------------------------------------------------------
+    // Internal helper coverage
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn extract_json_block_from_prose() {
+        let text = "Here is the result:\n[1, 2, 3]\nDone.";
+        let extracted = extract_json_block(text);
+        assert_eq!(extracted, "[1, 2, 3]");
+    }
+
+    #[test]
+    fn extract_json_block_no_array_returns_full() {
+        let text = "no array here";
+        let extracted = extract_json_block(text);
+        assert_eq!(extracted, "no array here");
+    }
+
+    #[test]
+    fn strip_markdown_fence_json() {
+        let input = "```json\n{\"a\": 1}\n```";
+        let result = strip_markdown_fence(input);
+        assert_eq!(result, "{\"a\": 1}");
+    }
+
+    #[test]
+    fn strip_markdown_fence_no_fence() {
+        let input = "{\"a\": 1}";
+        let result = strip_markdown_fence(input);
+        assert_eq!(result, "{\"a\": 1}");
+    }
+
+    #[test]
+    fn sanitize_json_escapes_valid_passthrough() {
+        let input = r#"{"title": "foo\nbar"}"#;
+        let result = sanitize_json_escapes(input);
+        assert_eq!(result, input);
+    }
+
+    #[test]
+    fn sanitize_json_escapes_fixes_invalid() {
+        let input = r#"{"title": "regex \d+"}"#;
+        let result = sanitize_json_escapes(input);
+        assert!(result.contains(r#"\\d"#));
+    }
+
+    #[test]
+    fn is_valid_json_true_for_object() {
+        assert!(is_valid_json("{\"a\": 1}"));
+    }
+
+    #[test]
+    fn is_valid_json_true_for_array() {
+        assert!(is_valid_json("[1, 2]"));
+    }
+
+    #[test]
+    fn is_valid_json_false_for_garbage() {
+        assert!(!is_valid_json("not json at all"));
+    }
+}

--- a/src/skill_output.rs
+++ b/src/skill_output.rs
@@ -138,10 +138,10 @@ const RAW_SNIPPET_MAX_LEN: usize = 200;
 /// Truncate a string to at most `RAW_SNIPPET_MAX_LEN` chars, appending
 /// "..." if truncated.
 fn snippet(raw: &str) -> String {
-    if raw.len() <= RAW_SNIPPET_MAX_LEN {
+    let char_count = raw.chars().count();
+    if char_count <= RAW_SNIPPET_MAX_LEN {
         raw.to_owned()
     } else {
-        // Truncate at a char boundary.
         let end = raw
             .char_indices()
             .nth(RAW_SNIPPET_MAX_LEN)

--- a/src/skill_output.rs
+++ b/src/skill_output.rs
@@ -86,17 +86,14 @@ pub fn capabilities_for(family: ModelFamily) -> ModelCapabilities {
 /// for models that support JSON mode, or `None` if the family does not
 /// support structured output.
 ///
-/// The caller (issue #410 wiring) is responsible for merging this into the
-/// request body when `Some`.
+/// Currently returns `None` for all families: `json_object` forces a
+/// top-level object, which conflicts with the `Vec<Finding>` array
+/// contract. Foundation C (#410) will implement `json_schema` with an
+/// explicit schema for providers that support it.
 #[must_use]
-pub fn build_json_mode_params(family: ModelFamily) -> Option<serde_json::Value> {
-    if capabilities_for(family).supports_json_mode {
-        Some(serde_json::json!({
-            "type": "json_object"
-        }))
-    } else {
-        None
-    }
+pub fn build_json_mode_params(_family: ModelFamily) -> Option<serde_json::Value> {
+    // Deferred: json_schema with explicit Finding[] schema (#410).
+    None
 }
 
 // ---------------------------------------------------------------------------
@@ -195,18 +192,11 @@ pub fn classify_response(raw: &str, finish_reason: Option<&str>) -> SkillRespons
     //    d) Sanitize invalid JSON escapes and retry both shapes
 
     let stripped = strip_control_chars(raw);
-    let extracted = extract_json_block(&stripped);
-
-    // Try bare array.
-    if let Some(findings) = try_parse_findings(&extracted) {
-        return SkillResponseOutcome::Ok {
-            findings,
-            parse_warnings: vec![],
-        };
-    }
-
-    // Try envelope shape on the full (fence-stripped) payload.
     let defenced = strip_markdown_fence(&stripped);
+
+    // Try envelope first — if the response is `{"findings": [...]}`, bare
+    // array extraction would grab the first `[...]` it finds (which could
+    // be a different field like `"warnings": []`).
     if let Some(findings) = try_parse_envelope(&defenced) {
         return SkillResponseOutcome::Ok {
             findings,
@@ -214,17 +204,26 @@ pub fn classify_response(raw: &str, finish_reason: Option<&str>) -> SkillRespons
         };
     }
 
-    // Sanitize invalid JSON escapes and retry.
-    let sanitized_extracted = sanitize_json_escapes(&extracted);
-    if let Some(findings) = try_parse_findings(&sanitized_extracted) {
+    // Try bare array via bracket-depth extraction.
+    let extracted = extract_json_block(&stripped);
+    if let Some(findings) = try_parse_findings(&extracted) {
+        return SkillResponseOutcome::Ok {
+            findings,
+            parse_warnings: vec![],
+        };
+    }
+
+    // Sanitize invalid JSON escapes and retry both shapes.
+    let sanitized_defenced = sanitize_json_escapes(&defenced);
+    if let Some(findings) = try_parse_envelope(&sanitized_defenced) {
         return SkillResponseOutcome::Ok {
             findings,
             parse_warnings: vec!["sanitized invalid JSON escapes".to_owned()],
         };
     }
 
-    let sanitized_defenced = sanitize_json_escapes(&defenced);
-    if let Some(findings) = try_parse_envelope(&sanitized_defenced) {
+    let sanitized_extracted = sanitize_json_escapes(&extracted);
+    if let Some(findings) = try_parse_findings(&sanitized_extracted) {
         return SkillResponseOutcome::Ok {
             findings,
             parse_warnings: vec!["sanitized invalid JSON escapes".to_owned()],
@@ -495,29 +494,19 @@ mod tests {
     // -----------------------------------------------------------------------
 
     #[test]
-    fn json_mode_params_openai_returns_some() {
-        let params = build_json_mode_params(ModelFamily::OpenAi);
-        assert!(params.is_some());
-        let val = params.unwrap();
-        assert_eq!(val["type"], "json_object");
-    }
-
-    #[test]
-    fn json_mode_params_google_returns_some() {
-        let params = build_json_mode_params(ModelFamily::Google);
-        assert!(params.is_some());
-        let val = params.unwrap();
-        assert_eq!(val["type"], "json_object");
-    }
-
-    #[test]
-    fn json_mode_params_anthropic_returns_none() {
-        assert!(build_json_mode_params(ModelFamily::Anthropic).is_none());
-    }
-
-    #[test]
-    fn json_mode_params_other_returns_none() {
-        assert!(build_json_mode_params(ModelFamily::Other).is_none());
+    fn json_mode_params_returns_none_for_all_families() {
+        for family in [
+            ModelFamily::Anthropic,
+            ModelFamily::OpenAi,
+            ModelFamily::Google,
+            ModelFamily::Other,
+        ] {
+            assert!(
+                build_json_mode_params(family).is_none(),
+                "build_json_mode_params should return None for {family} \
+                 (json_schema deferred to #410)"
+            );
+        }
     }
 
     // -----------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Foundation B of the multi-axis review skills framework, implementing issues #407 and #409:

- **`src/skill_output.rs`** (#407): Strict JSON review output contract
  - `ParseErrorClass` taxonomy: `Empty`, `NotJson`, `WrongSchema`, `Truncated`
  - `ModelCapabilities` per-family detection (JSON mode for OpenAI/Google)
  - `build_json_mode_params()` for `response_format` injection
  - `SkillResponseOutcome` classifier with finish-reason awareness
  - 42 unit tests

- **`src/skill_audit.rs`** (#409): Audit log infrastructure
  - Generic `AuditWriter<T>` / `AuditReader<T>` with cross-process `fs2` file locking
  - `SkillInvocationRecord` (26 fields per design spec §5.2)
  - `IntegratorDecisionRecord` with `ClusterKey` for dedup tracking
  - `SkillsLock` TOML manifest with silent-edit detection
  - 29 unit tests

Both modules are library-only additions with no behavioral changes to existing code paths. They provide the building blocks that Foundation C (skill invocation orchestrator) will wire together.

Closes #407, closes #409.

## Test plan

- [x] `cargo test --lib -- skill_output` — 42 tests pass
- [x] `cargo test --lib -- skill_audit` — 29 tests pass
- [x] `cargo test --bin quorum` — 1680 tests pass (full suite, no regressions)
- [x] `cargo clippy --all-targets` — clean
- [x] `cargo fmt --check` — clean
- [ ] CI: rustfmt, clippy, test (ubuntu + macos), msrv, cargo-audit, cargo-deny, CodeQL, Semgrep

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added audit logging for skill invocations and integrator decisions with safe append/read semantics and tamper-detection for skill manifests.
  * Added strict skill response parsing with detailed error classification, sanitization, and retry guidance.
* **Tests**
  * Comprehensive unit tests for audit IO, lock behavior, schema roundtrips, parsing logic, and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->