### PR TITLE
feat: wire finding_id linkage through feedback recording paths (#436)

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -2,7 +2,9 @@
   "permissions": {
     "allow": [
       "Bash(rtk git:*)",
-      "Bash(git commit -m ':*)"
+      "Bash(git commit -m ':*)",
+      "mcp__plugin_context-mode_context-mode__ctx_batch_execute",
+      "WebSearch"
     ]
   }
 }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -739,6 +739,11 @@ pub struct FeedbackOpts {
     #[arg(long, requires = "fp_kind")]
     pub fp_tracked_in: Option<String>,
 
+    /// Explicit finding ID (ULID) to link this feedback entry to a specific
+    /// review finding. Bypasses auto-link resolution.
+    #[arg(long, value_parser = parse_finding_id)]
+    pub finding_id: Option<String>,
+
     /// Whether the finding was inside the diff (true), outside (false), or
     /// unknown (omitted). Flows through both Human and External paths.
     #[arg(long)]
@@ -815,6 +820,15 @@ pub fn parse_provenance(s: &str) -> Result<crate::feedback::Provenance, String> 
             "unknown provenance '{other}': expected post_fix or human"
         )),
     }
+}
+
+/// Validate and normalize a ULID string for `--finding-id`. Rejects
+/// non-ULID input with a clear error; round-trips through `ulid::Ulid`
+/// so the stored value is always canonical uppercase.
+pub fn parse_finding_id(s: &str) -> Result<String, String> {
+    ulid::Ulid::from_string(s)
+        .map(|u| u.to_string())
+        .map_err(|e| format!("invalid ULID: {e}"))
 }
 
 pub fn parse_confidence(s: &str) -> Result<f32, String> {
@@ -2129,5 +2143,89 @@ mod tests {
         use clap::Parser;
         let r = Args::try_parse_from(["quorum", "context", "index", "--source", "my-source"]);
         assert!(r.is_ok(), "'my-source' is a valid source name for index");
+    }
+
+    // --- Task 5: --finding-id ULID validation --------------------------------
+
+    #[test]
+    fn finding_id_valid_ulid_accepted() {
+        let valid = "01HXYZ1234567890ABCDEFGHJK";
+        assert!(parse_finding_id(valid).is_ok());
+    }
+
+    #[test]
+    fn finding_id_invalid_rejected() {
+        assert!(parse_finding_id("not-a-ulid").is_err());
+        assert!(parse_finding_id("").is_err());
+        assert!(parse_finding_id("too-short").is_err());
+    }
+
+    #[test]
+    fn finding_id_flag_parses_in_feedback() {
+        use clap::Parser;
+        let ulid = "01HXYZ1234567890ABCDEFGHJK";
+        let args = Args::parse_from([
+            "quorum",
+            "feedback",
+            "--file",
+            "f.rs",
+            "--finding",
+            "x",
+            "--verdict",
+            "tp",
+            "--reason",
+            "r",
+            "--finding-id",
+            ulid,
+        ]);
+        match args.command {
+            Command::Feedback(opts) => {
+                assert_eq!(opts.finding_id.as_deref(), Some(ulid));
+            }
+            _ => panic!("Expected Feedback command"),
+        }
+    }
+
+    #[test]
+    fn finding_id_flag_is_optional() {
+        use clap::Parser;
+        let args = Args::parse_from([
+            "quorum",
+            "feedback",
+            "--file",
+            "f.rs",
+            "--finding",
+            "x",
+            "--verdict",
+            "tp",
+            "--reason",
+            "r",
+        ]);
+        match args.command {
+            Command::Feedback(opts) => {
+                assert!(opts.finding_id.is_none());
+            }
+            _ => panic!("Expected Feedback command"),
+        }
+    }
+
+    #[test]
+    fn finding_id_invalid_ulid_rejected_at_parse_time() {
+        use clap::Parser;
+        let res = Args::try_parse_from([
+            "quorum",
+            "feedback",
+            "--file",
+            "f.rs",
+            "--finding",
+            "x",
+            "--verdict",
+            "tp",
+            "--reason",
+            "r",
+            "--finding-id",
+            "not-a-ulid",
+        ]);
+        assert!(res.is_err(), "invalid ULID must be rejected at parse time");
     }
 }

--- a/src/feedback.rs
+++ b/src/feedback.rs
@@ -150,6 +150,7 @@ pub struct ExternalVerdictInput {
     pub agent_model: Option<String>,
     pub confidence: Option<f32>,
     pub in_diff: Option<bool>,
+    pub finding_id: Option<String>,
 }
 
 /// #123 Layer 1 (Task 10): adoption telemetry for the FpKind taxonomy.
@@ -268,6 +269,7 @@ impl From<ExternalVerdictInputWire> for ExternalVerdictInput {
             agent_model: w.agent_model,
             confidence: w.confidence,
             in_diff: None,
+            finding_id: None,
         }
     }
 }
@@ -828,7 +830,7 @@ impl FeedbackStore {
                 confidence,
             },
             fp_kind: None,
-            finding_id: None,
+            finding_id: input.finding_id,
             rule_id: None,
             in_diff: input.in_diff,
             skill_name: None,

--- a/src/feedback.rs
+++ b/src/feedback.rs
@@ -1488,6 +1488,7 @@ mod tests {
             agent_model: Some("gemini-3-pro-preview".into()),
             confidence: Some(0.85),
             in_diff: None,
+            finding_id: None,
         };
         store.record_external(input).unwrap();
         let all = store.load_all().unwrap();
@@ -1524,6 +1525,7 @@ mod tests {
                 agent_model: None,
                 confidence: None,
                 in_diff: None,
+                finding_id: None,
             })
             .unwrap();
         let all = store.load_all().unwrap();
@@ -1547,6 +1549,7 @@ mod tests {
                 agent_model: None,
                 confidence: None,
                 in_diff: None,
+                finding_id: None,
             })
             .expect_err("empty agent must be rejected");
         assert!(
@@ -1569,6 +1572,7 @@ mod tests {
                 agent_model: None,
                 confidence: None,
                 in_diff: None,
+                finding_id: None,
             })
             .unwrap();
         let all = store.load_all().unwrap();
@@ -1589,6 +1593,7 @@ mod tests {
                 agent_model: None,
                 confidence: Some(1.5),
                 in_diff: None,
+                finding_id: None,
             })
             .unwrap();
         let all = store.load_all().unwrap();
@@ -1619,6 +1624,7 @@ mod tests {
                 agent_model: None,
                 confidence: None,
                 in_diff: None,
+                finding_id: None,
             })
             .expect_err("ContextMisleading must be rejected for External provenance");
         assert!(
@@ -1695,6 +1701,7 @@ mod tests {
                 agent_model: None,
                 confidence: None,
                 in_diff: None,
+                finding_id: None,
             })
             .expect_err("Wontfix must be rejected for External provenance");
         assert!(

--- a/src/main.rs
+++ b/src/main.rs
@@ -2439,15 +2439,14 @@ fn run_feedback(opts: cli::FeedbackOpts) -> i32 {
                 return 3;
             }
         };
-        // Auto-resolve finding_id from the review log for the external path.
-        let finding_id = {
-            let quorum_home = quorum_dir();
-            quorum_home.and_then(|home| {
-                let handle = crate::storage::initialize(&home).ok()?;
-                let log = review_log::ReviewLog::with_storage(handle);
-                log.resolve_finding_id(&opts.file, &opts.finding)
-            })
-        };
+        // Explicit --finding-id bypasses auto-resolve; otherwise fall back
+        // to auto-resolution from the review log.
+        let finding_id = opts.finding_id.clone().or_else(|| {
+            let quorum_home = quorum_dir()?;
+            let handle = crate::storage::initialize(&quorum_home).ok()?;
+            let log = review_log::ReviewLog::with_storage(handle);
+            log.resolve_finding_id(&opts.file, &opts.finding)
+        });
         let input = feedback::ExternalVerdictInput {
             file_path: opts.file.clone(),
             finding_title: opts.finding.clone(),
@@ -2551,7 +2550,7 @@ fn run_feedback(opts: cli::FeedbackOpts) -> i32 {
             opts.provenance,
             opts.json,
             &feedback_path,
-            None, // finding_id_override: auto-resolved inside run_feedback_inner
+            opts.finding_id.clone(),
         );
         if exit_code != 0 {
             eprintln!("{}", output);

--- a/src/main.rs
+++ b/src/main.rs
@@ -1972,6 +1972,17 @@ async fn run_review(opts: cli::ReviewOpts) -> i32 {
             context_telem = review_log::ContextTelemetry::default();
         }
 
+        let finding_meta: Vec<review_log::FindingMeta> = file_results
+            .iter()
+            .flat_map(|fr| {
+                fr.findings.iter().map(|f| review_log::FindingMeta {
+                    id: f.id.clone(),
+                    title: f.title.clone(),
+                    file_path: fr.file_path.clone(),
+                })
+            })
+            .collect();
+
         let record = review_log::ReviewRecord {
             run_id: run_id.clone(),
             timestamp: chrono::Utc::now(),
@@ -2004,7 +2015,7 @@ async fn run_review(opts: cli::ReviewOpts) -> i32 {
             skill_findings: None,
             integrator_findings_out: None,
         };
-        if let Err(e) = review_log.record(&record) {
+        if let Err(e) = review_log.record_with_meta(&record, &finding_meta) {
             eprintln!("Warning: failed to write review log: {}", e);
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -2325,6 +2325,7 @@ fn run_feedback_inner(
     provenance: Option<feedback::Provenance>,
     json: bool,
     feedback_path: &std::path::Path,
+    finding_id_override: Option<String>,
 ) -> (i32, String) {
     let mut verdict = match cli::parse_verdict(verdict_str) {
         Ok(v) => v,
@@ -2346,6 +2347,14 @@ fn run_feedback_inner(
         *blamed_chunk_ids = parsed_chunks;
     }
 
+    // Auto-resolve finding_id from the review log when not explicitly provided.
+    let finding_id = finding_id_override.or_else(|| {
+        let quorum_home = quorum_dir()?;
+        let handle = crate::storage::initialize(&quorum_home).ok()?;
+        let log = review_log::ReviewLog::with_storage(handle);
+        log.resolve_finding_id(file, finding)
+    });
+
     let entry = feedback::FeedbackEntry {
         file_path: file.to_string(),
         finding_title: finding.to_string(),
@@ -2362,7 +2371,7 @@ fn run_feedback_inner(
         timestamp: chrono::Utc::now(),
         provenance: provenance.unwrap_or(feedback::Provenance::Human),
         fp_kind,
-        finding_id: None,
+        finding_id,
         rule_id: None,
         in_diff,
         skill_name: None,
@@ -2430,6 +2439,15 @@ fn run_feedback(opts: cli::FeedbackOpts) -> i32 {
                 return 3;
             }
         };
+        // Auto-resolve finding_id from the review log for the external path.
+        let finding_id = {
+            let quorum_home = quorum_dir();
+            quorum_home.and_then(|home| {
+                let handle = crate::storage::initialize(&home).ok()?;
+                let log = review_log::ReviewLog::with_storage(handle);
+                log.resolve_finding_id(&opts.file, &opts.finding)
+            })
+        };
         let input = feedback::ExternalVerdictInput {
             file_path: opts.file.clone(),
             finding_title: opts.finding.clone(),
@@ -2440,6 +2458,7 @@ fn run_feedback(opts: cli::FeedbackOpts) -> i32 {
             agent_model: opts.agent_model.clone(),
             confidence: opts.confidence,
             in_diff: opts.in_diff,
+            finding_id,
         };
         if let Some(parent) = feedback_path.parent()
             && let Err(e) = std::fs::create_dir_all(parent)
@@ -2532,6 +2551,7 @@ fn run_feedback(opts: cli::FeedbackOpts) -> i32 {
             opts.provenance,
             opts.json,
             &feedback_path,
+            None, // finding_id_override: auto-resolved inside run_feedback_inner
         );
         if exit_code != 0 {
             eprintln!("{}", output);
@@ -3110,6 +3130,7 @@ mod feedback_tests {
             None,
             false,
             &path,
+            None, // finding_id_override
         );
         assert_eq!(exit_code, 0);
         let contents = std::fs::read_to_string(&path).unwrap();
@@ -3135,6 +3156,7 @@ mod feedback_tests {
             None,
             false,
             &path,
+            None, // finding_id_override
         );
         assert_eq!(exit_code, 3);
         assert!(output.contains("Invalid verdict"));
@@ -3157,6 +3179,7 @@ mod feedback_tests {
             None,
             false,
             &path,
+            None, // finding_id_override
         );
         assert_eq!(exit_code, 0);
         let contents = std::fs::read_to_string(&path).unwrap();
@@ -3180,6 +3203,7 @@ mod feedback_tests {
             Some(feedback::Provenance::PostFix),
             false,
             &path,
+            None, // finding_id_override
         );
         assert_eq!(exit_code, 0);
         let contents = std::fs::read_to_string(&path).unwrap();
@@ -3203,6 +3227,7 @@ mod feedback_tests {
             None,
             false,
             &path,
+            None, // finding_id_override
         );
         assert_eq!(exit_code, 0);
         let contents = std::fs::read_to_string(&path).unwrap();
@@ -3226,6 +3251,7 @@ mod feedback_tests {
             None,
             false,
             &path,
+            None, // finding_id_override
         );
         assert!(output.contains("tp"));
         assert!(output.contains("src/auth.rs"));
@@ -3249,6 +3275,7 @@ mod feedback_tests {
             None,
             false,
             &path,
+            None, // finding_id_override
         );
         assert_eq!(exit_code, 0);
         // In test environment stdout is not a TTY, so output should be JSON
@@ -3278,6 +3305,7 @@ mod feedback_tests {
             None,
             false,
             &path,
+            None, // finding_id_override
         );
         assert_eq!(exit_code, 0);
         let contents = std::fs::read_to_string(&path).unwrap();
@@ -3301,6 +3329,7 @@ mod feedback_tests {
             None, // provenance
             false,
             &path,
+            None, // finding_id_override
         );
         assert_eq!(exit_code, 0);
         let contents = std::fs::read_to_string(&path).unwrap();
@@ -3353,6 +3382,7 @@ mod feedback_tests {
             None, // provenance
             false,
             &path,
+            None, // finding_id_override
         );
         assert_eq!(exit_code, 3, "expected tool error on malformed chunk list");
         assert!(
@@ -3381,6 +3411,7 @@ mod feedback_tests {
             None, // provenance
             false,
             &path,
+            None, // finding_id_override
         );
         assert_eq!(
             exit_code, 0,

--- a/src/mcp/handler.rs
+++ b/src/mcp/handler.rs
@@ -217,7 +217,7 @@ impl QuorumHandler {
                 agent_model: params.agent_model,
                 confidence: params.confidence,
                 in_diff: params.in_diff,
-                finding_id: None, // Task 5 will wire MCP finding_id
+                finding_id: params.finding_id.clone(),
             };
             self.feedback_store
                 .record_external(input)
@@ -243,7 +243,7 @@ impl QuorumHandler {
             timestamp: chrono::Utc::now(),
             provenance: crate::feedback::Provenance::Human,
             fp_kind,
-            finding_id: None,
+            finding_id: params.finding_id.clone(),
             rule_id: None,
             in_diff: params.in_diff,
             skill_name: None,
@@ -639,6 +639,7 @@ mod tests {
             category: None,
             fp_kind: None,
             in_diff: None,
+            finding_id: None,
         };
 
         let result = handler.handle_feedback(params).unwrap();
@@ -682,6 +683,7 @@ mod tests {
             category: None,
             fp_kind: None,
             in_diff: None,
+            finding_id: None,
         };
 
         let result = handler.handle_feedback(params).unwrap();
@@ -730,6 +732,7 @@ mod tests {
             category: None,
             fp_kind: None,
             in_diff: None,
+            finding_id: None,
         };
 
         let err = handler.handle_feedback(params).expect_err("must reject");
@@ -770,6 +773,7 @@ mod tests {
             category: None,
             fp_kind: None,
             in_diff: None,
+            finding_id: None,
         };
         handler.handle_feedback(params).unwrap();
 
@@ -818,6 +822,7 @@ mod tests {
             category: None,
             fp_kind: None,
             in_diff: None,
+            finding_id: None,
         };
         handler.handle_feedback(params).unwrap();
 
@@ -1496,6 +1501,7 @@ mod tests {
                 category: None,
                 fp_kind: Some(kind.clone()),
                 in_diff: None,
+                finding_id: None,
             };
             handler.handle_feedback(params).unwrap();
 
@@ -1565,6 +1571,7 @@ mod tests {
             category: None,
             fp_kind: Some(FpKind::Hallucination),
             in_diff: None,
+            finding_id: None,
         };
         handler.handle_feedback(params).unwrap();
 
@@ -1722,6 +1729,7 @@ mod tests {
             category: None,
             fp_kind: None,
             in_diff: None,
+            finding_id: None,
         };
         let err = handler
             .handle_feedback(params)
@@ -1766,6 +1774,7 @@ mod tests {
             category: None,
             fp_kind: None,
             in_diff: None,
+            finding_id: None,
         };
         handler
             .handle_feedback(params)

--- a/src/mcp/handler.rs
+++ b/src/mcp/handler.rs
@@ -217,6 +217,7 @@ impl QuorumHandler {
                 agent_model: params.agent_model,
                 confidence: params.confidence,
                 in_diff: params.in_diff,
+                finding_id: None, // Task 5 will wire MCP finding_id
             };
             self.feedback_store
                 .record_external(input)

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -96,6 +96,10 @@ pub struct FeedbackTool {
     /// unknown (omitted). Flows through both Human and External paths.
     #[serde(default, rename = "inDiff", skip_serializing_if = "Option::is_none")]
     pub in_diff: Option<bool>,
+    /// Explicit finding ID (ULID) to link this feedback to a specific review finding.
+    /// Bypasses auto-link resolution when provided.
+    #[serde(default, rename = "findingId", skip_serializing_if = "Option::is_none")]
+    pub finding_id: Option<String>,
 }
 
 #[mcp_tool(
@@ -351,7 +355,8 @@ mod tests {
             "agentModel":"gemini",
             "confidence":0.9,
             "category":"security",
-            "fpKind":"hallucination"
+            "fpKind":"hallucination",
+            "findingId":"01HXYZ1234567890ABCDEFGHJK"
         }"#;
         let tool: FeedbackTool =
             serde_json::from_str(json).expect("all declared fields must parse");

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -825,6 +825,24 @@ mod tests {
         assert!(out.contains("injection"), "title content missing: {out}");
     }
 
+    // -- JSON finding id verification --
+
+    #[test]
+    fn json_output_includes_finding_id() {
+        let f = FindingBuilder::new()
+            .title("SQL injection")
+            .severity(Severity::High)
+            .category("security".into())
+            .lines(42, 42)
+            .build();
+        assert!(!f.id.is_empty(), "Finding should have a ULID id");
+        let json = serde_json::to_string(&f).unwrap();
+        assert!(
+            json.contains(&format!("\"id\":\"{}\"", f.id)),
+            "JSON should include the finding id field: {json}"
+        );
+    }
+
     // -- format_compact_review --
 
     #[test]

--- a/src/review_log.rs
+++ b/src/review_log.rs
@@ -608,6 +608,95 @@ impl ReviewLog {
         }
     }
 
+    // ── Finding-ID resolution ──────────────────────────────────────────
+
+    /// Attempt to match a `(file_path, finding_title)` pair against the
+    /// `review_finding_ids` table using word-level Jaccard similarity with
+    /// a substring bonus. Returns the best-matching `finding_id` when the
+    /// combined score meets or exceeds the 0.6 threshold, or `None`
+    /// otherwise.
+    ///
+    /// Only the SQLite backend is supported; the JSONL backend always
+    /// returns `None`. Legacy rows with empty titles are filtered at the
+    /// SQL level (`title <> ''`).
+    pub fn resolve_finding_id(&self, file_path: &str, finding_title: &str) -> Option<String> {
+        let Backend::Sqlite(handle) = &self.backend else {
+            return None;
+        };
+        let conn = handle.lock().ok()?;
+        let mut stmt = conn
+            .prepare(
+                "SELECT rfi.finding_id, rfi.title
+                 FROM review_finding_ids rfi
+                 JOIN reviews r ON r.run_id = rfi.run_id
+                 WHERE rfi.file_path = ?1
+                   AND rfi.title <> ''
+                 ORDER BY r.timestamp DESC
+                 LIMIT 50",
+            )
+            .ok()?;
+        let candidates: Vec<(String, String)> = stmt
+            .query_map(rusqlite::params![file_path], |row| {
+                Ok((row.get(0)?, row.get(1)?))
+            })
+            .ok()?
+            .filter_map(|r| r.ok())
+            .collect();
+
+        let query_lower = finding_title.to_lowercase();
+        let query_words: std::collections::HashSet<&str> =
+            query_lower.split_whitespace().collect();
+
+        let mut best_id: Option<String> = None;
+        let mut best_score: f64 = 0.0;
+
+        for (fid, title) in &candidates {
+            let title_lower = title.to_lowercase();
+            let title_words: std::collections::HashSet<&str> =
+                title_lower.split_whitespace().collect();
+
+            let intersection = query_words.intersection(&title_words).count();
+            let union = query_words.union(&title_words).count();
+            let jaccard = if union > 0 {
+                intersection as f64 / union as f64
+            } else {
+                0.0
+            };
+
+            let substring_bonus = if title_lower.contains(&query_lower)
+                || query_lower.contains(&title_lower)
+            {
+                0.3
+            } else {
+                0.0
+            };
+
+            let score = (jaccard + substring_bonus).min(1.0);
+            if score > best_score {
+                best_score = score;
+                best_id = Some(fid.clone());
+            }
+        }
+
+        if best_score >= 0.6 {
+            tracing::debug!(
+                finding_id = best_id.as_deref().unwrap_or(""),
+                score = best_score,
+                file = file_path,
+                "auto-linked feedback to finding"
+            );
+            best_id
+        } else {
+            tracing::info!(
+                file = file_path,
+                title = finding_title,
+                best_score = best_score,
+                "no auto-link match found for feedback"
+            );
+            None
+        }
+    }
+
     // ── JSONL backend ──────────────────────────────────────────────────
 
     fn record_jsonl(path: &Path, entry: &ReviewRecord) -> anyhow::Result<()> {
@@ -2347,5 +2436,82 @@ mod tests {
         let loaded = log.load_all().unwrap();
         assert_eq!(loaded.len(), 1);
         assert_eq!(loaded[0].finding_ids, vec!["FA"]);
+    }
+
+    // ── resolve_finding_id tests ─────────────────────────────────────
+
+    #[test]
+    fn resolve_finding_id_exact_match() {
+        let dir = TempDir::new().unwrap();
+        let log = sqlite_review_log(&dir);
+        let mut record = sample_record();
+        record.finding_ids = vec!["F1".into()];
+        let meta = vec![FindingMeta {
+            id: "F1".into(),
+            title: "SQL injection risk".into(),
+            file_path: "src/auth.rs".into(),
+        }];
+        log.record_with_meta(&record, &meta).unwrap();
+        let result = log.resolve_finding_id("src/auth.rs", "SQL injection risk");
+        assert_eq!(result, Some("F1".to_string()));
+    }
+
+    #[test]
+    fn resolve_finding_id_partial_match() {
+        let dir = TempDir::new().unwrap();
+        let log = sqlite_review_log(&dir);
+        let mut record = sample_record();
+        record.finding_ids = vec!["F1".into()];
+        let meta = vec![FindingMeta {
+            id: "F1".into(),
+            title: "SQL injection vulnerability in auth module".into(),
+            file_path: "src/auth.rs".into(),
+        }];
+        log.record_with_meta(&record, &meta).unwrap();
+        let result = log.resolve_finding_id("src/auth.rs", "SQL injection");
+        assert_eq!(result, Some("F1".to_string()));
+    }
+
+    #[test]
+    fn resolve_finding_id_no_match_wrong_file() {
+        let dir = TempDir::new().unwrap();
+        let log = sqlite_review_log(&dir);
+        let mut record = sample_record();
+        record.finding_ids = vec!["F1".into()];
+        let meta = vec![FindingMeta {
+            id: "F1".into(),
+            title: "SQL injection".into(),
+            file_path: "src/auth.rs".into(),
+        }];
+        log.record_with_meta(&record, &meta).unwrap();
+        let result = log.resolve_finding_id("src/other.rs", "SQL injection");
+        assert_eq!(result, None);
+    }
+
+    #[test]
+    fn resolve_finding_id_no_match_below_threshold() {
+        let dir = TempDir::new().unwrap();
+        let log = sqlite_review_log(&dir);
+        let mut record = sample_record();
+        record.finding_ids = vec!["F1".into()];
+        let meta = vec![FindingMeta {
+            id: "F1".into(),
+            title: "SQL injection vulnerability".into(),
+            file_path: "src/auth.rs".into(),
+        }];
+        log.record_with_meta(&record, &meta).unwrap();
+        let result = log.resolve_finding_id("src/auth.rs", "completely unrelated finding title xyz");
+        assert_eq!(result, None);
+    }
+
+    #[test]
+    fn resolve_finding_id_skips_legacy_empty_title() {
+        let dir = TempDir::new().unwrap();
+        let log = sqlite_review_log(&dir);
+        let mut record = sample_record();
+        record.finding_ids = vec!["LEGACY".into()];
+        log.record(&record).unwrap();
+        let result = log.resolve_finding_id("src/auth.rs", "SQL injection");
+        assert_eq!(result, None);
     }
 }

--- a/src/review_log.rs
+++ b/src/review_log.rs
@@ -15,6 +15,16 @@ use ulid::Ulid;
 use crate::finding::Severity;
 use crate::storage::StorageHandle;
 
+/// Lightweight per-finding metadata written alongside `ReviewRecord` to the
+/// `review_finding_ids` table. Carries the finding's title and originating
+/// file path so downstream analytics (stats, feedback joins) can display
+/// context without re-parsing the full review output.
+pub struct FindingMeta {
+    pub id: String,
+    pub title: String,
+    pub file_path: String,
+}
+
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
 pub struct SeverityCounts {
     #[serde(default)]
@@ -582,6 +592,22 @@ impl ReviewLog {
         }
     }
 
+    /// Append one record with enriched per-finding metadata (title, file_path).
+    ///
+    /// The JSONL backend ignores `meta` (finding metadata is embedded in the
+    /// serialized record's `finding_ids`). The SQLite backend writes the
+    /// `title` and `file_path` columns into `review_finding_ids`.
+    pub fn record_with_meta(
+        &self,
+        entry: &ReviewRecord,
+        meta: &[FindingMeta],
+    ) -> anyhow::Result<()> {
+        match &self.backend {
+            Backend::Jsonl(path) => Self::record_jsonl(path, entry),
+            Backend::Sqlite(handle) => Self::record_sqlite_with_meta(handle, entry, meta),
+        }
+    }
+
     // ── JSONL backend ──────────────────────────────────────────────────
 
     fn record_jsonl(path: &Path, entry: &ReviewRecord) -> anyhow::Result<()> {
@@ -671,6 +697,83 @@ impl ReviewLog {
             tx.execute(
                 "INSERT INTO review_finding_ids (run_id, finding_id) VALUES (?1, ?2)",
                 params![entry.run_id, fid],
+            )?;
+        }
+
+        tx.commit()?;
+        Ok(())
+    }
+
+    /// Like `record_sqlite` but writes enriched finding metadata (title,
+    /// file_path) into the `review_finding_ids` child table instead of
+    /// bare finding_ids from the entry.
+    fn record_sqlite_with_meta(
+        handle: &StorageHandle,
+        entry: &ReviewRecord,
+        meta: &[FindingMeta],
+    ) -> anyhow::Result<()> {
+        use rusqlite::params;
+
+        let conn = handle
+            .lock()
+            .map_err(|e| anyhow::anyhow!("lock poisoned: {e}"))?;
+        let tx = conn.unchecked_transaction()?;
+
+        let context_json = serde_json::to_string(&entry.context)?;
+        let suppressed_json = serde_json::to_string(&entry.suppressed_by_rule)?;
+        let ts = entry.timestamp.to_rfc3339();
+
+        #[allow(clippy::cast_possible_wrap)]
+        tx.execute(
+            "INSERT INTO reviews (
+                run_id, timestamp, quorum_version, repo, invoked_from, model,
+                files_reviewed, lines_added, lines_removed,
+                critical, high, medium, low, info,
+                suppressed_by_rule,
+                tokens_in, tokens_out, tokens_cache_read, duration_ms,
+                flag_deep, flag_parallel_n, flag_ensemble,
+                mode, context
+            ) VALUES (
+                ?1, ?2, ?3, ?4, ?5, ?6,
+                ?7, ?8, ?9,
+                ?10, ?11, ?12, ?13, ?14,
+                ?15,
+                ?16, ?17, ?18, ?19,
+                ?20, ?21, ?22,
+                ?23, ?24
+            )",
+            params![
+                entry.run_id,
+                ts,
+                entry.quorum_version,
+                entry.repo,
+                entry.invoked_from,
+                entry.model,
+                entry.files_reviewed,
+                entry.lines_added.map(i64::from),
+                entry.lines_removed.map(i64::from),
+                i64::from(entry.findings_by_severity.critical),
+                i64::from(entry.findings_by_severity.high),
+                i64::from(entry.findings_by_severity.medium),
+                i64::from(entry.findings_by_severity.low),
+                i64::from(entry.findings_by_severity.info),
+                suppressed_json,
+                entry.tokens_in as i64,
+                entry.tokens_out as i64,
+                entry.tokens_cache_read as i64,
+                entry.duration_ms as i64,
+                i32::from(entry.flags.deep),
+                i64::from(entry.flags.parallel_n),
+                i32::from(entry.flags.ensemble),
+                entry.mode,
+                context_json,
+            ],
+        )?;
+
+        for fm in meta {
+            tx.execute(
+                "INSERT INTO review_finding_ids (run_id, finding_id, title, file_path) VALUES (?1, ?2, ?3, ?4)",
+                params![entry.run_id, fm.id, fm.title, fm.file_path],
             )?;
         }
 
@@ -2163,5 +2266,86 @@ mod tests {
             !json.contains("integrator_findings_out"),
             "None integrator_findings_out must not write the key: {json}"
         );
+    }
+
+    // ── FindingMeta / record_with_meta tests ───────────────────────────
+
+    #[test]
+    fn sqlite_finding_meta_round_trip() {
+        let dir = TempDir::new().unwrap();
+        let log = sqlite_review_log(&dir);
+        let mut record = test_review_record("01TEST_META_ROUNDTRIP001");
+        record.finding_ids = vec!["F1".into(), "F2".into()];
+        let meta = vec![
+            FindingMeta {
+                id: "F1".into(),
+                title: "SQL injection".into(),
+                file_path: "src/auth.rs".into(),
+            },
+            FindingMeta {
+                id: "F2".into(),
+                title: "XSS risk".into(),
+                file_path: "src/web.rs".into(),
+            },
+        ];
+        log.record_with_meta(&record, &meta).unwrap();
+
+        let conn = match &log.backend {
+            Backend::Sqlite(h) => h.lock().unwrap(),
+            _ => panic!("expected sqlite"),
+        };
+        let mut stmt = conn
+            .prepare(
+                "SELECT finding_id, title, file_path FROM review_finding_ids WHERE run_id = ?1 ORDER BY rowid",
+            )
+            .unwrap();
+        let rows: Vec<(String, String, String)> = stmt
+            .query_map(rusqlite::params![record.run_id], |row| {
+                Ok((row.get(0)?, row.get(1)?, row.get(2)?))
+            })
+            .unwrap()
+            .map(|r| r.unwrap())
+            .collect();
+        assert_eq!(rows.len(), 2);
+        assert_eq!(
+            rows[0],
+            ("F1".into(), "SQL injection".into(), "src/auth.rs".into())
+        );
+        assert_eq!(
+            rows[1],
+            ("F2".into(), "XSS risk".into(), "src/web.rs".into())
+        );
+    }
+
+    #[test]
+    fn sqlite_finding_meta_empty_vec_writes_no_child_rows() {
+        let dir = TempDir::new().unwrap();
+        let log = sqlite_review_log(&dir);
+        let record = test_review_record("01TEST_META_EMPTY0000001");
+        log.record_with_meta(&record, &[]).unwrap();
+
+        let loaded = log.load_all().unwrap();
+        assert_eq!(loaded.len(), 1);
+        assert!(loaded[0].finding_ids.is_empty());
+    }
+
+    #[test]
+    fn sqlite_finding_meta_review_record_still_loads_via_load_all() {
+        // Verify the reviews INSERT is compatible with load_all's JOIN
+        // path even when we write via record_with_meta.
+        let dir = TempDir::new().unwrap();
+        let log = sqlite_review_log(&dir);
+        let mut record = test_review_record("01TEST_META_LOADALL0001");
+        record.finding_ids = vec!["FA".into()];
+        let meta = vec![FindingMeta {
+            id: "FA".into(),
+            title: "Buffer overflow".into(),
+            file_path: "src/lib.rs".into(),
+        }];
+        log.record_with_meta(&record, &meta).unwrap();
+
+        let loaded = log.load_all().unwrap();
+        assert_eq!(loaded.len(), 1);
+        assert_eq!(loaded[0].finding_ids, vec!["FA"]);
     }
 }

--- a/src/review_log.rs
+++ b/src/review_log.rs
@@ -644,8 +644,7 @@ impl ReviewLog {
             .collect();
 
         let query_lower = finding_title.to_lowercase();
-        let query_words: std::collections::HashSet<&str> =
-            query_lower.split_whitespace().collect();
+        let query_words: std::collections::HashSet<&str> = query_lower.split_whitespace().collect();
 
         let mut best_id: Option<String> = None;
         let mut best_score: f64 = 0.0;
@@ -663,13 +662,12 @@ impl ReviewLog {
                 0.0
             };
 
-            let substring_bonus = if title_lower.contains(&query_lower)
-                || query_lower.contains(&title_lower)
-            {
-                0.3
-            } else {
-                0.0
-            };
+            let substring_bonus =
+                if title_lower.contains(&query_lower) || query_lower.contains(&title_lower) {
+                    0.3
+                } else {
+                    0.0
+                };
 
             let score = (jaccard + substring_bonus).min(1.0);
             if score > best_score {
@@ -2500,7 +2498,8 @@ mod tests {
             file_path: "src/auth.rs".into(),
         }];
         log.record_with_meta(&record, &meta).unwrap();
-        let result = log.resolve_finding_id("src/auth.rs", "completely unrelated finding title xyz");
+        let result =
+            log.resolve_finding_id("src/auth.rs", "completely unrelated finding title xyz");
         assert_eq!(result, None);
     }
 

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -20,7 +20,7 @@ pub type StorageHandle = Arc<Mutex<Connection>>;
 
 /// Current schema version. Bumped by each `migrate_vN_to_vN+1` function.
 #[cfg(test)]
-const SCHEMA_VERSION: u32 = 2;
+const SCHEMA_VERSION: u32 = 3;
 
 /// Open (or create) the quorum SQLite database and run any pending
 /// migrations. Returns a shared connection handle ready for use.
@@ -119,8 +119,9 @@ fn run_migrations(conn: &Connection) -> anyhow::Result<()> {
         migrate_v1_to_v2(conn).context("schema migration v1 -> v2 failed")?;
     }
 
-    // Future migrations slot in here:
-    // if version < 3 { migrate_v2_to_v3(conn)?; }
+    if version < 3 {
+        migrate_v2_to_v3(conn).context("schema migration v2 -> v3 failed")?;
+    }
 
     Ok(())
 }
@@ -202,6 +203,23 @@ fn migrate_v1_to_v2(conn: &Connection) -> anyhow::Result<()> {
     let tx = conn.unchecked_transaction()?;
     tx.execute_batch("CREATE INDEX IF NOT EXISTS idx_reviews_timestamp ON reviews(timestamp);")?;
     tx.pragma_update(None, "user_version", 2)?;
+    tx.commit()?;
+    Ok(())
+}
+
+/// Schema v3: add `title` and `file_path` columns to `review_finding_ids`.
+///
+/// These columns allow finding records to carry human-readable metadata
+/// (the finding title and the source file it was raised against) so that
+/// downstream consumers (PR comments, feedback joins) can display them
+/// without a round-trip to the LLM response cache.
+fn migrate_v2_to_v3(conn: &Connection) -> anyhow::Result<()> {
+    let tx = conn.unchecked_transaction()?;
+    tx.execute_batch(
+        "ALTER TABLE review_finding_ids ADD COLUMN title TEXT NOT NULL DEFAULT '';
+         ALTER TABLE review_finding_ids ADD COLUMN file_path TEXT NOT NULL DEFAULT '';",
+    )?;
+    tx.pragma_update(None, "user_version", 3)?;
     tx.commit()?;
     Ok(())
 }
@@ -814,10 +832,71 @@ mod tests {
     }
 
     #[test]
-    fn run_migrations_advances_to_v2() {
+    fn migrate_v2_to_v3_adds_title_and_file_path_columns() {
+        let conn = rusqlite::Connection::open_in_memory().unwrap();
+
+        // Run v1 + v2 migrations to establish baseline schema.
+        migrate_v0_to_v1(&conn).unwrap();
+        migrate_v1_to_v2(&conn).unwrap();
+        assert_eq!(current_version(&conn).unwrap(), 2);
+
+        // Insert a review + finding_id row under the v2 schema.
+        conn.execute(
+            "INSERT INTO reviews (
+                run_id, timestamp, quorum_version, invoked_from, model,
+                files_reviewed, tokens_in, tokens_out, duration_ms
+            ) VALUES ('run-v2-test', '2026-06-01T00:00:00Z', '0.23.0', 'tty', 'gpt-5.4', 1, 100, 50, 500)",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO review_finding_ids (run_id, finding_id) VALUES ('run-v2-test', 'fid-legacy')",
+            [],
+        )
+        .unwrap();
+
+        // Run v3 migration.
+        migrate_v2_to_v3(&conn).unwrap();
+        assert_eq!(current_version(&conn).unwrap(), 3);
+
+        // Legacy row should have empty defaults for the new columns.
+        let (title, file_path): (String, String) = conn
+            .query_row(
+                "SELECT title, file_path FROM review_finding_ids WHERE finding_id = 'fid-legacy'",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .unwrap();
+        assert_eq!(title, "", "legacy row title should default to empty string");
+        assert_eq!(
+            file_path, "",
+            "legacy row file_path should default to empty string"
+        );
+
+        // New inserts with title + file_path should work.
+        conn.execute(
+            "INSERT INTO review_finding_ids (run_id, finding_id, title, file_path) \
+             VALUES ('run-v2-test', 'fid-new', 'SQL injection risk', 'src/db.rs')",
+            [],
+        )
+        .unwrap();
+
+        let (new_title, new_fp): (String, String) = conn
+            .query_row(
+                "SELECT title, file_path FROM review_finding_ids WHERE finding_id = 'fid-new'",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .unwrap();
+        assert_eq!(new_title, "SQL injection risk");
+        assert_eq!(new_fp, "src/db.rs");
+    }
+
+    #[test]
+    fn run_migrations_advances_to_latest() {
         let conn = rusqlite::Connection::open_in_memory().unwrap();
         run_migrations(&conn).unwrap();
-        assert_eq!(current_version(&conn).unwrap(), 2);
+        assert_eq!(current_version(&conn).unwrap(), SCHEMA_VERSION);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Join health was at 0% — every feedback entry had `finding_id: None`. The schema existed but no recording path populated it. This PR wires the complete linkage pipeline:

- **Schema v3 migration**: Adds `title` and `file_path` columns to `review_finding_ids` table (backward-compatible defaults for legacy rows)
- **FindingMeta write path**: At review completion, stores per-finding metadata (id, title, file_path) alongside the existing finding_ids
- **Auto-link resolver**: `resolve_finding_id()` fuzzy-matches file_path + title against recent reviews using Jaccard word similarity + substring containment (0.6 threshold)
- **Feedback wiring**: Both human and external feedback paths auto-resolve `finding_id` when not explicitly provided
- **CLI `--finding-id`**: Explicit ULID override with `ulid::Ulid::from_string()` validation
- **MCP `findingId`**: Same bypass for MCP tool consumers
- **JSON output**: Verified `Finding.id` is included in `--json` output for downstream tooling

## Test plan

- [x] Schema migration: legacy row defaults, new column inserts, version bump (1 test)
- [x] FindingMeta round-trip: titles + file_paths persisted and queryable (3 tests)
- [x] resolve_finding_id: exact match, partial match, wrong file, below threshold, legacy empty-title skip (5 tests)
- [x] ULID validation: valid accepted, invalid/empty/short rejected (5 tests)
- [x] JSON output includes Finding.id (1 test)
- [x] 1699 unit tests pass, 0 regressions
- [x] Clippy clean, release build succeeds
- [x] Quorum review: 0 in-diff findings

Closes #436

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CLI: `quorum feedback` accepts an optional `--finding-id` to associate feedback with a specific finding.
  * Feedback ingestion (MCP and agent paths) can carry and persist finding associations.
  * Review logs now persist per-finding metadata (id, title, file path) and are used to auto-resolve finding IDs.

* **Database**
  * Storage schema upgraded to v3 to support the enriched finding metadata.

* **Output**
  * Serialized output now includes finding IDs for better traceability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->