### PR TITLE
test(skills): dirs-only load seam to fix 16 stale skill_manifest tests on main

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -3454,7 +3454,9 @@ fn run_feedback_inner(
     let use_json = json || (!use_compact && !std::io::IsTerminal::is_terminal(&std::io::stdout()));
 
     let linked = entry.finding_id.as_deref();
-    let linked_suffix = linked.map(|fid| format!("|linked:{fid}")).unwrap_or_default();
+    let linked_suffix = linked
+        .map(|fid| format!("|linked:{fid}"))
+        .unwrap_or_default();
     let output = if use_json {
         let mut json_obj = serde_json::json!({
             "verdict": verdict_label,
@@ -3472,7 +3474,9 @@ fn run_feedback_inner(
             verdict_label, entry.file_path, entry.finding_title, linked_suffix
         )
     } else {
-        let link_info = linked.map(|fid| format!(", linked: {fid}")).unwrap_or_default();
+        let link_info = linked
+            .map(|fid| format!(", linked: {fid}"))
+            .unwrap_or_default();
         format!(
             "Recorded: {} for \"{}\" in {} ({} entries{})",
             verdict_label, entry.finding_title, entry.file_path, total, link_info,

--- a/src/review_log.rs
+++ b/src/review_log.rs
@@ -618,15 +618,17 @@ impl ReviewLog {
 
     pub fn resolve_finding_id(&self, file_path: &str, finding_title: &str) -> Option<String> {
         use std::sync::LazyLock;
-        static STOP_WORDS: LazyLock<std::collections::HashSet<&'static str>> = LazyLock::new(|| {
-            [
-                "a", "an", "and", "are", "as", "at", "be", "but", "by", "can", "could", "for",
-                "from", "has", "have", "in", "is", "it", "its", "may", "might", "not", "of", "on",
-                "or", "should", "that", "the", "this", "to", "was", "were", "will", "with", "would",
-            ]
-            .into_iter()
-            .collect()
-        });
+        static STOP_WORDS: LazyLock<std::collections::HashSet<&'static str>> =
+            LazyLock::new(|| {
+                [
+                    "a", "an", "and", "are", "as", "at", "be", "but", "by", "can", "could", "for",
+                    "from", "has", "have", "in", "is", "it", "its", "may", "might", "not", "of",
+                    "on", "or", "should", "that", "the", "this", "to", "was", "were", "will",
+                    "with", "would",
+                ]
+                .into_iter()
+                .collect()
+            });
 
         let Backend::Sqlite(handle) = &self.backend else {
             return None;

--- a/src/skill_manifest.rs
+++ b/src/skill_manifest.rs
@@ -315,11 +315,37 @@ fn load_embedded_skills(
 /// Malformed TOML files are skipped with a `tracing::warn` rather than
 /// aborting the entire load.
 pub fn load_skills(bundled_dir: &Path, user_dir: &Path) -> anyhow::Result<Vec<LoadedSkill>> {
+    load_skills_impl(bundled_dir, user_dir, true)
+}
+
+/// Test/introspection seam: loads only filesystem skills, excluding
+/// compile-time embedded defaults.
+///
+/// Identical to [`load_skills`] except Phase 0 (embedded skills) is skipped,
+/// so the returned set reflects exactly what lives in `bundled_dir` and
+/// `user_dir`. Used by tests that assert on precise directory contents.
+// Currently only exercised by tests; kept available for non-test introspection.
+#[allow(dead_code)]
+pub(crate) fn load_skills_dirs_only(
+    bundled_dir: &Path,
+    user_dir: &Path,
+) -> anyhow::Result<Vec<LoadedSkill>> {
+    load_skills_impl(bundled_dir, user_dir, false)
+}
+
+fn load_skills_impl(
+    bundled_dir: &Path,
+    user_dir: &Path,
+    include_embedded: bool,
+) -> anyhow::Result<Vec<LoadedSkill>> {
     let mut skills_by_name: HashMap<String, LoadedSkill> = HashMap::new();
     let mut bundled_namespaces: HashMap<String, String> = HashMap::new();
 
-    // Phase 0: embedded skills (compiled into the binary).
-    load_embedded_skills(&mut skills_by_name, &mut bundled_namespaces);
+    // Phase 0: embedded skills (compiled into the binary). Skipped for the
+    // dirs-only test seam.
+    if include_embedded {
+        load_embedded_skills(&mut skills_by_name, &mut bundled_namespaces);
+    }
 
     // Phase 1: filesystem bundled skills (override embedded on name collision).
     load_from_dir(
@@ -619,7 +645,7 @@ primary = "Review the code for security issues."
             &minimal_toml("performance"),
         );
 
-        let skills = load_skills(bundled.path(), user.path()).unwrap();
+        let skills = load_skills_dirs_only(bundled.path(), user.path()).unwrap();
         assert_eq!(skills.len(), 2);
         let names: Vec<&str> = skills.iter().map(|s| s.manifest.name.as_str()).collect();
         assert!(names.contains(&"security"));
@@ -666,7 +692,7 @@ primary = "User prompt."
         write_skill(bundled.path(), "security.toml", bundled_toml);
         write_skill(user.path(), "security.toml", user_toml);
 
-        let skills = load_skills(bundled.path(), user.path()).unwrap();
+        let skills = load_skills_dirs_only(bundled.path(), user.path()).unwrap();
         assert_eq!(skills.len(), 1);
         assert_eq!(skills[0].manifest.display_name, "User Security");
         assert_eq!(skills[0].manifest.version, "2.0.0");
@@ -696,7 +722,7 @@ mode = "pure"
 primary = "prompt"
 "#;
         write_skill(bundled.path(), "bad.toml", toml);
-        let skills = load_skills(bundled.path(), user.path()).unwrap();
+        let skills = load_skills_dirs_only(bundled.path(), user.path()).unwrap();
         assert!(
             skills.is_empty(),
             "skill with empty calibration_namespace must be skipped"
@@ -772,7 +798,7 @@ mode = "pure"
 primary = "prompt"
 "#;
         write_skill(bundled.path(), "bad.toml", toml);
-        let skills = load_skills(bundled.path(), user.path()).unwrap();
+        let skills = load_skills_dirs_only(bundled.path(), user.path()).unwrap();
         // Malformed/invalid manifests are skipped with a warning, not hard errors.
         assert!(skills.is_empty());
     }
@@ -797,7 +823,7 @@ mode = "pure"
 primary = ""
 "#;
         write_skill(bundled.path(), "bad.toml", toml);
-        let skills = load_skills(bundled.path(), user.path()).unwrap();
+        let skills = load_skills_dirs_only(bundled.path(), user.path()).unwrap();
         assert!(skills.is_empty());
     }
 
@@ -823,7 +849,7 @@ mode = "pure"
 primary = "prompt"
 "#;
         write_skill(bundled.path(), "bad.toml", toml);
-        let skills = load_skills(bundled.path(), user.path()).unwrap();
+        let skills = load_skills_dirs_only(bundled.path(), user.path()).unwrap();
         assert!(
             skills.is_empty(),
             "unknown axis should fail deserialization"
@@ -852,7 +878,7 @@ mode = "indexed"
 primary = "prompt"
 "#;
         write_skill(bundled.path(), "bad.toml", toml);
-        let skills = load_skills(bundled.path(), user.path()).unwrap();
+        let skills = load_skills_dirs_only(bundled.path(), user.path()).unwrap();
         assert!(
             skills.is_empty(),
             "non-pure capability mode should be rejected as reserved"
@@ -882,7 +908,7 @@ mode = "pure"
 primary = "prompt"
 "#;
         write_skill(bundled.path(), "security.toml", toml);
-        let skills = load_skills(bundled.path(), user.path()).unwrap();
+        let skills = load_skills_dirs_only(bundled.path(), user.path()).unwrap();
         assert_eq!(skills.len(), 1);
         assert_eq!(
             skills[0].manifest.ast_rules,
@@ -979,13 +1005,13 @@ primary   =   "p"
     fn empty_dirs_produce_empty_vec() {
         let bundled = tempdir().unwrap();
         let user = tempdir().unwrap();
-        let skills = load_skills(bundled.path(), user.path()).unwrap();
+        let skills = load_skills_dirs_only(bundled.path(), user.path()).unwrap();
         assert!(skills.is_empty());
     }
 
     #[test]
     fn nonexistent_dirs_produce_empty_vec() {
-        let skills = load_skills(Path::new("/nonexistent/a"), Path::new("/nonexistent/b")).unwrap();
+        let skills = load_skills_dirs_only(Path::new("/nonexistent/a"), Path::new("/nonexistent/b")).unwrap();
         assert!(skills.is_empty());
     }
 
@@ -999,7 +1025,7 @@ primary   =   "p"
         write_skill(bundled.path(), "bad.toml", "this is not {{ valid toml");
         write_skill(bundled.path(), "good.toml", &minimal_toml("good-skill"));
 
-        let skills = load_skills(bundled.path(), user.path()).unwrap();
+        let skills = load_skills_dirs_only(bundled.path(), user.path()).unwrap();
         assert_eq!(skills.len(), 1);
         assert_eq!(skills[0].manifest.name, "good-skill");
     }
@@ -1161,7 +1187,7 @@ mode = "pure"
 primary = "prompt"
 "#;
         write_skill(bundled.path(), "bad.toml", toml);
-        let skills = load_skills(bundled.path(), user.path()).unwrap();
+        let skills = load_skills_dirs_only(bundled.path(), user.path()).unwrap();
         assert!(skills.is_empty(), "invalid semver should be rejected");
     }
 
@@ -1209,7 +1235,7 @@ primary = "prompt"
 "#;
         write_skill(bundled.path(), "aaa.toml", toml_aaa);
 
-        let skills = load_skills(bundled.path(), user.path()).unwrap();
+        let skills = load_skills_dirs_only(bundled.path(), user.path()).unwrap();
         let names: Vec<&str> = skills.iter().map(|s| s.manifest.name.as_str()).collect();
         assert_eq!(names, vec!["aaa", "zzz"]);
     }
@@ -1222,7 +1248,7 @@ primary = "prompt"
         let user = tempdir().unwrap();
 
         write_skill(bundled.path(), "test.toml", &minimal_toml("test"));
-        let skills = load_skills(bundled.path(), user.path()).unwrap();
+        let skills = load_skills_dirs_only(bundled.path(), user.path()).unwrap();
         assert_eq!(skills.len(), 1);
         assert_eq!(
             skills[0].manifest_sha256.len(),
@@ -1363,7 +1389,7 @@ mode = "pure"
 primary = "prompt"
 "#;
         write_skill(bundled.path(), "bad.toml", toml);
-        let skills = load_skills(bundled.path(), user.path()).unwrap();
+        let skills = load_skills_dirs_only(bundled.path(), user.path()).unwrap();
         assert!(
             skills.is_empty(),
             "empty preferred_model should be rejected"
@@ -1434,11 +1460,47 @@ primary = "prompt"
         let user = tempdir().unwrap();
 
         write_skill(bundled.path(), "test.toml", &minimal_toml("test"));
-        let skills = load_skills(bundled.path(), user.path()).unwrap();
+        let skills = load_skills_dirs_only(bundled.path(), user.path()).unwrap();
         assert!(
             skills[0].source_path.ends_with("skills/test.toml"),
             "source_path should end with skills/test.toml: {:?}",
             skills[0].source_path
         );
+    }
+
+    // ── Public loader always includes compile-time embedded defaults ──
+
+    #[test]
+    fn load_skills_includes_embedded_defaults() {
+        // Empty temp dirs: any result must come from the embedded set.
+        let bundled = tempdir().unwrap();
+        let user = tempdir().unwrap();
+
+        let skills = load_skills(bundled.path(), user.path()).unwrap();
+        assert!(
+            !skills.is_empty(),
+            "public load_skills must surface embedded defaults even with empty dirs"
+        );
+
+        // Derive the expected skill names straight from EMBEDDED_SKILLS so this
+        // test tracks the const and cannot be masked by the dirs-only seam.
+        let expected: Vec<String> = EMBEDDED_SKILLS
+            .iter()
+            .map(|(_, content)| {
+                toml::from_str::<SkillManifest>(content)
+                    .expect("embedded skill must parse")
+                    .name
+            })
+            .collect();
+        assert!(!expected.is_empty(), "EMBEDDED_SKILLS must not be empty");
+
+        let loaded_names: Vec<&str> =
+            skills.iter().map(|s| s.manifest.name.as_str()).collect();
+        for name in &expected {
+            assert!(
+                loaded_names.contains(&name.as_str()),
+                "embedded skill {name:?} missing from load_skills output: {loaded_names:?}"
+            );
+        }
     }
 }

--- a/src/skill_manifest.rs
+++ b/src/skill_manifest.rs
@@ -264,14 +264,20 @@ fn is_valid_semver(s: &str) -> bool {
 // ---------------------------------------------------------------------------
 
 const EMBEDDED_SKILLS: &[(&str, &str)] = &[
-    ("correctness.toml", include_str!("../skills/correctness.toml")),
+    (
+        "correctness.toml",
+        include_str!("../skills/correctness.toml"),
+    ),
     ("security.toml", include_str!("../skills/security.toml")),
     (
         "testing-antipatterns.toml",
         include_str!("../skills/testing-antipatterns.toml"),
     ),
     ("simplicity.toml", include_str!("../skills/simplicity.toml")),
-    ("performance.toml", include_str!("../skills/performance.toml")),
+    (
+        "performance.toml",
+        include_str!("../skills/performance.toml"),
+    ),
     (
         "architecture.toml",
         include_str!("../skills/architecture.toml"),
@@ -283,8 +289,7 @@ fn load_embedded_skills(
     bundled_namespaces: &mut HashMap<String, String>,
 ) {
     for (filename, content) in EMBEDDED_SKILLS {
-        let manifest: SkillManifest =
-            toml::from_str(content).expect("embedded skill must parse");
+        let manifest: SkillManifest = toml::from_str(content).expect("embedded skill must parse");
         let sha = canonical_sha256(&manifest).expect("embedded skill must hash");
         let name = manifest.name.clone();
         if let Some(ns) = manifest.calibration_namespace.clone() {
@@ -1011,7 +1016,9 @@ primary   =   "p"
 
     #[test]
     fn nonexistent_dirs_produce_empty_vec() {
-        let skills = load_skills_dirs_only(Path::new("/nonexistent/a"), Path::new("/nonexistent/b")).unwrap();
+        let skills =
+            load_skills_dirs_only(Path::new("/nonexistent/a"), Path::new("/nonexistent/b"))
+                .unwrap();
         assert!(skills.is_empty());
     }
 
@@ -1494,8 +1501,7 @@ primary = "prompt"
             .collect();
         assert!(!expected.is_empty(), "EMBEDDED_SKILLS must not be empty");
 
-        let loaded_names: Vec<&str> =
-            skills.iter().map(|s| s.manifest.name.as_str()).collect();
+        let loaded_names: Vec<&str> = skills.iter().map(|s| s.manifest.name.as_str()).collect();
         for name in &expected {
             assert!(
                 loaded_names.contains(&name.as_str()),


### PR DESCRIPTION
## Summary

`main` is currently red: 16 `skill_manifest::tests` fail. This is a test-fixture staleness bug, not a production regression.

**Root cause:** `c5ed59d` made bundled skills compile-time-embedded, so `load_skills()` always merges the embedded set (Phase 0), and `e4775ef` added new axes (`architecture`, `performance`) to that set. The affected tests pass temporary dirs to `load_skills` and expect **only** the skills they wrote — so the embedded skills leak into their assertions. Tests like `empty_dirs_produce_empty_vec` and `nonexistent_dirs_produce_empty_vec` have a premise (empty dirs → empty vec) that became false by design.

## Fix: a dirs-only test seam (production behavior unchanged)

- Extract the body into `fn load_skills_impl(bundled, user, include_embedded: bool)`.
- `pub fn load_skills(bundled, user)` — signature unchanged — calls `load_skills_impl(.., true)` (embedded-always in production).
- Add `pub(crate) fn load_skills_dirs_only(bundled, user)` = `load_skills_impl(.., false)` — a test/introspection seam that skips the compile-time embedded defaults.
- 16 dir-isolation tests now call `load_skills_dirs_only`; their **original exact-content assertions are unchanged** and correct again (no assertions weakened).
- New test `load_skills_includes_embedded_defaults` locks the production embedded-always behavior via the **public** `load_skills`, deriving expected names from the `EMBEDDED_SKILLS` const so it tracks the set automatically. This guards against the seam masking a real regression.

## Verification

- `cargo test --lib skill_manifest`: 31 passed, 0 failed
- Full `cargo test`: all suites 0 failed (1728 passed, 1 ignored)
- `cargo clippy --all-targets -- -D warnings`: clean · `cargo build`: clean

Discovered while verifying an unrelated calibrator branch against the full suite; filed and fixed separately for scope hygiene.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Directory-based skill loading now cleanly separates installed skills from built-in embedded defaults, preventing unintended interference in directory-only scenarios.
  * Empty skill directories no longer disrupt the default embedded skills when using the standard loading flow.

* **Tests**
  * Updated tests to validate “directories-only” behavior without embedded defaults.
  * Added coverage confirming embedded defaults are still included in the normal loading path.

* **Refactor**
  * Streamlined formatting for “linked” metadata in non-JSON feedback output and cleaned up review log stop-word formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->