### PR TITLE
ci(quorum): analyze comment-only (unblock PR findings), skip docs, model passthrough

### DIFF
--- a/.github/workflows/quorum-review-analyze.yml
+++ b/.github/workflows/quorum-review-analyze.yml
@@ -19,10 +19,30 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
       - name: Run review
-        run: quorum review --json --diff-file pr.diff $(git diff --name-only ${{ github.event.pull_request.base.sha }}...HEAD) > findings.json
+        # Generate findings.json for the companion "report" workflow to post as PR
+        # comments. This job must SUCCEED regardless of what the review finds:
+        #   - quorum exits 1 (warnings) / 2 (critical) when it finds issues; those
+        #     are review *results*, not job failures. The report job is gated on this
+        #     job's success (workflow_run.conclusion == 'success'), so failing here
+        #     silently suppresses ALL PR comments.
+        #   - Only reviewable code files are passed; prose/docs files just emit noise.
+        # LLM vs AST: if QUORUM_API_KEY is set (e.g. a direct Anthropic key -- the
+        # built-in base-URL allowlist already permits api.anthropic.com), quorum runs
+        # the full LLM review; if unset, it cleanly falls back to AST-only. No code
+        # change to switch -- just add the secrets.
+        run: |
+          files=$(git diff --name-only ${{ github.event.pull_request.base.sha }}...HEAD \
+            | grep -vE '(^|/)docs/|\.(md|markdown|txt|lock)$' || true)
+          if [ -z "$files" ]; then
+            echo "No reviewable code files changed; nothing to review."
+            echo '[]' > findings.json
+            exit 0
+          fi
+          quorum review --json --diff-file pr.diff $files > findings.json || true
         env:
           QUORUM_BASE_URL: ${{ secrets.QUORUM_BASE_URL }}
           QUORUM_API_KEY: ${{ secrets.QUORUM_API_KEY }}
+          QUORUM_MODEL: ${{ secrets.QUORUM_MODEL }}
       - uses: actions/upload-artifact@v4
         with:
           name: quorum-findings


### PR DESCRIPTION
## Summary

The `Quorum Review (analyze)` job has been silently broken since it was added: it **failed whenever the review found anything**, which (because the companion `report` job is gated on `workflow_run.conclusion == 'success'`) meant **PR comments were never posted**. All block, no triage.

Two root causes:
1. `quorum review` exits **1** (warnings) / **2** (critical) when it finds issues — those are review *results*, not job failures. The step had no tolerance for them.
2. It passed **all** changed files, including `.md` plan docs, so a code review emitted prose-file warnings that also tripped the non-zero exit.

## Fix (comment-only)

- Filter to reviewable **code** files (drop `docs/`, `*.md`, `*.txt`, `*.lock`).
- Handle the no-code-files case (write `[]`, exit 0).
- `|| true` on the review so the job succeeds and uploads `findings.json` → the `report` job can post findings as PR comments.
- Add `QUORUM_MODEL` passthrough.

Result: findings are **posted as comments, not gated**. This is the right default while quorum-in-CI is uncalibrated (no `~/.quorum` in CI). A deliberate hard-gate on `critical` can come later, once calibration is trustworthy and available in CI (tracked separately).

## Enabling LLM review (optional, no code change)

CI currently has **no `QUORUM_*` secrets**, so it runs **AST-only**. To turn on full LLM review, add repo secrets:

- `QUORUM_API_KEY` — a direct **Anthropic** key (`sk-ant-…`). `api.anthropic.com` is public and already on quorum's built-in base-URL allowlist, so no allowlist env is needed (unlike the private litellm host).
- `QUORUM_BASE_URL` — Anthropic's OpenAI-compatible endpoint (confirm exact base path against current Anthropic docs before adding).
- `QUORUM_MODEL` — a Claude model (e.g. Haiku 4.5 for cheap per-PR runs).

With no secrets set, the job stays AST-only — a defensible zero-secret posture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved review automation to focus only on relevant code changes.
  * Non-code updates like docs and prose are now skipped during review checks.
  * Review runs now always produce a results artifact, even when there are no reviewable files, avoiding unnecessary job failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->