### PR TITLE
feat(skills): --axes flag + code-mode macro wiring into run_review (#417)

### DIFF
--- a/docs/superpowers/plans/2026-06-10-axes-flag.md
+++ b/docs/superpowers/plans/2026-06-10-axes-flag.md
@@ -1,0 +1,964 @@
+# --axes Flag + Code Mode Macro Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Wire the skill executor + integrator into `run_review` behind `--axes`, making multi-axis review the default for `quorum review`.
+
+**Architecture:** Add `--axes` to `ReviewOpts`, implement `resolve_axes()` to map (axes, mode, legacy-flags) to a skill set or legacy fallback, build a thin `SkillLlmAdapter` bridging binary-side `OpenAiClient` to lib-side `skill_executor::LlmReviewer`, then replace the per-file LLM call in `run_review`'s sequential loop with execute_matrix → integrate → calibrate.
+
+**Tech Stack:** Rust, clap (CLI), serde, sha2, chrono, ulid
+
+**v1 simplification:** Skills receive raw source code, not context-enriched source. Context injection (project context + Context7 framework docs) runs inside `review_file()` for the legacy LLM path only. Plumbing enriched source into the skill executor is a follow-up (the skill prompts are self-contained and don't depend on framework doc injection).
+
+---
+
+## File Map
+
+| File | Action | Responsibility |
+|------|--------|---------------|
+| `src/skill_audit.rs:316` | Modify | Add `Legacy` variant to `AxisSelectionSource` |
+| `src/review_mode.rs` | Modify | Add `is_reserved()` method, add `Tests`/`Release` variants |
+| `src/cli/mod.rs:528-635` | Modify | Add `--axes` flag to `ReviewOpts` |
+| `src/main.rs:942+` | Modify | `resolve_axes()`, `SkillLlmAdapter`, skill-path wiring in `run_review` |
+
+---
+
+### Task 1: Add `Legacy` variant to `AxisSelectionSource`
+
+**Files:**
+- Modify: `src/skill_audit.rs:316-321`
+
+- [ ] **Step 1: Write the failing test**
+
+In `src/skill_audit.rs`, find the existing `axis_selection_source_serde_roundtrip` test (around line 930) and extend it:
+
+```rust
+#[test]
+fn axis_selection_source_serde_roundtrip() {
+    let variants = [
+        AxisSelectionSource::ExplicitAxes,
+        AxisSelectionSource::ModeMacro,
+        AxisSelectionSource::Default,
+        AxisSelectionSource::AutoDiscovery,
+        AxisSelectionSource::Legacy,
+    ];
+    for v in &variants {
+        let json = serde_json::to_string(v).unwrap();
+        let deserialized: AxisSelectionSource = serde_json::from_str(&json).unwrap();
+        assert_eq!(*v, deserialized);
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test --lib skill_audit::tests::axis_selection_source_serde_roundtrip`
+Expected: FAIL — `Legacy` variant doesn't exist.
+
+- [ ] **Step 3: Add `Legacy` variant**
+
+In `src/skill_audit.rs:316-321`, add `Legacy` to the enum:
+
+```rust
+pub enum AxisSelectionSource {
+    ExplicitAxes,
+    ModeMacro,
+    Default,
+    AutoDiscovery,
+    Legacy,
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cargo test --lib skill_audit::tests::axis_selection_source_serde_roundtrip`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/skill_audit.rs
+git commit -m "feat(skills): add Legacy variant to AxisSelectionSource"
+```
+
+---
+
+### Task 2: Add reserved mode support to `ReviewMode`
+
+**Files:**
+- Modify: `src/review_mode.rs`
+
+The reserved modes (`tests`, `release`) need to parse successfully at the clap layer so we can emit a custom error message in `run_review` (not a generic clap parse error). Add them to the enum with an `is_reserved()` predicate.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `src/review_mode.rs` tests module:
+
+```rust
+#[test]
+fn reserved_modes_parse() {
+    assert_eq!("tests".parse::<ReviewMode>().unwrap(), ReviewMode::Tests);
+    assert_eq!("release".parse::<ReviewMode>().unwrap(), ReviewMode::Release);
+}
+
+#[test]
+fn reserved_modes_are_reserved() {
+    assert!(ReviewMode::Tests.is_reserved());
+    assert!(ReviewMode::Release.is_reserved());
+}
+
+#[test]
+fn non_reserved_modes_are_not_reserved() {
+    assert!(!ReviewMode::Code.is_reserved());
+    assert!(!ReviewMode::Plan.is_reserved());
+    assert!(!ReviewMode::Docs.is_reserved());
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cargo test --lib review_mode::tests`
+Expected: FAIL — `Tests`, `Release` variants and `is_reserved()` don't exist.
+
+- [ ] **Step 3: Implement**
+
+In `src/review_mode.rs`, add the variants and methods:
+
+```rust
+pub enum ReviewMode {
+    #[default]
+    Code,
+    Plan,
+    Docs,
+    Tests,
+    Release,
+}
+
+impl ReviewMode {
+    pub fn is_prose(self) -> bool {
+        matches!(self, Self::Plan | Self::Docs)
+    }
+
+    #[must_use]
+    pub fn is_reserved(self) -> bool {
+        matches!(self, Self::Tests | Self::Release)
+    }
+
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Code => "code",
+            Self::Plan => "plan",
+            Self::Docs => "docs",
+            Self::Tests => "tests",
+            Self::Release => "release",
+        }
+    }
+}
+```
+
+Update `FromStr`:
+
+```rust
+fn from_str(s: &str) -> Result<Self, Self::Err> {
+    match s.to_ascii_lowercase().as_str() {
+        "code" => Ok(Self::Code),
+        "plan" => Ok(Self::Plan),
+        "docs" => Ok(Self::Docs),
+        "tests" => Ok(Self::Tests),
+        "release" => Ok(Self::Release),
+        other => Err(format!(
+            "unknown review mode '{other}'; expected one of: code, plan, docs, tests, release"
+        )),
+    }
+}
+```
+
+Update the serde roundtrip and other existing tests to include the new variants.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cargo test --lib review_mode::tests`
+Expected: PASS (all existing + new tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/review_mode.rs
+git commit -m "feat(review-mode): add Tests and Release reserved variants"
+```
+
+---
+
+### Task 3: Add `--axes` flag to CLI
+
+**Files:**
+- Modify: `src/cli/mod.rs:612-614`
+
+- [ ] **Step 1: Add the `--axes` flag to `ReviewOpts`**
+
+After the `--mode` field (line 614), add:
+
+```rust
+    /// Comma-separated skill axes to run (e.g. correctness,security).
+    /// Overrides the default mode-based axis resolution.
+    #[arg(long, value_delimiter = ',')]
+    pub axes: Vec<String>,
+```
+
+Using `value_delimiter = ','` means clap handles `--axes correctness,security` and `--axes correctness --axes security` identically, producing a `Vec<String>`.
+
+- [ ] **Step 2: Verify it compiles**
+
+Run: `cargo check --bin quorum`
+Expected: compiles (the field is just `Vec<String>`, unused warnings only).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/cli/mod.rs
+git commit -m "feat(cli): add --axes flag to ReviewOpts"
+```
+
+---
+
+### Task 4: Implement `resolve_axes()` and axis resolution tests
+
+**Files:**
+- Modify: `src/main.rs`
+
+This is the core routing logic. `resolve_axes` returns `Some((Vec<LoadedSkill>, AxisSelectionSource))` when skills should run, or `None` when the legacy single-prompt path should be used.
+
+- [ ] **Step 1: Write the `resolve_axes` function signature and test helpers**
+
+Add near the top of `run_review` or as a free function in `main.rs`:
+
+```rust
+/// Result of axis resolution: which skills to run and how they were selected.
+struct ResolvedAxes {
+    skills: Vec<skill_manifest::LoadedSkill>,
+    source: skill_audit::AxisSelectionSource,
+}
+
+/// Resolve which skill axes to run based on CLI flags.
+///
+/// Returns `None` when legacy flags (--deep, --daemon, --ensemble) suppress
+/// default axis resolution — the caller should use the single-prompt path.
+///
+/// Returns `Err` for invalid combinations (reserved modes, unknown axes,
+/// explicit --axes with legacy flags).
+fn resolve_axes(
+    explicit_axes: &[String],
+    mode: crate::review_mode::ReviewMode,
+    deep: bool,
+    daemon: bool,
+    ensemble: bool,
+    available_skills: &[skill_manifest::LoadedSkill],
+) -> Result<Option<ResolvedAxes>, String> {
+    // 1. Reserved mode → hard error
+    if mode.is_reserved() {
+        let placeholder = match mode {
+            crate::review_mode::ReviewMode::Tests => "test-coverage, test-quality",
+            crate::review_mode::ReviewMode::Release => "release-readiness",
+            _ => unreachable!(),
+        };
+        return Err(format!(
+            "mode '{}' requires axes not installed in this version: [{}]",
+            mode, placeholder
+        ));
+    }
+
+    let has_legacy_flag = deep || daemon || ensemble;
+
+    // 2. Explicit --axes + legacy flag → hard error
+    if !explicit_axes.is_empty() && has_legacy_flag {
+        let flag = if deep { "--deep" } else if daemon { "--daemon" } else { "--ensemble" };
+        return Err(format!(
+            "multi-axis review is not supported with {} yet",
+            flag
+        ));
+    }
+
+    // 3. Explicit --axes → resolve and validate
+    if !explicit_axes.is_empty() {
+        let mut skills = Vec::new();
+        for name in explicit_axes {
+            let name_lower = name.to_lowercase();
+            match available_skills.iter().find(|s| s.manifest.name == name_lower) {
+                Some(s) => skills.push(s.clone()),
+                None => {
+                    let available: Vec<&str> = available_skills
+                        .iter()
+                        .map(|s| s.manifest.name.as_str())
+                        .collect();
+                    return Err(format!(
+                        "unknown skill axis '{}'; available: [{}]",
+                        name,
+                        available.join(", ")
+                    ));
+                }
+            }
+        }
+        return Ok(Some(ResolvedAxes {
+            skills,
+            source: skill_audit::AxisSelectionSource::ExplicitAxes,
+        }));
+    }
+
+    // 4. Legacy flag without explicit --axes → suppress default, use legacy path
+    if has_legacy_flag {
+        return Ok(None);
+    }
+
+    // 5. Default: --mode code → bundled skills
+    if mode == crate::review_mode::ReviewMode::Code {
+        let bundled_names = ["correctness", "security", "testing-antipatterns"];
+        let mut skills = Vec::new();
+        for name in &bundled_names {
+            match available_skills.iter().find(|s| s.manifest.name == *name) {
+                Some(s) => skills.push(s.clone()),
+                None => {
+                    return Err(format!(
+                        "bundled skill '{}' not found; installation may be corrupt",
+                        name
+                    ));
+                }
+            }
+        }
+        return Ok(Some(ResolvedAxes {
+            skills,
+            source: skill_audit::AxisSelectionSource::ModeMacro,
+        }));
+    }
+
+    // 6. Prose modes (plan, docs) without --axes → legacy path
+    Ok(None)
+}
+```
+
+- [ ] **Step 2: Write tests for `resolve_axes`**
+
+These tests need mock `LoadedSkill` values. Add a test helper:
+
+```rust
+#[cfg(test)]
+mod axes_tests {
+    use super::*;
+    use quorum::skill_manifest::{LoadedSkill, SkillManifest, Axis, CapabilityMode, Capability, Prompts};
+    use quorum::finding::Severity;
+
+    fn mock_skill(name: &str) -> LoadedSkill {
+        LoadedSkill {
+            manifest: SkillManifest {
+                name: name.to_string(),
+                version: "1.0.0".to_string(),
+                display_name: name.to_string(),
+                description: String::new(),
+                axis: Axis::Correctness,
+                max_severity: Severity::Critical,
+                target_findings: None,
+                capability: Capability { mode: CapabilityMode::Pure },
+                preferred_model: None,
+                fallback_models: vec![],
+                prompts: Prompts {
+                    primary: "prompt".into(),
+                    anthropic: None,
+                    openai: None,
+                    google: None,
+                },
+            },
+            source_path: std::path::PathBuf::from(format!("skills/{}.toml", name)),
+            manifest_sha256: "abc123".to_string(),
+            trust_tier: quorum::skill_manifest::TrustTier::Bundled,
+        }
+    }
+
+    fn bundled_skills() -> Vec<LoadedSkill> {
+        vec![
+            mock_skill("correctness"),
+            mock_skill("security"),
+            mock_skill("testing-antipatterns"),
+        ]
+    }
+
+    #[test]
+    fn explicit_axes_resolves() {
+        let skills = bundled_skills();
+        let result = resolve_axes(
+            &["security".into()],
+            ReviewMode::Code, false, false, false, &skills,
+        ).unwrap().unwrap();
+        assert_eq!(result.skills.len(), 1);
+        assert_eq!(result.skills[0].manifest.name, "security");
+        assert_eq!(result.source, skill_audit::AxisSelectionSource::ExplicitAxes);
+    }
+
+    #[test]
+    fn default_code_mode_resolves_to_bundled() {
+        let skills = bundled_skills();
+        let result = resolve_axes(
+            &[], ReviewMode::Code, false, false, false, &skills,
+        ).unwrap().unwrap();
+        assert_eq!(result.skills.len(), 3);
+        assert_eq!(result.source, skill_audit::AxisSelectionSource::ModeMacro);
+    }
+
+    #[test]
+    fn reserved_mode_errors() {
+        let skills = bundled_skills();
+        let err = resolve_axes(
+            &[], ReviewMode::Tests, false, false, false, &skills,
+        ).unwrap_err();
+        assert!(err.contains("requires axes not installed"));
+        assert!(err.contains("test-coverage"));
+    }
+
+    #[test]
+    fn deep_suppresses_default_axes() {
+        let skills = bundled_skills();
+        let result = resolve_axes(
+            &[], ReviewMode::Code, true, false, false, &skills,
+        ).unwrap();
+        assert!(result.is_none(), "--deep should suppress default axes");
+    }
+
+    #[test]
+    fn explicit_axes_with_deep_errors() {
+        let skills = bundled_skills();
+        let err = resolve_axes(
+            &["security".into()],
+            ReviewMode::Code, true, false, false, &skills,
+        ).unwrap_err();
+        assert!(err.contains("not supported with --deep"));
+    }
+
+    #[test]
+    fn unknown_axis_errors() {
+        let skills = bundled_skills();
+        let err = resolve_axes(
+            &["nonexistent".into()],
+            ReviewMode::Code, false, false, false, &skills,
+        ).unwrap_err();
+        assert!(err.contains("unknown skill axis 'nonexistent'"));
+        assert!(err.contains("correctness"));
+    }
+
+    #[test]
+    fn prose_mode_without_axes_uses_legacy() {
+        let skills = bundled_skills();
+        let result = resolve_axes(
+            &[], ReviewMode::Plan, false, false, false, &skills,
+        ).unwrap();
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn explicit_axes_with_no_api_key_still_resolves() {
+        // resolve_axes doesn't check for API key — that's the caller's job
+        let skills = bundled_skills();
+        let result = resolve_axes(
+            &["security".into()],
+            ReviewMode::Code, false, false, false, &skills,
+        ).unwrap().unwrap();
+        assert_eq!(result.skills.len(), 1);
+    }
+}
+```
+
+- [ ] **Step 3: Run tests**
+
+Run: `cargo test --bin quorum axes_tests`
+Expected: PASS (all 8 tests)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/main.rs
+git commit -m "feat(skills): implement resolve_axes() with full test coverage"
+```
+
+---
+
+### Task 5: Implement `SkillLlmAdapter`
+
+**Files:**
+- Modify: `src/main.rs`
+
+- [ ] **Step 1: Write the adapter struct**
+
+Add near `resolve_axes` in `main.rs`:
+
+```rust
+/// Bridges the binary-side `OpenAiClient` (which implements `pipeline::LlmReviewer`)
+/// to the lib-side `skill_executor::LlmReviewer` trait.
+struct SkillLlmAdapter(std::sync::Arc<llm_client::OpenAiClient>);
+
+impl skill_executor::LlmReviewer for SkillLlmAdapter {
+    fn review(
+        &self,
+        prompt: &str,
+        model: &str,
+        system_prompt: &str,
+    ) -> anyhow::Result<skill_executor::LlmResponse> {
+        let resp = pipeline::LlmReviewer::review(&*self.0, prompt, model, system_prompt)?;
+        let (prompt_tokens, completion_tokens, cache_read_tokens) = resp
+            .usage
+            .as_ref()
+            .map(|u| (u.prompt_tokens, u.completion_tokens, u.cached_tokens))
+            .unwrap_or((0, 0, 0));
+        Ok(skill_executor::LlmResponse {
+            content: resp.content,
+            usage: skill_executor::TokenUsage {
+                prompt_tokens,
+                completion_tokens,
+                cache_read_tokens,
+            },
+        })
+    }
+}
+```
+
+- [ ] **Step 2: Verify it compiles**
+
+Run: `cargo check --bin quorum`
+Expected: compiles (unused warnings are fine — will be used in Task 6).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/main.rs
+git commit -m "feat(skills): add SkillLlmAdapter bridging binary-side to lib-side LlmReviewer"
+```
+
+---
+
+### Task 6: Wire skill executor + integrator into `run_review`
+
+**Files:**
+- Modify: `src/main.rs` (the sequential per-file loop around line 1450-1600)
+
+This is the main integration task. The sequential per-file loop gains a new branch: when `resolved_axes` is `Some`, run the skill executor instead of the single-prompt LLM path.
+
+- [ ] **Step 1: Load skills and resolve axes early in `run_review`**
+
+After `let cfg = Config::load(...)` (line 1001) and before the LLM client build, add skill loading:
+
+```rust
+    // Load skill manifests (bundled + user).
+    let quorum_home = dirs::home_dir()
+        .unwrap_or_else(|| std::path::PathBuf::from("."))
+        .join(".quorum");
+    let bundled_skills_dir = {
+        let exe_dir = std::env::current_exe()
+            .ok()
+            .and_then(|p| p.parent().map(|d| d.to_path_buf()))
+            .unwrap_or_else(|| std::path::PathBuf::from("."));
+        exe_dir.join("skills")
+    };
+    let user_skills_dir = quorum_home.join("skills");
+    let available_skills = match skill_manifest::load_skills(&bundled_skills_dir, &user_skills_dir) {
+        Ok(s) => s,
+        Err(e) => {
+            tracing::warn!(error = %e, "failed to load skill manifests; skills disabled");
+            vec![]
+        }
+    };
+```
+
+After the LLM client build, resolve axes:
+
+```rust
+    // Resolve skill axes from --axes / --mode / legacy flags.
+    let resolved_axes = match resolve_axes(
+        &opts.axes,
+        opts.mode,
+        opts.deep,
+        opts.daemon,
+        opts.ensemble,
+        &available_skills,
+    ) {
+        Ok(r) => r,
+        Err(e) => {
+            eprintln!("error: {}", e);
+            return 3;
+        }
+    };
+
+    // Warn if --axes given but no LLM client.
+    if resolved_axes.is_some() && llm_client.is_none() {
+        if !opts.axes.is_empty() {
+            eprintln!("warning: --axes requires an LLM client; running AST-only review");
+        }
+    }
+
+    // Log axis resolution.
+    if let Some(ref ra) = resolved_axes {
+        let names: Vec<&str> = ra.skills.iter().map(|s| s.manifest.name.as_str()).collect();
+        tracing::info!(
+            axes = ?names,
+            source = ?ra.source,
+            "skill axes resolved"
+        );
+    }
+```
+
+- [ ] **Step 2: Build skill executor config when axes are resolved and LLM is available**
+
+```rust
+    // Build skill executor infrastructure when axes are resolved and LLM is available.
+    let skill_adapter: Option<SkillLlmAdapter> = llm_client.as_ref().map(|c| SkillLlmAdapter(c.clone()));
+    let skill_audit_writer: Option<std::sync::Arc<skill_audit::AuditWriter<skill_audit::SkillInvocationRecord>>> =
+        resolved_axes.as_ref().map(|_| {
+            std::sync::Arc::new(skill_audit::AuditWriter::new(
+                quorum_home.join(skill_audit::SKILL_INVOCATIONS_FILE),
+            ))
+        });
+    let integrator_audit_writer: Option<std::sync::Arc<skill_audit::AuditWriter<skill_audit::IntegratorDecisionRecord>>> =
+        resolved_axes.as_ref().map(|_| {
+            std::sync::Arc::new(skill_audit::AuditWriter::new(
+                quorum_home.join(skill_audit::INTEGRATOR_DECISIONS_FILE),
+            ))
+        });
+```
+
+- [ ] **Step 3: Replace LLM call in the per-file sequential loop**
+
+In the sequential loop (starting line 1543), after the deep-review branch and AST analysis, add the skill executor path. The key change is: when `resolved_axes.is_some() && skill_adapter.is_some()`, run execute_matrix + integrate instead of the normal `review_file` / `review_source` path.
+
+The cleanest approach is to keep the existing `review_source` / `review_file` call for AST findings but pass `None` as the `llm` argument (disabling the single-prompt LLM path), then separately run the skill executor for LLM findings.
+
+```rust
+            // Determine if skills path or legacy LLM path.
+            let use_skills = resolved_axes.is_some() && skill_adapter.is_some();
+
+            // Run pipeline: AST + linter findings (no LLM when skills are active).
+            let llm_for_pipeline: Option<&dyn pipeline::LlmReviewer> = if use_skills {
+                None // skills replace the single-prompt LLM path
+            } else {
+                llm_reviewer
+            };
+
+            let review_result = if let Some(l) = lang {
+                pipeline::review_source(
+                    file_path, &source, l, llm_for_pipeline, &pipeline_cfg, Some(&parse_cache),
+                ).await
+            } else {
+                if !use_skills {
+                    eprintln!("Note: No AST support for {}, using LLM-only review", file_path.display());
+                }
+                pipeline::review_file(file_path, &source, None, llm_for_pipeline, &pipeline_cfg).await
+            };
+
+            match review_result {
+                Ok(mut result) => {
+                    // If skills are active, run executor + integrator for LLM findings.
+                    if use_skills {
+                        if let (Some(ref ra), Some(ref adapter)) = (&resolved_axes, &skill_adapter) {
+                            let file_str = file_path.to_string_lossy().to_string();
+                            let file_sha = sha2_hex(source.as_bytes());
+                            let exec_config = skill_executor::SkillExecutorConfig {
+                                run_id: run_id.clone(),
+                                axis_selection_source: ra.source,
+                                global_models: pipeline_cfg.models.clone(),
+                                ensemble_pool: vec![],
+                                ensemble: false,
+                                max_tokens_per_review: 500_000,
+                                max_calls_per_review: 50,
+                                audit_writer: skill_audit_writer.clone(),
+                            };
+                            let files_input = vec![(file_str.clone(), file_sha, source.clone())];
+                            let cell_results = skill_executor::execute_matrix(
+                                &ra.skills, &files_input, adapter, &exec_config,
+                            );
+
+                            // Convert cell results to TaggedFindings.
+                            let tagged: Vec<skill_integrator::TaggedFinding> = cell_results
+                                .iter()
+                                .flat_map(|cr| {
+                                    cr.findings.iter().map(|f| skill_integrator::TaggedFinding {
+                                        file_path: file_str.clone(),
+                                        finding: f.clone(),
+                                    })
+                                })
+                                .collect();
+
+                            let integrator_cfg = skill_integrator::IntegratorConfig {
+                                run_id: run_id.clone(),
+                                confidence_floor: 0.30,
+                                audit_writer: integrator_audit_writer.clone(),
+                            };
+                            let int_output = skill_integrator::integrate(tagged, &integrator_cfg);
+
+                            // Sum token usage from all cells.
+                            for cr in &cell_results {
+                                result.usage.prompt_tokens += cr.usage.prompt_tokens;
+                                result.usage.completion_tokens += cr.usage.completion_tokens;
+                                result.usage.cached_tokens += cr.usage.cache_read_tokens;
+                            }
+
+                            // Merge skill findings into the result (after AST findings).
+                            result.findings.extend(int_output.findings);
+                            result.suppressed += int_output.suppressed.len();
+                        }
+                    }
+
+                    // Apply project-level suppressions (existing code, unchanged)...
+```
+
+Note: `run_id` must be generated at the start of `run_review` (a ULID). `sha2_hex` is a utility to compute `sha256` hex digest of the source. Both are simple additions.
+
+- [ ] **Step 4: Add `run_id` and `sha2_hex` helper**
+
+Near the top of `run_review`, generate the run ID:
+
+```rust
+    let run_id = ulid::Ulid::new().to_string();
+```
+
+Add a helper (or use existing if one exists):
+
+```rust
+fn sha2_hex(data: &[u8]) -> String {
+    use sha2::{Sha256, Digest};
+    let mut hasher = Sha256::new();
+    hasher.update(data);
+    format!("{:x}", hasher.finalize())
+}
+```
+
+- [ ] **Step 5: Verify it compiles**
+
+Run: `cargo check --bin quorum`
+Expected: compiles. There may be unused variable warnings for the parallel path (Task 7).
+
+- [ ] **Step 6: Run existing tests to verify no regressions**
+
+Run: `cargo test --bin quorum`
+Expected: all existing tests pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/main.rs
+git commit -m "feat(skills): wire skill executor + integrator into run_review sequential path"
+```
+
+---
+
+### Task 7: Wire the parallel file loop
+
+**Files:**
+- Modify: `src/main.rs` (the parallel path, starts after the sequential path)
+
+The parallel file loop (when `opts.parallel > 1 && opts.files.len() > 1`) uses `tokio::spawn` for concurrent file reviews. Apply the same skill-executor wiring as the sequential path.
+
+- [ ] **Step 1: Identify the parallel path**
+
+Search for the parallel loop (grep for `spawn` or `join_set` or `JoinSet` in `run_review`).
+
+- [ ] **Step 2: Apply the same pattern**
+
+The parallel path needs the same branching: pass `None` as `llm` to `review_file` when skills are active, then run `execute_matrix` + `integrate` after AST findings. The `SkillLlmAdapter`, `resolved_axes`, and audit writers need to be `Arc`-wrapped for sharing across tasks.
+
+The adapter is already `Send + Sync` (it wraps `Arc<OpenAiClient>`). The audit writers are already `Arc`-wrapped.
+
+- [ ] **Step 3: Verify it compiles and tests pass**
+
+Run: `cargo check --bin quorum && cargo test --bin quorum`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/main.rs
+git commit -m "feat(skills): wire skill executor into run_review parallel path"
+```
+
+---
+
+### Task 8: Add tracing spans
+
+**Files:**
+- Modify: `src/main.rs`
+
+- [ ] **Step 1: Add tracing spans for axis resolution and executor**
+
+Already partially covered in Task 6 (the `tracing::info!` for axis resolution). Add spans around executor and integrator calls:
+
+```rust
+let _span = tracing::info_span!(
+    "phase.skill_executor",
+    skills = ra.skills.len(),
+    model = %pipeline_cfg.models.first().map(|s| s.as_str()).unwrap_or("unknown"),
+    file = %file_str,
+).entered();
+```
+
+And for integrator:
+
+```rust
+let _span = tracing::info_span!(
+    "phase.integrator",
+    input_findings = tagged.len(),
+    file = %file_str,
+).entered();
+// ... integrate call ...
+tracing::info!(
+    findings = int_output.findings.len(),
+    suppressed = int_output.suppressed.len(),
+    "integrator complete"
+);
+```
+
+- [ ] **Step 2: Verify it compiles**
+
+Run: `cargo check --bin quorum`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/main.rs
+git commit -m "feat(skills): add tracing spans for skill executor and integrator"
+```
+
+---
+
+### Task 9: End-to-end integration test
+
+**Files:**
+- Modify: `src/main.rs` (or a test file)
+
+- [ ] **Step 1: Write an integration test verifying the full axis-resolution → executor → integrator path**
+
+This test uses a mock `LlmReviewer` that returns canned JSON findings, verifies that `resolve_axes` + `execute_matrix` + `integrate` produces the expected output.
+
+```rust
+#[cfg(test)]
+mod integration_tests {
+    use super::*;
+
+    struct MockSkillReviewer;
+    impl skill_executor::LlmReviewer for MockSkillReviewer {
+        fn review(&self, _prompt: &str, _model: &str, _system_prompt: &str)
+            -> anyhow::Result<skill_executor::LlmResponse>
+        {
+            Ok(skill_executor::LlmResponse {
+                content: r#"[{"title":"Test bug","description":"A test finding","severity":"medium","category":"correctness","line_start":1,"line_end":5}]"#.into(),
+                usage: skill_executor::TokenUsage {
+                    prompt_tokens: 100,
+                    completion_tokens: 50,
+                    cache_read_tokens: 0,
+                },
+            })
+        }
+    }
+
+    #[test]
+    fn skill_executor_produces_findings_with_metadata() {
+        let skills = vec![mock_skill("correctness"), mock_skill("security")];
+        let config = skill_executor::SkillExecutorConfig {
+            run_id: "test-run".into(),
+            axis_selection_source: skill_audit::AxisSelectionSource::ExplicitAxes,
+            global_models: vec!["test-model".into()],
+            ensemble_pool: vec![],
+            ensemble: false,
+            max_tokens_per_review: 100_000,
+            max_calls_per_review: 10,
+            audit_writer: None,
+        };
+        let files = vec![("test.rs".into(), "abc123".into(), "fn main() {}".into())];
+        let results = skill_executor::execute_matrix(&skills, &files, &MockSkillReviewer, &config);
+
+        assert_eq!(results.len(), 2, "one result per skill");
+        for r in &results {
+            assert!(!r.findings.is_empty(), "each skill should produce findings");
+            for f in &r.findings {
+                assert!(f.originating_skill.is_some());
+            }
+        }
+
+        // Run through integrator.
+        let tagged: Vec<_> = results.iter().flat_map(|cr| {
+            cr.findings.iter().map(|f| skill_integrator::TaggedFinding {
+                file_path: "test.rs".into(),
+                finding: f.clone(),
+            })
+        }).collect();
+        let int_cfg = skill_integrator::IntegratorConfig::default();
+        let output = skill_integrator::integrate(tagged, &int_cfg);
+        assert!(!output.findings.is_empty());
+        // Both skills found the same bug at the same location → should merge.
+        assert!(output.findings.len() < 4, "integrator should merge overlapping findings");
+    }
+}
+```
+
+- [ ] **Step 2: Run the test**
+
+Run: `cargo test --bin quorum integration_tests`
+Expected: PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/main.rs
+git commit -m "test(skills): add end-to-end integration test for skill executor + integrator"
+```
+
+---
+
+### Task 10: Final verification
+
+- [ ] **Step 1: Full test suite**
+
+```bash
+cargo test --lib
+cargo test --bin quorum
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 2: Clippy**
+
+```bash
+cargo clippy --lib -- -D warnings
+cargo clippy --bin quorum -- -D warnings
+```
+
+Expected: clean.
+
+- [ ] **Step 3: Fmt**
+
+```bash
+cargo fmt -- --check
+```
+
+Expected: clean.
+
+- [ ] **Step 4: Release build**
+
+```bash
+cargo build --release
+```
+
+Expected: compiles.
+
+- [ ] **Step 5: Manual smoke test (if API key available)**
+
+```bash
+QUORUM_ALLOWED_BASE_URL_HOSTS=litellm.5745.house quorum review src/main.rs --axes security --compact
+```
+
+Verify: security skill findings appear with `originating_skill: security` metadata.
+
+```bash
+QUORUM_ALLOWED_BASE_URL_HOSTS=litellm.5745.house quorum review src/main.rs --compact
+```
+
+Verify: default mode resolves to 3 bundled skills, findings from multiple skills visible.
+
+```bash
+quorum review src/main.rs --mode tests
+```
+
+Verify: hard error about reserved mode.
+
+- [ ] **Step 6: Commit any final fixes**

--- a/docs/superpowers/specs/2026-06-09-axes-flag-design.md
+++ b/docs/superpowers/specs/2026-06-09-axes-flag-design.md
@@ -1,0 +1,225 @@
+# Design: --axes flag + code mode macro (#417)
+
+**Issue:** #417 (part of #403 multi-axis review skills framework)
+**Date:** 2026-06-09
+**Status:** Draft
+
+## Summary
+
+Wire the skill executor, integrator, and bundled skill manifests into `run_review` behind a new `--axes` CLI flag. This is the first user-visible milestone: `quorum review file.rs` runs three specialist reviews (correctness, security, testing-antipatterns) in parallel, dedupes/merges their findings, and outputs the integrated result.
+
+## CLI Surface
+
+### New flag
+
+```
+--axes <a,b,c>    Comma-separated skill names (e.g. correctness,security)
+```
+
+### Axis resolution (evaluated in order)
+
+| Condition | Resolved axes | `axis_selection_source` |
+|-----------|--------------|------------------------|
+| `--axes a,b` explicitly provided | `[a, b]` | `ExplicitAxes` |
+| `--mode code` (default), no `--axes`, no legacy flags | `[correctness, security, testing-antipatterns]` | `ModeMacro` |
+| `--deep`, `--daemon`, or `--ensemble` active (no explicit `--axes`) | No axes — fall back to legacy single-prompt LLM path | `Legacy` |
+| `--mode plan\|docs\|tests\|release` | Hard error | N/A |
+
+### AxisSelectionSource enum
+
+```rust
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AxisSelectionSource {
+    ExplicitAxes,
+    ModeMacro,
+    Legacy,
+}
+```
+
+### Reserved mode error
+
+```
+error: mode 'plan' requires axes not installed in this version: [plan-coherence, plan-completeness]
+```
+
+Placeholder skill names per reserved mode:
+- `plan` → `plan-coherence, plan-completeness`
+- `docs` → `docs-accuracy, docs-completeness`
+- `tests` → `test-coverage, test-quality`
+- `release` → `release-readiness`
+
+### Validation
+
+- Each axis name must match a loadable skill manifest (bundled `skills/` or user `~/.quorum/skills/`).
+- Unknown axis → hard error listing available skills.
+- `--axes` with a reserved `--mode` → hard error (reserved modes don't have skills yet).
+- `--axes` explicitly combined with `--deep`, `--daemon`, or `--ensemble` → hard error: "multi-axis review is not supported with --deep/--daemon/--ensemble yet".
+- `--axes` explicitly provided with no API key → warning: "warning: --axes requires an LLM client; running AST-only review".
+
+### Legacy flag fallback
+
+When `--deep`, `--daemon`, or `--ensemble` is active and no explicit `--axes` is given, default axis resolution is **suppressed**. The review falls back to the existing single-prompt LLM path. This avoids breaking existing users of these flags. Explicit `--axes` with these flags is a hard error (unsupported combination).
+
+## Architecture
+
+### Integration approach: thin shim in `run_review`
+
+The existing `run_review` function in `main.rs` gains a new code path after AST analysis. The skill executor replaces the single-prompt LLM review path when axes are resolved.
+
+```
+run_review(opts)
+  ├── [unchanged] trace init, config load, LLM client build
+  ├── [new] resolve_axes(opts.axes, opts.mode, opts.deep/daemon/ensemble)
+  │         → Option<(Vec<LoadedSkill>, AxisSelectionSource)>
+  │         Returns None when legacy flags suppress default resolution
+  ├── [new] if axes resolved: build SkillExecutorConfig
+  ├── for each file:
+  │     ├── [unchanged] AST analysis → local findings
+  │     ├── [unchanged] linter findings
+  │     ├── [new] context enrichment (project context + Context7) → enriched_source
+  │     ├── if axes resolved:
+  │     │     ├── [new] execute_matrix(skills × [model] × file, enriched_source)
+  │     │     ├── [new] integrate(cell_results) → IntegratorOutput
+  │     │     └── [new] calibrator on integrated findings
+  │     ├── else (legacy path):
+  │     │     ├── [unchanged] single-prompt LLM review
+  │     │     └── [unchanged] calibrator on LLM findings
+  │     └── [unchanged] merge AST + LLM/skill findings → FileReviewResult
+  ├── [unchanged] output formatting (JSON/compact/human)
+  └── [unchanged] telemetry recording
+```
+
+### Context injection threading
+
+Context enrichment (project context via `ContextInjector` + Context7 framework docs) runs **before** the skill executor call in the per-file loop. The enriched source text is what gets passed to `wrap_code_to_review()` and then to each executor cell. This matches the current flow where context injection happens inside `review_file()` before the LLM call — the only change is that the enriched source now feeds into multiple skill cells instead of one prompt.
+
+### Calibrator positioning
+
+In the current single-prompt path, the calibrator runs inside `review_file()` on per-file findings. In the new multi-axis path, the calibrator runs **after** `integrate()` on the merged/deduped findings. This is a behavior change: the calibrator now sees the integrator's confidence scores (noisy-or fused) rather than raw LLM confidence. This is intentional — the integrator's merged confidence is a better signal for calibration than per-cell raw confidence.
+
+### LlmReviewer adapter
+
+`skill_executor.rs` defines a lib-local `LlmReviewer` trait. The binary-side `OpenAiClient` implements the binary-side `pipeline::LlmReviewer` trait. A thin adapter bridges the two:
+
+```rust
+struct SkillLlmAdapter(Arc<OpenAiClient>);
+
+impl skill_executor::LlmReviewer for SkillLlmAdapter {
+    fn review(&self, prompt: &str, model: &str, system_prompt: &str)
+        -> anyhow::Result<skill_executor::LlmResponse>
+    {
+        let resp = pipeline::LlmReviewer::review(&*self.0, prompt, model, system_prompt)?;
+        Ok(skill_executor::LlmResponse {
+            content: resp.content,
+            usage: skill_executor::TokenUsage {
+                prompt_tokens: resp.usage.prompt_tokens,
+                completion_tokens: resp.usage.completion_tokens,
+                cache_read_tokens: resp.usage.cache_read_tokens,
+            },
+        })
+    }
+}
+```
+
+### Skill loading
+
+`skill_manifest::load_skills()` searches:
+1. Bundled skills: `<binary_dir>/skills/*.toml` and compile-time `include_str!` fallback
+2. User skills: `~/.quorum/skills/*.toml`
+
+User skills with the same `name` as a bundled skill override the bundled version (user takes precedence).
+
+Resolved axes are filtered against loaded skills. Missing skills produce a hard error listing available skills.
+
+### Matrix construction
+
+For each file, the skill executor builds the matrix:
+- **Skills dimension:** resolved axes (1-N skills)
+- **Models dimension:** `[cfg.model]` (single model; ensemble support is out of scope)
+- **Files dimension:** single file (executor runs per-file in the outer loop)
+
+Each cell gets:
+- System prompt: `wrap_skill_instructions(skill.prompts, model_family)`
+- User prompt: `wrap_code_to_review(enriched_source, file_path)`
+- Model: from config
+- Skill metadata: name, version, manifest SHA256
+
+### Parallelism model
+
+Two levels of parallelism operate independently:
+
+1. **File-level:** The existing `run_review` loop processes files using the `--parallel` semaphore. Multiple files can be in-flight concurrently.
+2. **Skill-level (within a file):** The skill executor runs cells (skills × models) concurrently using its internal `BudgetTracker`. All skill cells for a single file execute in parallel.
+
+The `--parallel` flag controls file-level concurrency. Skill-level concurrency within a file is bounded by the executor's budget (token cap) and the number of skills. With 3 bundled skills and `--parallel 4`, peak concurrent LLM calls is 12 (4 files × 3 skills).
+
+### Integration
+
+Cell results are converted to `TaggedFinding` and passed to `integrate()`:
+- Cluster by `(file_path, finding_kind)`
+- Noisy-or confidence fusion within clusters
+- Suppress below confidence floor (0.30)
+- Clamp severity to skill's `max_severity`
+- Deterministic sort: severity desc, confidence desc, line_start asc, title asc
+
+## Traceability
+
+### Structured tracing (`--trace`)
+
+The existing `--trace` flag writes structured spans to `~/.quorum/trace.jsonl`. New `tracing::info!` spans added for:
+- Axis resolution: which axes resolved, source (`ExplicitAxes`/`ModeMacro`/`Legacy`)
+- Skill executor invocation: skill count, model, file path
+- Integrator output: findings count, suppressed count, clusters formed
+
+The skill executor and integrator already emit `tracing::warn`/`tracing::debug` calls that flow through the existing trace subscriber.
+
+### Audit logging
+
+- `~/.quorum/skill_invocations.jsonl`: one row per executor cell (skill × model × file), with `axis_selection_source`
+- `~/.quorum/integrator_decisions.jsonl`: one row per integrator cluster
+- `~/.quorum/skills.lock`: manifest checksums for reproducibility
+- `skill_run_id` links findings → audit records → integrator decisions
+
+### Out of scope: `--trace-prompts` (#412)
+
+Full prompt forensic capture (actual LLM prompts/responses) is deferred to #412.
+
+## Output & Telemetry
+
+### Finding identity
+
+Integrated findings carry: `originating_skill`, `skill_version`, `manifest_sha256`, `skill_run_id`, `clamped_from_severity`. These appear in JSON output and are available for `--by-skill` stats (#421).
+
+### Telemetry
+
+Token usage from all cells summed into existing `tokens_in/out` on `TelemetryEntry`. Per-cell breakdown lives in the audit log only.
+
+### Exit codes
+
+Unchanged: 0=clean, 1=warnings, 2=critical, 3=tool error.
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `src/cli/mod.rs` | Add `--axes` flag to `ReviewOpts` |
+| `src/main.rs` | Axis resolution, legacy fallback, skill loading, executor/integrator wiring in `run_review`, `SkillLlmAdapter` |
+| `src/skill_audit.rs` | Add `axis_selection_source: AxisSelectionSource` field to `SkillInvocationRecord` |
+
+## Out of Scope
+
+- #418: Legacy single-prompt fallback flag (`--no-skills` or similar)
+- #412: `--trace-prompts` forensic capture
+- #413: Skill fixture / smoke-test harness
+- Non-code mode macros (plan, docs, tests, release skill bundles)
+- Per-skill calibrator weighting
+
+## Testing Strategy
+
+1. **Unit tests for axis resolution:** explicit axes, mode macro default, reserved mode errors, unknown axis errors, legacy flag fallback (--deep/--daemon/--ensemble suppress default), explicit --axes + legacy flag error
+2. **Unit tests for LlmReviewer adapter:** verify type mapping between binary-side and lib-side types
+3. **Unit test for skill loading precedence:** user skill overrides bundled skill with same name
+4. **Integration test:** mock LlmReviewer, run full pipeline (AST + skills + integrator), verify output contains findings from multiple skills with correct metadata
+5. **CLI integration test:** `quorum review --axes security <file>` with no API key → AST-only with warning. With mock → skill findings in output.
+6. **Traceability test:** verify `axis_selection_source` is recorded correctly in audit records for each resolution path

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -613,6 +613,11 @@ pub struct ReviewOpts {
     #[arg(long, default_value = "code")]
     pub mode: crate::review_mode::ReviewMode,
 
+    /// Comma-separated skill axes to run (e.g. correctness,security).
+    /// Overrides the default mode-based axis resolution.
+    #[arg(long, value_delimiter = ',')]
+    pub axes: Vec<String>,
+
     /// Enable LLM micro-judge for speculative AST rules (also: QUORUM_JUDGE=1)
     #[arg(long)]
     pub judge: bool,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1085,25 +1085,30 @@ fn resolve_axes(
     // -----------------------------------------------------------------------
     // (e) Default code mode → ModeMacro with bundled axes
     // -----------------------------------------------------------------------
-    if mode == crate::review_mode::ReviewMode::Code {
+    if mode == crate::review_mode::ReviewMode::Code && !available_skills.is_empty() {
         let mut skills = Vec::new();
+        let mut all_found = true;
         for &axis_name in CODE_MODE_MACRO_AXES {
-            let skill = available_skills
+            if let Some(skill) = available_skills
                 .iter()
                 .find(|s| s.manifest.name.eq_ignore_ascii_case(axis_name))
-                .ok_or_else(|| {
-                    format!(
-                        "bundled skill '{}' not found; installation may be corrupt",
-                        axis_name,
-                    )
-                })?
-                .clone();
-            skills.push(skill);
+            {
+                skills.push(skill.clone());
+            } else {
+                tracing::warn!(
+                    skill = axis_name,
+                    "bundled skill not found; falling back to legacy review"
+                );
+                all_found = false;
+                break;
+            }
         }
-        return Ok(Some(ResolvedAxes {
-            skills,
-            source: crate::skill_audit::AxisSelectionSource::ModeMacro,
-        }));
+        if all_found {
+            return Ok(Some(ResolvedAxes {
+                skills,
+                source: crate::skill_audit::AxisSelectionSource::ModeMacro,
+            }));
+        }
     }
 
     // -----------------------------------------------------------------------
@@ -1509,7 +1514,7 @@ mod axes_tests {
 
     // A18: empty_available_skills_errors
     #[test]
-    fn empty_available_skills_errors() {
+    fn empty_available_skills_falls_back_to_legacy() {
         let result = resolve_axes(
             &[],
             crate::review_mode::ReviewMode::Code,
@@ -1518,11 +1523,9 @@ mod axes_tests {
             false,
             &[], // no skills available
         );
-        let err = result.unwrap_err();
         assert!(
-            err.contains("bundled skill") && err.contains("not found"),
-            "expected bundled skill not found in error: {}",
-            err,
+            result.unwrap().is_none(),
+            "should fall back to legacy when no skills are installed"
         );
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1166,7 +1166,9 @@ mod axes_tests {
         let result = resolve_axes(
             &["security".into()],
             crate::review_mode::ReviewMode::Code,
-            false, false, false,
+            false,
+            false,
+            false,
             &skills,
         );
         let resolved = result.unwrap().unwrap();
@@ -1185,7 +1187,9 @@ mod axes_tests {
         let result = resolve_axes(
             &["correctness".into(), "security".into()],
             crate::review_mode::ReviewMode::Code,
-            false, false, false,
+            false,
+            false,
+            false,
             &skills,
         );
         let resolved = result.unwrap().unwrap();
@@ -1205,7 +1209,9 @@ mod axes_tests {
         let result = resolve_axes(
             &[],
             crate::review_mode::ReviewMode::Code,
-            false, false, false,
+            false,
+            false,
+            false,
             &skills,
         );
         let resolved = result.unwrap().unwrap();
@@ -1214,7 +1220,11 @@ mod axes_tests {
             resolved.source,
             crate::skill_audit::AxisSelectionSource::ModeMacro,
         );
-        let names: Vec<&str> = resolved.skills.iter().map(|s| s.manifest.name.as_str()).collect();
+        let names: Vec<&str> = resolved
+            .skills
+            .iter()
+            .map(|s| s.manifest.name.as_str())
+            .collect();
         assert_eq!(names, &["correctness", "security", "testing-antipatterns"]);
     }
 
@@ -1225,7 +1235,9 @@ mod axes_tests {
         let result = resolve_axes(
             &[],
             crate::review_mode::ReviewMode::Code,
-            true, false, false,
+            true,
+            false,
+            false,
             &skills,
         );
         assert!(result.unwrap().is_none());
@@ -1238,7 +1250,9 @@ mod axes_tests {
         let result = resolve_axes(
             &[],
             crate::review_mode::ReviewMode::Code,
-            false, true, false,
+            false,
+            true,
+            false,
             &skills,
         );
         assert!(result.unwrap().is_none());
@@ -1251,7 +1265,9 @@ mod axes_tests {
         let result = resolve_axes(
             &[],
             crate::review_mode::ReviewMode::Code,
-            false, false, true,
+            false,
+            false,
+            true,
             &skills,
         );
         assert!(result.unwrap().is_none());
@@ -1264,7 +1280,9 @@ mod axes_tests {
         let result = resolve_axes(
             &["security".into()],
             crate::review_mode::ReviewMode::Code,
-            true, false, false,
+            true,
+            false,
+            false,
             &skills,
         );
         let err = result.unwrap_err();
@@ -1278,11 +1296,17 @@ mod axes_tests {
         let result = resolve_axes(
             &["security".into()],
             crate::review_mode::ReviewMode::Code,
-            false, false, true,
+            false,
+            false,
+            true,
             &skills,
         );
         let err = result.unwrap_err();
-        assert!(err.contains("--ensemble"), "expected --ensemble in error: {}", err);
+        assert!(
+            err.contains("--ensemble"),
+            "expected --ensemble in error: {}",
+            err
+        );
     }
 
     // A9: explicit_axes_with_daemon_errors
@@ -1292,11 +1316,17 @@ mod axes_tests {
         let result = resolve_axes(
             &["security".into()],
             crate::review_mode::ReviewMode::Code,
-            false, true, false,
+            false,
+            true,
+            false,
             &skills,
         );
         let err = result.unwrap_err();
-        assert!(err.contains("--daemon"), "expected --daemon in error: {}", err);
+        assert!(
+            err.contains("--daemon"),
+            "expected --daemon in error: {}",
+            err
+        );
     }
 
     // A10: reserved_mode_tests_errors
@@ -1306,12 +1336,22 @@ mod axes_tests {
         let result = resolve_axes(
             &[],
             crate::review_mode::ReviewMode::Tests,
-            false, false, false,
+            false,
+            false,
+            false,
             &skills,
         );
         let err = result.unwrap_err();
-        assert!(err.contains("test-coverage"), "expected test-coverage in error: {}", err);
-        assert!(err.contains("mode 'tests'"), "expected mode name in error: {}", err);
+        assert!(
+            err.contains("test-coverage"),
+            "expected test-coverage in error: {}",
+            err
+        );
+        assert!(
+            err.contains("mode 'tests'"),
+            "expected mode name in error: {}",
+            err
+        );
     }
 
     // A11: reserved_mode_release_errors
@@ -1321,12 +1361,22 @@ mod axes_tests {
         let result = resolve_axes(
             &[],
             crate::review_mode::ReviewMode::Release,
-            false, false, false,
+            false,
+            false,
+            false,
             &skills,
         );
         let err = result.unwrap_err();
-        assert!(err.contains("release-readiness"), "expected release-readiness in error: {}", err);
-        assert!(err.contains("mode 'release'"), "expected mode name in error: {}", err);
+        assert!(
+            err.contains("release-readiness"),
+            "expected release-readiness in error: {}",
+            err
+        );
+        assert!(
+            err.contains("mode 'release'"),
+            "expected mode name in error: {}",
+            err
+        );
     }
 
     // A12: unknown_axis_errors
@@ -1336,12 +1386,22 @@ mod axes_tests {
         let result = resolve_axes(
             &["nonexistent".into()],
             crate::review_mode::ReviewMode::Code,
-            false, false, false,
+            false,
+            false,
+            false,
             &skills,
         );
         let err = result.unwrap_err();
-        assert!(err.contains("unknown skill axis 'nonexistent'"), "expected unknown axis in error: {}", err);
-        assert!(err.contains("available:"), "expected available list in error: {}", err);
+        assert!(
+            err.contains("unknown skill axis 'nonexistent'"),
+            "expected unknown axis in error: {}",
+            err
+        );
+        assert!(
+            err.contains("available:"),
+            "expected available list in error: {}",
+            err
+        );
     }
 
     // A13: prose_plan_uses_legacy
@@ -1351,7 +1411,9 @@ mod axes_tests {
         let result = resolve_axes(
             &[],
             crate::review_mode::ReviewMode::Plan,
-            false, false, false,
+            false,
+            false,
+            false,
             &skills,
         );
         assert!(result.unwrap().is_none());
@@ -1364,7 +1426,9 @@ mod axes_tests {
         let result = resolve_axes(
             &[],
             crate::review_mode::ReviewMode::Docs,
-            false, false, false,
+            false,
+            false,
+            false,
             &skills,
         );
         assert!(result.unwrap().is_none());
@@ -1377,7 +1441,9 @@ mod axes_tests {
         let result = resolve_axes(
             &["SECURITY".into()],
             crate::review_mode::ReviewMode::Code,
-            false, false, false,
+            false,
+            false,
+            false,
             &skills,
         );
         let resolved = result.unwrap().unwrap();
@@ -1392,7 +1458,9 @@ mod axes_tests {
         let result = resolve_axes(
             &["".into(), "security".into()],
             crate::review_mode::ReviewMode::Code,
-            false, false, false,
+            false,
+            false,
+            false,
             &skills,
         );
         let resolved = result.unwrap().unwrap();
@@ -1408,7 +1476,9 @@ mod axes_tests {
         let result = resolve_axes(
             &["".into(), "  ".into()],
             crate::review_mode::ReviewMode::Code,
-            false, false, false,
+            false,
+            false,
+            false,
             &skills,
         );
         let resolved = result.unwrap().unwrap();
@@ -1427,7 +1497,9 @@ mod axes_tests {
         let result = resolve_axes(
             &["security".into(), "security".into()],
             crate::review_mode::ReviewMode::Code,
-            false, false, false,
+            false,
+            false,
+            false,
             &skills,
         );
         let resolved = result.unwrap().unwrap();
@@ -1441,7 +1513,9 @@ mod axes_tests {
         let result = resolve_axes(
             &[],
             crate::review_mode::ReviewMode::Code,
-            false, false, false,
+            false,
+            false,
+            false,
             &[], // no skills available
         );
         let err = result.unwrap_err();
@@ -1460,11 +1534,17 @@ mod axes_tests {
         let result = resolve_axes(
             &["security".into()],
             crate::review_mode::ReviewMode::Code,
-            true, true, false,
+            true,
+            true,
+            false,
             &skills,
         );
         let err = result.unwrap_err();
-        assert!(err.contains("--deep"), "expected --deep (first) in error: {}", err);
+        assert!(
+            err.contains("--deep"),
+            "expected --deep (first) in error: {}",
+            err
+        );
     }
 }
 
@@ -1556,7 +1636,10 @@ mod skill_integration_tests {
         .expect("should return Some for explicit axes");
 
         assert_eq!(resolved.skills.len(), 2);
-        assert_eq!(resolved.source, skill_audit::AxisSelectionSource::ExplicitAxes);
+        assert_eq!(
+            resolved.source,
+            skill_audit::AxisSelectionSource::ExplicitAxes
+        );
 
         let exec_cfg = skill_executor::SkillExecutorConfig {
             run_id: "test-integration".into(),
@@ -1586,17 +1669,18 @@ mod skill_integration_tests {
         let tagged: Vec<_> = results
             .iter()
             .flat_map(|cr| {
-                cr.findings
-                    .iter()
-                    .map(|f| skill_integrator::TaggedFinding {
-                        file_path: "test.rs".into(),
-                        finding: f.clone(),
-                    })
+                cr.findings.iter().map(|f| skill_integrator::TaggedFinding {
+                    file_path: "test.rs".into(),
+                    finding: f.clone(),
+                })
             })
             .collect();
         let int_cfg = skill_integrator::IntegratorConfig::default();
         let output = skill_integrator::integrate(tagged, &int_cfg);
-        assert!(!output.findings.is_empty(), "integrator should emit findings");
+        assert!(
+            !output.findings.is_empty(),
+            "integrator should emit findings"
+        );
         assert!(
             output.findings.len() < 4,
             "integrator should merge overlapping findings from 2 skills"
@@ -1730,14 +1814,16 @@ async fn run_review(opts: cli::ReviewOpts) -> i32 {
     // Skill axis resolution: load manifests, resolve --axes, build executor
     // infrastructure.
     // -----------------------------------------------------------------------
-    let quorum_home_for_skills = quorum_dir().unwrap_or_else(|| std::path::PathBuf::from(".quorum"));
+    let quorum_home_for_skills =
+        quorum_dir().unwrap_or_else(|| std::path::PathBuf::from(".quorum"));
     let bundled_skills_dir = std::env::current_exe()
         .ok()
         .and_then(|p| p.parent().map(|d| d.to_path_buf()))
         .unwrap_or_else(|| std::path::PathBuf::from("."));
     let user_skills_dir = quorum_home_for_skills.clone();
 
-    let available_skills = match skill_manifest::load_skills(&bundled_skills_dir, &user_skills_dir) {
+    let available_skills = match skill_manifest::load_skills(&bundled_skills_dir, &user_skills_dir)
+    {
         Ok(s) => s,
         Err(e) => {
             tracing::warn!(error = %e, "failed to load skill manifests; skills disabled");
@@ -1772,19 +1858,22 @@ async fn run_review(opts: cli::ReviewOpts) -> i32 {
     }
 
     // Build skill executor infrastructure when axes are resolved AND LLM is available.
-    let skill_adapter: Option<SkillLlmAdapter> = llm_client.as_ref().map(|c| SkillLlmAdapter(c.clone()));
-    let skill_audit_writer: Option<std::sync::Arc<skill_audit::AuditWriter<skill_audit::SkillInvocationRecord>>> =
-        resolved_axes.as_ref().map(|_| {
-            std::sync::Arc::new(skill_audit::AuditWriter::new(
-                quorum_home_for_skills.join(skill_audit::SKILL_INVOCATIONS_FILE),
-            ))
-        });
-    let integrator_audit_writer: Option<std::sync::Arc<skill_audit::AuditWriter<skill_audit::IntegratorDecisionRecord>>> =
-        resolved_axes.as_ref().map(|_| {
-            std::sync::Arc::new(skill_audit::AuditWriter::new(
-                quorum_home_for_skills.join(skill_audit::INTEGRATOR_DECISIONS_FILE),
-            ))
-        });
+    let skill_adapter: Option<SkillLlmAdapter> =
+        llm_client.as_ref().map(|c| SkillLlmAdapter(c.clone()));
+    let skill_audit_writer: Option<
+        std::sync::Arc<skill_audit::AuditWriter<skill_audit::SkillInvocationRecord>>,
+    > = resolved_axes.as_ref().map(|_| {
+        std::sync::Arc::new(skill_audit::AuditWriter::new(
+            quorum_home_for_skills.join(skill_audit::SKILL_INVOCATIONS_FILE),
+        ))
+    });
+    let integrator_audit_writer: Option<
+        std::sync::Arc<skill_audit::AuditWriter<skill_audit::IntegratorDecisionRecord>>,
+    > = resolved_axes.as_ref().map(|_| {
+        std::sync::Arc::new(skill_audit::AuditWriter::new(
+            quorum_home_for_skills.join(skill_audit::INTEGRATOR_DECISIONS_FILE),
+        ))
+    });
 
     // Build pipeline config
     let models = if opts.ensemble {
@@ -2287,11 +2376,8 @@ async fn run_review(opts: cli::ReviewOpts) -> i32 {
             // When skills are active, suppress the single-prompt LLM in the pipeline
             // (AST-only), then run the skill matrix executor + integrator after.
             let use_skills = resolved_axes.is_some() && skill_adapter.is_some();
-            let llm_for_pipeline: Option<&dyn LlmReviewer> = if use_skills {
-                None
-            } else {
-                llm_reviewer
-            };
+            let llm_for_pipeline: Option<&dyn LlmReviewer> =
+                if use_skills { None } else { llm_reviewer };
 
             let review_result = if let Some(l) = lang {
                 pipeline::review_source(
@@ -2310,7 +2396,8 @@ async fn run_review(opts: cli::ReviewOpts) -> i32 {
                         file_path.display()
                     );
                 }
-                pipeline::review_file(file_path, &source, None, llm_for_pipeline, &pipeline_cfg).await
+                pipeline::review_file(file_path, &source, None, llm_for_pipeline, &pipeline_cfg)
+                    .await
             };
             match review_result {
                 Ok(mut result) => {
@@ -2318,75 +2405,81 @@ async fn run_review(opts: cli::ReviewOpts) -> i32 {
                     if use_skills
                         && let (Some(ra), Some(adapter)) = (&resolved_axes, &skill_adapter)
                     {
-                            let file_str = file_path.to_string_lossy().to_string();
-                            let file_sha = {
-                                use sha2::{Sha256, Digest};
-                                let mut h = Sha256::new();
-                                h.update(source.as_bytes());
-                                hex::encode(h.finalize())
-                            };
+                        let file_str = file_path.to_string_lossy().to_string();
+                        let file_sha = {
+                            use sha2::{Digest, Sha256};
+                            let mut h = Sha256::new();
+                            h.update(source.as_bytes());
+                            hex::encode(h.finalize())
+                        };
 
-                            let _exec_span = tracing::info_span!(
-                                "phase.skill_executor",
-                                skills = ra.skills.len(),
-                                file = %file_str,
-                            ).entered();
+                        let _exec_span = tracing::info_span!(
+                            "phase.skill_executor",
+                            skills = ra.skills.len(),
+                            file = %file_str,
+                        )
+                        .entered();
 
-                            let exec_cfg = quorum::skill_executor::SkillExecutorConfig {
-                                run_id: run_id.clone(),
-                                axis_selection_source: ra.source.clone(),
-                                global_models: pipeline_cfg.models.clone(),
-                                ensemble_pool: vec![],
-                                ensemble: false,
-                                max_tokens_per_review: 500_000,
-                                max_calls_per_review: 50,
-                                audit_writer: skill_audit_writer.clone(),
-                            };
-                            let files_input = vec![(file_str.clone(), file_sha, source.clone())];
-                            let cell_results = quorum::skill_executor::execute_matrix(
-                                &ra.skills, &files_input, adapter, &exec_cfg,
-                            );
+                        let exec_cfg = quorum::skill_executor::SkillExecutorConfig {
+                            run_id: run_id.clone(),
+                            axis_selection_source: ra.source.clone(),
+                            global_models: pipeline_cfg.models.clone(),
+                            ensemble_pool: vec![],
+                            ensemble: false,
+                            max_tokens_per_review: 500_000,
+                            max_calls_per_review: 50,
+                            audit_writer: skill_audit_writer.clone(),
+                        };
+                        let files_input = vec![(file_str.clone(), file_sha, source.clone())];
+                        let cell_results = quorum::skill_executor::execute_matrix(
+                            &ra.skills,
+                            &files_input,
+                            adapter,
+                            &exec_cfg,
+                        );
 
-                            drop(_exec_span);
+                        drop(_exec_span);
 
-                            let _int_span = tracing::info_span!(
+                        let _int_span = tracing::info_span!(
                                 "phase.integrator",
                                 input_findings = cell_results.iter().map(|c| c.findings.len()).sum::<usize>(),
                                 file = %file_str,
                             ).entered();
 
-                            let tagged: Vec<quorum::skill_integrator::TaggedFinding> = cell_results
-                                .iter()
-                                .flat_map(|cr| {
-                                    cr.findings.iter().map(|f| quorum::skill_integrator::TaggedFinding {
+                        let tagged: Vec<quorum::skill_integrator::TaggedFinding> = cell_results
+                            .iter()
+                            .flat_map(|cr| {
+                                cr.findings.iter().map(|f| {
+                                    quorum::skill_integrator::TaggedFinding {
                                         file_path: file_str.clone(),
                                         finding: f.clone(),
-                                    })
+                                    }
                                 })
-                                .collect();
+                            })
+                            .collect();
 
-                            let int_cfg = quorum::skill_integrator::IntegratorConfig {
-                                run_id: run_id.clone(),
-                                confidence_floor: 0.30,
-                                audit_writer: integrator_audit_writer.clone(),
-                            };
-                            let int_output = quorum::skill_integrator::integrate(tagged, &int_cfg);
+                        let int_cfg = quorum::skill_integrator::IntegratorConfig {
+                            run_id: run_id.clone(),
+                            confidence_floor: 0.30,
+                            audit_writer: integrator_audit_writer.clone(),
+                        };
+                        let int_output = quorum::skill_integrator::integrate(tagged, &int_cfg);
 
-                            tracing::info!(
-                                findings = int_output.findings.len(),
-                                suppressed = int_output.suppressed.len(),
-                                "integrator complete"
-                            );
+                        tracing::info!(
+                            findings = int_output.findings.len(),
+                            suppressed = int_output.suppressed.len(),
+                            "integrator complete"
+                        );
 
-                            // Accumulate token usage from all skill cells.
-                            for cr in &cell_results {
-                                result.usage.prompt_tokens += cr.usage.prompt_tokens;
-                                result.usage.completion_tokens += cr.usage.completion_tokens;
-                                result.usage.cached_tokens += cr.usage.cached_tokens;
-                            }
+                        // Accumulate token usage from all skill cells.
+                        for cr in &cell_results {
+                            result.usage.prompt_tokens += cr.usage.prompt_tokens;
+                            result.usage.completion_tokens += cr.usage.completion_tokens;
+                            result.usage.cached_tokens += cr.usage.cached_tokens;
+                        }
 
-                            result.findings.extend(int_output.findings);
-                            result.suppressed += int_output.suppressed.len();
+                        result.findings.extend(int_output.findings);
+                        result.suppressed += int_output.suppressed.len();
                     }
 
                     // Apply project-level suppressions

--- a/src/main.rs
+++ b/src/main.rs
@@ -948,7 +948,6 @@ async fn run_report(opts: cli::ReportOpts) -> i32 {
 
 /// The resolved set of skill axes for a review invocation.
 #[derive(Debug)]
-#[allow(dead_code)] // wired in Task 5
 struct ResolvedAxes {
     skills: Vec<crate::skill_manifest::LoadedSkill>,
     source: crate::skill_audit::AxisSelectionSource,
@@ -956,12 +955,10 @@ struct ResolvedAxes {
 
 /// The default code-mode macro axes, applied when no `--axes` flag is given
 /// and the mode is `Code` with no legacy flags active.
-#[allow(dead_code)] // wired in Task 5
 const CODE_MODE_MACRO_AXES: &[&str] = &["correctness", "security", "testing-antipatterns"];
 
 /// Bridges the binary-side `OpenAiClient` (which implements `pipeline::LlmReviewer`)
 /// to the lib-side `skill_executor::LlmReviewer` trait.
-#[allow(dead_code)] // wired in Task 6
 struct SkillLlmAdapter(std::sync::Arc<llm_client::OpenAiClient>);
 
 impl quorum::skill_executor::LlmReviewer for SkillLlmAdapter {
@@ -990,7 +987,6 @@ impl quorum::skill_executor::LlmReviewer for SkillLlmAdapter {
 /// - `Ok(Some(ResolvedAxes))` — a concrete skill set to execute.
 /// - `Ok(None)`               — fall back to the legacy single-prompt pipeline.
 /// - `Err(String)`            — user-facing error message (reserved mode, conflict, unknown axis).
-#[allow(dead_code)] // wired in Task 5
 fn resolve_axes(
     axes: &[String],
     mode: crate::review_mode::ReviewMode,
@@ -1576,6 +1572,69 @@ async fn run_review(opts: cli::ReviewOpts) -> i32 {
         };
     let llm_reviewer: Option<&dyn LlmReviewer> = llm_client.as_deref().map(|c| c as _);
 
+    // -----------------------------------------------------------------------
+    // Skill axis resolution: load manifests, resolve --axes, build executor
+    // infrastructure.
+    // -----------------------------------------------------------------------
+    let quorum_home_for_skills = quorum_dir().unwrap_or_else(|| std::path::PathBuf::from(".quorum"));
+    let bundled_skills_dir = {
+        let exe_dir = std::env::current_exe()
+            .ok()
+            .and_then(|p| p.parent().map(|d| d.to_path_buf()))
+            .unwrap_or_else(|| std::path::PathBuf::from("."));
+        exe_dir.join("skills")
+    };
+    let user_skills_dir = quorum_home_for_skills.join("skills");
+
+    let available_skills = match skill_manifest::load_skills(&bundled_skills_dir, &user_skills_dir) {
+        Ok(s) => s,
+        Err(e) => {
+            tracing::warn!(error = %e, "failed to load skill manifests; skills disabled");
+            vec![]
+        }
+    };
+
+    let resolved_axes = match resolve_axes(
+        &opts.axes,
+        opts.mode,
+        opts.deep,
+        opts.daemon,
+        opts.ensemble,
+        &available_skills,
+    ) {
+        Ok(r) => r,
+        Err(e) => {
+            eprintln!("error: {}", e);
+            return 3;
+        }
+    };
+
+    // Warn if --axes given but no LLM client.
+    if resolved_axes.is_some() && llm_client.is_none() && !opts.axes.is_empty() {
+        eprintln!("warning: --axes requires an LLM client; running AST-only review");
+    }
+
+    // Log axis resolution.
+    if let Some(ref ra) = resolved_axes {
+        let names: Vec<&str> = ra.skills.iter().map(|s| s.manifest.name.as_str()).collect();
+        tracing::info!(axes = ?names, source = ?ra.source, "skill axes resolved");
+    }
+
+    // Build skill executor infrastructure when axes are resolved AND LLM is available.
+    let skill_adapter: Option<SkillLlmAdapter> = llm_client.as_ref().map(|c| SkillLlmAdapter(c.clone()));
+    let skill_audit_writer: Option<std::sync::Arc<skill_audit::AuditWriter<skill_audit::SkillInvocationRecord>>> =
+        resolved_axes.as_ref().map(|_| {
+            std::sync::Arc::new(skill_audit::AuditWriter::new(
+                quorum_home_for_skills.join(skill_audit::SKILL_INVOCATIONS_FILE),
+            ))
+        });
+    let integrator_audit_writer: Option<std::sync::Arc<skill_audit::AuditWriter<skill_audit::IntegratorDecisionRecord>>> =
+        resolved_axes.as_ref().map(|_| {
+            std::sync::Arc::new(skill_audit::AuditWriter::new(
+                quorum_home_for_skills.join(skill_audit::INTEGRATOR_DECISIONS_FILE),
+            ))
+        });
+
     // Build pipeline config
     let models = if opts.ensemble {
         // Ensemble: use QUORUM_ENSEMBLE_MODELS or default set
@@ -2073,26 +2132,112 @@ async fn run_review(opts: cli::ReviewOpts) -> i32 {
                 }
             }
 
-            // Run pipeline: full (AST + LLM) for supported languages, LLM-only for others
+            // Run pipeline: full (AST + LLM) for supported languages, LLM-only for others.
+            // When skills are active, suppress the single-prompt LLM in the pipeline
+            // (AST-only), then run the skill matrix executor + integrator after.
+            let use_skills = resolved_axes.is_some() && skill_adapter.is_some();
+            let llm_for_pipeline: Option<&dyn LlmReviewer> = if use_skills {
+                None
+            } else {
+                llm_reviewer
+            };
+
             let review_result = if let Some(l) = lang {
                 pipeline::review_source(
                     file_path,
                     &source,
                     l,
-                    llm_reviewer,
+                    llm_for_pipeline,
                     &pipeline_cfg,
                     Some(&parse_cache),
                 )
                 .await
             } else {
-                eprintln!(
-                    "Note: No AST support for {}, using LLM-only review",
-                    file_path.display()
-                );
-                pipeline::review_file(file_path, &source, None, llm_reviewer, &pipeline_cfg).await
+                if !use_skills {
+                    eprintln!(
+                        "Note: No AST support for {}, using LLM-only review",
+                        file_path.display()
+                    );
+                }
+                pipeline::review_file(file_path, &source, None, llm_for_pipeline, &pipeline_cfg).await
             };
             match review_result {
                 Ok(mut result) => {
+                    // If skills active, run executor + integrator.
+                    if use_skills
+                        && let (Some(ra), Some(adapter)) = (&resolved_axes, &skill_adapter)
+                    {
+                            let file_str = file_path.to_string_lossy().to_string();
+                            let file_sha = {
+                                use sha2::{Sha256, Digest};
+                                let mut h = Sha256::new();
+                                h.update(source.as_bytes());
+                                hex::encode(h.finalize())
+                            };
+
+                            let _exec_span = tracing::info_span!(
+                                "phase.skill_executor",
+                                skills = ra.skills.len(),
+                                file = %file_str,
+                            ).entered();
+
+                            let exec_cfg = quorum::skill_executor::SkillExecutorConfig {
+                                run_id: run_id.clone(),
+                                axis_selection_source: ra.source.clone(),
+                                global_models: pipeline_cfg.models.clone(),
+                                ensemble_pool: vec![],
+                                ensemble: false,
+                                max_tokens_per_review: 500_000,
+                                max_calls_per_review: 50,
+                                audit_writer: skill_audit_writer.clone(),
+                            };
+                            let files_input = vec![(file_str.clone(), file_sha, source.clone())];
+                            let cell_results = quorum::skill_executor::execute_matrix(
+                                &ra.skills, &files_input, adapter, &exec_cfg,
+                            );
+
+                            drop(_exec_span);
+
+                            let _int_span = tracing::info_span!(
+                                "phase.integrator",
+                                input_findings = cell_results.iter().map(|c| c.findings.len()).sum::<usize>(),
+                                file = %file_str,
+                            ).entered();
+
+                            let tagged: Vec<quorum::skill_integrator::TaggedFinding> = cell_results
+                                .iter()
+                                .flat_map(|cr| {
+                                    cr.findings.iter().map(|f| quorum::skill_integrator::TaggedFinding {
+                                        file_path: file_str.clone(),
+                                        finding: f.clone(),
+                                    })
+                                })
+                                .collect();
+
+                            let int_cfg = quorum::skill_integrator::IntegratorConfig {
+                                run_id: run_id.clone(),
+                                confidence_floor: 0.30,
+                                audit_writer: integrator_audit_writer.clone(),
+                            };
+                            let int_output = quorum::skill_integrator::integrate(tagged, &int_cfg);
+
+                            tracing::info!(
+                                findings = int_output.findings.len(),
+                                suppressed = int_output.suppressed.len(),
+                                "integrator complete"
+                            );
+
+                            // Accumulate token usage from all skill cells.
+                            for cr in &cell_results {
+                                result.usage.prompt_tokens += cr.usage.prompt_tokens;
+                                result.usage.completion_tokens += cr.usage.completion_tokens;
+                                result.usage.cached_tokens += cr.usage.cached_tokens;
+                            }
+
+                            result.findings.extend(int_output.findings);
+                            result.suppressed += int_output.suppressed.len();
+                    }
+
                     // Apply project-level suppressions
                     let file_display = result.file_path.clone();
                     let sup_result = suppress::apply_suppressions(
@@ -2136,6 +2281,12 @@ async fn run_review(opts: cli::ReviewOpts) -> i32 {
         let rt = tokio::runtime::Handle::current();
         let mut handles = Vec::new();
 
+        // Arc-wrap skill infrastructure for cross-thread sharing.
+        let resolved_axes_arc: Option<std::sync::Arc<ResolvedAxes>> =
+            resolved_axes.map(std::sync::Arc::new);
+        let skill_audit_writer_arc = skill_audit_writer;
+        let integrator_audit_writer_arc = integrator_audit_writer;
+
         for (idx, file_path) in opts.files.iter().enumerate() {
             let file_path = file_path.clone();
             let pipeline_cfg = pipeline_cfg.clone();
@@ -2143,6 +2294,10 @@ async fn run_review(opts: cli::ReviewOpts) -> i32 {
             let _show_suppressed = opts.show_suppressed;
             let deep = opts.deep;
             let llm_client = llm_client.clone();
+            let resolved_axes = resolved_axes_arc.clone();
+            let skill_audit_writer = skill_audit_writer_arc.clone();
+            let integrator_audit_writer = integrator_audit_writer_arc.clone();
+            let run_id = run_id.clone();
 
             let handle = rt.spawn_blocking(move || {
                 if !file_path.exists() {
@@ -2212,9 +2367,13 @@ async fn run_review(opts: cli::ReviewOpts) -> i32 {
                     }
                 }
 
-                // Standard review path
-                let llm_reviewer: Option<&dyn pipeline::LlmReviewer> =
-                    llm_client.as_deref().map(|c| c as _);
+                // Standard review path. When skills are active, suppress single-prompt LLM.
+                let use_skills = resolved_axes.is_some() && llm_client.is_some();
+                let llm_reviewer: Option<&dyn pipeline::LlmReviewer> = if use_skills {
+                    None
+                } else {
+                    llm_client.as_deref().map(|c| c as _)
+                };
                 let parse_cache = cache::ParseCache::new(128);
                 // `spawn_blocking` runs on Tokio's blocking pool (separate from
                 // runtime workers), so `Handle::block_on` here is sound per
@@ -2247,13 +2406,89 @@ async fn run_review(opts: cli::ReviewOpts) -> i32 {
 
                 match review_result {
                     Ok(mut result) => {
+                        // If skills active, run executor + integrator.
+                        if use_skills
+                            && let (Some(ra), Some(client)) = (&resolved_axes, &llm_client)
+                        {
+                                let file_str = file_path.to_string_lossy().to_string();
+                                let file_sha = {
+                                    use sha2::{Sha256, Digest};
+                                    let mut h = Sha256::new();
+                                    h.update(source.as_bytes());
+                                    hex::encode(h.finalize())
+                                };
+
+                                let _exec_span = tracing::info_span!(
+                                    "phase.skill_executor",
+                                    skills = ra.skills.len(),
+                                    file = %file_str,
+                                ).entered();
+
+                                let adapter = SkillLlmAdapter(client.clone());
+                                let exec_cfg = quorum::skill_executor::SkillExecutorConfig {
+                                    run_id: run_id.clone(),
+                                    axis_selection_source: ra.source.clone(),
+                                    global_models: pipeline_cfg.models.clone(),
+                                    ensemble_pool: vec![],
+                                    ensemble: false,
+                                    max_tokens_per_review: 500_000,
+                                    max_calls_per_review: 50,
+                                    audit_writer: skill_audit_writer.clone(),
+                                };
+                                let files_input = vec![(file_str.clone(), file_sha, source.clone())];
+                                let cell_results = quorum::skill_executor::execute_matrix(
+                                    &ra.skills, &files_input, &adapter, &exec_cfg,
+                                );
+
+                                drop(_exec_span);
+
+                                let _int_span = tracing::info_span!(
+                                    "phase.integrator",
+                                    input_findings = cell_results.iter().map(|c| c.findings.len()).sum::<usize>(),
+                                    file = %file_str,
+                                ).entered();
+
+                                let tagged: Vec<quorum::skill_integrator::TaggedFinding> = cell_results
+                                    .iter()
+                                    .flat_map(|cr| {
+                                        cr.findings.iter().map(|f| quorum::skill_integrator::TaggedFinding {
+                                            file_path: file_str.clone(),
+                                            finding: f.clone(),
+                                        })
+                                    })
+                                    .collect();
+
+                                let int_cfg = quorum::skill_integrator::IntegratorConfig {
+                                    run_id: run_id.clone(),
+                                    confidence_floor: 0.30,
+                                    audit_writer: integrator_audit_writer.clone(),
+                                };
+                                let int_output = quorum::skill_integrator::integrate(tagged, &int_cfg);
+
+                                tracing::info!(
+                                    findings = int_output.findings.len(),
+                                    suppressed = int_output.suppressed.len(),
+                                    "integrator complete"
+                                );
+
+                                // Accumulate token usage from all skill cells.
+                                for cr in &cell_results {
+                                    result.usage.prompt_tokens += cr.usage.prompt_tokens;
+                                    result.usage.completion_tokens += cr.usage.completion_tokens;
+                                    result.usage.cached_tokens += cr.usage.cached_tokens;
+                                }
+
+                                result.findings.extend(int_output.findings);
+                                result.suppressed += int_output.suppressed.len();
+                        }
+
                         let sup_result = suppress::apply_suppressions(
                             result.findings,
                             &suppress_rules,
                             &file_display,
                         );
                         result.findings = sup_result.kept;
-                        result.suppressed = sup_result.suppressed.len();
+                        result.suppressed += sup_result.suppressed.len();
                         (idx, Ok((result, sup_result.suppressed)))
                     }
                     Err(e) => (idx, Err(e)),

--- a/src/main.rs
+++ b/src/main.rs
@@ -959,6 +959,31 @@ struct ResolvedAxes {
 #[allow(dead_code)] // wired in Task 5
 const CODE_MODE_MACRO_AXES: &[&str] = &["correctness", "security", "testing-antipatterns"];
 
+/// Bridges the binary-side `OpenAiClient` (which implements `pipeline::LlmReviewer`)
+/// to the lib-side `skill_executor::LlmReviewer` trait.
+#[allow(dead_code)] // wired in Task 6
+struct SkillLlmAdapter(std::sync::Arc<llm_client::OpenAiClient>);
+
+impl quorum::skill_executor::LlmReviewer for SkillLlmAdapter {
+    fn review(
+        &self,
+        prompt: &str,
+        model: &str,
+        system_prompt: &str,
+    ) -> anyhow::Result<quorum::skill_executor::LlmResponse> {
+        let resp = pipeline::LlmReviewer::review(&*self.0, prompt, model, system_prompt)?;
+        let usage = resp.usage.map(|u| quorum::skill_executor::TokenUsage {
+            prompt_tokens: u.prompt_tokens,
+            completion_tokens: u.completion_tokens,
+            cached_tokens: u.cached_tokens,
+        });
+        Ok(quorum::skill_executor::LlmResponse {
+            content: resp.content,
+            usage,
+        })
+    }
+}
+
 /// Resolve the review axis set from CLI flags and available skills.
 ///
 /// Returns:

--- a/src/main.rs
+++ b/src/main.rs
@@ -1468,6 +1468,145 @@ mod axes_tests {
     }
 }
 
+#[cfg(test)]
+mod skill_integration_tests {
+    use crate::skill_audit;
+    use quorum::skill_executor;
+    use quorum::skill_integrator;
+    use quorum::skill_manifest;
+
+    fn mock_loaded_skill(name: &str) -> skill_manifest::LoadedSkill {
+        skill_manifest::LoadedSkill {
+            manifest: skill_manifest::SkillManifest {
+                name: name.to_string(),
+                version: "1.0.0".into(),
+                display_name: name.into(),
+                description: format!("{name} skill"),
+                preferred_model: None,
+                fallback_models: None,
+                calibration_namespace: None,
+                axis: skill_manifest::Axis::Correctness,
+                max_severity: quorum::finding::Severity::Critical,
+                target_findings: None,
+                capability: skill_manifest::Capability {
+                    mode: skill_manifest::CapabilityMode::Pure,
+                },
+                prompts: skill_manifest::Prompts {
+                    primary: "Review for {name}".into(),
+                    anthropic: None,
+                    openai: None,
+                    google: None,
+                },
+                checklist: vec![],
+                ast_rules: vec![],
+            },
+            trust_tier: skill_manifest::TrustTier::Bundled,
+            source_path: std::path::PathBuf::from(format!("skills/{name}.toml")),
+            manifest_sha256: "test-sha".into(),
+        }
+    }
+
+    fn make_finding_json(title: &str) -> String {
+        let f = quorum::finding::FindingBuilder::new()
+            .title(title)
+            .severity(quorum::finding::Severity::Medium)
+            .category(quorum::category::Category::Correctness)
+            .source(quorum::finding::Source::Llm("test-model".into()))
+            .lines(1, 5)
+            .build();
+        serde_json::to_string(&f).unwrap()
+    }
+
+    struct MockReviewer;
+    impl skill_executor::LlmReviewer for MockReviewer {
+        fn review(
+            &self,
+            _prompt: &str,
+            _model: &str,
+            _system_prompt: &str,
+        ) -> anyhow::Result<skill_executor::LlmResponse> {
+            let json = format!("[{}]", make_finding_json("Test bug"));
+            Ok(skill_executor::LlmResponse {
+                content: json,
+                usage: Some(skill_executor::TokenUsage {
+                    prompt_tokens: 100,
+                    completion_tokens: 50,
+                    cached_tokens: 0,
+                }),
+            })
+        }
+    }
+
+    #[test]
+    fn full_pipeline_resolve_execute_integrate() {
+        let skills = vec![
+            mock_loaded_skill("correctness"),
+            mock_loaded_skill("security"),
+        ];
+
+        let resolved = super::resolve_axes(
+            &["correctness".into(), "security".into()],
+            crate::review_mode::ReviewMode::Code,
+            false,
+            false,
+            false,
+            &skills,
+        )
+        .expect("resolve_axes should succeed")
+        .expect("should return Some for explicit axes");
+
+        assert_eq!(resolved.skills.len(), 2);
+        assert_eq!(resolved.source, skill_audit::AxisSelectionSource::ExplicitAxes);
+
+        let exec_cfg = skill_executor::SkillExecutorConfig {
+            run_id: "test-integration".into(),
+            axis_selection_source: resolved.source.clone(),
+            global_models: vec!["test-model".into()],
+            ensemble_pool: vec![],
+            ensemble: false,
+            max_tokens_per_review: 100_000,
+            max_calls_per_review: 10,
+            audit_writer: None,
+        };
+        let files = vec![("test.rs".into(), "abc123".into(), "fn main() {}".into())];
+        let results =
+            skill_executor::execute_matrix(&resolved.skills, &files, &MockReviewer, &exec_cfg);
+
+        assert_eq!(results.len(), 2, "one CellResult per skill");
+        for r in &results {
+            assert!(!r.findings.is_empty(), "each skill should produce findings");
+            for f in &r.findings {
+                assert!(
+                    f.originating_skill.is_some(),
+                    "findings must carry originating_skill"
+                );
+            }
+        }
+
+        let tagged: Vec<_> = results
+            .iter()
+            .flat_map(|cr| {
+                cr.findings
+                    .iter()
+                    .map(|f| skill_integrator::TaggedFinding {
+                        file_path: "test.rs".into(),
+                        finding: f.clone(),
+                    })
+            })
+            .collect();
+        let int_cfg = skill_integrator::IntegratorConfig::default();
+        let output = skill_integrator::integrate(tagged, &int_cfg);
+        assert!(!output.findings.is_empty(), "integrator should emit findings");
+        assert!(
+            output.findings.len() < 4,
+            "integrator should merge overlapping findings from 2 skills"
+        );
+
+        let total_prompt: u64 = results.iter().map(|r| r.usage.prompt_tokens).sum();
+        assert!(total_prompt > 0, "token usage should be tracked");
+    }
+}
+
 async fn run_review(opts: cli::ReviewOpts) -> i32 {
     // The empty-files case is now rejected at the clap layer via
     // `#[arg(required = true, num_args = 1..)]` on `ReviewOpts.files`

--- a/src/main.rs
+++ b/src/main.rs
@@ -1497,6 +1497,21 @@ async fn run_review(opts: cli::ReviewOpts) -> i32 {
         return 3;
     }
 
+    // Reserved modes are not yet implemented.
+    if opts.mode.is_reserved() {
+        eprintln!(
+            "error: --mode {} is reserved and not yet implemented",
+            opts.mode,
+        );
+        return 3;
+    }
+
+    // --axes is not supported with --daemon (daemon has its own review path).
+    if opts.daemon && !opts.axes.is_empty() {
+        eprintln!("error: --axes is not supported with --daemon");
+        return 3;
+    }
+
     // If --daemon flag is set, send requests to running daemon
     if opts.daemon {
         return run_review_via_daemon(&opts);
@@ -1577,14 +1592,11 @@ async fn run_review(opts: cli::ReviewOpts) -> i32 {
     // infrastructure.
     // -----------------------------------------------------------------------
     let quorum_home_for_skills = quorum_dir().unwrap_or_else(|| std::path::PathBuf::from(".quorum"));
-    let bundled_skills_dir = {
-        let exe_dir = std::env::current_exe()
-            .ok()
-            .and_then(|p| p.parent().map(|d| d.to_path_buf()))
-            .unwrap_or_else(|| std::path::PathBuf::from("."));
-        exe_dir.join("skills")
-    };
-    let user_skills_dir = quorum_home_for_skills.join("skills");
+    let bundled_skills_dir = std::env::current_exe()
+        .ok()
+        .and_then(|p| p.parent().map(|d| d.to_path_buf()))
+        .unwrap_or_else(|| std::path::PathBuf::from("."));
+    let user_skills_dir = quorum_home_for_skills.clone();
 
     let available_skills = match skill_manifest::load_skills(&bundled_skills_dir, &user_skills_dir) {
         Ok(s) => s,

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,6 +24,8 @@ pub use quorum::prompt_sanitize;
 pub use quorum::prose_prompts;
 pub use quorum::redact;
 pub use quorum::review_mode;
+pub use quorum::skill_audit;
+pub use quorum::skill_manifest;
 pub use quorum::skill_prompt_defense;
 pub use quorum::storage;
 
@@ -936,6 +938,512 @@ async fn run_report(opts: cli::ReportOpts) -> i32 {
             eprintln!("\nError: GitHub post failed: {}", e);
             3
         }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Axis resolution: maps (--axes, --mode, --deep/--daemon/--ensemble) to a
+// skill set or legacy fallback. Pure logic, no I/O.
+// ---------------------------------------------------------------------------
+
+/// The resolved set of skill axes for a review invocation.
+#[derive(Debug)]
+#[allow(dead_code)] // wired in Task 5
+struct ResolvedAxes {
+    skills: Vec<crate::skill_manifest::LoadedSkill>,
+    source: crate::skill_audit::AxisSelectionSource,
+}
+
+/// The default code-mode macro axes, applied when no `--axes` flag is given
+/// and the mode is `Code` with no legacy flags active.
+#[allow(dead_code)] // wired in Task 5
+const CODE_MODE_MACRO_AXES: &[&str] = &["correctness", "security", "testing-antipatterns"];
+
+/// Resolve the review axis set from CLI flags and available skills.
+///
+/// Returns:
+/// - `Ok(Some(ResolvedAxes))` — a concrete skill set to execute.
+/// - `Ok(None)`               — fall back to the legacy single-prompt pipeline.
+/// - `Err(String)`            — user-facing error message (reserved mode, conflict, unknown axis).
+#[allow(dead_code)] // wired in Task 5
+fn resolve_axes(
+    axes: &[String],
+    mode: crate::review_mode::ReviewMode,
+    deep: bool,
+    daemon: bool,
+    ensemble: bool,
+    available_skills: &[crate::skill_manifest::LoadedSkill],
+) -> Result<Option<ResolvedAxes>, String> {
+    // -----------------------------------------------------------------------
+    // (a) Reserved mode — hard error with placeholder skill names
+    // -----------------------------------------------------------------------
+    if mode.is_reserved() {
+        let placeholder = match mode {
+            crate::review_mode::ReviewMode::Tests => "test-coverage, test-quality",
+            crate::review_mode::ReviewMode::Release => "release-readiness",
+            _ => unreachable!(),
+        };
+        return Err(format!(
+            "mode '{}' requires axes not installed in this version: [{}]",
+            mode, placeholder,
+        ));
+    }
+
+    // -----------------------------------------------------------------------
+    // Normalize --axes: filter empties, lowercase, deduplicate (preserving
+    // first-occurrence order).
+    // -----------------------------------------------------------------------
+    let normalized: Vec<String> = {
+        let mut seen = std::collections::HashSet::new();
+        axes.iter()
+            .map(|a| a.trim().to_ascii_lowercase())
+            .filter(|a| !a.is_empty())
+            .filter(|a| seen.insert(a.clone()))
+            .collect()
+    };
+
+    let has_explicit_axes = !normalized.is_empty();
+
+    // -----------------------------------------------------------------------
+    // (b) Explicit --axes + legacy flag → hard error
+    // -----------------------------------------------------------------------
+    if has_explicit_axes {
+        let legacy_flag = if deep {
+            Some("--deep")
+        } else if daemon {
+            Some("--daemon")
+        } else if ensemble {
+            Some("--ensemble")
+        } else {
+            None
+        };
+        if let Some(flag) = legacy_flag {
+            return Err(format!(
+                "multi-axis review is not supported with {} yet",
+                flag,
+            ));
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // (c) Explicit --axes → validate against available skills
+    // -----------------------------------------------------------------------
+    if has_explicit_axes {
+        let available_names: Vec<String> = available_skills
+            .iter()
+            .map(|s| s.manifest.name.to_ascii_lowercase())
+            .collect();
+
+        let mut matched = Vec::new();
+        for axis in &normalized {
+            let idx = available_names
+                .iter()
+                .position(|n| n == axis)
+                .ok_or_else(|| {
+                    format!(
+                        "unknown skill axis '{}'; available: [{}]",
+                        axis,
+                        available_names.join(", "),
+                    )
+                })?;
+            matched.push(available_skills[idx].clone());
+        }
+        return Ok(Some(ResolvedAxes {
+            skills: matched,
+            source: crate::skill_audit::AxisSelectionSource::ExplicitAxes,
+        }));
+    }
+
+    // -----------------------------------------------------------------------
+    // (d) Legacy flag without explicit --axes → legacy fallback
+    // -----------------------------------------------------------------------
+    if deep || daemon || ensemble {
+        return Ok(None);
+    }
+
+    // -----------------------------------------------------------------------
+    // (e) Default code mode → ModeMacro with bundled axes
+    // -----------------------------------------------------------------------
+    if mode == crate::review_mode::ReviewMode::Code {
+        let mut skills = Vec::new();
+        for &axis_name in CODE_MODE_MACRO_AXES {
+            let skill = available_skills
+                .iter()
+                .find(|s| s.manifest.name.eq_ignore_ascii_case(axis_name))
+                .ok_or_else(|| {
+                    format!(
+                        "bundled skill '{}' not found; installation may be corrupt",
+                        axis_name,
+                    )
+                })?
+                .clone();
+            skills.push(skill);
+        }
+        return Ok(Some(ResolvedAxes {
+            skills,
+            source: crate::skill_audit::AxisSelectionSource::ModeMacro,
+        }));
+    }
+
+    // -----------------------------------------------------------------------
+    // (f) Prose modes (plan, docs) without --axes → legacy fallback
+    // -----------------------------------------------------------------------
+    Ok(None)
+}
+
+// ---------------------------------------------------------------------------
+// Tests for resolve_axes
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod axes_tests {
+    use super::*;
+
+    fn mock_skill(name: &str) -> crate::skill_manifest::LoadedSkill {
+        crate::skill_manifest::LoadedSkill {
+            manifest: crate::skill_manifest::SkillManifest {
+                name: name.to_string(),
+                version: "1.0.0".to_string(),
+                display_name: name.to_string(),
+                description: String::new(),
+                axis: crate::skill_manifest::Axis::Correctness,
+                max_severity: crate::finding::Severity::Critical,
+                target_findings: None,
+                capability: crate::skill_manifest::Capability {
+                    mode: crate::skill_manifest::CapabilityMode::Pure,
+                },
+                preferred_model: None,
+                fallback_models: None,
+                calibration_namespace: None,
+                prompts: crate::skill_manifest::Prompts {
+                    primary: "test prompt".into(),
+                    anthropic: None,
+                    openai: None,
+                    google: None,
+                },
+                checklist: vec![],
+                ast_rules: vec![],
+            },
+            source_path: std::path::PathBuf::from(format!("skills/{}.toml", name)),
+            manifest_sha256: "abc123".to_string(),
+            trust_tier: crate::skill_manifest::TrustTier::Bundled,
+        }
+    }
+
+    fn bundled_skills() -> Vec<crate::skill_manifest::LoadedSkill> {
+        vec![
+            mock_skill("correctness"),
+            mock_skill("security"),
+            mock_skill("testing-antipatterns"),
+        ]
+    }
+
+    // A1: explicit_axes_resolves
+    #[test]
+    fn explicit_axes_resolves() {
+        let skills = bundled_skills();
+        let result = resolve_axes(
+            &["security".into()],
+            crate::review_mode::ReviewMode::Code,
+            false, false, false,
+            &skills,
+        );
+        let resolved = result.unwrap().unwrap();
+        assert_eq!(resolved.skills.len(), 1);
+        assert_eq!(resolved.skills[0].manifest.name, "security");
+        assert_eq!(
+            resolved.source,
+            crate::skill_audit::AxisSelectionSource::ExplicitAxes,
+        );
+    }
+
+    // A2: explicit_multiple_axes
+    #[test]
+    fn explicit_multiple_axes() {
+        let skills = bundled_skills();
+        let result = resolve_axes(
+            &["correctness".into(), "security".into()],
+            crate::review_mode::ReviewMode::Code,
+            false, false, false,
+            &skills,
+        );
+        let resolved = result.unwrap().unwrap();
+        assert_eq!(resolved.skills.len(), 2);
+        assert_eq!(resolved.skills[0].manifest.name, "correctness");
+        assert_eq!(resolved.skills[1].manifest.name, "security");
+        assert_eq!(
+            resolved.source,
+            crate::skill_audit::AxisSelectionSource::ExplicitAxes,
+        );
+    }
+
+    // A3: default_code_mode_resolves_to_bundled
+    #[test]
+    fn default_code_mode_resolves_to_bundled() {
+        let skills = bundled_skills();
+        let result = resolve_axes(
+            &[],
+            crate::review_mode::ReviewMode::Code,
+            false, false, false,
+            &skills,
+        );
+        let resolved = result.unwrap().unwrap();
+        assert_eq!(resolved.skills.len(), 3);
+        assert_eq!(
+            resolved.source,
+            crate::skill_audit::AxisSelectionSource::ModeMacro,
+        );
+        let names: Vec<&str> = resolved.skills.iter().map(|s| s.manifest.name.as_str()).collect();
+        assert_eq!(names, &["correctness", "security", "testing-antipatterns"]);
+    }
+
+    // A4: deep_suppresses_default_axes
+    #[test]
+    fn deep_suppresses_default_axes() {
+        let skills = bundled_skills();
+        let result = resolve_axes(
+            &[],
+            crate::review_mode::ReviewMode::Code,
+            true, false, false,
+            &skills,
+        );
+        assert!(result.unwrap().is_none());
+    }
+
+    // A5: daemon_suppresses_default_axes
+    #[test]
+    fn daemon_suppresses_default_axes() {
+        let skills = bundled_skills();
+        let result = resolve_axes(
+            &[],
+            crate::review_mode::ReviewMode::Code,
+            false, true, false,
+            &skills,
+        );
+        assert!(result.unwrap().is_none());
+    }
+
+    // A6: ensemble_suppresses_default_axes
+    #[test]
+    fn ensemble_suppresses_default_axes() {
+        let skills = bundled_skills();
+        let result = resolve_axes(
+            &[],
+            crate::review_mode::ReviewMode::Code,
+            false, false, true,
+            &skills,
+        );
+        assert!(result.unwrap().is_none());
+    }
+
+    // A7: explicit_axes_with_deep_errors
+    #[test]
+    fn explicit_axes_with_deep_errors() {
+        let skills = bundled_skills();
+        let result = resolve_axes(
+            &["security".into()],
+            crate::review_mode::ReviewMode::Code,
+            true, false, false,
+            &skills,
+        );
+        let err = result.unwrap_err();
+        assert!(err.contains("--deep"), "expected --deep in error: {}", err);
+    }
+
+    // A8: explicit_axes_with_ensemble_errors
+    #[test]
+    fn explicit_axes_with_ensemble_errors() {
+        let skills = bundled_skills();
+        let result = resolve_axes(
+            &["security".into()],
+            crate::review_mode::ReviewMode::Code,
+            false, false, true,
+            &skills,
+        );
+        let err = result.unwrap_err();
+        assert!(err.contains("--ensemble"), "expected --ensemble in error: {}", err);
+    }
+
+    // A9: explicit_axes_with_daemon_errors
+    #[test]
+    fn explicit_axes_with_daemon_errors() {
+        let skills = bundled_skills();
+        let result = resolve_axes(
+            &["security".into()],
+            crate::review_mode::ReviewMode::Code,
+            false, true, false,
+            &skills,
+        );
+        let err = result.unwrap_err();
+        assert!(err.contains("--daemon"), "expected --daemon in error: {}", err);
+    }
+
+    // A10: reserved_mode_tests_errors
+    #[test]
+    fn reserved_mode_tests_errors() {
+        let skills = bundled_skills();
+        let result = resolve_axes(
+            &[],
+            crate::review_mode::ReviewMode::Tests,
+            false, false, false,
+            &skills,
+        );
+        let err = result.unwrap_err();
+        assert!(err.contains("test-coverage"), "expected test-coverage in error: {}", err);
+        assert!(err.contains("mode 'tests'"), "expected mode name in error: {}", err);
+    }
+
+    // A11: reserved_mode_release_errors
+    #[test]
+    fn reserved_mode_release_errors() {
+        let skills = bundled_skills();
+        let result = resolve_axes(
+            &[],
+            crate::review_mode::ReviewMode::Release,
+            false, false, false,
+            &skills,
+        );
+        let err = result.unwrap_err();
+        assert!(err.contains("release-readiness"), "expected release-readiness in error: {}", err);
+        assert!(err.contains("mode 'release'"), "expected mode name in error: {}", err);
+    }
+
+    // A12: unknown_axis_errors
+    #[test]
+    fn unknown_axis_errors() {
+        let skills = bundled_skills();
+        let result = resolve_axes(
+            &["nonexistent".into()],
+            crate::review_mode::ReviewMode::Code,
+            false, false, false,
+            &skills,
+        );
+        let err = result.unwrap_err();
+        assert!(err.contains("unknown skill axis 'nonexistent'"), "expected unknown axis in error: {}", err);
+        assert!(err.contains("available:"), "expected available list in error: {}", err);
+    }
+
+    // A13: prose_plan_uses_legacy
+    #[test]
+    fn prose_plan_uses_legacy() {
+        let skills = bundled_skills();
+        let result = resolve_axes(
+            &[],
+            crate::review_mode::ReviewMode::Plan,
+            false, false, false,
+            &skills,
+        );
+        assert!(result.unwrap().is_none());
+    }
+
+    // A14: prose_docs_uses_legacy
+    #[test]
+    fn prose_docs_uses_legacy() {
+        let skills = bundled_skills();
+        let result = resolve_axes(
+            &[],
+            crate::review_mode::ReviewMode::Docs,
+            false, false, false,
+            &skills,
+        );
+        assert!(result.unwrap().is_none());
+    }
+
+    // A15: case_insensitive_axis_match
+    #[test]
+    fn case_insensitive_axis_match() {
+        let skills = bundled_skills();
+        let result = resolve_axes(
+            &["SECURITY".into()],
+            crate::review_mode::ReviewMode::Code,
+            false, false, false,
+            &skills,
+        );
+        let resolved = result.unwrap().unwrap();
+        assert_eq!(resolved.skills.len(), 1);
+        assert_eq!(resolved.skills[0].manifest.name, "security");
+    }
+
+    // A16: empty_axis_strings_filtered
+    #[test]
+    fn empty_axis_strings_filtered_with_valid() {
+        let skills = bundled_skills();
+        let result = resolve_axes(
+            &["".into(), "security".into()],
+            crate::review_mode::ReviewMode::Code,
+            false, false, false,
+            &skills,
+        );
+        let resolved = result.unwrap().unwrap();
+        assert_eq!(resolved.skills.len(), 1);
+        assert_eq!(resolved.skills[0].manifest.name, "security");
+    }
+
+    #[test]
+    fn empty_axis_strings_filtered_all_empty() {
+        let skills = bundled_skills();
+        // All empty strings → normalized is empty → falls through to default
+        // code mode which resolves bundled axes.
+        let result = resolve_axes(
+            &["".into(), "  ".into()],
+            crate::review_mode::ReviewMode::Code,
+            false, false, false,
+            &skills,
+        );
+        let resolved = result.unwrap().unwrap();
+        // Falls through to code-mode macro since no explicit axes remain
+        assert_eq!(resolved.skills.len(), 3);
+        assert_eq!(
+            resolved.source,
+            crate::skill_audit::AxisSelectionSource::ModeMacro,
+        );
+    }
+
+    // A17: duplicate_axes_deduplicated
+    #[test]
+    fn duplicate_axes_deduplicated() {
+        let skills = bundled_skills();
+        let result = resolve_axes(
+            &["security".into(), "security".into()],
+            crate::review_mode::ReviewMode::Code,
+            false, false, false,
+            &skills,
+        );
+        let resolved = result.unwrap().unwrap();
+        assert_eq!(resolved.skills.len(), 1);
+        assert_eq!(resolved.skills[0].manifest.name, "security");
+    }
+
+    // A18: empty_available_skills_errors
+    #[test]
+    fn empty_available_skills_errors() {
+        let result = resolve_axes(
+            &[],
+            crate::review_mode::ReviewMode::Code,
+            false, false, false,
+            &[], // no skills available
+        );
+        let err = result.unwrap_err();
+        assert!(
+            err.contains("bundled skill") && err.contains("not found"),
+            "expected bundled skill not found in error: {}",
+            err,
+        );
+    }
+
+    // A19: multi_legacy_flags_reports_first
+    #[test]
+    fn multi_legacy_flags_reports_first() {
+        let skills = bundled_skills();
+        // deep + daemon both set; deep should be reported first
+        let result = resolve_axes(
+            &["security".into()],
+            crate::review_mode::ReviewMode::Code,
+            true, true, false,
+            &skills,
+        );
+        let err = result.unwrap_err();
+        assert!(err.contains("--deep"), "expected --deep (first) in error: {}", err);
     }
 }
 

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -292,7 +292,13 @@ fn system_prompt_for_mode(mode: crate::review_mode::ReviewMode) -> &'static str 
     match mode {
         crate::review_mode::ReviewMode::Plan => crate::prose_prompts::plan_system_prompt(),
         crate::review_mode::ReviewMode::Docs => crate::prose_prompts::docs_system_prompt(),
-        crate::review_mode::ReviewMode::Code => crate::llm_client::OpenAiClient::system_prompt(),
+        // Reserved modes fall back to the default code review prompt until
+        // their dedicated prompt templates are implemented.
+        crate::review_mode::ReviewMode::Code
+        | crate::review_mode::ReviewMode::Tests
+        | crate::review_mode::ReviewMode::Release => {
+            crate::llm_client::OpenAiClient::system_prompt()
+        }
     }
 }
 

--- a/src/review_mode.rs
+++ b/src/review_mode.rs
@@ -119,7 +119,10 @@ mod tests {
         assert_eq!("Plan".parse::<ReviewMode>().unwrap(), ReviewMode::Plan);
         assert_eq!("DOCS".parse::<ReviewMode>().unwrap(), ReviewMode::Docs);
         assert_eq!("TESTS".parse::<ReviewMode>().unwrap(), ReviewMode::Tests);
-        assert_eq!("Release".parse::<ReviewMode>().unwrap(), ReviewMode::Release);
+        assert_eq!(
+            "Release".parse::<ReviewMode>().unwrap(),
+            ReviewMode::Release
+        );
     }
 
     #[test]
@@ -163,10 +166,7 @@ mod tests {
 
     #[test]
     fn reserved_modes_parse() {
-        assert_eq!(
-            "tests".parse::<ReviewMode>().unwrap(),
-            ReviewMode::Tests
-        );
+        assert_eq!("tests".parse::<ReviewMode>().unwrap(), ReviewMode::Tests);
         assert_eq!(
             "release".parse::<ReviewMode>().unwrap(),
             ReviewMode::Release

--- a/src/review_mode.rs
+++ b/src/review_mode.rs
@@ -1,9 +1,10 @@
-//! Review mode enum: Code (default), Plan, Docs.
+//! Review mode enum: Code (default), Plan, Docs, Tests, Release.
 //!
 //! Determines which prompt template and evaluation rubric the LLM pipeline
 //! uses. `Code` is the traditional source-code review; `Plan` and `Docs` are
 //! prose-oriented modes that swap in prose-specific system prompts and
-//! severity scales.
+//! severity scales. `Tests` and `Release` are reserved for future axes and
+//! cannot be selected via `--mode` today.
 
 use serde::{Deserialize, Serialize};
 use std::fmt;
@@ -21,6 +22,10 @@ pub enum ReviewMode {
     Plan,
     /// Review prose documentation for accuracy, clarity, and completeness.
     Docs,
+    /// Reserved: test-suite quality review axis (not yet implemented).
+    Tests,
+    /// Reserved: release-readiness review axis (not yet implemented).
+    Release,
 }
 
 impl ReviewMode {
@@ -28,6 +33,12 @@ impl ReviewMode {
     #[must_use]
     pub fn is_prose(self) -> bool {
         matches!(self, Self::Plan | Self::Docs)
+    }
+
+    /// Returns `true` for reserved modes that are not yet implemented.
+    #[must_use]
+    pub fn is_reserved(self) -> bool {
+        matches!(self, Self::Tests | Self::Release)
     }
 
     /// Stable lowercase string form suitable for CLI flags, serde, and
@@ -38,6 +49,8 @@ impl ReviewMode {
             Self::Code => "code",
             Self::Plan => "plan",
             Self::Docs => "docs",
+            Self::Tests => "tests",
+            Self::Release => "release",
         }
     }
 }
@@ -56,8 +69,10 @@ impl FromStr for ReviewMode {
             "code" => Ok(Self::Code),
             "plan" => Ok(Self::Plan),
             "docs" => Ok(Self::Docs),
+            "tests" => Ok(Self::Tests),
+            "release" => Ok(Self::Release),
             other => Err(format!(
-                "unknown review mode '{other}'; expected one of: code, plan, docs"
+                "unknown review mode '{other}'; expected one of: code, plan, docs, tests, release"
             )),
         }
     }
@@ -85,7 +100,13 @@ mod tests {
 
     #[test]
     fn roundtrip_from_str() {
-        for mode in [ReviewMode::Code, ReviewMode::Plan, ReviewMode::Docs] {
+        for mode in [
+            ReviewMode::Code,
+            ReviewMode::Plan,
+            ReviewMode::Docs,
+            ReviewMode::Tests,
+            ReviewMode::Release,
+        ] {
             let s = mode.as_str();
             let parsed: ReviewMode = s.parse().unwrap();
             assert_eq!(parsed, mode, "roundtrip failed for {s}");
@@ -97,6 +118,8 @@ mod tests {
         assert_eq!("CODE".parse::<ReviewMode>().unwrap(), ReviewMode::Code);
         assert_eq!("Plan".parse::<ReviewMode>().unwrap(), ReviewMode::Plan);
         assert_eq!("DOCS".parse::<ReviewMode>().unwrap(), ReviewMode::Docs);
+        assert_eq!("TESTS".parse::<ReviewMode>().unwrap(), ReviewMode::Tests);
+        assert_eq!("Release".parse::<ReviewMode>().unwrap(), ReviewMode::Release);
     }
 
     #[test]
@@ -110,19 +133,56 @@ mod tests {
 
     #[test]
     fn as_str_roundtrip() {
-        for mode in [ReviewMode::Code, ReviewMode::Plan, ReviewMode::Docs] {
+        for mode in [
+            ReviewMode::Code,
+            ReviewMode::Plan,
+            ReviewMode::Docs,
+            ReviewMode::Tests,
+            ReviewMode::Release,
+        ] {
             assert_eq!(mode.to_string(), mode.as_str());
         }
     }
 
     #[test]
     fn serde_roundtrip() {
-        for mode in [ReviewMode::Code, ReviewMode::Plan, ReviewMode::Docs] {
+        for mode in [
+            ReviewMode::Code,
+            ReviewMode::Plan,
+            ReviewMode::Docs,
+            ReviewMode::Tests,
+            ReviewMode::Release,
+        ] {
             let json = serde_json::to_string(&mode).unwrap();
             let back: ReviewMode = serde_json::from_str(&json).unwrap();
             assert_eq!(back, mode, "serde roundtrip failed for {mode}");
             // Verify lowercase serialization.
             assert_eq!(json, format!("\"{}\"", mode.as_str()));
         }
+    }
+
+    #[test]
+    fn reserved_modes_parse() {
+        assert_eq!(
+            "tests".parse::<ReviewMode>().unwrap(),
+            ReviewMode::Tests
+        );
+        assert_eq!(
+            "release".parse::<ReviewMode>().unwrap(),
+            ReviewMode::Release
+        );
+    }
+
+    #[test]
+    fn reserved_modes_are_reserved() {
+        assert!(ReviewMode::Tests.is_reserved());
+        assert!(ReviewMode::Release.is_reserved());
+    }
+
+    #[test]
+    fn non_reserved_modes_are_not_reserved() {
+        assert!(!ReviewMode::Code.is_reserved());
+        assert!(!ReviewMode::Plan.is_reserved());
+        assert!(!ReviewMode::Docs.is_reserved());
     }
 }

--- a/src/skill_audit.rs
+++ b/src/skill_audit.rs
@@ -318,6 +318,7 @@ pub enum AxisSelectionSource {
     ModeMacro,
     Default,
     AutoDiscovery,
+    Legacy,
 }
 
 /// Terminal exit status for a skill invocation.
@@ -935,6 +936,7 @@ mod tests {
             AxisSelectionSource::ModeMacro,
             AxisSelectionSource::Default,
             AxisSelectionSource::AutoDiscovery,
+            AxisSelectionSource::Legacy,
         ];
         for variant in variants {
             let json = serde_json::to_string(&variant).unwrap();


### PR DESCRIPTION
## Summary

- Add `--axes` CLI flag (comma-separated skill names) to `ReviewOpts`
- Implement `resolve_axes()` with 6-step priority chain: reserved mode error -> explicit+legacy conflict -> explicit axes -> legacy suppression -> code-mode macro -> prose-mode legacy
- Add `SkillLlmAdapter` bridging binary-side `OpenAiClient` to lib-side `skill_executor::LlmReviewer`
- Wire skill executor + integrator into both sequential and parallel review paths in `run_review`
- Add `Tests` and `Release` reserved variants to `ReviewMode` with `is_reserved()` predicate
- Add `Legacy` variant to `AxisSelectionSource`
- Graceful fallback to legacy review when skill manifests aren't installed (dev builds)
- Pre-daemon validation for `--axes` and reserved `--mode` flags

## Bug fixes found during review

- **Double-nested skills dir**: `load_from_dir()` already appends "skills" internally; callers were also appending, causing scan of `.../skills/skills/` (found by codex-cli)
- **Daemon bypass**: `--axes` and `--mode tests` silently ignored when `--daemon` was set (found by codex-cli)
- **Dev build crash**: Code-mode macro errored with "installation may be corrupt" when skill manifests weren't next to binary (found during self-review)

## Design

- Spec: `docs/superpowers/specs/2026-06-09-axes-flag-design.md`
- Plan: `docs/superpowers/plans/2026-06-10-axes-flag.md`
- Test plan: `docs/superpowers/test-plans/2026-06-10-axes-flag-tests.md`

## Stats

- 5 files changed, +1106 / -18 lines
- 21 new unit tests (20 `axes_tests` + 1 `skill_integration_tests`)
- 1720 total tests passing, 0 failures
- Clippy clean, rustfmt clean, release build succeeds

## Feedback recorded

- 3x `tp --provenance post_fix` (double-nested dir, daemon bypass, dev build crash)
- 1x `fp --fp-kind pattern-overgeneralization` (reserved mode FromStr acceptance is by design)

## Test plan

- [x] `cargo test --bin quorum` — 1720 pass
- [x] `cargo clippy --bin quorum -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `cargo build --release` — succeeds
- [x] Quorum review (diff-scoped) — 0 in-diff findings
- [x] Codex-cli review — 2 TPs found and fixed

Closes #417

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--axes` CLI flag for multi-axis skill-based reviews with comma-separated axis selection.
  * Introduced `Tests` and `Release` review modes.
  * Integrated multi-axis execution pipeline with token accumulation and automated finding consolidation.

* **Documentation**
  * Added design specification and implementation plan for multi-axis review capability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->