### PR TITLE
feat: backfill-linkage command + markdown normalization (#438, #439)

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -26,6 +26,8 @@ pub enum Command {
     Calibrate(CalibrateOpts),
     /// Post review findings as GitHub PR comments
     Report(ReportOpts),
+    /// Re-link legacy feedback entries to review findings
+    BackfillLinkage(BackfillLinkageOpts),
     /// Print version
     Version,
 }
@@ -406,6 +408,13 @@ pub struct ReportOpts {
     /// Local diff file (default: fetch from PR API)
     #[arg(long)]
     pub diff_file: Option<PathBuf>,
+}
+
+#[derive(Parser)]
+pub struct BackfillLinkageOpts {
+    /// Output as JSON
+    #[arg(long)]
+    pub json: bool,
 }
 
 #[derive(Parser)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -451,6 +451,9 @@ async fn main() -> anyhow::Result<()> {
         cli::Command::Feedback(opts) => std::process::exit(run_feedback(opts)),
         cli::Command::Context(opts) => std::process::exit(run_context(opts)),
         cli::Command::Calibrate(opts) => std::process::exit(run_calibrate(opts)),
+        cli::Command::BackfillLinkage(opts) => {
+            std::process::exit(run_backfill_linkage(opts))
+        }
         cli::Command::Report(opts) => {
             let exit_code = run_report(opts).await;
             std::process::exit(exit_code);
@@ -2590,6 +2593,121 @@ fn load_jsonl(path: &std::path::Path) -> Result<Vec<serde_json::Value>, String> 
     Ok(entries)
 }
 
+// ── backfill-linkage ──────────────────────────────────────────────────
+
+/// Re-run `resolve_finding_id` on every unlinked feedback entry and
+/// atomically rewrite `feedback.jsonl`. Returns `(newly_linked, candidates)`
+/// where `candidates = total - already_linked`.
+fn backfill_linkage_inner(quorum_home: &std::path::Path) -> (usize, usize) {
+    let feedback_path = quorum_home.join("feedback.jsonl");
+    let store = feedback::FeedbackStore::new(feedback_path.clone());
+    let mut entries = match store.load_all() {
+        Ok(e) => e,
+        Err(e) => {
+            eprintln!("error: cannot read feedback: {e}");
+            return (0, 0);
+        }
+    };
+
+    let conn = match quorum::storage::initialize(quorum_home) {
+        Ok(h) => h,
+        Err(e) => {
+            eprintln!("error: cannot open review storage: {e}");
+            return (0, 0);
+        }
+    };
+    let log = review_log::ReviewLog::with_storage(conn);
+
+    let already_linked = entries.iter().filter(|e| e.finding_id.is_some()).count();
+    let candidates = entries.len() - already_linked;
+    let mut newly_linked = 0usize;
+
+    for entry in &mut entries {
+        if entry.finding_id.is_some() {
+            continue;
+        }
+        if let Some(fid) = log.resolve_finding_id(&entry.file_path, &entry.finding_title) {
+            entry.finding_id = Some(fid);
+            newly_linked += 1;
+        }
+    }
+
+    // Atomic rewrite: serialize to .tmp, then rename over the original.
+    if newly_linked > 0 {
+        let tmp_path = feedback_path.with_extension("jsonl.tmp");
+        let mut buf = String::new();
+        for entry in &entries {
+            match serde_json::to_string(entry) {
+                Ok(line) => {
+                    buf.push_str(&line);
+                    buf.push('\n');
+                }
+                Err(e) => {
+                    eprintln!("error: failed to serialize feedback entry: {e}");
+                    return (0, candidates);
+                }
+            }
+        }
+        if let Err(e) = std::fs::write(&tmp_path, &buf) {
+            eprintln!("error: failed to write {}: {e}", tmp_path.display());
+            return (0, candidates);
+        }
+        if let Err(e) = std::fs::rename(&tmp_path, &feedback_path) {
+            eprintln!("error: failed to rename tmp to feedback.jsonl: {e}");
+            return (0, candidates);
+        }
+    }
+
+    (newly_linked, candidates)
+}
+
+/// CLI entry point for `quorum backfill-linkage`.
+fn run_backfill_linkage(opts: cli::BackfillLinkageOpts) -> i32 {
+    let quorum_home = quorum_dir().unwrap_or_else(|| std::path::PathBuf::from(".quorum"));
+
+    // Pre-load counts for the summary.
+    let feedback_path = quorum_home.join("feedback.jsonl");
+    let store = feedback::FeedbackStore::new(feedback_path);
+    let all_entries = match store.load_all() {
+        Ok(e) => e,
+        Err(e) => {
+            eprintln!("error: cannot read feedback: {e}");
+            return 3;
+        }
+    };
+    let total = all_entries.len();
+    let already_linked = all_entries.iter().filter(|e| e.finding_id.is_some()).count();
+    drop(all_entries);
+
+    let (newly_linked, candidates) = backfill_linkage_inner(&quorum_home);
+
+    let is_pipe = !std::io::IsTerminal::is_terminal(&std::io::stdout());
+    let use_compact = output::should_use_compact(false);
+    let use_json = opts.json || (is_pipe && !use_compact);
+
+    if use_json {
+        let payload = serde_json::json!({
+            "total": total,
+            "already_linked": already_linked,
+            "candidates": candidates,
+            "newly_linked": newly_linked,
+        });
+        println!("{}", serde_json::to_string_pretty(&payload).unwrap());
+    } else if use_compact {
+        println!(
+            "backfill total={} already_linked={} candidates={} newly_linked={}",
+            total, already_linked, candidates, newly_linked
+        );
+    } else {
+        println!("Backfill linkage");
+        println!("  Total feedback entries: {}", total);
+        println!("  Already linked:         {}", already_linked);
+        println!("  Candidates (unlinked):  {}", candidates);
+        println!("  Newly linked:           {}", newly_linked);
+    }
+    0
+}
+
 /// CLI entry point for `quorum calibrate`.
 fn run_calibrate(opts: cli::CalibrateOpts) -> i32 {
     if let Err(e) = opts.validate() {
@@ -3582,5 +3700,97 @@ mod join_health_tests {
             out.contains("per-finding precision math active"),
             "got:\n{out}"
         );
+    }
+}
+
+#[cfg(test)]
+mod backfill_linkage_tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    /// Create a test environment with a SQLite DB containing a review record
+    /// with finding metadata, and a feedback.jsonl with an unlinked entry.
+    fn setup_backfill_env() -> (TempDir, std::path::PathBuf) {
+        let dir = TempDir::new().unwrap();
+        let qhome = dir.path().to_path_buf();
+
+        // Initialize SQLite storage and record a review with finding metadata.
+        let conn = quorum::storage::initialize(&qhome).unwrap();
+        let log = review_log::ReviewLog::with_storage(conn);
+        let record = review_log::ReviewRecord {
+            run_id: review_log::ReviewRecord::new_ulid(),
+            timestamp: chrono::Utc::now(),
+            quorum_version: "0.1".into(),
+            repo: None,
+            invoked_from: "test".into(),
+            model: "test".into(),
+            files_reviewed: 1,
+            lines_added: None,
+            lines_removed: None,
+            findings_by_severity: review_log::SeverityCounts::default(),
+            suppressed_by_rule: std::collections::HashMap::new(),
+            tokens_in: 0,
+            tokens_out: 0,
+            tokens_cache_read: 0,
+            duration_ms: 0,
+            flags: review_log::Flags {
+                deep: false,
+                parallel_n: 1,
+                ensemble: false,
+            },
+            mode: None,
+            context: review_log::ContextTelemetry::default(),
+            finding_ids: vec!["FIND1".into()],
+            skills_used: vec![],
+            skill_findings: None,
+            integrator_findings_out: None,
+        };
+        let meta = vec![review_log::FindingMeta {
+            id: "FIND1".into(),
+            title: "SQL injection risk".into(),
+            file_path: "src/auth.rs".into(),
+        }];
+        log.record_with_meta(&record, &meta).unwrap();
+
+        // Write a feedback.jsonl with one unlinked entry that should match.
+        let fb_path = qhome.join("feedback.jsonl");
+        let fb_line = r#"{"file_path":"src/auth.rs","finding_title":"SQL injection risk","finding_category":"security","verdict":"tp","reason":"fixed","model":null,"timestamp":"2026-01-01T00:00:00Z","provenance":"human"}"#;
+        std::fs::write(&fb_path, format!("{fb_line}\n")).unwrap();
+
+        (dir, qhome)
+    }
+
+    #[test]
+    fn backfill_linkage_links_matching_entries() {
+        let (_dir, qhome) = setup_backfill_env();
+
+        let (newly_linked, candidates) = backfill_linkage_inner(&qhome);
+        assert_eq!(candidates, 1, "one unlinked entry");
+        assert_eq!(newly_linked, 1, "should link the matching entry");
+
+        // Verify the rewritten feedback.jsonl has finding_id populated.
+        let store = feedback::FeedbackStore::new(qhome.join("feedback.jsonl"));
+        let entries = store.load_all().unwrap();
+        assert_eq!(entries.len(), 1);
+        assert_eq!(
+            entries[0].finding_id.as_deref(),
+            Some("FIND1"),
+            "finding_id must be populated after backfill"
+        );
+    }
+
+    #[test]
+    fn backfill_linkage_is_idempotent() {
+        let (_dir, qhome) = setup_backfill_env();
+
+        // First run: links the entry.
+        let (linked1, cand1) = backfill_linkage_inner(&qhome);
+        assert_eq!(linked1, 1);
+        assert_eq!(cand1, 1);
+
+        // Second run: entry already linked, 0 newly linked.
+        let (linked2, cand2) = backfill_linkage_inner(&qhome);
+        assert_eq!(linked2, 0, "second run must link 0 — already done");
+        assert_eq!(cand2, 0, "no unlinked candidates remain");
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -451,9 +451,7 @@ async fn main() -> anyhow::Result<()> {
         cli::Command::Feedback(opts) => std::process::exit(run_feedback(opts)),
         cli::Command::Context(opts) => std::process::exit(run_context(opts)),
         cli::Command::Calibrate(opts) => std::process::exit(run_calibrate(opts)),
-        cli::Command::BackfillLinkage(opts) => {
-            std::process::exit(run_backfill_linkage(opts))
-        }
+        cli::Command::BackfillLinkage(opts) => std::process::exit(run_backfill_linkage(opts)),
         cli::Command::Report(opts) => {
             let exit_code = run_report(opts).await;
             std::process::exit(exit_code);
@@ -2676,7 +2674,10 @@ fn run_backfill_linkage(opts: cli::BackfillLinkageOpts) -> i32 {
         }
     };
     let total = all_entries.len();
-    let already_linked = all_entries.iter().filter(|e| e.finding_id.is_some()).count();
+    let already_linked = all_entries
+        .iter()
+        .filter(|e| e.finding_id.is_some())
+        .count();
     drop(all_entries);
 
     let (newly_linked, candidates) = backfill_linkage_inner(&quorum_home);

--- a/src/review_log.rs
+++ b/src/review_log.rs
@@ -608,6 +608,15 @@ impl ReviewLog {
         }
     }
 
+    // ── Helpers ────────────────────────────────────────────────────────
+
+    /// Strip Markdown inline formatting (`backticks`, **bold**, _italic_)
+    /// and lowercase so that titles differing only in formatting match
+    /// during Jaccard comparison.
+    fn normalize_title(s: &str) -> String {
+        s.replace(['`', '*', '_'], "").to_lowercase()
+    }
+
     // ── Finding-ID resolution ──────────────────────────────────────────
 
     /// Attempt to match a `(file_path, finding_title)` pair against the
@@ -643,14 +652,14 @@ impl ReviewLog {
             .filter_map(|r| r.ok())
             .collect();
 
-        let query_lower = finding_title.to_lowercase();
+        let query_lower = Self::normalize_title(finding_title);
         let query_words: std::collections::HashSet<&str> = query_lower.split_whitespace().collect();
 
         let mut best_id: Option<String> = None;
         let mut best_score: f64 = 0.0;
 
         for (fid, title) in &candidates {
-            let title_lower = title.to_lowercase();
+            let title_lower = Self::normalize_title(title);
             let title_words: std::collections::HashSet<&str> =
                 title_lower.split_whitespace().collect();
 
@@ -2512,5 +2521,38 @@ mod tests {
         log.record(&record).unwrap();
         let result = log.resolve_finding_id("src/auth.rs", "SQL injection");
         assert_eq!(result, None);
+    }
+
+    #[test]
+    fn resolve_finding_id_matches_despite_backticks() {
+        let dir = TempDir::new().unwrap();
+        let log = sqlite_review_log(&dir);
+        let mut record = sample_record();
+        record.finding_ids = vec!["F1".into()];
+        let meta = vec![FindingMeta {
+            id: "F1".into(),
+            title: "`predict_one` trusts inconsistent public `LogisticFit` field lengths".into(),
+            file_path: "src/logistic.rs".into(),
+        }];
+        log.record_with_meta(&record, &meta).unwrap();
+        let result = log.resolve_finding_id(
+            "src/logistic.rs",
+            "predict_one trusts inconsistent public LogisticFit field lengths",
+        );
+        assert_eq!(result, Some("F1".to_string()));
+    }
+
+    #[test]
+    fn normalize_title_strips_markdown() {
+        assert_eq!(
+            ReviewLog::normalize_title("`predict_one` is **bad**"),
+            "predictone is bad"
+        );
+        assert_eq!(
+            ReviewLog::normalize_title("no_formatting_here"),
+            "noformattinghere"
+        );
+        assert_eq!(ReviewLog::normalize_title(""), "");
+        assert_eq!(ReviewLog::normalize_title("plain text"), "plain text");
     }
 }


### PR DESCRIPTION
## Summary

- **#438**: Fix markdown normalization in `resolve_finding_id` — strips backticks, asterisks, underscores before Jaccard tokenization. Fixes match failures on titles with `` `identifier` `` formatting.
- **#439**: Add `quorum backfill-linkage` command that re-runs `resolve_finding_id` on all feedback entries with `finding_id: None`, atomically rewrites `feedback.jsonl`.

## Live test results

```
$ quorum backfill-linkage
{
  "already_linked": 4,
  "candidates": 4805,
  "newly_linked": 59,
  "total": 4809
}

$ quorum stats --join-health
Linkage rate: 2%  (63 linked, up from 0%)

$ quorum backfill-linkage  # idempotent
{
  "already_linked": 63,
  "newly_linked": 0
}
```

## Test plan

- [x] `normalize_title` strips backticks, asterisks, underscores (1 test)
- [x] `resolve_finding_id` matches despite backtick formatting (1 test)
- [x] `backfill_linkage` links matching entries (1 test)
- [x] `backfill_linkage` is idempotent (1 test)
- [x] 1703 unit tests pass, 0 regressions
- [x] Clippy clean, release build succeeds

Closes #438, #439

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `quorum backfill-linkage` CLI command to automatically link unlinked feedback entries by re-resolving connections.
  * Added `--json` flag to output results in JSON format.
  * Enhanced title matching to better handle Markdown formatting in feedback entries.
  * Feedback files are updated atomically only when new links are discovered.

* **Tests**
  * Added validation tests for the backfill workflow, including idempotency checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->