### PR TITLE
Phase 1 (#458): deterministic thresholds + operating-point observability

### DIFF
--- a/docs/plans/2026-07-02-calibrator-simplification.md
+++ b/docs/plans/2026-07-02-calibrator-simplification.md
@@ -1,0 +1,259 @@
+# Calibrator: Replace the Learned Model with a Transparent Lookup
+
+**Date:** 2026-07-02
+**Author:** Fable 5 (lead architecture review → spec)
+**Related issues:** #437 (MERGED — finding_id linkage forward), #439 (OPEN — legacy finding_id backfill), #389 (OPEN — consolidate three join fns)
+**Basis:** Design review 2026-07-02 — three parallel decision paths, threshold flapping 0.317↔0.742, 37% join yield / 63% verdict loss, TP-enriched biased corpus, ~1000 LOC dead code. Numbers are run-observed unless labeled otherwise.
+
+## North star (the outcome, not the tidiness)
+
+What the maintainer has wanted from calibration and not gotten: **suppress real false positives without eating true positives — predictably, and in a way they can inspect, reason about, and hand-correct.** Every path below is judged against that, not against code cleanliness. Transparency is itself a feature that's been denied: a model the maintainer can open, understand, and override beats a black box that scores marginally higher on a metric they can't feel. "Predictably" matters as much as "accurately" — a system whose deployed behavior flips between retrains is untrustworthy even when its average is fine.
+
+## Problem
+
+The calibrator "does things but is problematic," and **several minor/moderate revisions have already been spent without delivering.** That track record is evidence, not noise. Three verified failure modes explain why:
+
+1. **The operating point flaps.** The logistic model's suppress/boost thresholds are recomputed from OOF percentiles every retrain. On a corpus differing by ~1 joined sample, suppress moved 0.317 → 0.742 and boost 0.162 → 0.048 (run-observed). This is the "stuck" feeling: retraining silently flips behavior.
+
+2. **The learned signal is thrown away at the door.** The trace↔feedback join is a six-tier text/path cascade keyed on `(finding_title, file_path)` strings. Run-observed: 1,675 / 4,504 eligible verdicts join (37%); 742 dropped ambiguous, 1,163 below-threshold, 924 unmatched. FP verdicts join ~30% worse than TP (25.9% FP eligible → 19.5% FP joined), so the model trains on a TP-enriched, benchmark-enriched slice and meets human triage at review time.
+
+3. **The "model" is 4 numbers in a costume.** Run-observed z-scored coefficients: `file_fp_rate` 0.20, `min_word_lor` 0.14, `max_word_lor` 0.11, `category_fp_rate` 0.05 carry it; 10 of 22 features are selected but the three `log1p_*_weight` features sit at 0.003–0.007 (dead), and the other 12 never make the cut. And it fails the one metric that matters at a safe operating point: **FP-recall@99%TP is 2.7–6.3%** (run-observed) — it can suppress almost no FPs without eating TPs. A model that can only be evaluated by a metric it fails is not worth iterating.
+
+**Prior art (do NOT re-propose).** #437 landed `finding_id` (ULID) forward: FindingMeta write path at review completion, `resolve_finding_id()` auto-link (Jaccard+substring, 0.6), feedback auto-resolves finding_id, CLI `--finding-id`, MCP `findingId`, `Finding.id` in `--json`. The ULID exists, is emitted, and is echoable today; the 3.7%-populated rate is only because it fills forward on a mostly-legacy corpus.
+
+**Keystone gap #437 did NOT close:** `CalibratorTraceEntry` (calibrator_trace.rs:63) has `run_id` in `TraceProvenance` but **no `finding_id`**, and the calibrator join never keys on an id. #437 linked feedback→review; nobody put finding_id into the trace or its join.
+
+---
+
+## Decision: Refactor vs Replace → **REPLACE**
+
+Two honest options:
+
+- **Path A — Refactor:** keep the logistic pipeline (GroupKFold CV, univariate screen, consensus selection, lambda grid, OOF percentile thresholds, composite fallback), stabilize thresholds, shrink features, measure bias. Lovingly simplify what exists.
+- **Path B — Replace:** delete the learned model + CV/logistic/composite machinery and install a **transparent beta-smoothed lookup** — per-file and per-category FP rates shrunk toward a global prior, plus the existing word-LOR title prior — producing a suppress score, with **policy thresholds** (a chosen precision/operating point, not a fit-from-percentile).
+
+**I recommend Path B, plainly.** Not as a preference — as the read the evidence forces:
+
+1. **Path A is not untried; it's a failure record.** The maintainer has already spent several revisions here and the system still doesn't deliver. Continuing to refactor the same architecture is choosing the strategy that has already not worked.
+2. **The threshold churn is intrinsic to the approach, not a bug in it.** Fitting a suppress cutoff from OOF percentiles over ~330 FPs on a biased sample will always be knife-edge. You can't refactor your way out of "the operating point is a fragile statistic." Path B sets the operating point by *policy*, so the churn disappears by construction.
+3. **The model is already a lookup.** Its live signal is `file_fp_rate` + `category_fp_rate` + word-LOR — exactly the lookup Path B builds. The CV/consensus/lambda machinery is ceremony wrapped around 4 numbers. Path B keeps the 4 numbers and deletes the ceremony.
+4. **It fails its own yardstick.** FP-recall@99%TP 2.7–6.3% means the fancy model provides essentially nothing at a safe operating point. There is no marginal accuracy to protect.
+5. **Transparency is the denied feature.** With a lookup, the maintainer can open the rate table, see "`error handling` has FP-rate 0.33," disagree, and correct it. That's the trustable-and-reasonable-about property the north star demands, which a logistic coefficient vector cannot offer.
+
+**Tripwire (prove it or it's gone — default is gone).** After the finding_id join lands and the corpus is clean (Phases 1–3), run the lookup and a *minimal* (≤5-feature) logistic in shadow for one evaluation window on the id-joined corpus. Keep the logistic **only if** it beats the lookup on FP-recall@99%TP by a margin that is both statistically real (outside the bootstrap CI) **and** operationally meaningful (≥10 absolute points — roughly doubling today's recall). Otherwise it is deleted. The burden of proof is on the fancy model; ties and marginal wins go to the transparent lookup.
+
+**Shared no-regret prefix.** The joinable-data work and operating-point stability are valuable under *both* paths — the lookup needs a clean, unbiased, id-keyed corpus every bit as much as the logistic does, and a stable operating point is the north star regardless. So Phases 1–3 come first no matter what, and the fork only resolves once we can actually *measure* whether the fancy model earns its keep. That shared-prefix framing is the real answer: fix the data and the stability first (no-regret), then let evidence — not today's argument — retire the logistic.
+
+---
+
+## Scope
+
+Five ordered, independently-shippable phases. Phases 1–3 are no-regret (hold under refactor or replace). Phases 4–5 execute the replacement. Out of scope: the precedent-weight semantics (`verdict_weight` / FpKind decay — #123's domain), context-injection calibration, and any review-prompt change.
+
+---
+
+## Phase 1 — Operating-point stability (interim bridge)
+
+**Status: NEW.** No existing issue. Smallest diff, immediate relief.
+
+**Why first:** The threshold flap is the live "stuck" symptom and a tiny change. It buys predictable behavior *while* the replacement is built. Under Path B it's ultimately superseded by policy thresholds — but it's cheap insurance for the interim, and the FP-recall instrumentation it adds is permanent.
+
+**Design:**
+- Replace "recompute suppress/boost from OOF percentile every retrain" with a **move-only-on-confidence** guard: bootstrap the OOF predictions for a CI on the candidate threshold; keep the deployed value when it's inside the CI, adopt only when outside, log the decision (n, direction, magnitude).
+- Add **FP-recall@99%TP to the calibrate report** as a first-class number (it's the metric the north star cares about and the one Path B's tripwire uses). Surface it for the current model now.
+
+**Definition of done:**
+- Two identical-corpus `calibrate` runs → byte-identical deployed thresholds.
+- Report prints, per threshold: candidate, CI, held-from-prior flag, and FP-recall@99%TP.
+
+**Test plan:** held-vs-adopted by CI bracket; deterministic bootstrap (reuse `deterministic_permutation`); regression against the 0.317/0.742 corpora holding the deployed value; FP-recall surfaced correctly.
+
+**Risk:** Low — adds a guard + a metric, deletes nothing. Over-stickiness bounded by the out-of-CI escape.
+
+---
+
+## Phase 2 — finding_id into traces + tier-0 id join (keystone, no-regret)
+
+**Status: NEW.** Builds on #437. Valuable under both paths — the lookup needs an unbiased joinable corpus as much as any model.
+
+**Design:**
+- Add `finding_id: Option<String>` to `CalibratorTraceEntry` (additive serde `default` + `skip_serializing_if`, matching the existing `file_path`/`in_diff` pattern). Populate from the `Finding.id` #437 already sets, in the trace write path (`make_trace_entry`, in scope there).
+- Add a **tier-0 exact-id join**: when both sides carry `finding_id`, join is a `HashMap<Ulid, weights>` equality lookup — no normalization, no Jaccard, no ambiguity. Tier-0 beats every text tier.
+- Wire tier-0 into the ONE join logistic/lookup training consumes (`extract_joined_samples`); leave the other two joins for Phase 3 (don't triplicate id logic).
+- **Honest expectation:** this is go-forward. The 17k historical traces have no id; tier-0 yield starts near zero and grows. The text cascade stays as fallback and *drains*. Report tier-0 vs cascade counts so the drain is visible.
+
+**Definition of done:** new traces carry finding_id; an id-equal pair joins tier-0 despite differing titles; report shows id vs text counts; legacy no-id traces join exactly as before (zero historical regression).
+
+**Test plan:** serde round-trip + pre-bump None; tier-0 precedence; id-on-one-side falls through; **trace id == `--json` Finding.id for the same run** (single-source guard); duplicate id caught, not silently dropped.
+
+**Risk:** Medium — silent id mismatch mis-joins tier-0. Mitigation: single-source the id, exact equality only (never fuzzy-match ids), and the `--json` equality test.
+
+---
+
+## Phase 3 — Consolidate the join into one canonical implementation (no-regret)
+
+**Status: COVERED-BY #389 (this scopes and supersedes it).** #389 asks to merge `join_feedback_and_traces_with_options`, `extract_join_features`, `extract_joined_samples` with property tests.
+
+**Why here:** Both training paths and the lookup read one join; the run-observed 1,692-vs-1,675 sample discrepancy (two joins disagreeing on the same run) must die before we compare models. Consolidate *toward the Phase-2 shape* (tier-0 id → raw exact → normalized exact → cascade), not toward the legacy tangle.
+
+**Design:** one canonical join; the other two become adapters or are deleted. Keep the fuzzy/deep-path/suffix/title-only tiers intact here (they're deleted in Phase 5) so this PR is behavior-preserving except the count reconciliation. Add #389's property tests.
+
+**Definition of done:** exactly one join; training corpus and calibrate report agree on sample/FP counts; property suite green.
+
+**Test plan:** golden corpus reproduction; order-independence / tier-attribution / idempotence properties; three-old-vs-one-new diff harness on the real corpus reconciling 1,692↔1,675.
+
+**Risk:** Medium (largest refactor). Mitigation: land after Phase 2 so it's a simplification; keep cascade tiers so it's behavior-preserving.
+
+---
+
+## Phase 4 — Build the transparent lookup + policy thresholds; shadow-eval + resolve the tripwire
+
+**Status: NEW (the replacement).** This is where Path B lands and the fork resolves.
+
+**Design:**
+- **The model is a lookup, not a fit.** Per-file and per-category FP rates, each **beta-smoothed toward the global FP rate** (shrinkage by support count — a file/category with 2 observations barely moves off the prior; one with 200 dominates), combined with the existing word-LOR title prior into a single suppress score in [0,1]. These rate maps already exist and already serialize in `calibrator_model.toml`; this phase makes them *the* model instead of logistic inputs.
+- **Category-key normalization is intrinsic and lands here** (run-observed: `race condition`/`race_condition`/`race-condition` are three keys; `error handling` 0.33 vs `error-handling` 0.19). Normalize before building rate maps — this is free accuracy and a transparency win (one row per concept the maintainer can inspect).
+- **Policy thresholds, not fitted.** The suppress/boost cutoffs are chosen against an explicit precision target + FP-recall floor and written as config the maintainer can read and override — no OOF percentile, no per-retrain drift. This is what structurally kills the churn.
+- **Hand-correctability:** the rate table is inspectable and overridable (a maintainer-pinned rate for a category/file survives recompute). State this as a first-class capability.
+- **Selection-bias table** (join-rate × verdict × provenance) lands in the report here — it's how we keep the corpus honest and how we down-weight/segregate the `quorum-benchmark` slice (run-observed 1,377 rows, 86% TP, 30% of labels).
+- **Resolve the tripwire:** run the lookup and a minimal ≤5-feature logistic in shadow on the clean id-joined corpus for one window; report FP-recall@99%TP + bootstrap CI for both, and the per-file beta-smoothed baseline. Record which wins by the tripwire rule.
+
+**Definition of done:**
+- Lookup produces suppress/boost decisions; thresholds are policy config, stable across identical-corpus recomputes.
+- Rate maps built on normalized keys; a pinned override survives recompute.
+- Report prints: lookup vs minimal-logistic vs baseline FP-recall@99%TP with CIs, and the join-bias table.
+- Tripwire outcome recorded (default: logistic does not clear the bar).
+
+**Test plan:** beta-shrinkage moves low-support rates toward the prior and high-support toward the sample; three race-condition spellings collapse to one key/rate; policy thresholds don't move on identical-corpus recompute; pinned override persists; bias table on synthetic disparity; tripwire arithmetic (margin + CI) on synthetic model pairs.
+
+**Risk:** Medium. The lookup could underperform on some category with sparse data — mitigated by shrinkage (sparse → global prior, the safe default) and by the fact that the operating point is now honest and inspectable rather than optimistic.
+
+---
+
+## Phase 5 — Rip out the logistic / CV / composite / compute_thresholds machinery
+
+**Status: NEW deletion.** Executes the replacement once Phase 4 resolves the tripwire (default: logistic gone).
+
+**Design — delete list, ranked by lines × risk-reduced:**
+1. **Logistic pipeline:** `learn_logistic`, GroupKFold (`group_k_fold`), `univariate_screen`, consensus selection, lambda grid, `logistic.rs` fit/predict as used by the calibrator, `ExpandedFeatures` (22-dim vector), OOF percentile threshold selection, `LogisticModel` from `calibrator_model.rs`. Gone unless the tripwire kept it.
+2. **Composite path:** `ScoreWeights`, `composite_score`, `learn_weights`, `grid_search_best`, `weights_stable`, `rescore_samples_with_model`, composite branch in `calibrate_core_decision` (calibrator.rs:597–668). Run-observed shadowed + hardcoded defaults.
+3. **`compute_thresholds` + `calibrator_thresholds.toml` + `--suppress/boost-precision` flags** (threshold_config.rs, 23-byte file). Never produced output.
+4. **Dead join tiers** (safe post-Phase-3): deep-path (0 joins), fuzzy same-file (45), suffix (16), title-only×2 (2+0). Keep tier-0/1/2.
+5. **Legacy magic-number duplication:** collapse the soft-suppress/confirm rules (re-implemented at calibrator.rs:558/568 and 674/709) into one `fallback_decision()` for the no-model case.
+
+**End state:** one transparent lookup + policy thresholds + one no-model fallback. Zero fitted thresholds, zero CV, zero composite, one join with three tiers.
+
+**Definition of done:** grep-clean of logistic/composite/compute_thresholds (modulo a tripwire-kept minimal logistic, if any); `calibrate_core_decision` has one active path + one fallback; suite green; no tier-0/1/2 yield regression.
+
+**Test plan:** decision-parity fixtures (lookup reproduces intended suppress/boost on a labeled set); `calibrate` no longer touches the thresholds toml; no-model fallback parity.
+
+**Risk:** Low-to-medium. Deletion is safe because Phase 4 already proved the survivor on the clean corpus. Estimated ~1,200+ LOC src+tests removed.
+
+---
+
+## Migration
+
+- New `Option<T>` fields (`CalibratorTraceEntry.finding_id`) are additive with serde `default`; pre-bump lines deserialize unchanged. No trace-file rewrite.
+- `calibrator_thresholds.toml` (Phase 5): ignored then removable; document as safe to delete.
+- The deployed logistic `calibrator_model.toml` stays loadable through Phase 4; Phase 4 writes the lookup model (rate maps are already in the file — this mostly stops writing the `[logistic_model]` block and starts treating rate maps as primary). Phase 5 removes the logistic block entirely.
+- **#439 (legacy finding_id backfill) is intentionally OFF the critical path** — see override note.
+
+## Risks (global)
+
+- **Silent id mismatch** (Phase 2) — single-source the id, exact equality, `--json` parity test.
+- **Sparse-category rates** (Phase 4) — beta shrinkage defaults them to the global prior (safe).
+- **Tripwire mis-called** — require both CI-separation and a ≥10-point margin; default to the lookup on ambiguity.
+
+## Definition of done (overall)
+
+One transparent, inspectable, hand-correctable lookup model; policy thresholds stable across identical-corpus recomputes; one id-keyed join with a draining text fallback; a standing join-bias table; FP-recall@99%TP reported for the deployed model and its baseline. The logistic/CV/composite machinery is gone (or explicitly kept only because it cleared the tripwire). The north star — predictable, trustable FP suppression the maintainer can reason about — is structurally achievable rather than fitted-and-hoped.
+
+## Files touched (by phase)
+
+- **P1:** `src/calibrate.rs` (threshold selection), `src/metrics.rs` (FP-recall), `src/main.rs` (report).
+- **P2:** `src/calibrator_trace.rs` (field), `src/calibrator.rs` (`make_trace_entry`), `src/calibrate.rs` (`extract_joined_samples` tier-0), `src/main.rs` (report).
+- **P3:** `src/calibrate.rs` (unify joins), tests.
+- **P4:** `src/calibrate.rs` (lookup + shrinkage + key normalization + bias table + shadow-eval), `src/calibrator.rs` (decision uses lookup score), `src/calibrator_model.rs` (rate maps primary), `src/main.rs`.
+- **P5:** `src/calibrate.rs`, `src/calibrator.rs`, `src/calibrator_model.rs`, `src/threshold_config.rs`, `src/logistic.rs`, `src/main.rs` (deletions).
+
+## Out of scope
+
+- FpKind / `verdict_weight` semantic decay (#123).
+- Context-injection calibration / `context_misleading`.
+- Review-prompt / few-shot changes.
+- Retroactively healing the historical 63% join loss — the id join is go-forward; the old corpus drains, it doesn't heal.
+
+---
+
+## Where I overrode the proposed ordering
+
+The originally-floated incremental order (freeze → finding_id → consolidate → delete → refit) treated the logistic architecture as the thing to preserve. I don't. Given the maintainer's stated track record — "several revisions, still doesn't deliver" — **the verdict is REPLACE, not refactor.** Concretely:
+
+1. **The refit phase becomes a replacement.** Instead of shrinking the logistic to ~5 features (Path A's Phase 5), Phases 4–5 delete the learned model and install a transparent beta-smoothed lookup with policy thresholds. Incremental has been tried and structurally can't reach the north star: OOF-percentile thresholds are intrinsically churny, the joinable corpus is biased, and the model already collapses to 4 rate-based numbers while failing FP-recall@99%TP.
+2. **No-regret prefix preserved and reordered up front.** finding_id-in-traces, join consolidation, and threshold stability come first because they're valuable under any outcome and let the tripwire be decided on *evidence over a clean corpus*, not on today's argument.
+3. **#439 pulled off the critical path** — it backfills legacy *feedback*; historical *traces* can't get an id, so it barely helps the calibrator join. Ship it in parallel, later, for precision/dedup value only.
+4. **Category-key normalization is intrinsic to the lookup** (Phase 4), not a tail-end tidy — under Path B the normalized rate table *is* the model.
+
+---
+
+## dev:start prompts
+
+### Phase 1
+> **Goal:** Stop the calibrator's suppress/boost thresholds from flapping between retrains. Replace per-retrain OOF-percentile selection with a bootstrap-CI move-only-on-confidence guard (keep deployed value inside CI, adopt only outside, log the decision). Add FP-recall@99%TP to the calibrate report as a first-class metric.
+> **Constraints:** Touch only threshold selection + reporting; reuse the seeded permutation helper; no deletions; no new decision path.
+> **DoD:** Identical-corpus runs → byte-identical thresholds; report prints candidate/CI/held-flag/FP-recall per threshold.
+> **Test plan:** held-vs-adopted by CI bracket; deterministic bootstrap; regression vs the 0.317/0.742 corpora; FP-recall surfaced.
+> **Out of scope:** Model replacement, join changes.
+
+### Phase 2
+> **Goal:** Add `finding_id: Option<String>` to `CalibratorTraceEntry`, populate from `Finding.id` (set by #437) in the trace write path, and add a tier-0 exact-id join to `extract_joined_samples` that beats all text tiers. Report join-by-id vs join-by-text counts.
+> **Constraints:** Additive serde-default field; wire tier-0 into ONLY the training join (Phase 3 unifies the rest); exact id equality only, never fuzzy; text cascade stays as fallback.
+> **DoD:** New traces carry finding_id; id-equal pair joins despite differing titles; report shows id vs text; legacy no-id traces unchanged.
+> **Test plan:** serde round-trip + pre-bump None; tier-0 precedence; id-on-one-side fallthrough; trace id == `--json` Finding.id for one run; duplicate-id caught not dropped.
+> **Out of scope:** Consolidating joins, deleting tiers, legacy backfill.
+
+### Phase 3 (extends #389)
+> **Goal:** Consolidate `join_feedback_and_traces_with_options`, `extract_join_features`, `extract_joined_samples` into one canonical join shaped tier-0 (id) → raw exact → normalized exact → cascade. Reconcile the 1,692-vs-1,675 discrepancy. Add #389's property tests.
+> **Constraints:** Behavior-preserving except the count reconciliation; keep fuzzy/deep-path/suffix/title-only tiers (deleted in Phase 5); one join read by training and report.
+> **DoD:** Exactly one join; training and report counts agree; property suite green.
+> **Test plan:** golden reproduction; order-independence/tier-attribution/idempotence; three-old-vs-one-new diff harness.
+> **Out of scope:** Deleting tiers, model changes.
+
+### Phase 4
+> **Goal:** Build the replacement: a transparent suppress model = per-file + per-category FP rates beta-smoothed toward the global prior + the existing word-LOR title prior, with policy thresholds (precision target + FP-recall floor, written as inspectable/overridable config — no OOF percentile). Normalize category keys before building rate maps. Add a join-bias table (join-rate × verdict × provenance) and down-weight/segregate the `quorum-benchmark` corpus. Shadow-run the lookup vs a minimal ≤5-feature logistic vs the per-file baseline; report FP-recall@99%TP + bootstrap CI for each and record the tripwire outcome.
+> **Constraints:** Thresholds are policy config, not fitted; rate maps are the model; a maintainer-pinned rate survives recompute; keep the logistic only if it beats the lookup on FP-recall@99%TP by ≥10 points AND outside CI — else default to the lookup.
+> **DoD:** Lookup drives decisions; identical-corpus recompute → stable thresholds; normalized keys; pinned override persists; report prints the three-way FP-recall comparison + bias table; tripwire outcome recorded.
+> **Test plan:** shrinkage behavior (sparse→prior, dense→sample); three race-condition spellings → one key; stable thresholds on recompute; pinned override; bias table on synthetic disparity; tripwire arithmetic.
+> **Out of scope:** Deleting the old machinery (Phase 5).
+
+### Phase 5
+> **Goal:** Delete the logistic pipeline (`learn_logistic`, GroupKFold, univariate screen, consensus selection, lambda grid, `ExpandedFeatures`, `LogisticModel`, OOF percentile thresholds), the composite path (`ScoreWeights`/`composite_score`/`learn_weights`/`grid_search_best`/`weights_stable`/`rescore_samples_with_model`), `compute_thresholds` + `calibrator_thresholds.toml` + `--suppress/boost-precision`, the dead join tiers, and collapse the duplicated legacy rules into one `fallback_decision()`. Lookup + policy thresholds is the sole path.
+> **Constraints:** Only after Phase 4's tripwire resolves; keep a minimal logistic only if it cleared the bar; decision parity on a labeled fixture set; no tier-0/1/2 yield regression.
+> **DoD:** grep-clean of the deleted machinery; one active path + one no-model fallback; suite green.
+> **Test plan:** decision-parity fixtures; `calibrate` no longer touches the thresholds toml; no-model fallback parity.
+> **Out of scope:** New feature work on the lookup.
+
+---
+
+## Proposed issues (draft — maintainer to file; not covered by #437/#439/#389)
+
+1. **Replace the learned calibrator with a transparent beta-smoothed lookup + policy thresholds**
+   The logistic model collapses to ~4 rate-based features, fails FP-recall@99%TP (2.7–6.3%), and churns thresholds between retrains; incremental revisions haven't delivered. Replace it with an inspectable per-file/per-category shrunk-rate lookup and policy thresholds. (Phases 4–5.)
+
+2. **Put finding_id into CalibratorTraceEntry and key the calibrator join on it**
+   #437 linked feedback→review but the trace has no finding_id and the join is still a 37%-yield text cascade. Add the field + tier-0 id-equality join. Go-forward keystone under any model. (Phase 2.)
+
+3. **Freeze the calibrator operating point (interim CI-overlap guard + FP-recall metric)**
+   Suppress/boost recompute from OOF percentiles; observed 0.317↔0.742 swing on a ~1-sample delta. Add a bootstrap-CI move-only-on-confidence guard and surface FP-recall@99%TP. (Phase 1.)
+
+4. **Delete the composite calibrator scoring path**
+   Shadowed by the current model whenever one exists, weights are hardcoded defaults, its threshold source never fires. Remove it. (Phase 5.)
+
+5. **Remove compute_thresholds and calibrator_thresholds.toml**
+   The precision-target threshold path has never produced output (23-byte file); delete it, the file, and `--suppress/boost-precision`. (Phase 5.)
+
+6. **Measure and correct calibrator join selection bias**
+   FP verdicts join ~30% worse than TP (25.9%→19.5% share); the benchmark corpus is 86% TP and 30% of labels. Add a join-rate × verdict × provenance report table and down-weight/segregate the benchmark slice. (Phase 4.)
+
+7. **Normalize category keys before building FP-rate maps**
+   `race condition`/`race_condition`/`race-condition` and `error handling`/`error-handling` (0.33 vs 0.19) are separate keys. Normalize before rate-map construction — accuracy + transparency win. (Phase 4, intrinsic to the lookup.)

--- a/docs/superpowers/plans/2026-07-02-calibrator-threshold-stability.md
+++ b/docs/superpowers/plans/2026-07-02-calibrator-threshold-stability.md
@@ -1,0 +1,160 @@
+# Calibrator Threshold Stability (Phase 1, #458) — Implementation Plan (rev 2, post-review)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the calibrator's operating point trustworthy — first by *measuring* whether the observed suppress/boost value-flap (0.317↔0.742) is behavioral or cosmetic, then (only if behavioral) holding the deployed threshold when it is still operationally safe under the new model.
+
+**Architecture:** Observability-first. `learn_logistic` already anchors each threshold to an operating point (suppress = 99% TP-recall percentile of OOF preds, calibrate.rs:2484-2498), and the report already prints AP/lift/FP-recall/suppress/boost (main.rs:4021-4032). Rev 1 tried to freeze the raw *value* via a bootstrap CI; a two-model review (gpt-5.5 + Fable) showed that is mis-targeted — the value moves because the logistic P(FP) score axis is non-stationary across retrains, so holding a prior value against new scores deploys a *third, unintended* operating point. Rev 2: (A) report candidate-vs-deployed + an instability band so we can see what the churn actually does; (B) if the band shows real behavioral swings, add a **safety-gated hold** — keep the prior threshold only if it still meets the 99%-TP-recall constraint on the *current* model's OOF (else adopt). No bootstrap.
+
+**Tech Stack:** Rust, existing `crate::metrics::fp_recall_at_tp_recall`.
+
+**Scope note:** Interim bridge — Phase 4 (#457) replaces fitted thresholds with policy config. No deletions, no review-time decision-path changes.
+
+**Review outcome (gpt-5.5 via codex-cli + Fable 5), folded in below:**
+1. **Confirmed bug (gpt-5.5):** `run_calibrate` builds a FRESH model from feedback (main.rs:3946) whose `logistic_model` is `None`; the persisted load at main.rs:2137 is a *different* path. Capturing prior from that fresh model gives nothing → any guard is inert. **Must explicitly load `calibrator_model.toml` inside `run_calibrate` before learning.**
+2. **Freeze behavior, not value (both):** replace value-CI bracketing with a current-corpus safety gate.
+3. **Bootstrap dropped (both):** high-variance/discrete on a 1%/5% tail; and Phase 4's tripwire wants a CI on the FP-recall *distribution*, not a tail order-statistic — so the "reused later" justification was wrong.
+4. **Determinism DoD narrowed (both):** `learn_logistic` is already deterministic (group_k_fold first-appearance, fixed lambda order, no RNG). Byte-identical *model file* is impossible (`computed_at`, HashMap TOML order). DoD is: **same ordered corpus → identical deployed thresholds**, and canonicalize joined-sample order before CV.
+5. **Two-corpus regression (both):** the flap test must train two real adjacent corpora, not construct a bracket.
+
+---
+
+## File structure
+
+- `src/main.rs` — `run_calibrate`: load prior `calibrator_model.toml` explicitly; canonicalize joined-sample order before learning; augment the report with candidate/deployed/instability; (Task 5, conditional) apply the safety gate.
+- `src/calibrate.rs` — canonical sample sort helper; `threshold_safe_under` predicate (does a given threshold meet the operating constraint on an OOF array); (Task 5) `hold_or_adopt_safe`.
+- `src/metrics.rs` — no change (FP-recall already exists).
+- Tests: in-file `#[cfg(test)] mod tests` in `calibrate.rs`.
+
+**Execution-time verification (do first, with rust-expert):** trace how `run_calibrate` obtains the model it writes (fresh at main.rs:3946 vs loaded at 2137) and confirm the prior thresholds must come from an explicit `CalibratorModel::load_from(model_path)` inside `run_calibrate`. Nail the suppress/boost inequality direction (suppress-when-`score < threshold` vs `>`) against calibrate.rs:744-768 before writing the safety predicate.
+
+---
+
+## Task 1: Canonicalize joined-sample order before CV (determinism prerequisite)
+
+**Files:** Modify `src/calibrate.rs` (sort `Vec<JoinedSample>` deterministically at the top of `learn_logistic`, or in `run_calibrate` before the call); Test: `calibrate.rs` tests.
+
+- [ ] **Step 1: Failing test** — build a `Vec<JoinedSample>`, train, capture thresholds; shuffle the input vec, train again; assert identical suppress/boost.
+
+```rust
+#[test]
+fn thresholds_are_order_invariant() {
+    let a = build_sample_corpus();           // existing test builder
+    let mut b = a.clone();
+    b.reverse();
+    let ra = learn_logistic(&a, 5).unwrap();
+    let rb = learn_logistic(&b, 5).unwrap();
+    assert_eq!(ra.suppress_threshold, rb.suppress_threshold);
+    assert_eq!(ra.boost_threshold, rb.boost_threshold);
+}
+```
+
+- [ ] **Step 2: Run, verify it FAILS** (fold assignment is first-appearance based, so order changes folds).
+- [ ] **Step 3: Implement** a stable sort by a canonical key (e.g. `(finding_id, file_path, title, score)`) before fold assignment. Document the key.
+- [ ] **Step 4: Run, verify PASS.**
+- [ ] **Step 5: Commit** — `test(calibrate): make thresholds order-invariant (#458)`.
+
+---
+
+## Task 2: Report candidate vs deployed + instability band (observability — the base)
+
+**Files:** Modify `src/main.rs` `run_calibrate` `Some(result)` arm (4021-4050).
+
+Rationale: this is the always-ship part. It costs almost nothing (FP-recall already printed) and produces the data that decides whether Task 5 is even warranted. "Deployed" == "candidate" until Task 5 exists.
+
+- [ ] **Step 1:** Emit, per threshold: candidate value, deployed value (== candidate for now), FP-recall@99%TP (already at 4028), and — if a prior model loaded — the delta from prior. Add a `tracing::info!` structured line (threshold, prior, candidate, deployed, delta).
+
+```rust
+eprintln!(
+    "  Suppress threshold: {:.4}  (candidate {:.4}; prior {}; d={})",
+    dep_suppress, result.suppress_threshold,
+    prior_suppress.map(|p| format!("{p:.4}")).unwrap_or_else(|| "none".into()),
+    prior_suppress.map(|p| format!("{:+.4}", result.suppress_threshold - p)).unwrap_or_else(|| "n/a".into()),
+);
+```
+
+- [ ] **Step 2:** Load the prior model explicitly (fixes review bug #1) to populate `prior_suppress`/`prior_boost`:
+
+```rust
+let prior = quorum::calibrator_model::CalibratorModel::load_from(&model_path.to_string_lossy());
+let (prior_suppress, prior_boost) = prior
+    .and_then(|m| m.logistic_model)
+    .map(|l| (Some(l.suppress_threshold), Some(l.boost_threshold)))
+    .unwrap_or((None, None));
+```
+(Confirm `model_path` is in scope here; it is used at main.rs:2137/4257.)
+
+- [ ] **Step 3:** Build + smoke — `cargo run -- calibrate --dry-run`; confirm the new lines render and prior deltas appear on a second run.
+- [ ] **Step 4: Commit** — `feat(calibrate): report candidate/deployed/prior-delta for thresholds (#458)`.
+
+---
+
+## Task 3: `threshold_safe_under` predicate (pure, for the gate)
+
+**Files:** Modify `src/calibrate.rs`; Test: `calibrate.rs` tests.
+
+```rust
+/// True if using `threshold` as the suppress cutoff on `oof` (current model's
+/// OOF predictions for the TP class) still keeps TP-recall >= `min_tp_recall`.
+/// (Boost side: analogous with the FP class and the boost inequality.)
+/// Direction of the inequality MUST match calibrate.rs:744-768 — verify first.
+pub(crate) fn threshold_safe_under(oof_tp: &[f64], threshold: f64, min_tp_recall: f64) -> bool { /* ... */ }
+```
+
+- [ ] **Step 1: Failing tests** — a prior threshold that still clears 99% TP-recall on a fresh OOF array → true; one that now suppresses >1% of TPs → false; empty → false.
+- [ ] **Step 2: Run, verify fail. Step 3: Implement (count fraction of TP OOF preds on the safe side of `threshold`). Step 4: Run, verify pass.**
+- [ ] **Step 5: Commit** — `feat(calibrate): threshold_safe_under operating-constraint predicate (#458)`.
+
+---
+
+## Task 4: DECISION GATE — is a hold even warranted?
+
+**Not a code task.** After Tasks 1–2 land and you have run `calibrate` on the real corpus a few times (or replayed recent `calibrator_model.toml` history), inspect the reported instability:
+
+- If candidate thresholds barely move once the corpus is order-canonical, **the flap was cosmetic → STOP. Phase 1 is done at Task 2** (observability). Skip Task 5; proceed to Phase 2 (#459).
+- If candidates swing materially *and* the swing changes realized suppression on held-out findings, **proceed to Task 5.**
+
+Record the finding (numbers) in the issue #458 thread either way. This gate is the whole point of observability-first: don't build the guard on an unconfirmed premise.
+
+---
+
+## Task 5 (CONDITIONAL): Safety-gated hold
+
+**Only if Task 4 confirms behavioral swings.** Files: `src/calibrate.rs` (`hold_or_adopt_safe`), `src/main.rs` (wire in).
+
+```rust
+/// Keep the prior threshold only if it is still operationally safe under the
+/// current model; otherwise adopt the candidate. Returns (deployed, held).
+pub(crate) fn hold_or_adopt_safe(
+    prior: Option<f64>, candidate: f64, oof_tp: &[f64], min_tp_recall: f64,
+) -> (f64, bool) {
+    match prior {
+        Some(p) if threshold_safe_under(oof_tp, p, min_tp_recall) => (p, true),
+        _ => (candidate, false),
+    }
+}
+```
+
+- [ ] **Step 1: Two-corpus regression (replaces rev-1 Task 5).** Build two real adjacent corpora A and B differing by ~1 sample that reproduce candidate ≈0.317 (A) then ≈0.742 (B). Train A, deploy 0.317. Train B; assert `hold_or_adopt_safe(Some(0.317), 0.742, oof_tp_B, 0.99)` **holds 0.317 IFF 0.317 still clears 99% TP-recall on B's OOF**, and adopts otherwise. This tests real behavior, not a constructed bracket.
+- [ ] **Step 2–4:** implement, wire into `run_calibrate` (deployed value flows into the emitted `LogisticModel` + the report's "deployed" column + a `held` flag), verify.
+- [ ] **Step 5: Commit** — `feat(calibrate): safety-gated threshold hold (#458)`.
+
+---
+
+## Verification
+
+- [ ] `cargo test --bin quorum` green; `cargo clippy --all-targets -- -D warnings` clean; `cargo build --release` ok.
+- [ ] `cargo run -- calibrate --dry-run` twice on the **same ordered corpus** → identical deployed thresholds (DoD, narrowed per review). Report shows candidate/deployed/prior-delta/FP-recall.
+
+## DoD (revised)
+
+1. Thresholds are order-invariant and identical across reruns on the same ordered corpus (Task 1).
+2. The calibrate report surfaces candidate, deployed, prior-delta, and FP-recall@99%TP per threshold (Task 2).
+3. A documented decision (Task 4) on whether the flap is behavioral, recorded in #458.
+4. If behavioral: prior thresholds are held only when still safe under the current model, proven by a two-corpus regression (Task 5).
+
+## Self-review notes
+
+- The confirmed prior-capture bug (review #1) is fixed in Task 2 Step 2 (explicit load), so it lands even in the observability-only path.
+- Bootstrap/CI removed entirely (review #3). No `LogisticResult` field changes needed now.
+- Task 4 is the ponytail guard against building a mechanism for a cosmetic problem.

--- a/docs/superpowers/plans/2026-07-02-calibrator-threshold-stability.md
+++ b/docs/superpowers/plans/2026-07-02-calibrator-threshold-stability.md
@@ -34,20 +34,29 @@
 
 **Files:** Modify `src/calibrate.rs` (sort `Vec<JoinedSample>` deterministically at the top of `learn_logistic`, or in `run_calibrate` before the call); Test: `calibrate.rs` tests.
 
-- [ ] **Step 1: Failing test** — build a `Vec<JoinedSample>`, train, capture thresholds; shuffle the input vec, train again; assert identical suppress/boost.
+- [ ] **Step 1: Failing test** — build a corpus LARGE ENOUGH that reordering actually reassigns first-appearance folds (antipattern review: on a small/symmetric corpus `reverse()` may not change fold membership and the test passes pre-fix). Use TWO distinct permutations (reverse + a seeded shuffle) so it can't pass trivially. Assert identical suppress/boost across all three orderings.
 
 ```rust
 #[test]
 fn thresholds_are_order_invariant() {
-    let a = build_sample_corpus();           // existing test builder
-    let mut b = a.clone();
-    b.reverse();
+    let a = build_sample_corpus_large(); // >= enough distinct families to span all folds
+    let mut rev = a.clone();
+    rev.reverse();
+    let mut shuf = a.clone();
+    // deterministic shuffle (mirror deterministic_permutation) so the test is reproducible
+    let perm = deterministic_permutation(shuf.len());
+    let shuf: Vec<_> = perm.iter().map(|&i| shuf[i].clone()).collect();
+
     let ra = learn_logistic(&a, 5).unwrap();
-    let rb = learn_logistic(&b, 5).unwrap();
-    assert_eq!(ra.suppress_threshold, rb.suppress_threshold);
-    assert_eq!(ra.boost_threshold, rb.boost_threshold);
+    let rrev = learn_logistic(&rev, 5).unwrap();
+    let rshuf = learn_logistic(&shuf, 5).unwrap();
+    assert_eq!(ra.suppress_threshold, rrev.suppress_threshold);
+    assert_eq!(ra.boost_threshold, rrev.boost_threshold);
+    assert_eq!(ra.suppress_threshold, rshuf.suppress_threshold);
+    assert_eq!(ra.boost_threshold, rshuf.boost_threshold);
 }
 ```
+Pre-flight: confirm `build_sample_corpus_large()` reorders folds without the fix (add a temporary assert that `a`'s and `rev`'s fold assignments differ, then remove) — otherwise the test is a no-op.
 
 - [ ] **Step 2: Run, verify it FAILS** (fold assignment is first-appearance based, so order changes folds).
 - [ ] **Step 3: Implement** a stable sort by a canonical key (e.g. `(finding_id, file_path, title, score)`) before fold assignment. Document the key.
@@ -101,8 +110,13 @@ let (prior_suppress, prior_boost) = prior
 pub(crate) fn threshold_safe_under(oof_tp: &[f64], threshold: f64, min_tp_recall: f64) -> bool { /* ... */ }
 ```
 
-- [ ] **Step 1: Failing tests** — a prior threshold that still clears 99% TP-recall on a fresh OOF array → true; one that now suppresses >1% of TPs → false; empty → false.
-- [ ] **Step 2: Run, verify fail. Step 3: Implement (count fraction of TP OOF preds on the safe side of `threshold`). Step 4: Run, verify pass.**
+- [ ] **Step 1: Failing tests** — hand-computed expectations on tiny literal arrays (NOT derived by calling the fn under test):
+  - prior threshold that still clears 99% TP-recall on a fresh OOF array → true
+  - prior threshold that now suppresses >1% of TPs → false
+  - empty `oof_tp` → false
+  - **tie boundary:** all-equal OOF scores → decide the documented behavior (recommend false: no distinction possible) and assert it
+  - **NaN guard:** an OOF array containing `f64::NAN` must not silently miscount the safe-side fraction (filter non-finite like `fp_recall_at_tp_recall` does at metrics.rs:139) → assert the finite-only fraction
+- [ ] **Step 2: Run, verify fail. Step 3: Implement (count fraction of finite TP OOF preds on the safe side of `threshold`; filter non-finite). Step 4: Run, verify pass.**
 - [ ] **Step 5: Commit** — `feat(calibrate): threshold_safe_under operating-constraint predicate (#458)`.
 
 ---
@@ -135,7 +149,10 @@ pub(crate) fn hold_or_adopt_safe(
 }
 ```
 
-- [ ] **Step 1: Two-corpus regression (replaces rev-1 Task 5).** Build two real adjacent corpora A and B differing by ~1 sample that reproduce candidate ≈0.317 (A) then ≈0.742 (B). Train A, deploy 0.317. Train B; assert `hold_or_adopt_safe(Some(0.317), 0.742, oof_tp_B, 0.99)` **holds 0.317 IFF 0.317 still clears 99% TP-recall on B's OOF**, and adopts otherwise. This tests real behavior, not a constructed bracket.
+- [ ] **Step 1: Regression + guard tests (replaces rev-1 Task 5; antipattern-hardened).** Do NOT target magic threshold literals (≈0.317/≈0.742) and do NOT derive the expected outcome by calling `threshold_safe_under` inside the test (that mirrors the impl). Instead:
+  - Two adjacent corpora A, B differing by ~1 sample. Train A → prior `p`. Train B → candidate `c`. From B's *known* OOF data, hand-determine the ONE concrete expected outcome and assert the literal tuple, e.g. `assert_eq!(hold_or_adopt_safe(Some(p), c, &oof_tp_b, 0.99), (p, true))` — pick the corpus so the outcome is unambiguous, and assert `(value, held)` directly.
+  - **First-run:** `assert_eq!(hold_or_adopt_safe(None, c, &oof_tp_b, 0.99), (c, false))`.
+  - The behavior under assertion is "held vs adopted," not any particular number.
 - [ ] **Step 2–4:** implement, wire into `run_calibrate` (deployed value flows into the emitted `LogisticModel` + the report's "deployed" column + a `held` flag), verify.
 - [ ] **Step 5: Commit** — `feat(calibrate): safety-gated threshold hold (#458)`.
 

--- a/src/calibrate.rs
+++ b/src/calibrate.rs
@@ -2324,7 +2324,7 @@ pub fn learn_logistic(samples: &[JoinedSample], k_folds: usize) -> Option<Logist
     // the caller's input ordering. This makes learned thresholds deterministic.
     let mut samples = samples.to_vec();
     samples.sort_by(canonical_key_cmp);
-    let samples = &samples[..];
+    let samples = samples.as_slice();
 
     let n = samples.len();
 

--- a/src/calibrate.rs
+++ b/src/calibrate.rs
@@ -2284,6 +2284,33 @@ fn group_k_fold(families: &[&str], k: usize) -> Vec<usize> {
         .collect()
 }
 
+/// Total order over the discriminating fields of a `JoinedSample`.
+///
+/// Used to canonicalize input order before training so that learned thresholds
+/// are byte-identical regardless of how the caller ordered the samples. Fully
+/// equal samples are interchangeable, so their relative order does not affect
+/// downstream floating-point summation.
+fn canonical_key_cmp(x: &JoinedSample, y: &JoinedSample) -> std::cmp::Ordering {
+    x.family
+        .cmp(&y.family)
+        .then_with(|| x.title.cmp(&y.title))
+        .then_with(|| x.file_path.cmp(&y.file_path))
+        .then_with(|| x.category.cmp(&y.category))
+        .then_with(|| x.severity.cmp(&y.severity))
+        .then_with(|| x.model.cmp(&y.model))
+        .then_with(|| x.is_fp.cmp(&y.is_fp))
+        .then_with(|| x.tp_weight.total_cmp(&y.tp_weight))
+        .then_with(|| x.fp_weight.total_cmp(&y.fp_weight))
+        .then_with(|| x.soft_fp_weight.total_cmp(&y.soft_fp_weight))
+        .then_with(|| x.full_suppress_weight.total_cmp(&y.full_suppress_weight))
+        .then_with(|| x.wontfix_weight.total_cmp(&y.wontfix_weight))
+        .then_with(|| x.max_similarity.total_cmp(&y.max_similarity))
+        .then_with(|| x.mean_similarity.total_cmp(&y.mean_similarity))
+        .then_with(|| x.precedent_count.cmp(&y.precedent_count))
+        .then_with(|| x.finding_span_lines.cmp(&y.finding_span_lines))
+        .then_with(|| x.source_is_ast.cmp(&y.source_is_ast))
+}
+
 /// Train a logistic model via cross-validation with per-fold feature screening.
 ///
 /// Returns `None` when:
@@ -2292,6 +2319,13 @@ fn group_k_fold(families: &[&str], k: usize) -> Vec<usize> {
 /// - Fewer than 2 features pass consensus selection
 /// - Model fails to beat baseline AP by >= 0.02
 pub fn learn_logistic(samples: &[JoinedSample], k_folds: usize) -> Option<LogisticResult> {
+    // Canonicalize sample order up front so every downstream step (fold
+    // assignment, feature stats, floating-point summation) is independent of
+    // the caller's input ordering. This makes learned thresholds deterministic.
+    let mut samples = samples.to_vec();
+    samples.sort_by(canonical_key_cmp);
+    let samples = &samples[..];
+
     let n = samples.len();
 
     // Safety gate: minimum sample count
@@ -4783,6 +4817,103 @@ mod tests {
             .map(|(_, fold)| *fold)
             .collect();
         assert!(b_folds.iter().all(|f| *f == b_folds[0]));
+    }
+
+    /// Build a corpus large enough to clear all `learn_logistic` gates
+    /// (>= 220 samples, >= 30 FP, >= 30 TP) and span many families so that
+    /// fold membership genuinely depends on family order-of-first-appearance.
+    fn build_order_test_corpus() -> Vec<JoinedSample> {
+        (0..300)
+            .map(|i| {
+                let is_fp = i < 60; // 60 FP, 240 TP
+                JoinedSample {
+                    title: if is_fp {
+                        "bad pattern unwrap".to_string()
+                    } else {
+                        "good error handling code".to_string()
+                    },
+                    category: if is_fp {
+                        "style".to_string()
+                    } else {
+                        "correctness".to_string()
+                    },
+                    severity: "medium".to_string(),
+                    model: "gpt-5.4".to_string(),
+                    tp_weight: if is_fp { 0.1 } else { 2.5 },
+                    fp_weight: if is_fp { 2.5 } else { 0.1 },
+                    soft_fp_weight: if is_fp { 1.5 } else { 0.0 },
+                    full_suppress_weight: if is_fp { 2.5 } else { 0.1 },
+                    wontfix_weight: 0.0,
+                    precedent_count: if is_fp { 0 } else { 4 },
+                    max_similarity: if is_fp { 0.3 } else { 0.85 },
+                    mean_similarity: if is_fp { 0.2 } else { 0.75 },
+                    is_fp,
+                    // 12 distinct families (>= 6) so fold membership depends on order
+                    family: format!("family_{}", i % 12),
+                    file_path: "src/some_file.rs".to_string(),
+                    source_is_ast: false,
+                    finding_span_lines: 3,
+                }
+            })
+            .collect()
+    }
+
+    /// Map each family to its assigned fold under `group_k_fold`, in the order
+    /// the samples appear. Used to prove that reordering changes fold membership.
+    fn family_to_fold_map(samples: &[JoinedSample], k: usize) -> HashMap<String, usize> {
+        let families: Vec<&str> = samples.iter().map(|s| s.family.as_str()).collect();
+        let folds = group_k_fold(&families, k);
+        let mut map = HashMap::new();
+        for (fam, fold) in families.iter().zip(folds.iter()) {
+            map.entry((*fam).to_string()).or_insert(*fold);
+        }
+        map
+    }
+
+    #[test]
+    fn thresholds_are_order_invariant() {
+        let a = build_order_test_corpus();
+
+        let mut a_rev = a.clone();
+        a_rev.reverse();
+
+        let perm = deterministic_permutation(a.len());
+        let a_perm: Vec<JoinedSample> = perm.iter().map(|&i| a[i].clone()).collect();
+
+        // PRE-FLIGHT: confirm the reorderings actually change the family->fold
+        // assignment, otherwise this test would prove nothing.
+        let map_a = family_to_fold_map(&a, 5);
+        let map_rev = family_to_fold_map(&a_rev, 5);
+        let map_perm = family_to_fold_map(&a_perm, 5);
+        assert_ne!(
+            map_a, map_rev,
+            "reversed corpus must change family->fold assignment for the test to be meaningful"
+        );
+        assert_ne!(
+            map_a, map_perm,
+            "permuted corpus must change family->fold assignment for the test to be meaningful"
+        );
+
+        let r_a = learn_logistic(&a, 5).expect("corpus should train");
+        let r_rev = learn_logistic(&a_rev, 5).expect("reversed corpus should train");
+        let r_perm = learn_logistic(&a_perm, 5).expect("permuted corpus should train");
+
+        assert_eq!(
+            r_a.suppress_threshold, r_rev.suppress_threshold,
+            "suppress_threshold must be identical under input reversal"
+        );
+        assert_eq!(
+            r_a.boost_threshold, r_rev.boost_threshold,
+            "boost_threshold must be identical under input reversal"
+        );
+        assert_eq!(
+            r_a.suppress_threshold, r_perm.suppress_threshold,
+            "suppress_threshold must be identical under input permutation"
+        );
+        assert_eq!(
+            r_a.boost_threshold, r_perm.boost_threshold,
+            "boost_threshold must be identical under input permutation"
+        );
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -4070,7 +4070,9 @@ fn run_calibrate(opts: cli::CalibrateOpts) -> i32 {
                 match prior_suppress {
                     Some(p) => eprintln!(
                         "  Suppress threshold: {:.4} deployed (= candidate; no hold guard in Phase 1)  [prior {:.4}, d={:+.4}]",
-                        result.suppress_threshold, p, result.suppress_threshold - p
+                        result.suppress_threshold,
+                        p,
+                        result.suppress_threshold - p
                     ),
                     None => eprintln!(
                         "  Suppress threshold: {:.4} deployed (= candidate; no hold guard in Phase 1)",
@@ -4080,7 +4082,9 @@ fn run_calibrate(opts: cli::CalibrateOpts) -> i32 {
                 match prior_boost {
                     Some(p) => eprintln!(
                         "  Boost threshold:    {:.4} deployed (= candidate; no hold guard in Phase 1)  [prior {:.4}, d={:+.4}]",
-                        result.boost_threshold, p, result.boost_threshold - p
+                        result.boost_threshold,
+                        p,
+                        result.boost_threshold - p
                     ),
                     None => eprintln!(
                         "  Boost threshold:    {:.4} deployed (= candidate; no hold guard in Phase 1)",
@@ -4970,9 +4974,7 @@ mod backfill_linkage_tests {
 #[cfg(test)]
 mod prior_thresholds_tests {
     use super::*;
-    use quorum::calibrator_model::{
-        CalibratorModel, LogisticModel, ModelMeta, ScoreWeights,
-    };
+    use quorum::calibrator_model::{CalibratorModel, LogisticModel, ModelMeta, ScoreWeights};
     use std::collections::HashMap;
 
     fn model_with(logistic: Option<LogisticModel>) -> CalibratorModel {

--- a/src/main.rs
+++ b/src/main.rs
@@ -3810,6 +3810,21 @@ fn run_backfill_linkage(opts: cli::BackfillLinkageOpts) -> i32 {
     0
 }
 
+/// Extract the previously-deployed logistic thresholds `(suppress, boost)` from
+/// a loaded calibrator model, if it carries a logistic sub-model.
+///
+/// Pure and unit-testable. Returns `(None, None)` when the model is absent or
+/// has no logistic sub-model. Used by `run_calibrate` to report prior-vs-candidate
+/// threshold deltas (Phase 1 observability).
+fn prior_thresholds(
+    model: Option<&calibrator_model::CalibratorModel>,
+) -> (Option<f64>, Option<f64>) {
+    match model.and_then(|m| m.logistic_model.as_ref()) {
+        Some(l) => (Some(l.suppress_threshold), Some(l.boost_threshold)),
+        None => (None, None),
+    }
+}
+
 /// CLI entry point for `quorum calibrate`.
 fn run_calibrate(opts: cli::CalibrateOpts) -> i32 {
     if let Err(e) = opts.validate() {
@@ -4009,6 +4024,18 @@ fn run_calibrate(opts: cli::CalibrateOpts) -> i32 {
             disable_fuzzy,
         );
 
+        // Load the previously-deployed model so we can report prior thresholds
+        // and prior->candidate deltas. NOTE: run_calibrate builds a *fresh*
+        // composite_model from feedback (whose logistic_model is None), which is
+        // a distinct code path from the review-time load at model_path (~2137).
+        // Without this explicit load there is no prior deployed threshold in
+        // scope here.
+        let prior_model_path = qhome.join("calibrator_model.toml");
+        let prior_model = quorum::calibrator_model::CalibratorModel::load_from(
+            &prior_model_path.to_string_lossy(),
+        );
+        let (prior_suppress, prior_boost) = prior_thresholds(prior_model.as_ref());
+
         match quorum::calibrate::learn_logistic(&joined, 5) {
             Some(result) => {
                 eprintln!(
@@ -4032,8 +4059,51 @@ fn run_calibrate(opts: cli::CalibrateOpts) -> i32 {
                     "  FP recall @ 99% TP recall: {:.4}",
                     result.fp_recall_at_99_tp_recall
                 );
-                eprintln!("  Suppress threshold: {:.4}", result.suppress_threshold);
-                eprintln!("  Boost threshold:    {:.4}", result.boost_threshold);
+                // Phase 1 is observability-first: there is NO hold guard yet, so
+                // the deployed value is ALWAYS the freshly-computed candidate.
+                // The label makes that explicit so nobody assumes a guard is
+                // gating deployment. The [prior ...] bracket is omitted on first
+                // run (no prior model on disk).
+                let suppress_delta = prior_suppress.map(|p| result.suppress_threshold - p);
+                let boost_delta = prior_boost.map(|p| result.boost_threshold - p);
+
+                match prior_suppress {
+                    Some(p) => eprintln!(
+                        "  Suppress threshold: {:.4} deployed (= candidate; no hold guard in Phase 1)  [prior {:.4}, d={:+.4}]",
+                        result.suppress_threshold, p, result.suppress_threshold - p
+                    ),
+                    None => eprintln!(
+                        "  Suppress threshold: {:.4} deployed (= candidate; no hold guard in Phase 1)",
+                        result.suppress_threshold
+                    ),
+                }
+                match prior_boost {
+                    Some(p) => eprintln!(
+                        "  Boost threshold:    {:.4} deployed (= candidate; no hold guard in Phase 1)  [prior {:.4}, d={:+.4}]",
+                        result.boost_threshold, p, result.boost_threshold - p
+                    ),
+                    None => eprintln!(
+                        "  Boost threshold:    {:.4} deployed (= candidate; no hold guard in Phase 1)",
+                        result.boost_threshold
+                    ),
+                }
+
+                tracing::info!(
+                    threshold = "suppress",
+                    prior = ?prior_suppress,
+                    candidate = result.suppress_threshold,
+                    deployed = result.suppress_threshold,
+                    delta = ?suppress_delta,
+                    "threshold report"
+                );
+                tracing::info!(
+                    threshold = "boost",
+                    prior = ?prior_boost,
+                    candidate = result.boost_threshold,
+                    deployed = result.boost_threshold,
+                    delta = ?boost_delta,
+                    "threshold report"
+                );
 
                 let lm = quorum::calibrator_model::LogisticModel {
                     computed_at: chrono::Utc::now().to_rfc3339(),
@@ -4894,5 +4964,81 @@ mod backfill_linkage_tests {
         let (linked2, cand2) = backfill_linkage_inner(&qhome);
         assert_eq!(linked2, 0, "second run must link 0 — already done");
         assert_eq!(cand2, 0, "no unlinked candidates remain");
+    }
+}
+
+#[cfg(test)]
+mod prior_thresholds_tests {
+    use super::*;
+    use quorum::calibrator_model::{
+        CalibratorModel, LogisticModel, ModelMeta, ScoreWeights,
+    };
+    use std::collections::HashMap;
+
+    fn model_with(logistic: Option<LogisticModel>) -> CalibratorModel {
+        CalibratorModel {
+            meta: ModelMeta {
+                computed_at: "2026-07-03T00:00:00Z".to_string(),
+                feedback_count: 10,
+                global_fp_rate: 0.3,
+                learned_weights: None,
+            },
+            weights: ScoreWeights {
+                score: 0.5,
+                word_lor: 1.5,
+                family_fp_inv: 1.0,
+                language_fp_inv: 0.5,
+            },
+            logistic_model: logistic,
+            word_lor: HashMap::new(),
+            family_fp_rate: HashMap::new(),
+            language_fp_rate: HashMap::new(),
+            category_fp_rate_map: None,
+            severity_fp_rate: None,
+            model_fp_rate: None,
+            file_fp_rate: None,
+            file_finding_counts: None,
+        }
+    }
+
+    fn logistic_with(suppress: f64, boost: f64) -> LogisticModel {
+        LogisticModel {
+            computed_at: "2026-07-03T00:00:00Z".to_string(),
+            n_samples: 300,
+            n_fp: 60,
+            selected_features: vec!["a".to_string(), "b".to_string()],
+            coefficients: vec![0.1, 0.2],
+            intercept: 0.0,
+            feature_means: vec![0.0, 0.0],
+            feature_stddevs: vec![1.0, 1.0],
+            suppress_threshold: suppress,
+            boost_threshold: boost,
+            ap_score: 0.5,
+            fp_recall_at_99_tp_recall: 0.2,
+            baseline_ap: 0.2,
+        }
+    }
+
+    #[test]
+    fn prior_thresholds_returns_both_when_logistic_present() {
+        let model = model_with(Some(logistic_with(0.3170, 0.7400)));
+        let (suppress, boost) = prior_thresholds(Some(&model));
+        assert_eq!(suppress, Some(0.3170));
+        assert_eq!(boost, Some(0.7400));
+    }
+
+    #[test]
+    fn prior_thresholds_returns_none_when_logistic_absent() {
+        let model = model_with(None);
+        let (suppress, boost) = prior_thresholds(Some(&model));
+        assert_eq!(suppress, None);
+        assert_eq!(boost, None);
+    }
+
+    #[test]
+    fn prior_thresholds_returns_none_when_model_absent() {
+        let (suppress, boost) = prior_thresholds(None);
+        assert_eq!(suppress, None);
+        assert_eq!(boost, None);
     }
 }


### PR DESCRIPTION
## Phase 1 of the calibrator simplification (#457) — freeze/observe the operating point (#458)

> Stacked on #464 (skill_manifest test-seam base fix). Merge #464 first; this PR retargets to `main` automatically.

### What this does

Phase 1 of the calibrator-simplification effort. Design review (gpt-5.5 + Fable 5) found the suppress/boost thresholds "flap" between retrains (observed 0.317↔0.742). This ships the **observability-first** slice: measure whether the flap is behavioral before mechanizing any guard.

**Two changes:**

1. **Deterministic thresholds** (`calibrate.rs`) — `learn_logistic` now canonicalizes sample order up front (`canonical_key_cmp`), so fold assignment *and* floating-point summation are independent of input order. The RED test proved the drift was ULP-level (`0.004181543264443876` vs `…791`), i.e. genuine float-order nondeterminism, not just fold shuffle.
2. **Threshold observability + prior-load fix** (`main.rs`) — the calibrate report now prints, per threshold: candidate value, deployed value, prior value + signed delta, alongside the existing FP-recall@99%TP. Fixes a real bug found in review: `run_calibrate` built a fresh model whose prior thresholds were never loaded, so any comparison to the deployed model was silently empty — now it explicitly loads `calibrator_model.toml`. Deployed still equals candidate (no hold guard — see below); the label says so plainly.

### The finding (why there's no guard)

Run-observed on the real corpus, with determinism now locked: the flap is **largely cosmetic**. A big share was our own nondeterminism (now fixed); the residual (suppress 0.317→0.60-capped) tracks a *fixed operating point* (the 99%-TP-recall percentile) as the model's score axis shifts between retrains, and FP-recall@99%TP sits at ~4.8% regardless — so the threshold value barely affects behavior. Per observability-first, the safety-gated hold (planned Task 5) is **deliberately skipped**: it would mechanize a non-problem. The real leverage is the finding_id join (Phase 2) and the model replacement (Phase 4).

### Tests
- `thresholds_are_order_invariant` — trains three orderings (original, reversed, seeded-shuffle) on a 300-sample corpus that spans folds; asserts identical suppress/boost. Antipattern-hardened (pre-flight asserts the orderings actually reassign folds).
- `prior_thresholds` helper unit tests (present/absent/None).

### Verification
- Full `cargo test`: 0 failures. `cargo clippy --all-targets -- -D warnings`: clean. `cargo build --release`: ok.

### Review feedback
Change-scoped quorum review surfaced 4 in-diff findings, all triaged with verdicts recorded (finding_id-linked): 1 FP (`string-byte-slice` on a `Vec` slice — fixed to `.as_slice()`), 3 wontfix (pre-existing / test-fixture complexity on code slated for Phase 5 deletion).

Docs: `docs/plans/2026-07-02-calibrator-simplification.md` (full effort), `docs/superpowers/plans/2026-07-02-calibrator-threshold-stability.md` (this phase).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
